### PR TITLE
improve accounting structure

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -63,8 +63,11 @@ test_accounts:
   code: 321321
 - phone: "+16505554333" # user12
   code: 321321
-- phone: "+12223334444" # user42
+- phone: "+12223334444" # user13
   code: "424242"
+- phone: "+16505554334" # user14
+  code: 321321
+  role: "bank"
 
 sms_provider: "twilio"
 

--- a/default.yaml
+++ b/default.yaml
@@ -67,7 +67,7 @@ test_accounts:
   code: "424242"
 - phone: "+16505554334" # user14
   code: 321321
-  role: "bank"
+  role: "bankowner"
 
 sms_provider: "twilio"
 

--- a/src/OnChain.ts
+++ b/src/OnChain.ts
@@ -22,7 +22,7 @@ import {
   TransactionRestrictedError,
   ValidationInternalError,
 } from "./error"
-import { accountPath, lndAccountingPath, onchainRevenuePath } from "./ledger/ledger"
+import { accountPath, bankOwnerMediciPath, lndAccountingPath } from "./ledger/ledger"
 import { getActiveOnchainLnd, getLndFromPubkey } from "./lndUtils"
 import { lockExtendOrThrow, redlock } from "./lock"
 import { baseLogger } from "./logger"
@@ -338,10 +338,12 @@ export const OnChainMixin = (superclass) =>
                 sendAll,
               }
 
+              const bankOwnerPath = await bankOwnerMediciPath()
+
               // TODO/FIXME refactor. add the transaction first and set the fees in a second tx.
               await MainBook.entry(memo)
                 .credit(lndAccountingPath, sats - this.user.withdrawFee, metadata)
-                .credit(onchainRevenuePath, this.user.withdrawFee, metadata)
+                .credit(bankOwnerPath, this.user.withdrawFee, metadata)
                 .debit(this.user.accountPath, sats, metadata)
                 .commit()
 
@@ -641,8 +643,10 @@ export const OnChainMixin = (superclass) =>
                 payee_addresses: addresses,
               }
 
+              const bankOwnerPath = await bankOwnerMediciPath()
+
               await MainBook.entry()
-                .credit(onchainRevenuePath, fee, metadata)
+                .credit(bankOwnerPath, fee, metadata)
                 .credit(this.user.accountPath, sats - fee, metadata)
                 .debit(lndAccountingPath, sats, metadata)
                 .commit()

--- a/src/OnChain.ts
+++ b/src/OnChain.ts
@@ -22,7 +22,7 @@ import {
   TransactionRestrictedError,
   ValidationInternalError,
 } from "./error"
-import { customerPath, lndAccountingPath, onchainRevenuePath } from "./ledger/ledger"
+import { accountPath, lndAccountingPath, onchainRevenuePath } from "./ledger/ledger"
 import { getActiveOnchainLnd, getLndFromPubkey } from "./lndUtils"
 import { lockExtendOrThrow, redlock } from "./lock"
 import { baseLogger } from "./logger"
@@ -192,7 +192,7 @@ export const OnChainMixin = (superclass) =>
 
             await lockExtendOrThrow({ lock, logger: onchainLoggerOnUs }, async () => {
               return await MainBook.entry()
-                .credit(customerPath(payeeUser._id), sats, metadata)
+                .credit(accountPath(payeeUser._id), sats, metadata)
                 .debit(this.user.accountPath, sats, { ...metadata, memo })
                 .commit()
             })

--- a/src/SpecterWallet.ts
+++ b/src/SpecterWallet.ts
@@ -1,7 +1,11 @@
 import assert from "assert"
 import { createChainAddress, sendToChainAddress } from "lightning"
 import _ from "lodash"
-import { bitcoindAccountingPath, lndAccountingPath, lndFeePath } from "./ledger/ledger"
+import {
+  bankOwnerMediciPath,
+  bitcoindAccountingPath,
+  lndAccountingPath,
+} from "./ledger/ledger"
 import { getActiveOnchainLnd, lndsBalances } from "./lndUtils"
 import { MainBook } from "./mongodb"
 import { getOnChainTransactions } from "./OnChain"
@@ -211,9 +215,11 @@ export class SpecterWallet {
       ...UserWallet.getCurrencyEquivalent({ sats, fee }),
     }
 
