### PR TITLE
Remove RTL-Config.json from deployment script

### DIFF
--- a/initLocalTest.sh
+++ b/initLocalTest.sh
@@ -134,7 +134,6 @@ fi
 rm -rf $INFRADIR/lnd
 
 helm pull --version=$lndVersion galoy/lnd -d $INFRADIR/ --untar
-cp "$INFRADIR/configs/lnd/RTL-Config.json" $INFRADIR/lnd/charts/rtl
 
 set +e
 kubectl apply -f $INFRADIR/configs/lnd/templates


### PR DESCRIPTION
It's now part of the rtl subchart within lnd so is no longer needed to be injected manually