### PR TITLE
multi-wallet-bitcoind

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -24,6 +24,12 @@ rebalancing:
   ratioTargetWithdraw: 1
   minOnchain: 10000000 # 0.1
 
+  # select which bitcoind wallet is used for rebalancing
+  # string.include() is being used as a filter
+  # 
+  # specter wallet always 
+  onchainWallet: "specter"
+
 test_accounts: 
 - phone: "+16505554321" # user0
   code: 321321

--- a/src/SpecterWallet.ts
+++ b/src/SpecterWallet.ts
@@ -9,9 +9,6 @@ import { lndBalances } from "./lndUtils"
 import { yamlConfig } from "./config"
 import { createChainAddress, sendToChainAddress } from "lightning";
 
-
-// TODO: we should not rely on OnChainMixin/UserWallet for this "wallet"
-
 export class SpecterWallet {
   bitcoindClient 
   logger
@@ -33,8 +30,8 @@ export class SpecterWallet {
   async setBitcoindClient(): Promise<string> {
     const wallets = await SpecterWallet.listWallets()
 
-    const pattern = "specter"
-    const specterWallets = _.filter(wallets, item => item.startsWith(pattern))
+    const pattern = yamlConfig.rebalancing.onchainWallet ?? "specter"
+    const specterWallets = _.filter(wallets, item => item.includes(pattern))
 
     // there should be only one specter wallet
     // TODO/FIXME this is a weak security assumption
@@ -49,7 +46,7 @@ export class SpecterWallet {
     }
 
     if (specterWallets.length > 1) {
-      throw Error("only one specter wallet in bitcoind is currently supported")
+      throw Error("currently one wallet can be selected for cold storage rebalancing")
     }
 
     this.logger.info({wallet: specterWallets[0]}, "setting BitcoindClient")

--- a/src/bitcoind.ts
+++ b/src/bitcoind.ts
@@ -1,0 +1,30 @@
+import _ from "lodash"
+import { BitcoindClient, bitcoindDefaultClient, btc2sat } from "./utils";
+
+const listWallets = async () => {
+  return bitcoindDefaultClient.listWallets()
+}
+
+export const getBalancesDetail = async (): Promise<{wallet: string, balance: number}[]> => {
+  const wallets = await listWallets()
+
+  const balances: {wallet: string, balance: number}[] = []
+
+  for await (const wallet of wallets) {
+    // do not use the default wallet for now (expect for testing).
+    if (wallet === "") {
+      continue
+    }
+
+    const client = BitcoindClient({ wallet })
+    const balance = btc2sat(await client.getBalance())
+    balances.push({wallet, balance})
+  }
+
+  return balances
+}
+
+export const getBalance = async (): Promise<number> => {
+  const balanceObj = await getBalancesDetail() 
+  return _.sumBy(balanceObj, 'balance');
+}

--- a/src/entrypoint/exporter.ts
+++ b/src/entrypoint/exporter.ts
@@ -5,10 +5,10 @@ import { balanceSheetIsBalanced, getBalanceSheet } from "../ledger/balanceSheet"
 import { getBosScore, lndBalances } from "../lndUtils";
 import { setupMongoConnection } from "../mongodb";
 import { Transaction, User } from "../schema";
-import { SpecterWallet } from "../SpecterWallet";
 import { baseLogger } from "../logger";
 import { getDealerWallet, getFunderWallet } from "../walletFactory";
 import { lnd } from "../lndConfig"
+import { getBalancesDetail } from "../bitcoind"
 import _ from "lodash"
 
 const logger = baseLogger.child({module: "exporter"})
@@ -44,7 +44,6 @@ const assetsLiabilitiesDifference_g = new client.Gauge({ name: `${prefix}_assets
 const bookingVersusRealWorldAssets_g = new client.Gauge({ name: `${prefix}_lndBalanceSync`, help: 'are lnd in syncs with our books' })
 const bos_g = new client.Gauge({ name: `${prefix}_bos`, help: 'bos score' })
 const bitcoin_g = new client.Gauge({ name: `${prefix}_bitcoin`, help: 'amount in accounting for cold storage' })
-const specter_g = new client.Gauge({ name: `${prefix}_bitcoind`, help: 'amount in cold storage' })
 const business_g = new client.Gauge({ name: `${prefix}_business`, help: 'number of businesses in the app' })
 const onchainWithdrawFees_g = new client.Gauge({ name: `${prefix}_onchainWithdrawFees`, help: 'onchain withdraw fees collected' })
 const onchainDepositFees_g = new client.Gauge({ name:`${prefix}_onchainDepositFees`, help: 'onchain deposit fees collected' })
@@ -110,8 +109,11 @@ const main = async () => {
     fundingRate_g.set(await dealerWallet.getNextFundingRate())
 
     try {
-      const specterWallet = new SpecterWallet({ logger })
-      specter_g.set(await specterWallet.getBitcoindBalance())
+      const balances = await getBalancesDetail()
+      for (const {wallet, balance} of balances) {
+        const gauge = new client.Gauge({ name: `${prefix}_bitcoind_${wallet}`, help: `amount in wallet ${wallet}` })
+        gauge.set(balance)
+      }
     } catch (err) {
       logger.error({err}, "error setting bitcoind/specter balance")
     }

--- a/src/ledger/balanceSheet.ts
+++ b/src/ledger/balanceSheet.ts
@@ -4,10 +4,10 @@ import { lnd } from "../lndConfig";
 import { lndBalances } from "../lndUtils";
 import { MainBook } from "../mongodb";
 import { User } from "../schema";
-import { SpecterWallet } from "../SpecterWallet";
 import { baseLogger } from '../logger'
 import { WalletFactory } from "../walletFactory";
 import { bitcoindAccountingPath, escrowAccountingPath, lndAccountingPath, lndFeePath } from "./ledger";
+import { getBalance as getBitcoindBalance } from "../bitcoind";
 
 const logger = baseLogger.child({module: "balanceSheet"})
 
@@ -38,8 +38,7 @@ export const balanceSheetIsBalanced = async () => {
   const {assets, liabilities, lightning, bitcoin, expenses, revenue } = await getBalanceSheet()
   const { total: lnd } = await lndBalances() // doesnt include escrow amount
 
-  const specterWallet = new SpecterWallet({ logger })
-  let bitcoind = await specterWallet.getBitcoindBalance()
+  let bitcoind = await getBitcoindBalance()
 
   const assetsLiabilitiesDifference = 
     assets /* assets is ___ */


### PR DESCRIPTION
export different bitcoind wallet in prometheus, and use the total balance of the wallet when calculating the balance sheet

node: the code between bitcoind.ts and specter.ts is a bit duplicated. they served different purpose. specter is for rebalancing, bitcoind is more for accounting purpose. this could be improve but I'll do that in a later PR, as I want this to get update shortly so that the balance sheet calculation is correct again (it stopped being after the use of multiple wallet on the bitcoind backend).