+    const bankOwnerPath = await bankOwnerMediciPath()
+
     await MainBook.entry(memo)
       .credit(lndAccountingPath, sats + fee, { ...metadata })
-      .debit(lndFeePath, fee, { ...metadata })
+      .debit(bankOwnerPath, fee, { ...metadata })
       .debit(bitcoindAccountingPath, sats, { ...metadata })
       .commit()
 
@@ -273,9 +279,11 @@ export class SpecterWallet {
     )
     const fee = btc2sat(-tx.fee) /* fee is negative */
 
+    const bankOwnerPath = await bankOwnerMediciPath()
+
     await MainBook.entry(memo)
       .debit(lndAccountingPath, sats, { ...metadata })
-      .debit(lndFeePath, fee, { ...metadata })
+      .debit(bankOwnerPath, fee, { ...metadata })
       .credit(bitcoindAccountingPath, sats + fee, { ...metadata })
       .commit()
 

--- a/src/debug/export_accounts_to_csv.ts
+++ b/src/debug/export_accounts_to_csv.ts
@@ -1,5 +1,5 @@
 import { CSVAccountExport } from "../csvAccountExport"
-import { customerPath } from "../ledger/ledger"
+import { accountPath } from "../ledger/ledger"
 import { MainBook, setupMongoConnectionSecondary } from "../mongodb"
 import { Transaction, User } from "../schema"
 import { Primitive } from "../types"
