### PR TITLE
try updated lnd version

### DIFF
--- a/initLocalTest.sh
+++ b/initLocalTest.sh
@@ -8,7 +8,7 @@ helm repo add jetstack https://charts.jetstack.io
 helm repo add galoy https://galoymoney.github.io/charts/
 helm repo update
 
-lndVersion="1.1.11"
+lndVersion="1.1.12"
 
 cd ./charts/galoy && helm dependency build && cd -
 cd ./charts/monitoring && helm dependency build && cd -


### PR DESCRIPTION
lnd still run as root. I think Docker from lightninglabs/lnd/Docker would need to be changed to avoid that.
but I think that is not so much as issue as the other satellite pod --> if someone would get access to lnd, it's a bit the end game.  and at this point root or not root access would not make a huge difference