### PR TITLE
optimize script for local dev

### DIFF
--- a/deletePods.sh
+++ b/deletePods.sh
@@ -8,4 +8,4 @@ kubectl delete pod lnd-0 lnd-outside-1-0 lnd-outside-2-0
 
 kubectl wait pod lnd-0 lnd-outside-1-0 lnd-outside-2-0 --for=condition=ready
 kubectl wait pod -l app.kubernetes.io/component=mongodb --for=condition=ready
-kubectl wait pod -l app=redis --for=condition=ready
+kubectl wait pod -l app.kubernetes.io/name=redis --for=condition=ready

--- a/initLocalTest.sh
+++ b/initLocalTest.sh
@@ -15,13 +15,21 @@ helm repo update
 lndVersion="1.2.3"
 bitcoindVersion="0.1.15"
 
-cd ./charts/galoy
-helm dependency build
-cd -
-
-cd ./charts/monitoring
-helm dependency build
-cd -
+if [ ${LOCAL} ]; then
+  cd ./charts/galoy
+  helm dependency build --skip-refresh
+  cd -
+  cd ./charts/monitoring
+  helm dependency build --skip-refresh
+  cd -
+else
+  cd ./charts/galoy
+  helm dependency build
+  cd -
+  cd ./charts/monitoring
+  helm dependency build
+  cd -
+fi
 
 INGRESS_NAMESPACE="ingress-nginx"
 INFRADIR=./charts


### PR DESCRIPTION
We are already updating the repos at the beginning of `initLocalTest.sh` so using a skip flag for helm dep build makes sense. On my machine, it reduced times by 50% and 66% for galoy and monitoring charts respectively. Eventually we will be removing this script, so I think the added 'ugliness' is okay for now because it provides a much faster local dev experience.

Edit: I am keeping `--skip-refresh` only for local dev because it's unavailable on CircleCI for some reason, not sure why. The very flag is missing from the `helm dep build` command despite the helm version being recent.