### PR TITLE
Reward users with a username via pushPayment

### DIFF
--- a/src/LightningUserWallet.ts
+++ b/src/LightningUserWallet.ts
@@ -44,8 +44,18 @@ export class LightningUserWallet extends OnChainMixin(LightningMixin(UserWallet)
         )
 
         if (userPastState.earn.findIndex((item) => item === id) === -1) {
-          const invoice = await this.addInvoice({ memo: id, value: amount })
-          await lightningFundingWallet.pay({ invoice, isReward: true })
+          if (this.user.username) {
+            await lightningFundingWallet.pay({
+              destination: this.getNodePubkey(),
+              username: this.user.username,
+              amount,
+              isReward: true,
+              memo: id,
+            })
+          } else {
+            const invoice = await this.addInvoice({ memo: id, value: amount })
+            await lightningFundingWallet.pay({ invoice, isReward: true })
+          }
         }
 
         result.push({ id, value: amount, completed: true })

--- a/src/LightningUserWallet.ts
+++ b/src/LightningUserWallet.ts
@@ -46,7 +46,7 @@ export class LightningUserWallet extends OnChainMixin(LightningMixin(UserWallet)
         if (userPastState.earn.findIndex((item) => item === id) === -1) {
           if (this.user.username) {
             await lightningFundingWallet.pay({
-              destination: this.getNodePubkey(),
+              destination: await this.getNodePubkey(),
               username: this.user.username,
               amount,
               isReward: true,

--- a/src/__tests__/04a-reward.ts
+++ b/src/__tests__/04a-reward.ts
@@ -19,6 +19,9 @@ let userWallet1
 jest.mock("../notifications/notification")
 jest.mock("../realtimePrice")
 
+const date = Date.now() + 1000 * 60 * 60 * 24 * 8
+jest.spyOn(global.Date, "now").mockImplementation(() => new Date(date).valueOf())
+
 beforeAll(async () => {
   await setupMongoConnection()
   mockGetExchangeBalance()


### PR DESCRIPTION
At the moment, when a user completes a quiz question, a new invoice is generated from their wallet and immediately paid by the funder wallet. This is inefficient because it puts unnecessary load on LND. We can instead make pushPayments to users that have a username set, whereas for users without a username we can continue with the older invoice approach.