### PR TITLE
use username instead of uid for public function

### DIFF
--- a/src/entrypoint/graphql.ts
+++ b/src/entrypoint/graphql.ts
@@ -193,9 +193,8 @@ const resolvers = {
         return true
       }
     }),
-    noauthAddInvoice: async (_, { uid }, { logger }) => {
-      const user = await User.findOne({_id: uid})
-      const wallet = await WalletFactory({ user, logger })
+    noauthAddInvoice: async (_, { username }, { logger }) => {
+      const wallet = await WalletFromUsername({username, logger})
       return wallet.addInvoice({ selfGenerated: false })
     },
     invoice: async (_, __, { wallet }) => ({


### PR DESCRIPTION
Reverting back to using username for the public invoice, because the getUid function is protected behind an editor+authenticated shield, and we shouldn't expose that function to the public imo.