### PR TITLE
Retry copying macaroon for integration tests

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -7,8 +7,16 @@ export TLSOUTSIDE2=$(base64 dev/lnd/tls.cert | tr -d '\n\r')
 fetch_macaroon() {
   local container_id=$(docker ps -q -f status=running -f name="galoy_$1_")
   if [[ "${container_id}" != "" ]]; then
-    docker cp $container_id:/data/.lnd/data/chain/bitcoin/$NETWORK/admin.macaroon dev/lnd/$1.macaroon
-    base64 dev/lnd/$1.macaroon | tr -d '\n\r'
+    # On Arch Linux `docker-compose up` appears to complete before the lnd containers have initialized the macaroons.
+    # Here we retry for 10 seconds until we can copy the macroon successfully
+    for i in {0..10}; do
+      docker cp $container_id:/data/.lnd/data/chain/bitcoin/$NETWORK/admin.macaroon dev/lnd/$1.macaroon > /dev/null
+      if [[ "$?" == "0" ]]; then
+        base64 dev/lnd/$1.macaroon | tr -d '\n\r'
+        break
+      fi
+      sleep 1
+    done
   fi
 }
 


### PR DESCRIPTION
The dev setup wasn't working consistently on Arch Linux.
Hopefully this workaround resolves the issue.

@krtk6160 can you please see if it works seamlessly now and merge if so?