### PR TITLE
Fix onchain notification issue with new account structure

### DIFF
--- a/src/entrypoint/trigger.ts
+++ b/src/entrypoint/trigger.ts
@@ -83,20 +83,12 @@ export async function onchainTransactionEventHandler(tx) {
       "payment completed",
     )
 
-    const entries = await Transaction.find({
+    const bankOwnerPath = await bankOwnerMediciPath()
+    const entry = await Transaction.findOne({
       account_path: liabilitiesMainAccount,
+      accounts: { $ne: bankOwnerPath },
       hash: tx.id,
     })
-
-    if (!entries) {
-      return
-    }
-
-    const bankOwnerPath = await bankOwnerMediciPath()
-
-    const entry = entries.find(
-      (p) => resolveAccountId(p.account_path) !== resolveAccountId(bankOwnerPath),
-    )
 
     const userId = resolveAccountId(entry?.account_path)
 

--- a/src/ledger/ledger.ts
+++ b/src/ledger/ledger.ts
@@ -10,7 +10,32 @@ export const lndAccountingPath = "Assets:Reserve:Lightning" // TODO: rename to A
 export const escrowAccountingPath = "Assets:Reserve:Escrow" // TODO: rename to Assets:Lnd:Escrow
 
 // liabilities
-export const accountPath = (uid) => `Liabilities:${uid}`
+export const liabilitiesMainAccount = "Liabilities"
+export const accountPath = (uid) => `${liabilitiesMainAccount}:${uid}`
+export const resolveAccountId = (accountPath: string | string[]) => {
+  let id: string | null = null
+
+  if (!accountPath) {
+    return id
+  }
+
+  let path = accountPath
+
+  if (typeof accountPath === "string") {
+    path = accountPath.split(":")
+  }
+
+  if (
+    Array.isArray(path) &&
+    path.length === 2 &&
+    path[0] === liabilitiesMainAccount &&
+    path[1]
+  ) {
+    id = path[1]
+  }
+
+  return id
+}
 
 let cacheDealerPath: string
 let cachebankOwnerPath: string

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -104,6 +104,7 @@ describe("UserWallet - onChainPay", () => {
     expect(sendNotification.mock.calls[0][0].title).toBe(
       getTitle["onchain_payment"]({ amount }),
     )
+    expect(sendNotification.mock.calls[0][0].user._id).toStrictEqual(userWallet0.user._id)
     expect(sendNotification.mock.calls[0][0].data.type).toBe("onchain_payment")
 
     const {

--- a/test/unit/ledger/ledger.spec.ts
+++ b/test/unit/ledger/ledger.spec.ts
@@ -1,0 +1,29 @@
+import { accountPath, liabilitiesMainAccount, resolveAccountId } from "src/ledger/ledger"
+
+describe("ledger.ts", () => {
+  describe("resolveAccountId", () => {
+    const accountId = "123542"
+    it("returns account id from string path", () => {
+      expect(resolveAccountId(accountPath(accountId))).toEqual(accountId)
+    })
+
+    it("returns account id from array path", () => {
+      expect(resolveAccountId([liabilitiesMainAccount, accountId])).toEqual(accountId)
+    })
+
+    it("returns null if invalid path", () => {
+      const lowerCasePrefix = liabilitiesMainAccount.toLowerCase()
+      expect(resolveAccountId("")).toBe(null)
+      expect(resolveAccountId("test")).toBe(null)
+      expect(resolveAccountId("test:id")).toBe(null)
+      expect(resolveAccountId(`${liabilitiesMainAccount}:`)).toBe(null)
+      expect(resolveAccountId(`${lowerCasePrefix}:`)).toBe(null)
+      expect(resolveAccountId([])).toBe(null)
+      expect(resolveAccountId(["a"])).toBe(null)
+      expect(resolveAccountId(["a", "b", "c"])).toBe(null)
+      expect(resolveAccountId([lowerCasePrefix, ""])).toBe(null)
+      expect(resolveAccountId([lowerCasePrefix, "id"])).toBe(null)
+      expect(resolveAccountId([lowerCasePrefix, "id", "b"])).toBe(null)
+    })
+  })
+})


### PR DESCRIPTION
- Add liabilitiesMainAccount path to ledger
- Add new way to resolve account id (user id) from account path
- Add new unit tests to account id resolver
- Add additional user id validation in onchain "sends a successful payment" test (this prevents future errors)

Ref: [PR 377 - improve accounting structure](https://github.com/GaloyMoney/galoy/pull/377)