### PR TITLE
Refactor 'UserWallet' types/config placement

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -38,10 +38,13 @@ export class TransactionLimits {
   oldEnoughForWithdrawalLimit = () => this.config.oldEnoughForWithdrawal / MS_IN_HOUR
 }
 
-export const getSpecterWalletConfig = (): SpecterWalletConfig => ({
-  lndHoldingBase: yamlConfig.rebalancing.lndHoldingBase,
-  ratioTargetDeposit: yamlConfig.rebalancing.ratioTargetDeposit,
-  ratioTargetWithdraw: yamlConfig.rebalancing.ratioTargetWithdraw,
-  minOnchain: yamlConfig.rebalancing.minOnchain,
-  onchainWallet: yamlConfig.rebalancing.onchainWallet || "specter",
-})
+export const getSpecterWalletConfig = (): SpecterWalletConfig => {
+  const config = yamlConfig.rebalancing
+  return {
+    lndHoldingBase: config.lndHoldingBase,
+    ratioTargetDeposit: config.ratioTargetDeposit,
+    ratioTargetWithdraw: config.ratioTargetWithdraw,
+    minOnchain: config.minOnchain,
+    onchainWallet: config.onchainWallet ?? "specter",
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import fs from "fs"
 import yaml from "js-yaml"
 import _ from "lodash"
 import { baseLogger } from "./logger"
-import { SpecterWalletConfig } from "./types"
+import { ITransactionLimits, UserWalletConfig, SpecterWalletConfig } from "./types"
 
 const defaultContent = fs.readFileSync("./default.yaml", "utf8")
 export const defaultConfig = yaml.load(defaultContent)
@@ -22,7 +22,7 @@ try {
 
 export const yamlConfig = _.merge(defaultConfig, customConfig)
 
-export class TransactionLimits {
+export class TransactionLimits implements ITransactionLimits {
   readonly config
   readonly level
 
@@ -36,6 +36,18 @@ export class TransactionLimits {
   withdrawalLimit = () => this.config.withdrawal.level[this.level]
 
   oldEnoughForWithdrawalLimit = () => this.config.oldEnoughForWithdrawal / MS_IN_HOUR
+}
+
+export const getUserWalletConfig = (user): UserWalletConfig => {
+  const transactionLimits = new TransactionLimits({
+    level: user.level,
+  })
+
+  return {
+    name: yamlConfig.name,
+    dustThreshold: yamlConfig.onChainWallet.dustThreshold,
+    limits: transactionLimits,
+  }
 }
 
 export const getSpecterWalletConfig = (): SpecterWalletConfig => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,11 +23,11 @@ try {
 export const yamlConfig = _.merge(defaultConfig, customConfig)
 
 export class TransactionLimits {
-  config
-  level
+  readonly config
+  readonly level
 
-  constructor({ config, level }) {
-    this.config = config
+  constructor({ level }) {
+    this.config = yamlConfig.limits
     this.level = level
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
 import { Logger as PinoLogger } from "pino"
-import { TransactionLimits } from "./config"
 import { User } from "./schema"
 
 export type Side = "buy" | "sell"
@@ -21,9 +20,17 @@ export type UserWalletConstructorArgs = WalletConstructorArgs & {
   config: UserWalletConfig
 }
 
+export interface ITransactionLimits {
+  config
+  level: number
+  onUsLimit: () => number
+  withdrawalLimit: () => number
+  oldEnoughForWithdrawalLimit: () => number
+}
+
 export type UserWalletConfig = {
   dustThreshold: number
-  limits: TransactionLimits
+  limits: ITransactionLimits
   name: string
 }
 

--- a/src/walletFactory.ts
+++ b/src/walletFactory.ts
@@ -18,7 +18,6 @@ export const WalletFactory = async ({
   UserWallet.setCurrentPrice(lastPrice)
 
   const transactionLimits = new TransactionLimits({
-    config: yamlConfig.limits,
     level: user.level,
   })
 

--- a/src/walletFactory.ts
+++ b/src/walletFactory.ts
@@ -1,9 +1,9 @@
-import { TransactionLimits, yamlConfig } from "./config"
+import { getUserWalletConfig, yamlConfig } from "./config"
 import { NotFoundError } from "./error"
 import { LightningUserWallet } from "./LightningUserWallet"
 import { getCurrentPrice } from "./realtimePrice"
 import { User } from "./schema"
-import { Logger, UserWalletConfig } from "./types"
+import { Logger } from "./types"
 import { UserWallet } from "./userWallet"
 
 export const WalletFactory = async ({
@@ -17,15 +17,7 @@ export const WalletFactory = async ({
   const lastPrice = await getCurrentPrice()
   UserWallet.setCurrentPrice(lastPrice)
 
-  const transactionLimits = new TransactionLimits({
-    level: user.level,
-  })
-
-  const userWalletConfig: UserWalletConfig = {
-    name: yamlConfig.name,
-    dustThreshold: yamlConfig.onChainWallet.dustThreshold,
-    limits: transactionLimits,
-  }
+  const userWalletConfig = getUserWalletConfig(user)
 
   return new LightningUserWallet({ user, logger, config: userWalletConfig })
 }

--- a/test/integration/02-user-wallet/02-receive-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-onchain.spec.ts
@@ -1,7 +1,7 @@
 import { once } from "events"
 import { filter } from "lodash"
 import { baseLogger } from "src/logger"
-import { TransactionLimits, yamlConfig } from "src/config"
+import { TransactionLimits } from "src/config"
 import { getCurrentPrice } from "src/realtimePrice"
 import { btc2sat, sat2btc, sleep } from "src/utils"
 import { getFunderWallet } from "src/walletFactory"
@@ -29,7 +29,6 @@ let walletUser12
 let amountBTC
 
 const transactionLimits = new TransactionLimits({
-  config: yamlConfig.limits,
   level: "1",
 })
 

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes } from "crypto"
-import { TransactionLimits, yamlConfig } from "src/config"
+import { TransactionLimits } from "src/config"
 import {
   InsufficientBalanceError,
   LightningPaymentError,
@@ -37,7 +37,6 @@ let userWallet0, userWallet1, userWallet2
 let initBalance0, initBalance1
 const amountInvoice = 1000
 const transactionLimits = new TransactionLimits({
-  config: yamlConfig.limits,
   level: "1",
 })
 


### PR DESCRIPTION
### Description

This is a cleanup PR from some of the work introduced in #321 to bring that work more in line with patterns introduced in #344. Specifically this PR:
- moves the `UserWalletConfig` into a getter function in the `config` module (similar to `SpecterWalletConfig`)

- creates a new `ITransactionLimits` interface to help remove a circular dependency between the `config.ts` and `types.ts` files. This helps to start establishing a **"`types.ts` -> `config.ts` -> `other modules`"** (DAG-like) hierarchy.