### PR TITLE
Config enable/disable the ip and proxy log information (Fixes GaloyMoney/galoy#130)

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -89,8 +89,10 @@ limits:
       1: 5000000
       2: 100000000
 
-proxyChecking:
+ipRecording:
   enabled: true
+  proxyChecking:
+    enabled: true
 
 # blacklistedIPTypes: ['VPN', 'Compromised Server']
 

--- a/src/entrypoint/graphql.ts
+++ b/src/entrypoint/graphql.ts
@@ -366,9 +366,11 @@ export async function startApolloServer() {
           { lastConnection: new Date() },
           { new: true },
         )
-        if (yamlConfig.proxyChecking.enabled) {
+
+        if (yamlConfig.ipRecording.enabled) {
           updateIPDetails({ ip, user, logger })
         }
+
         wallet =
           !!user && user.status === "active"
             ? await WalletFactory({ user, logger })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -157,34 +157,26 @@ export const updateIPDetails = async ({ ip, user, logger }): Promise<void> => {
     return
   }
 
-  let ipinfo
-
   try {
     // skip axios.get call if ip already exists in user object
     if (user.lastIPs.some((ipObject) => ipObject.ip === ip)) {
       return
     }
 
-    if (yamlConfig.ipRecording.proxyChecking.enabled) {
-      ipinfo = await fetchIP({ ip })
+    const res = await User.updateOne(
+      { "_id": user._id, "lastIPs.ip": ip },
+      { $set: { "lastIPs.$.lastConnection": Date.now() } },
+    )
+
+    if (!res.nModified && yamlConfig.ipRecording.proxyChecking.enabled) {
+      const ipinfo = await fetchIP({ ip })
+      await User.findOneAndUpdate(
+        { "_id": user._id, "lastIPs.ip": { $ne: ip } },
+        { $push: { lastIPs: { ip, ...ipinfo, Type: ipinfo?.type } } },
+      )
     }
   } catch (error) {
-    logger.info({ error }, "Failed to fetch ip details")
-  } finally {
-    try {
-      const res = await User.updateOne(
-        { "_id": user._id, "lastIPs.ip": ip },
-        { $set: { "lastIPs.$.lastConnection": Date.now() } },
-      )
-      if (!res.nModified) {
-        await User.findOneAndUpdate(
-          { "_id": user._id, "lastIPs.ip": { $ne: ip } },
-          { $push: { lastIPs: { ip, ...ipinfo, Type: ipinfo?.type } } },
-        )
-      }
-    } catch (err) {
-      logger.warn({ err }, "error setting last ip")
-    }
+    logger.warn({ error }, "error setting last ip")
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -165,7 +165,9 @@ export const updateIPDetails = async ({ ip, user, logger }): Promise<void> => {
       return
     }
 
-    ipinfo = await fetchIP({ ip })
+    if (yamlConfig.ipRecording.proxyChecking.enabled) {
+      ipinfo = await fetchIP({ ip })
+    }
   } catch (error) {
     logger.info({ error }, "Failed to fetch ip details")
   } finally {


### PR DESCRIPTION
(Fixes GaloyMoney/galoy#130)
> on the ip stuff, would be good to have a way to 1/ deactive ip logging 2/ deactive proxy checking (from the yaml)
- Added new config (ipRecording)
- Nest proxyChecking in the new configuration
- Added new validations in context and updateIPDetails
- Refactor ipinfo updates (remove double try/catch)

this PR replace https://github.com/GaloyMoney/galoy/pull/270 (the rebase created an overhead)