### PR TITLE
Use dev dependencies to run yarn build for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,15 @@ RUN apk update && apk add git
 
 COPY ./*.json ./yarn.lock ./
 
-RUN yarn install --frozen-lockfile  --production
+RUN yarn install --frozen-lockfile
 
 COPY ./src ./src
 
-RUN yarn global add typescript
 RUN find ./src -type d -depth -name '__tests__' -exec rm -r {} \; -prune
 
 RUN yarn build
+
+RUN yarn install --frozen-lockfile --production
 
 FROM gcr.io/distroless/nodejs:14
 COPY --from=BUILD_IMAGE /app/lib /app/lib


### PR DESCRIPTION
While this solves the build issue, I think the better solution would be to not run `yarn build` in Docker at all and instead run it locally prior to docker build, and then COPY `lib` instead of `src`. Let me know if you want me to update the PR for that (note that'll require changing where `docker build` is run so that `yarn build` is run before it)