@@ -42,7 +42,7 @@ const exportAllUserLedger = async () => {
   const csv = new CSVAccountExport()
 
   for await (const user of User.find({})) {
-    await csv.addAccount({ account: customerPath(user._id) })
+    await csv.addAccount({ account: accountPath(user._id) })
   }
 
   await csv.saveToDisk()

--- a/src/entrypoint/trigger.ts
+++ b/src/entrypoint/trigger.ts
@@ -78,7 +78,7 @@ export async function onchainTransactionEventHandler(tx) {
       "payment completed",
     )
     const entry = await Transaction.findOne({
-      account_path: { $all: ["Liabilities", "Customer"] },
+      account_path: "Liabilities",
       hash: tx.id,
     })
 

--- a/src/ledger/ledger.ts
+++ b/src/ledger/ledger.ts
@@ -13,7 +13,7 @@ export const escrowAccountingPath = "Assets:Reserve:Escrow" // TODO: rename to A
 export const accountPath = (uid) => `Liabilities:${uid}`
 
 let cacheDealerPath: string
-let cacheBankPath: string
+let cachebankOwnerPath: string
 
 export const dealerMediciPath = async () => {
   if (cacheDealerPath) {
@@ -25,21 +25,12 @@ export const dealerMediciPath = async () => {
   return cacheDealerPath
 }
 
-export const bankMediciPath = async () => {
-  if (cacheBankPath) {
-    return cacheBankPath
+export const bankOwnerMediciPath = async () => {
+  if (cachebankOwnerPath) {
+    return cachebankOwnerPath
   }
 
-  const bank = await User.findOne({ role: "bank" })
-  cacheBankPath = accountPath(bank._id)
-  return cacheBankPath
+  const bank = await User.findOne({ role: "bankowner" })
+  cachebankOwnerPath = accountPath(bank._id)
+  return cachebankOwnerPath
 }
-
-// expenses
-
-// FIXME Bitcoin --> Lnd
-export const lndFeePath = "Expenses:Bitcoin:Fees"
-
-// revenue
-export const onchainRevenuePath = "Revenue:Bitcoin:Fees"
-export const revenueFeePath = "Revenue:Lightning:Fees"

--- a/src/ledger/ledger.ts
+++ b/src/ledger/ledger.ts
@@ -10,9 +10,10 @@ export const lndAccountingPath = "Assets:Reserve:Lightning" // TODO: rename to A
 export const escrowAccountingPath = "Assets:Reserve:Escrow" // TODO: rename to Assets:Lnd:Escrow
 
 // liabilities
-export const customerPath = (uid) => `Liabilities:${uid}`
+export const accountPath = (uid) => `Liabilities:${uid}`
 
 let cacheDealerPath: string
+let cacheBankPath: string
 
 export const dealerMediciPath = async () => {
   if (cacheDealerPath) {
@@ -20,16 +21,24 @@ export const dealerMediciPath = async () => {
   }
 
   const dealer = await User.findOne({ role: "dealer" })
-  cacheDealerPath = customerPath(dealer._id)
+  cacheDealerPath = accountPath(dealer._id)
   return cacheDealerPath
+}
+
+export const bankMediciPath = async () => {
+  if (cacheBankPath) {
+    return cacheBankPath
+  }
+
+  const bank = await User.findOne({ role: "bank" })
+  cacheBankPath = accountPath(bank._id)
+  return cacheBankPath
 }
 
 // expenses
 
 // FIXME Bitcoin --> Lnd
 export const lndFeePath = "Expenses:Bitcoin:Fees"
-
-export const bitcoindFeePath = "Expenses:Bitcoin:Fees"
 
 // revenue
 export const onchainRevenuePath = "Revenue:Bitcoin:Fees"

--- a/src/ledger/ledger.ts
+++ b/src/ledger/ledger.ts
@@ -10,7 +10,7 @@ export const lndAccountingPath = "Assets:Reserve:Lightning" // TODO: rename to A
 export const escrowAccountingPath = "Assets:Reserve:Escrow" // TODO: rename to Assets:Lnd:Escrow
 
 // liabilities
-export const customerPath = (uid) => `Liabilities:Customer:${uid}`
+export const customerPath = (uid) => `Liabilities:${uid}`
 
 let cacheDealerPath: string
 
@@ -23,10 +23,6 @@ export const dealerMediciPath = async () => {
   cacheDealerPath = customerPath(dealer._id)
   return cacheDealerPath
 }
-
-// use for topping up lightning node that doesn't act at bitcoin wallet
-// only used during test for now
-export const liabilitiesReserve = `Liabilities:Reserve:Lightning`
 
 // expenses
 

--- a/src/ledger/transaction.ts
+++ b/src/ledger/transaction.ts
@@ -1,4 +1,4 @@
-import { dealerMediciPath, customerPath, lndAccountingPath } from "./ledger"
+import { dealerMediciPath, accountPath, lndAccountingPath } from "./ledger"
 import { MainBook } from "../mongodb"
 import { UserWallet } from "../userWallet"
 import { IAddTransactionOnUsPayment } from "../types"
@@ -89,7 +89,7 @@ export const addTransactionOnUsPayment = async ({
   const entry = MainBook.entry(description)
 
   entry
-    .credit(customerPath(payeeUser._id), sats * payeeUser.ratioBtc, {
+    .credit(accountPath(payeeUser._id), sats * payeeUser.ratioBtc, {
       ...metadata,
       memoPayer: shareMemoWithPayee ? memoPayer : null,
       username: payerUser.username,
@@ -118,7 +118,7 @@ export const addTransactionOnUsPayment = async ({
     const usdEq = sats * UserWallet.lastPrice
 
     entry
-      .credit(customerPath(payeeUser._id), usdEq * payeeUser.ratioUsd, {
+      .credit(accountPath(payeeUser._id), usdEq * payeeUser.ratioUsd, {
         ...metadata,
         memoPayer: shareMemoWithPayee ? memoPayer : null,
         username: payerUser.username,

--- a/src/migrations/20210726211641-simplify-accounting.ts
+++ b/src/migrations/20210726211641-simplify-accounting.ts
@@ -1,0 +1,85 @@
+module.exports = {
+  async up(db) {
+    const ftx_txs = await db
+      .getCollection("medici_transactions")
+      .find({ accounts: /FTX/i })
+
+    for (const ftx_tx of ftx_txs) {
+      const result = await db
+        .getCollection("medici_journal")
+        .deleteOne({ _id: ftx_tx._journal })
+      console.log({ result, ftx_tx }, "delete useless accounting journal entries")
+    }
+
+    {
+      const result = await db
+        .getCollection("medici_transactions")
+        .deleteAll({ accounts: /FTX/i })
+
+      console.log({ result }, "delete useless accounting transactions entries")
+    }
+
+    {
+      const result = await db
+        .collection("medici_transactions")
+        .updateMany({ account_path: "Liabilities" }, [
+          {
+            $set: {
+              account_path_org: "$account_path",
+              accounts_org: "$accounts",
+            },
+          },
+        ])
+
+      console.log({ result }, "backup the field in case a roll out is needed")
+    }
+
+    {
+      const result = await db
+        .collection("medici_transactions")
+        .updateMany(
+          { account_path: "Liabilities" },
+          { $pull: { account_path: "Customer" } },
+        )
+
+      console.log({ result }, "set up the account_path array")
+    }
+
+    {
+      const result = await db
+        .collection("medici_transactions")
+        .updateMany({ account_path: "Liabilities" }, [
+          { $set: { tmp_accounts_uid: { $substrCP: ["$accounts_org", 21, 100] } } },
+        ])
+
+      console.log({ result }, "create tmp_accounts_uid field")
+    }
+
+    {
+      const result = await db
+        .collection("medici_transactions")
+        .updateMany({ account_path: "Liabilities" }, [
+          {
+            $set: {
+              accounts: { $concat: ["Liabilities", ":", "$tmp_accounts_uid"] },
+            },
+          },
+        ])
+
+      console.log({ result }, "set the new accounts field")
+    }
+  },
+
+  async down(db) {
+    await db
+      .collection("medici_transactions")
+      .updateMany({ account_path: "Liabilities" }, [
+        {
+          $set: {
+            account_path: "$account_path_org",
+            accounts: "$accounts_org",
+          },
+        },
+      ])
+  },
+}

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -2,7 +2,7 @@ import * as _ from "lodash"
 import * as mongoose from "mongoose"
 import { yamlConfig } from "./config"
 import { NotFoundError } from "./error"
-import { customerPath } from "./ledger/ledger"
+import { accountPath } from "./ledger/ledger"
 import { baseLogger } from "./logger"
 import { Levels } from "./types"
 import { caseInsensitiveRegex } from "./utils"
@@ -98,7 +98,7 @@ const UserSchema = new Schema({
   },
   role: {
     type: String,
-    enum: ["user", "dealer", "editor"],
+    enum: ["user", "dealer", "editor", "bank"],
     required: true,
     default: "user",
     // TODO : enfore the fact there can be only one dealer
@@ -251,7 +251,7 @@ UserSchema.virtual("ratioBtc").get(function (this: typeof UserSchema) {
 // this is the accounting path in medici for this user
 // eslint-disable-next-line no-unused-vars
 UserSchema.virtual("accountPath").get(function (this: typeof UserSchema) {
-  return customerPath(this._id)
+  return accountPath(this._id)
 })
 
 // eslint-disable-next-line no-unused-vars

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -98,7 +98,7 @@ const UserSchema = new Schema({
   },
   role: {
     type: String,
-    enum: ["user", "dealer", "editor", "bank"],
+    enum: ["user", "dealer", "editor", "bankowner"],
     required: true,
     default: "user",
     // TODO : enfore the fact there can be only one dealer

--- a/src/userWallet.ts
+++ b/src/userWallet.ts
@@ -3,7 +3,7 @@ import moment from "moment"
 import { CSVAccountExport } from "./csvAccountExport"
 import { DbError } from "./error"
 import { Balances } from "./interface"
-import { customerPath } from "./ledger/ledger"
+import { accountPath } from "./ledger/ledger"
 import { MainBook } from "./mongodb"
 import { sendNotification } from "./notifications/notification"
 import { User } from "./schema"
@@ -141,7 +141,7 @@ export abstract class UserWallet {
 
   async getStringCsv() {
     const csv = new CSVAccountExport()
-    await csv.addAccount({ account: customerPath(this.user.id) })
+    await csv.addAccount({ account: accountPath(this.user.id) })
     return csv.getBase64()
   }
 

--- a/test/integration/01-setup/01-funds-bitcoind-lnds.spec.ts
+++ b/test/integration/01-setup/01-funds-bitcoind-lnds.spec.ts
@@ -17,6 +17,14 @@ jest.mock("src/phone-provider", () => require("test/mocks/phone-provider"))
 
 const defaultWallet = ""
 
+it("mandatory users", async () => {
+  // load funder wallet before use it
+  await getUserWallet(4)
+
+  // "bank" user
+  await getUserWallet(14)
+})
+
 describe("Bitcoind", () => {
   it("create default wallet", async () => {
     try {

--- a/test/integration/01-setup/01-funds-bitcoind-lnds.spec.ts
+++ b/test/integration/01-setup/01-funds-bitcoind-lnds.spec.ts
@@ -17,7 +17,7 @@ jest.mock("src/phone-provider", () => require("test/mocks/phone-provider"))
 
 const defaultWallet = ""
 
-it("mandatory users", async () => {
+beforeAll(async () => {
   // load funder wallet before use it
   await getUserWallet(4)
 

--- a/test/integration/01-setup/01-funds-bitcoind-lnds.spec.ts
+++ b/test/integration/01-setup/01-funds-bitcoind-lnds.spec.ts
@@ -21,7 +21,7 @@ it("mandatory users", async () => {
   // load funder wallet before use it
   await getUserWallet(4)
 
-  // "bank" user
+  // "bankowner" user
   await getUserWallet(14)
 })
 

--- a/test/integration/01-setup/01-lightning-channels.spec.ts
+++ b/test/integration/01-setup/01-lightning-channels.spec.ts
@@ -1,5 +1,5 @@
 import { MainBook } from "src/mongodb"
-import { lndFeePath } from "src/ledger/ledger"
+import { bankMediciPath } from "src/ledger/ledger"
 import {
   checkIsBalanced,
   closeChannel,
@@ -24,9 +24,11 @@ jest.mock("src/phone-provider", () => require("test/mocks/phone-provider"))
 const channelFee = 7637
 const lnds = [lnd1, lnd2, lndOutside1, lndOutside1]
 let channelLengthMain, channelLengthOutside1
+let bankPath: string
 
 beforeEach(async () => {
   await waitUntilSync({ lnds })
+  bankPath = await bankMediciPath()
   channelLengthMain = (await getChannels({ lnd: lnd1 })).channels.length
   channelLengthOutside1 = (await getChannels({ lnd: lndOutside1 })).channels.length
 })
@@ -58,7 +60,7 @@ describe("Lightning channels", () => {
   it("opens channel from lnd1 to lndOutside1", async () => {
     const socket = `lnd-outside-1:9735`
     const { balance: initFeeInLedger } = await MainBook.balance({
-      account: lndFeePath,
+      account: bankPath,
       currency: "BTC",
     })
 
@@ -72,7 +74,7 @@ describe("Lightning channels", () => {
     expect(channels.length).toEqual(channelLengthMain + 1)
 
     const { balance: finalFeeInLedger } = await MainBook.balance({
-      account: lndFeePath,
+      account: bankPath,
       currency: "BTC",
     })
     expect(finalFeeInLedger - initFeeInLedger).toBe(channelFee * -1)
@@ -100,7 +102,7 @@ describe("Lightning channels", () => {
   it("opens channel from lnd1 to lndOutside2", async () => {
     const socket = `lnd-outside-2:9735`
     const { balance: initFeeInLedger } = await MainBook.balance({
-      account: lndFeePath,
+      account: bankPath,
       currency: "BTC",
     })
 
@@ -114,7 +116,7 @@ describe("Lightning channels", () => {
     expect(channels.length).toEqual(channelLengthMain + 1)
 
     const { balance: finalFeeInLedger } = await MainBook.balance({
-      account: lndFeePath,
+      account: bankPath,
       currency: "BTC",
     })
     expect(finalFeeInLedger - initFeeInLedger).toBe(channelFee * -1)

--- a/test/integration/01-setup/01-lightning-channels.spec.ts
+++ b/test/integration/01-setup/01-lightning-channels.spec.ts
@@ -1,5 +1,5 @@
 import { MainBook } from "src/mongodb"
-import { bankMediciPath } from "src/ledger/ledger"
+import { bankOwnerMediciPath } from "src/ledger/ledger"
 import {
   checkIsBalanced,
   closeChannel,
@@ -24,11 +24,11 @@ jest.mock("src/phone-provider", () => require("test/mocks/phone-provider"))
 const channelFee = 7637
 const lnds = [lnd1, lnd2, lndOutside1, lndOutside1]
 let channelLengthMain, channelLengthOutside1
-let bankPath: string
+let bankOwnerPath: string
 
 beforeEach(async () => {
   await waitUntilSync({ lnds })
-  bankPath = await bankMediciPath()
+  bankOwnerPath = await bankOwnerMediciPath()
   channelLengthMain = (await getChannels({ lnd: lnd1 })).channels.length
   channelLengthOutside1 = (await getChannels({ lnd: lndOutside1 })).channels.length
 })
@@ -60,7 +60,7 @@ describe("Lightning channels", () => {
   it("opens channel from lnd1 to lndOutside1", async () => {
     const socket = `lnd-outside-1:9735`
     const { balance: initFeeInLedger } = await MainBook.balance({
-      account: bankPath,
+      account: bankOwnerPath,
       currency: "BTC",
     })
 
@@ -74,7 +74,7 @@ describe("Lightning channels", () => {
     expect(channels.length).toEqual(channelLengthMain + 1)
 
     const { balance: finalFeeInLedger } = await MainBook.balance({
-      account: bankPath,
+      account: bankOwnerPath,
       currency: "BTC",
     })
     expect(finalFeeInLedger - initFeeInLedger).toBe(channelFee * -1)
@@ -102,7 +102,7 @@ describe("Lightning channels", () => {
   it("opens channel from lnd1 to lndOutside2", async () => {
     const socket = `lnd-outside-2:9735`
     const { balance: initFeeInLedger } = await MainBook.balance({
-      account: bankPath,
+      account: bankOwnerPath,
       currency: "BTC",
     })
 
@@ -116,7 +116,7 @@ describe("Lightning channels", () => {
     expect(channels.length).toEqual(channelLengthMain + 1)
 
     const { balance: finalFeeInLedger } = await MainBook.balance({
-      account: bankPath,
+      account: bankOwnerPath,
       currency: "BTC",
     })
     expect(finalFeeInLedger - initFeeInLedger).toBe(channelFee * -1)

--- a/test/integration/entrypoint/graphql.spec.ts
+++ b/test/integration/entrypoint/graphql.spec.ts
@@ -4,6 +4,9 @@ import { yamlConfig } from "src/config"
 import { createTestClient } from "apollo-server-testing"
 import { startApolloServerForSchema } from "src/entrypoint/graphql-core-server"
 
+jest.mock("src/realtimePrice", () => require("test/mocks/realtimePrice"))
+jest.mock("src/phone-provider", () => require("test/mocks/phone-provider"))
+
 let server, httpServer
 const { phone, code: correctCode } = yamlConfig.test_accounts[9]
 const badCode = 123456

--- a/test/integration/lnd-utils.spec.ts
+++ b/test/integration/lnd-utils.spec.ts
@@ -39,7 +39,7 @@ describe("lndUtils", () => {
 
       const bankOwnerPath = await bankOwnerMediciPath()
 
-      // FIXME: may not be independant. should have a diff of balance instead.
+      // FIXME: may not be indempotant. should have a diff of balance instead.
       const { balance } = await MainBook.balance({
         accounts: bankOwnerPath,
       })

--- a/test/integration/lnd-utils.spec.ts
+++ b/test/integration/lnd-utils.spec.ts
@@ -1,7 +1,7 @@
 import { MainBook } from "src/mongodb"
 import { baseLogger } from "src/logger"
 import { updateRoutingFees } from "src/lndUtils"
-import { revenueFeePath } from "src/ledger/ledger"
+import { bankOwnerMediciPath } from "src/ledger/ledger"
 import {
   createInvoice,
   getForwards,
@@ -37,8 +37,11 @@ describe("lndUtils", () => {
 
       await updateRoutingFees()
 
+      const bankOwnerPath = await bankOwnerMediciPath()
+
+      // FIXME: may not be independant. should have a diff of balance instead.
       const { balance } = await MainBook.balance({
-        accounts: revenueFeePath,
+        accounts: bankOwnerPath,
       })
 
       // this fix lnd rounding issues

--- a/test/integration/notifications/notification.spec.ts
+++ b/test/integration/notifications/notification.spec.ts
@@ -1,6 +1,6 @@
 import { getCurrentPrice } from "src/realtimePrice"
 import { sendBalanceToUsers } from "src/entrypoint/dailyBalanceNotification"
-import { customerPath } from "src/ledger/ledger"
+import { accountPath } from "src/ledger/ledger"
 import { MainBook } from "src/mongodb"
 import { User } from "src/schema"
 jest.mock("src/notifications/notification")
@@ -30,7 +30,7 @@ describe("notification", () => {
       expect(sendNotification.mock.calls.length).toBe(numActiveUsers)
       for (const [call] of sendNotification.mock.calls) {
         const { balance } = await MainBook.balance({
-          accounts: customerPath(call.user._id),
+          accounts: accountPath(call.user._id),
         })
         const expectedUsdBalance = (price * balance).toLocaleString("en", {
           maximumFractionDigits: 2,

--- a/test/integration/schema.spec.ts
+++ b/test/integration/schema.spec.ts
@@ -5,6 +5,7 @@ import { getFunderWallet } from "src/walletFactory"
 import { getUserWallet } from "test/helpers"
 
 jest.mock("src/realtimePrice", () => require("test/mocks/realtimePrice"))
+jest.mock("src/phone-provider", () => require("test/mocks/phone-provider"))
 
 describe("schema", () => {
   describe("User", () => {

--- a/test/integration/schema.spec.ts
+++ b/test/integration/schema.spec.ts
@@ -1,4 +1,4 @@
-import { customerPath } from "src/ledger/ledger"
+import { accountPath } from "src/ledger/ledger"
 import { baseLogger } from "src/logger"
 import { User } from "src/schema"
 import { getFunderWallet } from "src/walletFactory"
@@ -19,7 +19,7 @@ describe("schema", () => {
         const activeUsers = await User.getActiveUsers()
         spy.mockClear()
 
-        const accountPaths = activeUsers.map((user) => customerPath(user._id))
+        const accountPaths = activeUsers.map((user) => accountPath(user._id))
         const userWallet0AccountPath = (await getUserWallet(0)).user.accountPath
         const funderWalletAccountPath = (await getFunderWallet({ logger: baseLogger }))
           .user.accountPath

--- a/test/mocks/phone-provider.ts
+++ b/test/mocks/phone-provider.ts
@@ -1,15 +1,11 @@
-export const sendTwilioText = async ({ body, to, logger }) => {
+export const sendTwilioText = async () => {
   return await new Promise((resolve) => resolve(true))
 }
 
-export const sendSMSalaText = async ({ body, to, logger }) => {
+export const sendSMSalaText = async () => {
   return await new Promise((resolve) => resolve(true))
 }
 
-export const getCarrier = async (phone: string) => {
+export const getCarrier = async () => {
   return await new Promise((resolve) => resolve(null))
-}
-
-const getTwilioClient = () => {
-  console.log("getTwilioClient")
 }


### PR DESCRIPTION
**make liabilities more compact in the db**

the liabilities will only exist for a particular account. so the intermediary "Account" in "Liabilities:Account:uid" is superflous, and make the index bigger/slower. 

**some definition**

for this issue, I'll use wallet as: a set of transactions and a balance that are represented within midici with `Liabilities:${uid}`
and an account: the representation of 1 or n wallets.

**refactor the revenue/fees of the bank account**

first read: first section "A Bank’s Balance Sheet" in 
https://courses.lumenlearning.com/wm-macroeconomics/chapter/banking-profits-and-losses-name/

The first (naive) implementation was to have the "NetWorth" account at the same level of the other wallets. NetWorth of the bank would have been equal to the fees minus the expenses.

fees being:
```
export const lndFeePath = "Expenses:Bitcoin:Fees"
export const bitcoindFeePath = "Expenses:Bitcoin:Fees"
```

revenue being:
```
export const onchainRevenuePath = "Revenue:Bitcoin:Fees"
export const revenueFeePath = "Revenue:Lightning:Fees"
```

Which make the bank account owner a very particular account because it includes wallet that are on a non standard path (not represented by a `Liabilities:uid` wallet path). I now believe this level of abstraction is not the right one. I think it's better to keep a simple structure where there is only Assets (the BTC the bank account) and Liabilities ("wallet") at the medici level. 

this reduce the complexity at the medici level. and will make proof of reserve easier to implement.

There is still a special "bankOwner" wallet that is used for all the fees that needs to be paid for opening channels or doing rebalancing for instance, and that will earn revenue on routing fees/transaction fees charge to the user, but this is now represented in the book like other wallet in `Liabilities:uid` and not by some special `Revenue:...` or `Fee:...` wallets.

We can now have a higher level of abstraction for the NetWorth/Equity of the bank by using a new layer of abstraction, that is being defines as an account that can include several wallets. 

This account abstraction for the bank account could include the "BankOwner" wallet, the "dealer" and maybe some other wallets that the bank manages. 

Other corporate account that are using our product might also want to have several wallets

**note**

- before merging this PR, we will need to update mongodb to align with the new schema. still need to work on a migration script
- instead of using `Liabilities:${uid}`, we may want to to add an abstraction and use `Liabilities:${wid}` (w: for wallet, instead of u for user)