### PR TITLE
Switch to installing LNDs serially

### DIFF
--- a/initLocalTest.sh
+++ b/initLocalTest.sh
@@ -147,7 +147,7 @@ set -e
 # helm dependency build
 # cd -
 
-helmUpgrade lnd1 --version=$lndVersion -f $INFRADIR/configs/lnd/$NETWORK.yaml $localdevpath $INFRADIR/lnd/ & \
+helmUpgrade lnd1 --version=$lndVersion -f $INFRADIR/configs/lnd/$NETWORK.yaml $localdevpath $INFRADIR/lnd/
 helmUpgrade lnd2 --version=$lndVersion -f $INFRADIR/configs/lnd/$NETWORK.yaml $localdevpath --set persistence.existingClaim="lnd2" $INFRADIR/lnd/
 
 


### PR DESCRIPTION
We have `Error: UPGRADE FAILED: another operation (install/upgrade/rollback) is in progress` in every testnet_deploy job we've had for the past week at least. 
This is causing lnd1 to not get upgraded, and is also clear when looking at the age of the lnd1 and lnd2 pods, where lnd2's age is always less than lnd1's.