### PR TITLE
Add restart-integration command

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -30,6 +30,19 @@ direnv: direnv: loading ~/projects/GaloyMoney/galoy/.envrc
 $ yarn install
 ```
 
+## Development
+
+To start the GraphQL server and its dependencies:
+```
+$ make start
+```
+
+
+Alernatively, to start the GraphQL server in watch mode (with automatic restart on changes):
+```
+$ make watch
+```
+
 ## Testing
 
 To execute the test suite runtime dependencies must be running.
@@ -49,11 +62,9 @@ $ echo $?
 0
 ```
 
-The tests are *not* idempotent (yet) so currently to re-run the tests you must reset the dependencies:
+The tests are *not* idempotent (yet) so currently to re-run the tests, run:
 ```
-$ make reset-deps
-(...)
-$ make integration
+$ make reset-integration
 ```
 
 ## Running checks

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,10 @@ clean-deps:
 
 reset-deps: clean-deps start-deps
 
-integration: reset-deps
+integration:
 	. ./.envrc && yarn jest --forceExit --bail --runInBand --verbose $$TEST | yarn pino-pretty -c -l
+
+restart-integration: reset-deps integration
 
 test-in-ci:
 	docker-compose up -d

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ reset-deps: clean-deps start-deps
 integration:
 	. ./.envrc && yarn jest --forceExit --bail --runInBand --verbose $$TEST | yarn pino-pretty -c -l
 
-restart-integration: reset-deps integration
+reset-integration: reset-deps integration
 
 test-in-ci:
 	docker-compose up -d


### PR DESCRIPTION
@bodymindarts Actually I realized I do use the "non-clean slate" integration command a lot. For example sometimes I want to re-run an idempotent test file multiple times while building a feature and having the `make integration` command do `reset-deps` made my dev workflow much slower.