### PR TITLE
Run mongodb as replicaset in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,10 @@ services:
     - MONGODB_PASSWORD=password
     - MONGODB_USERNAME=testGaloy
     - MONGODB_DATABASE=galoy
+    - MONGODB_REPLICA_SET_MODE=primary
+    - MONGODB_ROOT_PASSWORD=password
+    - MONGODB_REPLICA_SET_KEY=replicasetkey
+    - MONGODB_ADVERTISED_HOSTNAME=127.0.0.1
   bitcoind:
     image: lncm/bitcoind:v0.21.1
     ports:


### PR DESCRIPTION
Fixes https://github.com/GaloyMoney/galoy/issues/296

cc @sebastienverreault 