### PR TITLE
(`SpecterWallet`) Inject config via constructor

### DIFF
--- a/src/SpecterWallet.ts
+++ b/src/SpecterWallet.ts
@@ -18,20 +18,18 @@ export class SpecterWallet {
     this.config = config
   }
 
-  // below static method are {wallet} agnostics from bitcoin-core api perspective
-
-  static async listWallets() {
+  async listWallets() {
     return await bitcoindDefaultClient.listWallets()
   }
 
-  static async createWallet() {
+  async createWallet() {
     return await bitcoindDefaultClient.createWallet({
       wallet_name: "specter/coldstorage",
     })
   }
 
   async setBitcoindClient(): Promise<string> {
-    const wallets = await SpecterWallet.listWallets()
+    const wallets = await this.listWallets()
 
     const pattern = this.config.onchainWallet
     const specterWallets = _.filter(wallets, (item) => item.includes(pattern))

--- a/src/SpecterWallet.ts
+++ b/src/SpecterWallet.ts
@@ -1,6 +1,5 @@
 import { createChainAddress, sendToChainAddress } from "lightning"
 import _ from "lodash"
-import { yamlConfig } from "./config"
 import { bitcoindAccountingPath, lndAccountingPath, lndFeePath } from "./ledger/ledger"
 import { getActiveOnchainLnd, lndsBalances } from "./lndUtils"
 import { MainBook } from "./mongodb"
@@ -101,7 +100,7 @@ export class SpecterWallet {
     }
 
     const { total, onChain } = await lndsBalances()
-    const { action, sats, reason } = SpecterWallet.isRebalanceNeeded({
+    const { action, sats, reason } = this.isRebalanceNeeded({
       lndBalance: total,
       onChain,
     })
@@ -127,12 +126,12 @@ export class SpecterWallet {
     }
   }
 
-  static isRebalanceNeeded({ lndBalance, onChain }) {
+  isRebalanceNeeded({ lndBalance, onChain }) {
     // base number to calculate the different thresholds below
-    const lndHoldingBase = yamlConfig.rebalancing.lndHoldingBase
+    const lndHoldingBase = this.config.lndHoldingBase
 
-    const ratioTargetDeposit = yamlConfig.rebalancing.ratioTargetDeposit
-    const ratioTargetWithdraw = yamlConfig.rebalancing.ratioTargetWithdraw
+    const ratioTargetDeposit = this.config.ratioTargetDeposit
+    const ratioTargetWithdraw = this.config.ratioTargetWithdraw
 
     // threshold for when we need to move money from cold storage to the lnd wallet
     const thresholdLowBound = (lndHoldingBase * 70) / 100
@@ -153,7 +152,7 @@ export class SpecterWallet {
       let action: string | undefined = "deposit"
       let reason: string | undefined
 
-      const minOnchain = yamlConfig.rebalancing.minOnchain
+      const minOnchain = this.config.minOnchain
 
       if (onChain - sats < minOnchain) {
         action = undefined

--- a/src/SpecterWallet.ts
+++ b/src/SpecterWallet.ts
@@ -4,7 +4,7 @@ import { bitcoindAccountingPath, lndAccountingPath, lndFeePath } from "./ledger/
 import { getActiveOnchainLnd, lndsBalances } from "./lndUtils"
 import { MainBook } from "./mongodb"
 import { getOnChainTransactions } from "./OnChain"
-import { Logger, SpecterWalletConfig } from "./types"
+import { Logger, SpecterWalletConfig, SpecterWalletConstructorArgs } from "./types"
 import { UserWallet } from "./userWallet"
 import { BitcoindClient, bitcoindDefaultClient, btc2sat, sat2btc } from "./utils"
 
@@ -13,7 +13,7 @@ export class SpecterWallet {
   readonly logger: Logger
   readonly config: SpecterWalletConfig
 
-  constructor({ logger, config }) {
+  constructor({ logger, config }: SpecterWalletConstructorArgs) {
     this.logger = logger.child({ topic: "bitcoind" })
     this.config = config
   }

--- a/src/SpecterWallet.ts
+++ b/src/SpecterWallet.ts
@@ -187,7 +187,7 @@ export class SpecterWallet {
     let id
 
     try {
-      ; ({ id } = await sendToChainAddress({
+      ;({ id } = await sendToChainAddress({
         address,
         lnd,
         tokens: sats,

--- a/src/SpecterWallet.ts
+++ b/src/SpecterWallet.ts
@@ -1,3 +1,4 @@
+import assert from "assert"
 import { createChainAddress, sendToChainAddress } from "lightning"
 import _ from "lodash"
 import { bitcoindAccountingPath, lndAccountingPath, lndFeePath } from "./ledger/ledger"
@@ -16,6 +17,8 @@ export class SpecterWallet {
   constructor({ logger, config }: SpecterWalletConstructorArgs) {
     this.logger = logger.child({ topic: "bitcoind" })
     this.config = config
+
+    assert(this.config.onchainWallet != "")
   }
 
   async listWallets() {

--- a/src/SpecterWallet.ts
+++ b/src/SpecterWallet.ts
@@ -1,5 +1,6 @@
 import { createChainAddress, sendToChainAddress } from "lightning"
 import _ from "lodash"
+import { yamlConfig } from "./config"
 import { bitcoindAccountingPath, lndAccountingPath, lndFeePath } from "./ledger/ledger"
 import { getActiveOnchainLnd, lndsBalances } from "./lndUtils"
 import { MainBook } from "./mongodb"
@@ -128,10 +129,10 @@ export class SpecterWallet {
 
   static isRebalanceNeeded({ lndBalance, onChain }) {
     // base number to calculate the different thresholds below
-    const lndHoldingBase = this.config.lndHoldingBase
+    const lndHoldingBase = yamlConfig.rebalancing.lndHoldingBase
 
-    const ratioTargetDeposit = this.config.ratioTargetDeposit
-    const ratioTargetWithdraw = this.config.ratioTargetWithdraw
+    const ratioTargetDeposit = yamlConfig.rebalancing.ratioTargetDeposit
+    const ratioTargetWithdraw = yamlConfig.rebalancing.ratioTargetWithdraw
 
     // threshold for when we need to move money from cold storage to the lnd wallet
     const thresholdLowBound = (lndHoldingBase * 70) / 100
@@ -152,7 +153,7 @@ export class SpecterWallet {
       let action: string | undefined = "deposit"
       let reason: string | undefined
 
-      const minOnchain = this.config.minOnchain
+      const minOnchain = yamlConfig.rebalancing.minOnchain
 
       if (onChain - sats < minOnchain) {
         action = undefined

--- a/src/SpecterWallet.ts
+++ b/src/SpecterWallet.ts
@@ -33,7 +33,7 @@ export class SpecterWallet {
   async setBitcoindClient(): Promise<string> {
     const wallets = await SpecterWallet.listWallets()
 
-    const pattern = this.config.onchainWallet ?? "specter"
+    const pattern = this.config.onchainWallet
     const specterWallets = _.filter(wallets, (item) => item.includes(pattern))
 
     // there should be only one specter wallet

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,10 +38,10 @@ export class TransactionLimits {
   oldEnoughForWithdrawalLimit = () => this.config.oldEnoughForWithdrawal / MS_IN_HOUR
 }
 
-export const getSpecterWalletConfig = (config): SpecterWalletConfig => ({
-  lndHoldingBase: config.rebalancing.lndHoldingBase,
-  ratioTargetDeposit: config.rebalancing.ratioTargetDeposit,
-  ratioTargetWithdraw: config.rebalancing.ratioTargetWithdraw,
-  minOnchain: config.rebalancing.minOnchain,
-  onchainWallet: config.rebalancing.onchainWallet ?? "specter",
+export const getSpecterWalletConfig = (): SpecterWalletConfig => ({
+  lndHoldingBase: yamlConfig.rebalancing.lndHoldingBase,
+  ratioTargetDeposit: yamlConfig.rebalancing.ratioTargetDeposit,
+  ratioTargetWithdraw: yamlConfig.rebalancing.ratioTargetWithdraw,
+  minOnchain: yamlConfig.rebalancing.minOnchain,
+  onchainWallet: yamlConfig.rebalancing.onchainWallet ?? "specter",
 })

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,9 +39,9 @@ export class TransactionLimits {
 }
 
 export const getSpecterWalletConfig = (config): SpecterWalletConfig => ({
-    lndHoldingBase: config.rebalancing.lndHoldingBase,
-    ratioTargetDeposit: config.rebalancing.ratioTargetDeposit,
-    ratioTargetWithdraw: config.rebalancing.ratioTargetWithdraw,
-    minOnchain: config.rebalancing.minOnchain,
-    onchainWallet: config.rebalancing.onchainWallet ?? "specter",
+  lndHoldingBase: config.rebalancing.lndHoldingBase,
+  ratioTargetDeposit: config.rebalancing.ratioTargetDeposit,
+  ratioTargetWithdraw: config.rebalancing.ratioTargetWithdraw,
+  minOnchain: config.rebalancing.minOnchain,
+  onchainWallet: config.rebalancing.onchainWallet ?? "specter",
 })

--- a/src/config.ts
+++ b/src/config.ts
@@ -43,5 +43,5 @@ export const getSpecterWalletConfig = (): SpecterWalletConfig => ({
   ratioTargetDeposit: yamlConfig.rebalancing.ratioTargetDeposit,
   ratioTargetWithdraw: yamlConfig.rebalancing.ratioTargetWithdraw,
   minOnchain: yamlConfig.rebalancing.minOnchain,
-  onchainWallet: yamlConfig.rebalancing.onchainWallet ?? "specter",
+  onchainWallet: yamlConfig.rebalancing.onchainWallet || "specter",
 })

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import fs from "fs"
 import yaml from "js-yaml"
 import _ from "lodash"
 import { baseLogger } from "./logger"
+import { SpecterWalletConfig } from "./types"
 
 const defaultContent = fs.readFileSync("./default.yaml", "utf8")
 export const defaultConfig = yaml.load(defaultContent)
@@ -36,3 +37,11 @@ export class TransactionLimits {
 
   oldEnoughForWithdrawalLimit = () => this.config.oldEnoughForWithdrawal / MS_IN_HOUR
 }
+
+export const getSpecterWalletConfig = (config): SpecterWalletConfig => ({
+    lndHoldingBase: config.rebalancing.lndHoldingBase,
+    ratioTargetDeposit: config.rebalancing.ratioTargetDeposit,
+    ratioTargetWithdraw: config.rebalancing.ratioTargetWithdraw,
+    minOnchain: config.rebalancing.minOnchain,
+    onchainWallet: config.rebalancing.onchainWallet ?? "specter",
+})

--- a/src/entrypoint/cron.ts
+++ b/src/entrypoint/cron.ts
@@ -20,7 +20,10 @@ const main = async () => {
   await deleteFailedPaymentsAllLnds()
 
   const specterWalletConfig = getSpecterWalletConfig(yamlConfig)
-  const specterWallet = new SpecterWallet({ logger: baseLogger, config: specterWalletConfig })
+  const specterWallet = new SpecterWallet({
+    logger: baseLogger,
+    config: specterWalletConfig,
+  })
   await specterWallet.tentativelyRebalance()
 
   await updateRoutingFees()

--- a/src/entrypoint/cron.ts
+++ b/src/entrypoint/cron.ts
@@ -1,4 +1,4 @@
-import { yamlConfig, getSpecterWalletConfig } from "../config"
+import { getSpecterWalletConfig } from "../config"
 import { updateUsersPendingPayment } from "../ledger/balanceSheet"
 import {
   deleteExpiredInvoices,
@@ -19,7 +19,7 @@ const main = async () => {
   await deleteExpiredInvoices()
   await deleteFailedPaymentsAllLnds()
 
-  const specterWalletConfig = getSpecterWalletConfig(yamlConfig)
+  const specterWalletConfig = getSpecterWalletConfig()
   const specterWallet = new SpecterWallet({
     logger: baseLogger,
     config: specterWalletConfig,

--- a/src/entrypoint/cron.ts
+++ b/src/entrypoint/cron.ts
@@ -1,3 +1,4 @@
+import { yamlConfig } from "../config"
 import { updateUsersPendingPayment } from "../ledger/balanceSheet"
 import {
   deleteExpiredInvoices,
@@ -7,7 +8,16 @@ import {
 } from "../lndUtils"
 import { baseLogger } from "../logger"
 import { setupMongoConnection } from "../mongodb"
+import { SpecterWalletConfig } from "../types"
 import { SpecterWallet } from "../SpecterWallet"
+
+const specterWalletConfig: SpecterWalletConfig = {
+  lndHoldingBase: yamlConfig.rebalancing.lndHoldingBase,
+  ratioTargetDeposit: yamlConfig.rebalancing.ratioTargetDeposit,
+  ratioTargetWithdraw: yamlConfig.rebalancing.ratioTargetWithdraw,
+  minOnchain: yamlConfig.rebalancing.minOnchain,
+  onchainWallet: yamlConfig.rebalancing.onchainWallet,
+}
 
 const main = async () => {
   const mongoose = await setupMongoConnection()
@@ -18,7 +28,7 @@ const main = async () => {
   await deleteExpiredInvoices()
   await deleteFailedPaymentsAllLnds()
 
-  const specterWallet = new SpecterWallet({ logger: baseLogger })
+  const specterWallet = new SpecterWallet({ logger: baseLogger, config: specterWalletConfig })
   await specterWallet.tentativelyRebalance()
 
   await updateRoutingFees()

--- a/src/entrypoint/cron.ts
+++ b/src/entrypoint/cron.ts
@@ -1,4 +1,4 @@
-import { yamlConfig } from "../config"
+import { yamlConfig, getSpecterWalletConfig } from "../config"
 import { updateUsersPendingPayment } from "../ledger/balanceSheet"
 import {
   deleteExpiredInvoices,
@@ -8,16 +8,7 @@ import {
 } from "../lndUtils"
 import { baseLogger } from "../logger"
 import { setupMongoConnection } from "../mongodb"
-import { SpecterWalletConfig } from "../types"
 import { SpecterWallet } from "../SpecterWallet"
-
-const specterWalletConfig: SpecterWalletConfig = {
-  lndHoldingBase: yamlConfig.rebalancing.lndHoldingBase,
-  ratioTargetDeposit: yamlConfig.rebalancing.ratioTargetDeposit,
-  ratioTargetWithdraw: yamlConfig.rebalancing.ratioTargetWithdraw,
-  minOnchain: yamlConfig.rebalancing.minOnchain,
-  onchainWallet: yamlConfig.rebalancing.onchainWallet,
-}
 
 const main = async () => {
   const mongoose = await setupMongoConnection()
@@ -28,6 +19,7 @@ const main = async () => {
   await deleteExpiredInvoices()
   await deleteFailedPaymentsAllLnds()
 
+  const specterWalletConfig = getSpecterWalletConfig(yamlConfig)
   const specterWallet = new SpecterWallet({ logger: baseLogger, config: specterWalletConfig })
   await specterWallet.tentativelyRebalance()
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,14 @@ export type UserWalletConfig = {
   name: string
 }
 
+export type SpecterWalletConfig = {
+  lndHoldingBase: number
+  ratioTargetDeposit: number
+  ratioTargetWithdraw: number
+  minOnchain: number
+  onchainWallet: string
+}
+
 // Lightning
 
 export interface IAddInvoiceRequest {

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,11 @@ export type SpecterWalletConfig = {
   onchainWallet: string
 }
 
+export type SpecterWalletConstructorArgs = {
+  config: SpecterWalletConfig
+  logger: Logger
+}
+
 // Lightning
 
 export interface IAddInvoiceRequest {

--- a/test/integration/specter-wallet.spec.ts
+++ b/test/integration/specter-wallet.spec.ts
@@ -1,8 +1,7 @@
-import { yamlConfig } from "src/config"
+import { yamlConfig, getSpecterWalletConfig } from "src/config"
 import { baseLogger } from "src/logger"
 import { UserWallet } from "src/userWallet"
 import { SpecterWallet } from "src/SpecterWallet"
-import { SpecterWalletConfig } from "src/types"
 import { getActiveOnchainLnd } from "src/lndUtils"
 import { bitcoindClient, getChainBalance, mineBlockAndSyncAll } from "test/helpers"
 import { MainBook } from "src/mongodb"
@@ -10,17 +9,11 @@ import { bitcoindAccountingPath } from "src/ledger/ledger"
 
 const { lnd } = getActiveOnchainLnd()
 const specterWalletName = "specter/coldstorage"
-const specterWalletConfig: SpecterWalletConfig = {
-  lndHoldingBase: yamlConfig.rebalancing.lndHoldingBase,
-  ratioTargetDeposit: yamlConfig.rebalancing.ratioTargetDeposit,
-  ratioTargetWithdraw: yamlConfig.rebalancing.ratioTargetWithdraw,
-  minOnchain: yamlConfig.rebalancing.minOnchain,
-  onchainWallet: yamlConfig.rebalancing.onchainWallet,
-}
 let specterWallet
 
 beforeEach(() => {
   UserWallet.setCurrentPrice(10000)
+  const specterWalletConfig = getSpecterWalletConfig(yamlConfig)
   specterWallet = new SpecterWallet({ logger: baseLogger, config: specterWalletConfig })
 })
 

--- a/test/integration/specter-wallet.spec.ts
+++ b/test/integration/specter-wallet.spec.ts
@@ -1,6 +1,8 @@
+import { yamlConfig } from "src/config"
 import { baseLogger } from "src/logger"
 import { UserWallet } from "src/userWallet"
 import { SpecterWallet } from "src/SpecterWallet"
+import { SpecterWalletConfig } from "src/types"
 import { getActiveOnchainLnd } from "src/lndUtils"
 import { bitcoindClient, getChainBalance, mineBlockAndSyncAll } from "test/helpers"
 import { MainBook } from "src/mongodb"
@@ -8,11 +10,18 @@ import { bitcoindAccountingPath } from "src/ledger/ledger"
 
 const { lnd } = getActiveOnchainLnd()
 const specterWalletName = "specter/coldstorage"
+const specterWalletConfig: SpecterWalletConfig = {
+  lndHoldingBase: yamlConfig.rebalancing.lndHoldingBase,
+  ratioTargetDeposit: yamlConfig.rebalancing.ratioTargetDeposit,
+  ratioTargetWithdraw: yamlConfig.rebalancing.ratioTargetWithdraw,
+  minOnchain: yamlConfig.rebalancing.minOnchain,
+  onchainWallet: yamlConfig.rebalancing.onchainWallet,
+}
 let specterWallet
 
 beforeEach(() => {
   UserWallet.setCurrentPrice(10000)
-  specterWallet = new SpecterWallet({ logger: baseLogger })
+  specterWallet = new SpecterWallet({ logger: baseLogger, config: specterWalletConfig })
 })
 
 afterAll(async () => {

--- a/test/integration/specter-wallet.spec.ts
+++ b/test/integration/specter-wallet.spec.ts
@@ -1,4 +1,4 @@
-import { yamlConfig, getSpecterWalletConfig } from "src/config"
+import { getSpecterWalletConfig } from "src/config"
 import { baseLogger } from "src/logger"
 import { UserWallet } from "src/userWallet"
 import { SpecterWallet } from "src/SpecterWallet"
@@ -13,7 +13,7 @@ let specterWallet
 
 beforeEach(() => {
   UserWallet.setCurrentPrice(10000)
-  const specterWalletConfig = getSpecterWalletConfig(yamlConfig)
+  const specterWalletConfig = getSpecterWalletConfig()
   specterWallet = new SpecterWallet({ logger: baseLogger, config: specterWalletConfig })
 })
 

--- a/test/integration/specter-wallet.spec.ts
+++ b/test/integration/specter-wallet.spec.ts
@@ -23,18 +23,18 @@ afterAll(async () => {
 
 describe("SpecterWallet", () => {
   it("creates wallet", async () => {
-    let wallets = await SpecterWallet.listWallets()
+    let wallets = await specterWallet.listWallets()
 
     if (wallets.length < 2) {
       try {
-        await SpecterWallet.createWallet()
+        await specterWallet.createWallet()
       } catch {
         const { name } = await bitcoindClient.loadWallet(specterWalletName)
         expect(name).toBe(specterWalletName)
       }
     }
 
-    wallets = await SpecterWallet.listWallets()
+    wallets = await specterWallet.listWallets()
     expect(wallets.length).toBe(2)
   })
 

--- a/test/unit/specter-wallet.spec.ts
+++ b/test/unit/specter-wallet.spec.ts
@@ -1,10 +1,20 @@
 import { redis } from "src/redis"
 import { btc2sat } from "src/utils"
 import { SpecterWallet } from "src/SpecterWallet"
+import { getSpecterWalletConfig } from "src/config"
+import { baseLogger } from "src/logger"
+
+let specterWallet
 
 beforeAll(() => {
   // avoids to use --forceExit and the need of a running redis
   redis.disconnect()
+
+  const specterWalletConfig = getSpecterWalletConfig()
+  specterWallet = new SpecterWallet({
+    logger: baseLogger,
+    config: specterWalletConfig,
+  })
 })
 
 describe("SpecterWallet", () => {
@@ -12,7 +22,7 @@ describe("SpecterWallet", () => {
     it("returns deposit amount calculation", () => {
       const lndBalance = btc2sat(1)
       const onChain = btc2sat(0.8)
-      const result = SpecterWallet.isRebalanceNeeded({ lndBalance, onChain })
+      const result = specterWallet.isRebalanceNeeded({ lndBalance, onChain })
 
       expect(result).toStrictEqual({
         action: "deposit",
@@ -24,7 +34,7 @@ describe("SpecterWallet", () => {
     it("returns withdraw amount calculation", () => {
       const lndBalance = btc2sat(0.2)
       const onChain = btc2sat(0.1)
-      const result = SpecterWallet.isRebalanceNeeded({ lndBalance, onChain })
+      const result = specterWallet.isRebalanceNeeded({ lndBalance, onChain })
 
       expect(result).toStrictEqual({ action: "withdraw", sats: 30000000 })
     })
@@ -32,7 +42,7 @@ describe("SpecterWallet", () => {
     it("returns undefined when no action needed", () => {
       const lndBalance = btc2sat(0.5)
       const onChain = btc2sat(0.5)
-      const result = SpecterWallet.isRebalanceNeeded({ lndBalance, onChain })
+      const result = specterWallet.isRebalanceNeeded({ lndBalance, onChain })
 
       expect(result).toStrictEqual({ action: undefined })
     })


### PR DESCRIPTION
## Description

This PR refactors the `SpecterWallet` class to have the config defined and explicitly passed via its constructor instead of having config values called directly from global state (`yamlConfig`).

The global state is instead used to create the config that gets injected explicitly at `SpecterWallet` instantiation.
