### PR TITLE
fix typo regarding the non-deletion of the InvoiceUser entry

### DIFF
--- a/src/Lightning.ts
+++ b/src/Lightning.ts
@@ -798,10 +798,10 @@ export const LightningMixin = (superclass) =>
       }
 
       try {
-        // FIXME we should only be able to look at User invoice,
-        // but might not be a strong problem anyway
-        // at least return same error if invoice not from user
-        // or invoice doesn't exist. to preserve privacy and prevent DDOS attack.
+        // FIXME to preserve privacy and prevent DDOS attack
+        // we should only be able to look at an invoice that belongs to this.user
+        // at a minimum, we should return same error if :
+        // an invoice is not from user or if the invoice doesn't exist.
         invoice = await getInvoice({ lnd, id: hash })
 
         // TODO: we should not log/keep secret in the logs
@@ -822,7 +822,7 @@ export const LightningMixin = (superclass) =>
         )
         ;(async () => {
           try {
-            await InvoiceUser.deleteOne({ _id: hash, user: this.user._id })
+            await InvoiceUser.deleteOne({ _id: hash, uid: this.user._id })
           } catch (err) {
             this.logger.error({ invoice }, "impossible to delete InvoiceUser entry")
           }


### PR DESCRIPTION
after an invoice expired we want to delete the associated InvoiceUser entry in mongodb. we were not deleting the InvoiceUser correctly previously

there is no test on that because there were a related bug on lnd (https://github.com/lightningnetwork/lnd/issues/4587) where the invoice was not deleted immediately after it has expired but this bug should be fixed so a test would also be nice on this @dolcalmi 