### PR TITLE
Refactor 'TransactionLimits' types/config

### DIFF
--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -45,9 +45,11 @@ export const getGenericLimits = (limitsConfig = yamlConfig.limits): GenericLimit
   oldEnoughForWithdrawalMicroseconds: limitsConfig.oldEnoughForWithdrawal,
 })
 
-export const getFees = (feesConfig = yamlConfig.fees): FeeConstants => ({
-  depositFeeRate: feesConfig.deposit,
-  withdrawFeeFlat: feesConfig.withdraw,
+export const getFeeRates = (feesConfig = yamlConfig.fees): FeeRates => ({
+  depositFeeVariable: feesConfig.deposit,
+  depositFeeFixed: 0,
+  withdrawFeeVariable: 0,
+  withdrawFeeFixed: feesConfig.withdraw,
 })
 
 export const getUserLimits = ({

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -40,12 +40,12 @@ export const getLndParams = (): LndParams[] => {
   }))
 }
 
-const limitConstants = {
+export const limitConstants: LimitConstants = {
   oldEnoughForWithdrawalHours: yamlConfig.limits.oldEnoughForWithdrawal / MS_IN_HOUR,
   oldEnoughForWithdrawalMicroseconds: yamlConfig.limits.oldEnoughForWithdrawal,
 }
 
-export const selectUserLimits = ({ level }: { level: number }): IUserLimits => {
+export const selectUserLimits = ({ level }: UserLimitsArgs): IUserLimits => {
   const config = yamlConfig.limits
   return {
     onUsLimit: config.onUs.level[level],
@@ -76,16 +76,20 @@ export const getLoginAttemptLimits = () => getRateLimits(yamlConfig.limits.login
 export const getFailedAttemptPerIpLimits = () =>
   getRateLimits(yamlConfig.limits.failedAttemptPerIp)
 
-export const getUserWalletConfig = (user): UserWalletConfig => {
-  const userLimits = selectUserLimits({ level: user.level })
+export const selectTransactionLimits = ({
+  level,
+}: UserLimitsArgs): ITransactionLimits => ({
+  oldEnoughForWithdrawalLimit: limitConstants.oldEnoughForWithdrawalMicroseconds,
+  oldEnoughForWithdrawalLimitHours: limitConstants.oldEnoughForWithdrawalHours,
+  ...selectUserLimits({ level }),
+})
 
+export const getUserWalletConfig = (user): UserWalletConfig => {
+  const transactionLimits = selectTransactionLimits({ level: user.level })
   return {
     name: yamlConfig.name,
     dustThreshold: yamlConfig.onChainWallet.dustThreshold,
-    limits: {
-      oldEnoughForWithdrawalLimit: limitConstants.oldEnoughForWithdrawalHours,
-      ...userLimits,
-    },
+    limits: transactionLimits,
   }
 }
 

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -40,7 +40,7 @@ export const getLndParams = (): LndParams[] => {
   }))
 }
 
-export const getLimitConstants = (limitsConfig = yamlConfig.limits): LimitConstants => ({
+export const getGenericLimits = (limitsConfig = yamlConfig.limits): GenericLimits => ({
   oldEnoughForWithdrawalHours: limitsConfig.oldEnoughForWithdrawal / MS_IN_HOUR,
   oldEnoughForWithdrawalMicroseconds: limitsConfig.oldEnoughForWithdrawal,
 })
@@ -87,10 +87,10 @@ export const getTransactionLimits = ({
   level,
   limitsConfig = yamlConfig.limits,
 }: UserLimitsArgs): ITransactionLimits => {
-  const limitConstants = getLimitConstants(limitsConfig)
+  const genericLimits = getGenericLimits(limitsConfig)
   return {
-    oldEnoughForWithdrawalLimit: limitConstants.oldEnoughForWithdrawalMicroseconds,
-    oldEnoughForWithdrawalLimitHours: limitConstants.oldEnoughForWithdrawalHours,
+    oldEnoughForWithdrawalLimit: genericLimits.oldEnoughForWithdrawalMicroseconds,
+    oldEnoughForWithdrawalLimitHours: genericLimits.oldEnoughForWithdrawalHours,
     ...getUserLimits({ level, limitsConfig }),
   }
 }

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -40,16 +40,20 @@ export const getLndParams = (): LndParams[] => {
   }))
 }
 
-export const limitConstants: LimitConstants = {
-  oldEnoughForWithdrawalHours: yamlConfig.limits.oldEnoughForWithdrawal / MS_IN_HOUR,
-  oldEnoughForWithdrawalMicroseconds: yamlConfig.limits.oldEnoughForWithdrawal,
-}
+export const generateLimitConstants = (
+  limitsConfig = yamlConfig.limits,
+): LimitConstants => ({
+  oldEnoughForWithdrawalHours: limitsConfig.oldEnoughForWithdrawal / MS_IN_HOUR,
+  oldEnoughForWithdrawalMicroseconds: limitsConfig.oldEnoughForWithdrawal,
+})
 
-export const selectUserLimits = ({ level }: UserLimitsArgs): IUserLimits => {
-  const config = yamlConfig.limits
+export const selectUserLimits = ({
+  level,
+  limitsConfig = yamlConfig.limits,
+}: UserLimitsArgs): IUserLimits => {
   return {
-    onUsLimit: config.onUs.level[level],
-    withdrawalLimit: config.withdrawal.level[level],
+    onUsLimit: limitsConfig.onUs.level[level],
+    withdrawalLimit: limitsConfig.withdrawal.level[level],
   }
 }
 
@@ -78,14 +82,21 @@ export const getFailedAttemptPerIpLimits = () =>
 
 export const selectTransactionLimits = ({
   level,
-}: UserLimitsArgs): ITransactionLimits => ({
-  oldEnoughForWithdrawalLimit: limitConstants.oldEnoughForWithdrawalMicroseconds,
-  oldEnoughForWithdrawalLimitHours: limitConstants.oldEnoughForWithdrawalHours,
-  ...selectUserLimits({ level }),
-})
+  limitsConfig = yamlConfig.limits,
+}: UserLimitsArgs): ITransactionLimits => {
+  const limitConstants = generateLimitConstants(limitsConfig)
+  return {
+    oldEnoughForWithdrawalLimit: limitConstants.oldEnoughForWithdrawalMicroseconds,
+    oldEnoughForWithdrawalLimitHours: limitConstants.oldEnoughForWithdrawalHours,
+    ...selectUserLimits({ level, limitsConfig }),
+  }
+}
 
-export const getUserWalletConfig = (user): UserWalletConfig => {
-  const transactionLimits = selectTransactionLimits({ level: user.level })
+export const getUserWalletConfig = (
+  user,
+  limitsConfig = yamlConfig.limits,
+): UserWalletConfig => {
+  const transactionLimits = selectTransactionLimits({ level: user.level, limitsConfig })
   return {
     name: yamlConfig.name,
     dustThreshold: yamlConfig.onChainWallet.dustThreshold,

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -8,7 +8,9 @@ import { baseLogger } from "@services/logger"
 const defaultContent = fs.readFileSync("./default.yaml", "utf8")
 export const defaultConfig = yaml.load(defaultContent)
 
-const MS_IN_HOUR = 60 * 60 * 1000
+export const MS_PER_HOUR = 60 * 60 * 1000
+export const MS_PER_DAY = 24 * MS_PER_HOUR
+export const MS_PER_30_DAYs = 30 * MS_PER_DAY
 
 let customContent, customConfig
 
@@ -41,7 +43,7 @@ export const getLndParams = (): LndParams[] => {
 }
 
 export const getGenericLimits = (limitsConfig = yamlConfig.limits): GenericLimits => ({
-  oldEnoughForWithdrawalHours: limitsConfig.oldEnoughForWithdrawal / MS_IN_HOUR,
+  oldEnoughForWithdrawalHours: limitsConfig.oldEnoughForWithdrawal / MS_PER_HOUR,
   oldEnoughForWithdrawalMicroseconds: limitsConfig.oldEnoughForWithdrawal,
 })
 

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -47,6 +47,11 @@ export const generateLimitConstants = (
   oldEnoughForWithdrawalMicroseconds: limitsConfig.oldEnoughForWithdrawal,
 })
 
+export const generateFeeConstants = (feesConfig = yamlConfig.fees): FeeConstants => ({
+  depositFeeRate: feesConfig.deposit,
+  withdrawFeeFlat: feesConfig.withdraw,
+})
+
 export const selectUserLimits = ({
   level,
   limitsConfig = yamlConfig.limits,

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -91,8 +91,8 @@ export const getTransactionLimits = ({
 }: UserLimitsArgs): ITransactionLimits => {
   const genericLimits = getGenericLimits(limitsConfig)
   return {
-    oldEnoughForWithdrawalLimit: genericLimits.oldEnoughForWithdrawalMicroseconds,
-    oldEnoughForWithdrawalLimitHours: genericLimits.oldEnoughForWithdrawalHours,
+    oldEnoughForWithdrawalMicroseconds: genericLimits.oldEnoughForWithdrawalMicroseconds,
+    oldEnoughForWithdrawalHours: genericLimits.oldEnoughForWithdrawalHours,
     ...getUserLimits({ level, limitsConfig }),
   }
 }

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -40,19 +40,17 @@ export const getLndParams = (): LndParams[] => {
   }))
 }
 
-export const generateLimitConstants = (
-  limitsConfig = yamlConfig.limits,
-): LimitConstants => ({
+export const getLimitConstants = (limitsConfig = yamlConfig.limits): LimitConstants => ({
   oldEnoughForWithdrawalHours: limitsConfig.oldEnoughForWithdrawal / MS_IN_HOUR,
   oldEnoughForWithdrawalMicroseconds: limitsConfig.oldEnoughForWithdrawal,
 })
 
-export const generateFeeConstants = (feesConfig = yamlConfig.fees): FeeConstants => ({
+export const getFees = (feesConfig = yamlConfig.fees): FeeConstants => ({
   depositFeeRate: feesConfig.deposit,
   withdrawFeeFlat: feesConfig.withdraw,
 })
 
-export const selectUserLimits = ({
+export const getUserLimits = ({
   level,
   limitsConfig = yamlConfig.limits,
 }: UserLimitsArgs): IUserLimits => {
@@ -85,15 +83,15 @@ export const getLoginAttemptLimits = () => getRateLimits(yamlConfig.limits.login
 export const getFailedAttemptPerIpLimits = () =>
   getRateLimits(yamlConfig.limits.failedAttemptPerIp)
 
-export const selectTransactionLimits = ({
+export const getTransactionLimits = ({
   level,
   limitsConfig = yamlConfig.limits,
 }: UserLimitsArgs): ITransactionLimits => {
-  const limitConstants = generateLimitConstants(limitsConfig)
+  const limitConstants = getLimitConstants(limitsConfig)
   return {
     oldEnoughForWithdrawalLimit: limitConstants.oldEnoughForWithdrawalMicroseconds,
     oldEnoughForWithdrawalLimitHours: limitConstants.oldEnoughForWithdrawalHours,
-    ...selectUserLimits({ level, limitsConfig }),
+    ...getUserLimits({ level, limitsConfig }),
   }
 }
 
@@ -101,7 +99,7 @@ export const getUserWalletConfig = (
   user,
   limitsConfig = yamlConfig.limits,
 ): UserWalletConfig => {
-  const transactionLimits = selectTransactionLimits({ level: user.level, limitsConfig })
+  const transactionLimits = getTransactionLimits({ level: user.level, limitsConfig })
   return {
     name: yamlConfig.name,
     dustThreshold: yamlConfig.onChainWallet.dustThreshold,

--- a/src/core/error.ts
+++ b/src/core/error.ts
@@ -133,7 +133,7 @@ export class RebalanceNeededError extends CustomError {
 
 export class DustAmountError extends CustomError {
   constructor(
-    message = `Use lightning to send amounts less than ${yamlConfig.onchainDustAmount}`,
+    message = `Use lightning to send amounts less than ${yamlConfig.onChainWallet.dustThreshold}`,
     { forwardToClient = true, logger, level = "warn" as const, ...metadata },
   ) {
     super(message, "ENTERED_DUST_AMOUNT", { forwardToClient, logger, level, metadata })

--- a/src/core/lightning/index.ts
+++ b/src/core/lightning/index.ts
@@ -432,7 +432,7 @@ export const LightningMixin = (superclass) =>
 
           // "normal" transaction: paying another lightning node
           if (!this.user.oldEnoughForWithdrawal) {
-            const error = `New accounts have to wait ${this.config.limits.oldEnoughForWithdrawalLimitHours}h before withdrawing`
+            const error = `New accounts have to wait ${this.config.limits.oldEnoughForWithdrawalHours}h before withdrawing`
             throw new NewAccountWithdrawalError(error, { logger: lightningLogger })
           }
 

--- a/src/core/lightning/index.ts
+++ b/src/core/lightning/index.ts
@@ -304,7 +304,7 @@ export const LightningMixin = (superclass) =>
             const lightningLoggerOnUs = lightningLogger.child({ onUs: true, fee: 0 })
 
             if (await this.user.limitHit({ on_us: true, amount: tokens })) {
-              const error = `Cannot transfer more than ${this.config.limits.onUsLimit()} sats in 24 hours`
+              const error = `Cannot transfer more than ${this.config.limits.onUsLimit} sats in 24 hours`
               throw new TransactionRestrictedError(error, { logger: lightningLoggerOnUs })
             }
 
@@ -432,12 +432,12 @@ export const LightningMixin = (superclass) =>
 
           // "normal" transaction: paying another lightning node
           if (!this.user.oldEnoughForWithdrawal) {
-            const error = `New accounts have to wait ${this.config.limits.oldEnoughForWithdrawalLimit()}h before withdrawing`
+            const error = `New accounts have to wait ${this.config.limits.oldEnoughForWithdrawalLimit}h before withdrawing`
             throw new NewAccountWithdrawalError(error, { logger: lightningLogger })
           }
 
           if (await this.user.limitHit({ on_us: false, amount: tokens })) {
-            const error = `Cannot transfer more than ${this.config.limits.withdrawalLimit()} sats in 24 hours`
+            const error = `Cannot transfer more than ${this.config.limits.withdrawalLimit} sats in 24 hours`
             throw new TransactionRestrictedError(error, { logger: lightningLogger })
           }
 

--- a/src/core/lightning/index.ts
+++ b/src/core/lightning/index.ts
@@ -432,7 +432,7 @@ export const LightningMixin = (superclass) =>
 
           // "normal" transaction: paying another lightning node
           if (!this.user.oldEnoughForWithdrawal) {
-            const error = `New accounts have to wait ${this.config.limits.oldEnoughForWithdrawalLimit}h before withdrawing`
+            const error = `New accounts have to wait ${this.config.limits.oldEnoughForWithdrawalLimitHours}h before withdrawing`
             throw new NewAccountWithdrawalError(error, { logger: lightningLogger })
           }
 

--- a/src/core/on-chain/index.ts
+++ b/src/core/on-chain/index.ts
@@ -171,7 +171,7 @@ export const OnChainMixin = (superclass) =>
             if (
               await this.user.limitHit({ on_us: true, amount: amountToSendPayeeUser })
             ) {
-              const error = `Cannot transfer more than ${this.config.limits.onUsLimit()} sats in 24 hours`
+              const error = `Cannot transfer more than ${this.config.limits.onUsLimit} sats in 24 hours`
               throw new TransactionRestrictedError(error, { logger: onchainLoggerOnUs })
             }
 
@@ -215,7 +215,7 @@ export const OnChainMixin = (superclass) =>
           onchainLogger = onchainLogger.child({ onUs: false })
 
           if (!this.user.oldEnoughForWithdrawal) {
-            const error = `New accounts have to wait ${this.config.limits.oldEnoughForWithdrawalLimit()}h before withdrawing`
+            const error = `New accounts have to wait ${this.config.limits.oldEnoughForWithdrawalLimit}h before withdrawing`
             throw new NewAccountWithdrawalError(error, { logger: onchainLogger })
           }
 
@@ -229,7 +229,7 @@ export const OnChainMixin = (superclass) =>
           }
 
           if (await this.user.limitHit({ on_us: false, amount: checksAmount })) {
-            const error = `Cannot withdraw more than ${this.config.limits.withdrawalLimit()} sats in 24 hours`
+            const error = `Cannot withdraw more than ${this.config.limits.withdrawalLimit} sats in 24 hours`
             throw new TransactionRestrictedError(error, { logger: onchainLogger })
           }
 

--- a/src/core/on-chain/index.ts
+++ b/src/core/on-chain/index.ts
@@ -215,7 +215,7 @@ export const OnChainMixin = (superclass) =>
           onchainLogger = onchainLogger.child({ onUs: false })
 
           if (!this.user.oldEnoughForWithdrawal) {
-            const error = `New accounts have to wait ${this.config.limits.oldEnoughForWithdrawalLimit}h before withdrawing`
+            const error = `New accounts have to wait ${this.config.limits.oldEnoughForWithdrawalLimitHours}h before withdrawing`
             throw new NewAccountWithdrawalError(error, { logger: onchainLogger })
           }
 

--- a/src/core/on-chain/index.ts
+++ b/src/core/on-chain/index.ts
@@ -215,7 +215,7 @@ export const OnChainMixin = (superclass) =>
           onchainLogger = onchainLogger.child({ onUs: false })
 
           if (!this.user.oldEnoughForWithdrawal) {
-            const error = `New accounts have to wait ${this.config.limits.oldEnoughForWithdrawalLimitHours}h before withdrawing`
+            const error = `New accounts have to wait ${this.config.limits.oldEnoughForWithdrawalHours}h before withdrawing`
             throw new NewAccountWithdrawalError(error, { logger: onchainLogger })
           }
 

--- a/src/core/types.d.ts
+++ b/src/core/types.d.ts
@@ -9,7 +9,7 @@ type Primitive = string | boolean | number
 // TODO: clean up this section when "constructor typing" work is
 //       being done
 
-type LimitConstants = {
+type GenericLimits = {
   oldEnoughForWithdrawalHours: number
   oldEnoughForWithdrawalMicroseconds: number
 }

--- a/src/core/types.d.ts
+++ b/src/core/types.d.ts
@@ -14,9 +14,11 @@ type GenericLimits = {
   oldEnoughForWithdrawalMicroseconds: number
 }
 
-type FeeConstants = {
-  depositFeeRate: number
-  withdrawFeeFlat: number
+type FeeRates = {
+  depositFeeVariable: number
+  depositFeeFixed: number
+  withdrawFeeVariable: number
+  withdrawFeeFixed: number
 }
 
 type UserLimitsArgs = { level: number; limitsConfig? }

--- a/src/core/types.d.ts
+++ b/src/core/types.d.ts
@@ -14,6 +14,11 @@ type LimitConstants = {
   oldEnoughForWithdrawalMicroseconds: number
 }
 
+type FeeConstants = {
+  depositFeeRate: number
+  withdrawFeeFlat: number
+}
+
 type UserLimitsArgs = { level: number; limitsConfig? }
 
 interface IUserLimits {

--- a/src/core/types.d.ts
+++ b/src/core/types.d.ts
@@ -8,6 +8,14 @@ type Primitive = string | boolean | number
 // configs & constructors
 // TODO: clean up this section when "constructor typing" work is
 //       being done
+
+type LimitConstants = {
+  oldEnoughForWithdrawalHours: number
+  oldEnoughForWithdrawalMicroseconds: number
+}
+
+type UserLimitsArgs = { level: number }
+
 interface IUserLimits {
   onUsLimit: number
   withdrawalLimit: number
@@ -15,6 +23,7 @@ interface IUserLimits {
 
 interface ITransactionLimits extends IUserLimits {
   oldEnoughForWithdrawalLimit: number
+  oldEnoughForWithdrawalLimitHours: number
 }
 
 interface IRateLimits {

--- a/src/core/types.d.ts
+++ b/src/core/types.d.ts
@@ -14,7 +14,7 @@ type LimitConstants = {
   oldEnoughForWithdrawalMicroseconds: number
 }
 
-type UserLimitsArgs = { level: number }
+type UserLimitsArgs = { level: number; limitsConfig? }
 
 interface IUserLimits {
   onUsLimit: number

--- a/src/core/types.d.ts
+++ b/src/core/types.d.ts
@@ -29,8 +29,8 @@ interface IUserLimits {
 }
 
 interface ITransactionLimits extends IUserLimits {
-  oldEnoughForWithdrawalLimit: number
-  oldEnoughForWithdrawalLimitHours: number
+  oldEnoughForWithdrawalMicroseconds: number
+  oldEnoughForWithdrawalHours: number
 }
 
 interface IRateLimits {

--- a/src/core/types.d.ts
+++ b/src/core/types.d.ts
@@ -8,12 +8,13 @@ type Primitive = string | boolean | number
 // configs & constructors
 // TODO: clean up this section when "constructor typing" work is
 //       being done
-interface ITransactionLimits {
-  config
-  level: number
-  onUsLimit: () => number
-  withdrawalLimit: () => number
-  oldEnoughForWithdrawalLimit: () => number
+interface IUserLimits {
+  onUsLimit: number
+  withdrawalLimit: number
+}
+
+interface ITransactionLimits extends IUserLimits {
+  oldEnoughForWithdrawalLimit: number
 }
 
 interface IRateLimits {

--- a/src/servers/graphql-main-server.ts
+++ b/src/servers/graphql-main-server.ts
@@ -12,7 +12,12 @@ import { makeExecutableSchema } from "graphql-tools"
 import moment from "moment"
 import path from "path"
 
-import { yamlConfig, levels, onboardingEarn, selectTransactionLimits } from "@config/app"
+import {
+  levels,
+  onboardingEarn,
+  selectTransactionLimits,
+  generateFeeConstants,
+} from "@config/app"
 
 import { setupMongoConnection } from "@services/mongodb"
 import { activateLndHealthCheck } from "@services/lnd/health"
@@ -162,9 +167,10 @@ const resolvers = {
         onUs: transactionLimits.onUsLimit,
       }
     },
-    getWalletFees: () => ({
-      deposit: yamlConfig.fees.deposit,
-    }),
+    getWalletFees: () => {
+      const feeConstants = generateFeeConstants()
+      return { deposit: feeConstants.depositFeeRate }
+    },
   },
   Mutation: {
     requestPhoneCode: async (_, { phone }, { logger, ip }) => ({

--- a/src/servers/graphql-main-server.ts
+++ b/src/servers/graphql-main-server.ts
@@ -157,7 +157,7 @@ const resolvers = {
     getLimits: (_, __, { user }) => {
       const transactionLimits = getTransactionLimits({ level: user.level })
       return {
-        oldEnoughForWithdrawal: transactionLimits.oldEnoughForWithdrawalLimit,
+        oldEnoughForWithdrawal: transactionLimits.oldEnoughForWithdrawalMicroseconds,
         withdrawal: transactionLimits.withdrawalLimit,
         onUs: transactionLimits.onUsLimit,
       }

--- a/src/servers/graphql-main-server.ts
+++ b/src/servers/graphql-main-server.ts
@@ -12,7 +12,7 @@ import { makeExecutableSchema } from "graphql-tools"
 import moment from "moment"
 import path from "path"
 
-import { yamlConfig, levels, onboardingEarn } from "@config/app"
+import { yamlConfig, levels, onboardingEarn, selectTransactionLimits } from "@config/app"
 
 import { setupMongoConnection } from "@services/mongodb"
 import { activateLndHealthCheck } from "@services/lnd/health"
@@ -155,10 +155,11 @@ const resolvers = {
     },
     getLevels: () => levels,
     getLimits: (_, __, { user }) => {
+      const transactionLimits = selectTransactionLimits({ level: user.level })
       return {
-        oldEnoughForWithdrawal: yamlConfig.limits.oldEnoughForWithdrawal,
-        withdrawal: yamlConfig.limits.withdrawal.level[user.level],
-        onUs: yamlConfig.limits.onUs.level[user.level],
+        oldEnoughForWithdrawal: transactionLimits.oldEnoughForWithdrawalLimit,
+        withdrawal: transactionLimits.withdrawalLimit,
+        onUs: transactionLimits.onUsLimit,
       }
     },
     getWalletFees: () => ({

--- a/src/servers/graphql-main-server.ts
+++ b/src/servers/graphql-main-server.ts
@@ -12,12 +12,7 @@ import { makeExecutableSchema } from "graphql-tools"
 import moment from "moment"
 import path from "path"
 
-import {
-  levels,
-  onboardingEarn,
-  selectTransactionLimits,
-  generateFeeConstants,
-} from "@config/app"
+import { levels, onboardingEarn, getTransactionLimits, getFees } from "@config/app"
 
 import { setupMongoConnection } from "@services/mongodb"
 import { activateLndHealthCheck } from "@services/lnd/health"
@@ -160,7 +155,7 @@ const resolvers = {
     },
     getLevels: () => levels,
     getLimits: (_, __, { user }) => {
-      const transactionLimits = selectTransactionLimits({ level: user.level })
+      const transactionLimits = getTransactionLimits({ level: user.level })
       return {
         oldEnoughForWithdrawal: transactionLimits.oldEnoughForWithdrawalLimit,
         withdrawal: transactionLimits.withdrawalLimit,
@@ -168,7 +163,7 @@ const resolvers = {
       }
     },
     getWalletFees: () => {
-      const feeConstants = generateFeeConstants()
+      const feeConstants = getFees()
       return { deposit: feeConstants.depositFeeRate }
     },
   },

--- a/src/servers/graphql-main-server.ts
+++ b/src/servers/graphql-main-server.ts
@@ -12,7 +12,7 @@ import { makeExecutableSchema } from "graphql-tools"
 import moment from "moment"
 import path from "path"
 
-import { levels, onboardingEarn, getTransactionLimits, getFees } from "@config/app"
+import { levels, onboardingEarn, getTransactionLimits, getFeeRates } from "@config/app"
 
 import { setupMongoConnection } from "@services/mongodb"
 import { activateLndHealthCheck } from "@services/lnd/health"
@@ -163,8 +163,8 @@ const resolvers = {
       }
     },
     getWalletFees: () => {
-      const feeConstants = getFees()
-      return { deposit: feeConstants.depositFeeRate }
+      const feeRates = getFeeRates()
+      return { deposit: feeRates.depositFeeVariable }
     },
   },
   Mutation: {

--- a/src/services/lnd/utils.ts
+++ b/src/services/lnd/utils.ts
@@ -18,7 +18,7 @@ import {
 import _ from "lodash"
 import { Logger } from "pino"
 
-import { getGaloyInstanceName } from "@config/app"
+import { getGaloyInstanceName, MS_PER_DAY } from "@config/app"
 
 import { baseLogger } from "@services/logger"
 import { ledger } from "@services/mongodb"
@@ -28,9 +28,6 @@ import { DbError, LndOfflineError, ValidationInternalError } from "@core/error"
 import { LoggedError, LOOK_BACK } from "@core/utils"
 
 import { FEECAP, FEEMIN, params } from "./auth"
-
-// milliseconds in a day
-const MS_PER_DAY = 864e5
 
 export const deleteExpiredInvoiceUser = () => {
   // this should be longer than the invoice validity time

--- a/src/services/mongoose/schema.ts
+++ b/src/services/mongoose/schema.ts
@@ -1,6 +1,6 @@
 import * as _ from "lodash"
 import * as mongoose from "mongoose"
-import { levels, getUserLimits, getGenericLimits, getFees } from "@config/app"
+import { levels, getUserLimits, getGenericLimits, getFeeRates } from "@config/app"
 import { NotFoundError } from "@core/error"
 import { accountPath } from "@core/ledger/accounts"
 import { Transaction } from "@core/ledger/schema"
@@ -58,18 +58,18 @@ export const InvoiceUser = mongoose.model("InvoiceUser", invoiceUserSchema)
 
 export const regexUsername = /(?!^(1|3|bc1|lnbc1))^[0-9a-z_]+$/i
 
-const feeConstants = getFees()
+const feeRates = getFeeRates()
 
 const UserSchema = new Schema({
   depositFeeRatio: {
     type: Number,
-    default: feeConstants.depositFeeRate,
+    default: feeRates.depositFeeVariable,
     min: 0,
     max: 1,
   },
   withdrawFee: {
     type: Number,
-    default: feeConstants.withdrawFeeFlat,
+    default: feeRates.withdrawFeeFixed,
     min: 0,
   },
   lastConnection: Date,

--- a/src/services/mongoose/schema.ts
+++ b/src/services/mongoose/schema.ts
@@ -1,6 +1,6 @@
 import * as _ from "lodash"
 import * as mongoose from "mongoose"
-import { levels, getUserLimits, getLimitConstants, getFees } from "@config/app"
+import { levels, getUserLimits, getGenericLimits, getFees } from "@config/app"
 import { NotFoundError } from "@core/error"
 import { accountPath } from "@core/ledger/accounts"
 import { Transaction } from "@core/ledger/schema"
@@ -265,8 +265,8 @@ UserSchema.virtual("accountPath").get(function (this: typeof UserSchema) {
 // eslint-disable-next-line no-unused-vars
 UserSchema.virtual("oldEnoughForWithdrawal").get(function (this: typeof UserSchema) {
   const elapsed = Date.now() - this.created_at.getTime()
-  const limitConstants = getLimitConstants()
-  return elapsed > limitConstants.oldEnoughForWithdrawalMicroseconds
+  const genericLimits = getGenericLimits()
+  return elapsed > genericLimits.oldEnoughForWithdrawalMicroseconds
 })
 
 UserSchema.methods.limitHit = async function ({

--- a/src/services/mongoose/schema.ts
+++ b/src/services/mongoose/schema.ts
@@ -1,6 +1,6 @@
 import * as _ from "lodash"
 import * as mongoose from "mongoose"
-import { yamlConfig, levels } from "@config/app"
+import { yamlConfig, levels, selectUserLimits, limitConstants } from "@config/app"
 import { NotFoundError } from "@core/error"
 import { accountPath } from "@core/ledger/accounts"
 import { Transaction } from "@core/ledger/schema"
@@ -262,9 +262,9 @@ UserSchema.virtual("accountPath").get(function (this: typeof UserSchema) {
 
 // eslint-disable-next-line no-unused-vars
 UserSchema.virtual("oldEnoughForWithdrawal").get(function (this: typeof UserSchema) {
-  const d = Date.now()
+  const elapsed = Date.now() - this.created_at.getTime()
   // console.log({d, created_at: this.created_at.getTime(), oldEnough: yamlConfig.limits.oldEnoughForWithdrawal})
-  return d - this.created_at.getTime() > yamlConfig.limits.oldEnoughForWithdrawal
+  return elapsed > limitConstants.oldEnoughForWithdrawalMicroseconds
 })
 
 UserSchema.methods.limitHit = async function ({
@@ -280,7 +280,8 @@ UserSchema.methods.limitHit = async function ({
     ? [{ type: "on_us" }, { type: "onchain_on_us" }]
     : [{ type: { $ne: "on_us" } }]
 
-  const limit = yamlConfig.limits[on_us ? "onUs" : "withdrawal"].level[this.level]
+  const userLimits = selectUserLimits({ level: this.level })
+  const limit = on_us ? userLimits.onUsLimit : userLimits.withdrawalLimit
 
   const outgoingSats =
     (

--- a/src/services/mongoose/schema.ts
+++ b/src/services/mongoose/schema.ts
@@ -1,11 +1,6 @@
 import * as _ from "lodash"
 import * as mongoose from "mongoose"
-import {
-  levels,
-  selectUserLimits,
-  generateLimitConstants,
-  generateFeeConstants,
-} from "@config/app"
+import { levels, getUserLimits, getLimitConstants, getFees } from "@config/app"
 import { NotFoundError } from "@core/error"
 import { accountPath } from "@core/ledger/accounts"
 import { Transaction } from "@core/ledger/schema"
@@ -63,7 +58,7 @@ export const InvoiceUser = mongoose.model("InvoiceUser", invoiceUserSchema)
 
 export const regexUsername = /(?!^(1|3|bc1|lnbc1))^[0-9a-z_]+$/i
 
-const feeConstants = generateFeeConstants()
+const feeConstants = getFees()
 
 const UserSchema = new Schema({
   depositFeeRatio: {
@@ -270,7 +265,7 @@ UserSchema.virtual("accountPath").get(function (this: typeof UserSchema) {
 // eslint-disable-next-line no-unused-vars
 UserSchema.virtual("oldEnoughForWithdrawal").get(function (this: typeof UserSchema) {
   const elapsed = Date.now() - this.created_at.getTime()
-  const limitConstants = generateLimitConstants()
+  const limitConstants = getLimitConstants()
   return elapsed > limitConstants.oldEnoughForWithdrawalMicroseconds
 })
 
@@ -287,7 +282,7 @@ UserSchema.methods.limitHit = async function ({
     ? [{ type: "on_us" }, { type: "onchain_on_us" }]
     : [{ type: { $ne: "on_us" } }]
 
-  const userLimits = selectUserLimits({ level: this.level })
+  const userLimits = getUserLimits({ level: this.level })
   const limit = on_us ? userLimits.onUsLimit : userLimits.withdrawalLimit
 
   const outgoingSats =

--- a/src/services/mongoose/schema.ts
+++ b/src/services/mongoose/schema.ts
@@ -1,6 +1,11 @@
 import * as _ from "lodash"
 import * as mongoose from "mongoose"
-import { yamlConfig, levels, selectUserLimits, generateLimitConstants } from "@config/app"
+import {
+  levels,
+  selectUserLimits,
+  generateLimitConstants,
+  generateFeeConstants,
+} from "@config/app"
 import { NotFoundError } from "@core/error"
 import { accountPath } from "@core/ledger/accounts"
 import { Transaction } from "@core/ledger/schema"
@@ -58,16 +63,18 @@ export const InvoiceUser = mongoose.model("InvoiceUser", invoiceUserSchema)
 
 export const regexUsername = /(?!^(1|3|bc1|lnbc1))^[0-9a-z_]+$/i
 
+const feeConstants = generateFeeConstants()
+
 const UserSchema = new Schema({
   depositFeeRatio: {
     type: Number,
-    default: yamlConfig.fees.deposit,
+    default: feeConstants.depositFeeRate,
     min: 0,
     max: 1,
   },
   withdrawFee: {
     type: Number,
-    default: yamlConfig.fees.withdraw,
+    default: feeConstants.withdrawFeeFlat,
     min: 0,
   },
   lastConnection: Date,
@@ -264,7 +271,6 @@ UserSchema.virtual("accountPath").get(function (this: typeof UserSchema) {
 UserSchema.virtual("oldEnoughForWithdrawal").get(function (this: typeof UserSchema) {
   const elapsed = Date.now() - this.created_at.getTime()
   const limitConstants = generateLimitConstants()
-  // console.log({d, created_at: this.created_at.getTime(), oldEnough: yamlConfig.limits.oldEnoughForWithdrawal})
   return elapsed > limitConstants.oldEnoughForWithdrawalMicroseconds
 })
 

--- a/src/services/mongoose/schema.ts
+++ b/src/services/mongoose/schema.ts
@@ -1,6 +1,13 @@
 import * as _ from "lodash"
 import * as mongoose from "mongoose"
-import { levels, getUserLimits, getGenericLimits, getFeeRates } from "@config/app"
+import {
+  levels,
+  getUserLimits,
+  getGenericLimits,
+  getFeeRates,
+  MS_PER_DAY,
+  MS_PER_30_DAYs,
+} from "@config/app"
 import { NotFoundError } from "@core/error"
 import { accountPath } from "@core/ledger/accounts"
 import { Transaction } from "@core/ledger/schema"
@@ -20,8 +27,6 @@ const dbMetadataSchema = new Schema({
   routingFeeLastEntry: Date,
 })
 export const DbMetadata = mongoose.model("DbMetadata", dbMetadataSchema)
-
-const MS_PER_DAY = 24 * 60 * 60 * 1000
 
 const invoiceUserSchema = new Schema({
   _id: String, // hash of invoice
@@ -341,7 +346,7 @@ UserSchema.virtual("onchain_pubkey").get(function (this: typeof UserSchema) {
 // user is considered active if there has been one transaction of more than 1000 sats in the last 30 days
 // eslint-disable-next-line no-unused-vars
 UserSchema.virtual("userIsActive").get(async function (this: typeof UserSchema) {
-  const timestamp30DaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000
+  const timestamp30DaysAgo = Date.now() - MS_PER_30_DAYs
 
   const volume = await User.getVolume({
     after: timestamp30DaysAgo,

--- a/src/services/mongoose/schema.ts
+++ b/src/services/mongoose/schema.ts
@@ -1,6 +1,6 @@
 import * as _ from "lodash"
 import * as mongoose from "mongoose"
-import { yamlConfig, levels, selectUserLimits, limitConstants } from "@config/app"
+import { yamlConfig, levels, selectUserLimits, generateLimitConstants } from "@config/app"
 import { NotFoundError } from "@core/error"
 import { accountPath } from "@core/ledger/accounts"
 import { Transaction } from "@core/ledger/schema"
@@ -263,6 +263,7 @@ UserSchema.virtual("accountPath").get(function (this: typeof UserSchema) {
 // eslint-disable-next-line no-unused-vars
 UserSchema.virtual("oldEnoughForWithdrawal").get(function (this: typeof UserSchema) {
   const elapsed = Date.now() - this.created_at.getTime()
+  const limitConstants = generateLimitConstants()
   // console.log({d, created_at: this.created_at.getTime(), oldEnough: yamlConfig.limits.oldEnoughForWithdrawal})
   return elapsed > limitConstants.oldEnoughForWithdrawalMicroseconds
 })

--- a/test/integration/02-user-wallet/02-index.spec.ts
+++ b/test/integration/02-user-wallet/02-index.spec.ts
@@ -1,4 +1,4 @@
-import { yamlConfig } from "@config/app"
+import { getGenericLimits } from "@config/app"
 import { getUserWallet } from "test/helpers"
 import { setAccountStatus } from "@core/admin-ops"
 import { usernameExists } from "@domain/user"
@@ -36,7 +36,9 @@ describe("UserWallet", () => {
     expect(userWallet2.user.oldEnoughForWithdrawal).toBeFalsy()
 
     // in 6 days:
-    const date = Date.now() + yamlConfig.limits.oldEnoughForWithdrawal - 60 * 60 * 1000
+    const genericLimits = getGenericLimits()
+    const date =
+      Date.now() + genericLimits.oldEnoughForWithdrawalMicroseconds - 60 * 60 * 1000
 
     jest.spyOn(global.Date, "now").mockImplementationOnce(() => new Date(date).valueOf())
 
@@ -48,7 +50,9 @@ describe("UserWallet", () => {
 
     // TODO make this configurable
     // in 8 days:
-    const date = Date.now() + yamlConfig.limits.oldEnoughForWithdrawal + 60 * 60 * 1000
+    const genericLimits = getGenericLimits()
+    const date =
+      Date.now() + genericLimits.oldEnoughForWithdrawalMicroseconds + 60 * 60 * 1000
 
     jest.spyOn(global.Date, "now").mockImplementationOnce(() => new Date(date).valueOf())
 

--- a/test/integration/02-user-wallet/02-index.spec.ts
+++ b/test/integration/02-user-wallet/02-index.spec.ts
@@ -1,4 +1,4 @@
-import { getGenericLimits } from "@config/app"
+import { getGenericLimits, MS_PER_HOUR } from "@config/app"
 import { getUserWallet } from "test/helpers"
 import { setAccountStatus } from "@core/admin-ops"
 import { usernameExists } from "@domain/user"
@@ -38,7 +38,7 @@ describe("UserWallet", () => {
     // in 6 days:
     const genericLimits = getGenericLimits()
     const date =
-      Date.now() + genericLimits.oldEnoughForWithdrawalMicroseconds - 60 * 60 * 1000
+      Date.now() + genericLimits.oldEnoughForWithdrawalMicroseconds - MS_PER_HOUR
 
     jest.spyOn(global.Date, "now").mockImplementationOnce(() => new Date(date).valueOf())
 
@@ -52,7 +52,7 @@ describe("UserWallet", () => {
     // in 8 days:
     const genericLimits = getGenericLimits()
     const date =
-      Date.now() + genericLimits.oldEnoughForWithdrawalMicroseconds + 60 * 60 * 1000
+      Date.now() + genericLimits.oldEnoughForWithdrawalMicroseconds + MS_PER_HOUR
 
     jest.spyOn(global.Date, "now").mockImplementationOnce(() => new Date(date).valueOf())
 

--- a/test/integration/02-user-wallet/02-receive-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-onchain.spec.ts
@@ -1,7 +1,7 @@
 import { once } from "events"
 import { filter } from "lodash"
 import { baseLogger } from "@services/logger"
-import { TransactionLimits } from "@config/app"
+import { selectUserLimits } from "@config/app"
 import { getCurrentPrice } from "@services/realtime-price"
 import { btc2sat, sat2btc, sleep } from "@core/utils"
 import { getTitle } from "@core/notifications/payment"
@@ -30,9 +30,7 @@ let walletUser11
 let walletUser12
 let amountBTC
 
-const transactionLimits = new TransactionLimits({
-  level: "1",
-})
+const userLimits = selectUserLimits({ level: 1 })
 
 jest.mock("@core/notifications/notification")
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -72,14 +70,14 @@ describe("UserWallet - On chain", () => {
 
   it("receives on-chain transaction with max limit for withdrawal level1", async () => {
     /// TODO? add sendAll tests in which the user has more than the limit?
-    const level1WithdrawalLimit = transactionLimits.withdrawalLimit() // sats
+    const level1WithdrawalLimit = userLimits.withdrawalLimit // sats
     amountBTC = sat2btc(level1WithdrawalLimit)
     walletUser11 = await getUserWallet(11)
     await sendToWallet({ walletDestination: walletUser11 })
   })
 
   it("receives on-chain transaction with max limit for onUs level1", async () => {
-    const level1OnUsLimit = transactionLimits.onUsLimit() // sats
+    const level1OnUsLimit = userLimits.onUsLimit // sats
     amountBTC = sat2btc(level1OnUsLimit)
     walletUser12 = await getUserWallet(12)
     await sendToWallet({ walletDestination: walletUser12 })

--- a/test/integration/02-user-wallet/02-receive-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-onchain.spec.ts
@@ -1,7 +1,7 @@
 import { once } from "events"
 import { filter } from "lodash"
 import { baseLogger } from "@services/logger"
-import { selectUserLimits } from "@config/app"
+import { getUserLimits } from "@config/app"
 import { getCurrentPrice } from "@services/realtime-price"
 import { btc2sat, sat2btc, sleep } from "@core/utils"
 import { getTitle } from "@core/notifications/payment"
@@ -30,7 +30,7 @@ let walletUser11
 let walletUser12
 let amountBTC
 
-const userLimits = selectUserLimits({ level: 1 })
+const userLimits = getUserLimits({ level: 1 })
 
 jest.mock("@core/notifications/notification")
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes } from "crypto"
-import { TransactionLimits } from "@config/app"
+import { selectUserLimits } from "@config/app"
 import {
   InsufficientBalanceError,
   LightningPaymentError,
@@ -37,9 +37,7 @@ jest.mock("@services/phone-provider", () => require("test/mocks/phone-provider")
 let userWallet0, userWallet1, userWallet2
 let initBalance0, initBalance1
 const amountInvoice = 1000
-const transactionLimits = new TransactionLimits({
-  level: "1",
-})
+const userLimits = selectUserLimits({ level: 1 })
 
 beforeAll(async () => {
   userWallet0 = await getUserWallet(0)
@@ -271,7 +269,7 @@ describe("UserWallet - Lightning Pay", () => {
   it("fails to pay when withdrawalLimit exceeded", async () => {
     const { request } = await createInvoice({
       lnd: lndOutside1,
-      tokens: transactionLimits.withdrawalLimit() + 1,
+      tokens: userLimits.withdrawalLimit + 1,
     })
     await expect(userWallet1.pay({ invoice: request })).rejects.toThrow(
       TransactionRestrictedError,
@@ -280,7 +278,7 @@ describe("UserWallet - Lightning Pay", () => {
 
   it("fails to pay when amount exceeds onUs limit", async () => {
     const request = await userWallet0.addInvoice({
-      value: transactionLimits.onUsLimit() + 1,
+      value: userLimits.onUsLimit + 1,
     })
     await expect(userWallet1.pay({ invoice: request })).rejects.toThrow(
       TransactionRestrictedError,

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes } from "crypto"
-import { selectUserLimits } from "@config/app"
+import { getUserLimits } from "@config/app"
 import {
   InsufficientBalanceError,
   LightningPaymentError,
@@ -37,7 +37,7 @@ jest.mock("@services/phone-provider", () => require("test/mocks/phone-provider")
 let userWallet0, userWallet1, userWallet2
 let initBalance0, initBalance1
 const amountInvoice = 1000
-const userLimits = selectUserLimits({ level: 1 })
+const userLimits = getUserLimits({ level: 1 })
 
 beforeAll(async () => {
   userWallet0 = await getUserWallet(0)

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -1,7 +1,7 @@
 import { once } from "events"
 import { sleep } from "@core/utils"
 import { filter, first } from "lodash"
-import { getFeeRates, getUserLimits, yamlConfig } from "@config/app"
+import { getFeeRates, getUserLimits, MS_PER_DAY, yamlConfig } from "@config/app"
 import { Transaction } from "@services/mongoose/schema"
 import { getTitle } from "@core/notifications/payment"
 import { onchainTransactionEventHandler } from "@servers/trigger"
@@ -337,7 +337,7 @@ describe("UserWallet - onChainPay", () => {
       format: "p2wpkh",
     })
 
-    const timestampYesterday = new Date(Date.now() - 24 * 60 * 60 * 1000)
+    const timestampYesterday = new Date(Date.now() - MS_PER_DAY)
     const [result] = await Transaction.aggregate([
       {
         $match: {

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -1,7 +1,7 @@
 import { once } from "events"
 import { sleep } from "@core/utils"
 import { filter, first } from "lodash"
-import { yamlConfig } from "@config/app"
+import { generateFeeConstants, yamlConfig } from "@config/app"
 import { Transaction } from "@services/mongoose/schema"
 import { getTitle } from "@core/notifications/payment"
 import { onchainTransactionEventHandler } from "@servers/trigger"
@@ -115,9 +115,10 @@ describe("UserWallet - onChainPay", () => {
     } = await ledger.getAccountTransactions(userWallet0.accountPath, {
       hash: pendingTxn.hash,
     })
+    const feeConstants = generateFeeConstants()
 
     expect(pending).toBe(false)
-    expect(fee).toBe(yamlConfig.fees.withdraw + 7050)
+    expect(fee).toBe(feeConstants.withdrawFeeFlat + 7050)
     expect(feeUsd).toBeGreaterThan(0)
 
     const [txn] = (await userWallet0.getTransactions()).filter(
@@ -190,9 +191,10 @@ describe("UserWallet - onChainPay", () => {
     } = await ledger.getAccountTransactions(userWallet11.accountPath, {
       hash: pendingTxn.hash,
     })
+    const feeConstants = generateFeeConstants()
 
     expect(pending).toBe(false)
-    expect(fee).toBe(yamlConfig.fees.withdraw + 7050) // 7050?
+    expect(fee).toBe(feeConstants.withdrawFeeFlat + 7050) // 7050?
     expect(feeUsd).toBeGreaterThan(0)
 
     const [txn] = (await userWallet11.getTransactions()).filter(

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -1,7 +1,7 @@
 import { once } from "events"
 import { sleep } from "@core/utils"
 import { filter, first } from "lodash"
-import { getFeeRates, yamlConfig } from "@config/app"
+import { getFeeRates, getUserLimits, yamlConfig } from "@config/app"
 import { Transaction } from "@services/mongoose/schema"
 import { getTitle } from "@core/notifications/payment"
 import { onchainTransactionEventHandler } from "@servers/trigger"
@@ -350,9 +350,8 @@ describe("UserWallet - onChainPay", () => {
     ])
     const { outgoingSats } = result || { outgoingSats: 0 }
 
-    // FIXME: 'withdrawalLimit' no longer exists as of
-    //        https://github.com/GaloyMoney/galoy/commit/2c3433ea42df59272c673bad473c95f524be8d9e#diff-94d4d5bb5c048793536625edb8adffb17e89b5f3821cec6d1c7c337578cda8e4L51
-    const amount = yamlConfig.withdrawalLimit - outgoingSats
+    const userLimits = getUserLimits({ level: userWallet0.user.level })
+    const amount = userLimits.withdrawalLimit - outgoingSats
 
     await expect(userWallet0.onChainPay({ address, amount })).rejects.toThrow()
   })

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -347,6 +347,9 @@ describe("UserWallet - onChainPay", () => {
       { $group: { _id: null, outgoingSats: { $sum: "$debit" } } },
     ])
     const { outgoingSats } = result || { outgoingSats: 0 }
+
+    // FIXME: 'withdrawalLimit' no longer exists as of
+    //        https://github.com/GaloyMoney/galoy/commit/2c3433ea42df59272c673bad473c95f524be8d9e#diff-94d4d5bb5c048793536625edb8adffb17e89b5f3821cec6d1c7c337578cda8e4L51
     const amount = yamlConfig.withdrawalLimit - outgoingSats
 
     await expect(userWallet0.onChainPay({ address, amount })).rejects.toThrow()
@@ -355,7 +358,10 @@ describe("UserWallet - onChainPay", () => {
   it("fails if the amount is less than on chain dust amount", async () => {
     const address = await bitcoindOutside.getNewAddress()
     expect(
-      userWallet0.onChainPay({ address, amount: yamlConfig.onchainDustAmount - 1 }),
+      userWallet0.onChainPay({
+        address,
+        amount: yamlConfig.onChainWallet.dustThreshold - 1,
+      }),
     ).rejects.toThrow()
   })
 })

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -1,7 +1,7 @@
 import { once } from "events"
 import { sleep } from "@core/utils"
 import { filter, first } from "lodash"
-import { generateFeeConstants, yamlConfig } from "@config/app"
+import { getFees, yamlConfig } from "@config/app"
 import { Transaction } from "@services/mongoose/schema"
 import { getTitle } from "@core/notifications/payment"
 import { onchainTransactionEventHandler } from "@servers/trigger"
@@ -115,7 +115,7 @@ describe("UserWallet - onChainPay", () => {
     } = await ledger.getAccountTransactions(userWallet0.accountPath, {
       hash: pendingTxn.hash,
     })
-    const feeConstants = generateFeeConstants()
+    const feeConstants = getFees()
 
     expect(pending).toBe(false)
     expect(fee).toBe(feeConstants.withdrawFeeFlat + 7050)
@@ -191,7 +191,7 @@ describe("UserWallet - onChainPay", () => {
     } = await ledger.getAccountTransactions(userWallet11.accountPath, {
       hash: pendingTxn.hash,
     })
-    const feeConstants = generateFeeConstants()
+    const feeConstants = getFees()
 
     expect(pending).toBe(false)
     expect(fee).toBe(feeConstants.withdrawFeeFlat + 7050) // 7050?

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -1,7 +1,7 @@
 import { once } from "events"
 import { sleep } from "@core/utils"
 import { filter, first } from "lodash"
-import { getFees, yamlConfig } from "@config/app"
+import { getFeeRates, yamlConfig } from "@config/app"
 import { Transaction } from "@services/mongoose/schema"
 import { getTitle } from "@core/notifications/payment"
 import { onchainTransactionEventHandler } from "@servers/trigger"
@@ -115,10 +115,10 @@ describe("UserWallet - onChainPay", () => {
     } = await ledger.getAccountTransactions(userWallet0.accountPath, {
       hash: pendingTxn.hash,
     })
-    const feeConstants = getFees()
+    const feeRates = getFeeRates()
 
     expect(pending).toBe(false)
-    expect(fee).toBe(feeConstants.withdrawFeeFlat + 7050)
+    expect(fee).toBe(feeRates.withdrawFeeFixed + 7050)
     expect(feeUsd).toBeGreaterThan(0)
 
     const [txn] = (await userWallet0.getTransactions()).filter(
@@ -191,10 +191,10 @@ describe("UserWallet - onChainPay", () => {
     } = await ledger.getAccountTransactions(userWallet11.accountPath, {
       hash: pendingTxn.hash,
     })
-    const feeConstants = getFees()
+    const feeRates = getFeeRates()
 
     expect(pending).toBe(false)
-    expect(fee).toBe(feeConstants.withdrawFeeFlat + 7050) // 7050?
+    expect(fee).toBe(feeRates.withdrawFeeFixed + 7050) // 7050?
     expect(feeUsd).toBeGreaterThan(0)
 
     const [txn] = (await userWallet11.getTransactions()).filter(

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -17,6 +17,7 @@ import {
   mineBlockAndSync,
 } from "test/helpers"
 import { ledger } from "@services/mongodb"
+import { TransactionRestrictedError } from "@core/error"
 
 jest.mock("@services/realtime-price", () => require("test/mocks/realtime-price"))
 jest.mock("@services/phone-provider", () => require("test/mocks/phone-provider"))
@@ -351,9 +352,11 @@ describe("UserWallet - onChainPay", () => {
     const { outgoingSats } = result || { outgoingSats: 0 }
 
     const userLimits = getUserLimits({ level: userWallet0.user.level })
-    const amount = userLimits.withdrawalLimit - outgoingSats
+    const amount = userLimits.withdrawalLimit - outgoingSats + 1
 
-    await expect(userWallet0.onChainPay({ address, amount })).rejects.toThrow()
+    await expect(userWallet0.onChainPay({ address, amount })).rejects.toThrow(
+      TransactionRestrictedError,
+    )
   })
 
   it("fails if the amount is less than on chain dust amount", async () => {

--- a/test/integration/services/lnd/utils.spec.ts
+++ b/test/integration/services/lnd/utils.spec.ts
@@ -1,4 +1,5 @@
 import moment from "moment"
+import { MS_PER_DAY } from "@config/app"
 import {
   deleteExpiredInvoiceUser,
   getInvoiceAttempt,
@@ -19,10 +20,6 @@ import {
   subscribeToInvoice,
   waitFor,
 } from "test/helpers"
-import { MS_PER_DAY } from "@config/app"
-
-// milliseconds in a day
-const MS_PER_DAY = 864e5
 
 afterEach(() => {
   jest.restoreAllMocks()

--- a/test/integration/services/lnd/utils.spec.ts
+++ b/test/integration/services/lnd/utils.spec.ts
@@ -19,6 +19,7 @@ import {
   subscribeToInvoice,
   waitFor,
 } from "test/helpers"
+import { MS_PER_DAY } from "@config/app"
 
 // milliseconds in a day
 const MS_PER_DAY = 864e5
@@ -90,7 +91,7 @@ describe("lndUtils", () => {
       }
     })
 
-    const date = Date.now() + 60 * 60 * 1000 * 24 * 2
+    const date = Date.now() + MS_PER_DAY * 2
     jest.spyOn(global.Date, "now").mockImplementation(() => new Date(date).valueOf())
 
     const startDate = new Date(0)

--- a/test/unit/config.spec.ts
+++ b/test/unit/config.spec.ts
@@ -1,0 +1,65 @@
+import {
+  selectUserLimits,
+  selectTransactionLimits,
+  generateLimitConstants,
+} from "@config/app"
+
+const testLimitsConfig = {
+  oldEnoughForWithdrawal: 172800000,
+  withdrawal: {
+    level: {
+      1: 2000000,
+      2: 100000000,
+    },
+  },
+  onUs: {
+    level: {
+      1: 5000000,
+      2: 100000000,
+    },
+  },
+}
+const testLimitConstants = generateLimitConstants(testLimitsConfig)
+
+describe("config.ts", () => {
+  describe("generates expected constants from a limits config object", () => {
+    it("generates expected limitConstants", () => {
+      expect(testLimitConstants.oldEnoughForWithdrawalHours).toEqual(48)
+      expect(testLimitConstants.oldEnoughForWithdrawalMicroseconds).toEqual(172800000)
+    })
+
+    it("selects user limits for level 1", () => {
+      const userLimits = selectUserLimits({ level: 1, limitsConfig: testLimitsConfig })
+      expect(userLimits.onUsLimit).toEqual(5000000)
+      expect(userLimits.withdrawalLimit).toEqual(2000000)
+    })
+
+    it("selects user limits for level 2", () => {
+      const userLimits = selectUserLimits({ level: 2, limitsConfig: testLimitsConfig })
+      expect(userLimits.onUsLimit).toEqual(100000000)
+      expect(userLimits.withdrawalLimit).toEqual(100000000)
+    })
+
+    it("selects transaction limits for level 1", () => {
+      const transactionLimits = selectTransactionLimits({
+        level: 1,
+        limitsConfig: testLimitsConfig,
+      })
+      expect(transactionLimits.oldEnoughForWithdrawalLimit).toEqual(172800000)
+      expect(transactionLimits.oldEnoughForWithdrawalLimitHours).toEqual(48)
+      expect(transactionLimits.onUsLimit).toEqual(5000000)
+      expect(transactionLimits.withdrawalLimit).toEqual(2000000)
+    })
+
+    it("selects transaction limits for level 2", () => {
+      const transactionLimits = selectTransactionLimits({
+        level: 2,
+        limitsConfig: testLimitsConfig,
+      })
+      expect(transactionLimits.oldEnoughForWithdrawalLimit).toEqual(172800000)
+      expect(transactionLimits.oldEnoughForWithdrawalLimitHours).toEqual(48)
+      expect(transactionLimits.onUsLimit).toEqual(100000000)
+      expect(transactionLimits.withdrawalLimit).toEqual(100000000)
+    })
+  })
+})

--- a/test/unit/config.spec.ts
+++ b/test/unit/config.spec.ts
@@ -1,8 +1,4 @@
-import {
-  selectUserLimits,
-  selectTransactionLimits,
-  generateLimitConstants,
-} from "@config/app"
+import { getUserLimits, getTransactionLimits, getLimitConstants } from "@config/app"
 
 const testLimitsConfig = {
   oldEnoughForWithdrawal: 172800000,
@@ -19,7 +15,7 @@ const testLimitsConfig = {
     },
   },
 }
-const testLimitConstants = generateLimitConstants(testLimitsConfig)
+const testLimitConstants = getLimitConstants(testLimitsConfig)
 
 describe("config.ts", () => {
   describe("generates expected constants from a limits config object", () => {
@@ -29,19 +25,19 @@ describe("config.ts", () => {
     })
 
     it("selects user limits for level 1", () => {
-      const userLimits = selectUserLimits({ level: 1, limitsConfig: testLimitsConfig })
+      const userLimits = getUserLimits({ level: 1, limitsConfig: testLimitsConfig })
       expect(userLimits.onUsLimit).toEqual(5000000)
       expect(userLimits.withdrawalLimit).toEqual(2000000)
     })
 
     it("selects user limits for level 2", () => {
-      const userLimits = selectUserLimits({ level: 2, limitsConfig: testLimitsConfig })
+      const userLimits = getUserLimits({ level: 2, limitsConfig: testLimitsConfig })
       expect(userLimits.onUsLimit).toEqual(100000000)
       expect(userLimits.withdrawalLimit).toEqual(100000000)
     })
 
     it("selects transaction limits for level 1", () => {
-      const transactionLimits = selectTransactionLimits({
+      const transactionLimits = getTransactionLimits({
         level: 1,
         limitsConfig: testLimitsConfig,
       })
@@ -52,7 +48,7 @@ describe("config.ts", () => {
     })
 
     it("selects transaction limits for level 2", () => {
-      const transactionLimits = selectTransactionLimits({
+      const transactionLimits = getTransactionLimits({
         level: 2,
         limitsConfig: testLimitsConfig,
       })

--- a/test/unit/config.spec.ts
+++ b/test/unit/config.spec.ts
@@ -1,4 +1,4 @@
-import { getUserLimits, getTransactionLimits, getLimitConstants } from "@config/app"
+import { getUserLimits, getTransactionLimits, getGenericLimits } from "@config/app"
 
 const testLimitsConfig = {
   oldEnoughForWithdrawal: 172800000,
@@ -15,13 +15,13 @@ const testLimitsConfig = {
     },
   },
 }
-const testLimitConstants = getLimitConstants(testLimitsConfig)
+const testGenericLimits = getGenericLimits(testLimitsConfig)
 
 describe("config.ts", () => {
   describe("generates expected constants from a limits config object", () => {
-    it("generates expected limitConstants", () => {
-      expect(testLimitConstants.oldEnoughForWithdrawalHours).toEqual(48)
-      expect(testLimitConstants.oldEnoughForWithdrawalMicroseconds).toEqual(172800000)
+    it("generates expected genericLimits", () => {
+      expect(testGenericLimits.oldEnoughForWithdrawalHours).toEqual(48)
+      expect(testGenericLimits.oldEnoughForWithdrawalMicroseconds).toEqual(172800000)
     })
 
     it("selects user limits for level 1", () => {

--- a/test/unit/config.spec.ts
+++ b/test/unit/config.spec.ts
@@ -41,8 +41,8 @@ describe("config.ts", () => {
         level: 1,
         limitsConfig: testLimitsConfig,
       })
-      expect(transactionLimits.oldEnoughForWithdrawalLimit).toEqual(172800000)
-      expect(transactionLimits.oldEnoughForWithdrawalLimitHours).toEqual(48)
+      expect(transactionLimits.oldEnoughForWithdrawalMicroseconds).toEqual(172800000)
+      expect(transactionLimits.oldEnoughForWithdrawalHours).toEqual(48)
       expect(transactionLimits.onUsLimit).toEqual(5000000)
       expect(transactionLimits.withdrawalLimit).toEqual(2000000)
     })
@@ -52,8 +52,8 @@ describe("config.ts", () => {
         level: 2,
         limitsConfig: testLimitsConfig,
       })
-      expect(transactionLimits.oldEnoughForWithdrawalLimit).toEqual(172800000)
-      expect(transactionLimits.oldEnoughForWithdrawalLimitHours).toEqual(48)
+      expect(transactionLimits.oldEnoughForWithdrawalMicroseconds).toEqual(172800000)
+      expect(transactionLimits.oldEnoughForWithdrawalHours).toEqual(48)
       expect(transactionLimits.onUsLimit).toEqual(100000000)
       expect(transactionLimits.withdrawalLimit).toEqual(100000000)
     })


### PR DESCRIPTION
## Description

This PR refactors the `TransactionLimits` class to instead be a function where the entire limits config is set up on function call instead of on individual method calls. It also splits off a `UserLimits` class to handle _level-specific_ limits. This split was done because there are places in the codebase where properties like `oldEnoughForWithdrawal` from the `TransactionLimits` object are called without needing a `level` value.

These changes are used to remove limits-related `yamlConfig` references from the `schema.ts` & `graphql-core-server.ts` files.

**_Edit 1:_**

_To round off this PR, configs were also created for `yamlConfig.fees` values so the the `yamlConfig` import could be removed entirely from `schema.ts` & `graphql-core-server.ts`._

---
### Open `TODO`s from PR comments:
- [x] ~Rebase to latest tip of `main` after all changes are confirmed to resolve current merge conflicts~ **_[Done](https://github.com/GaloyMoney/galoy/pull/393#issuecomment-891118363)_**
- [x] ~Add time suffix everywhere ([here](https://github.com/GaloyMoney/galoy/pull/393#discussion_r680658651))~ **_Done https://github.com/GaloyMoney/galoy/pull/393/commits/2cb48add8c997ebbff77f711fb0ede1e61374671_**
- [x] ~Add time constant ([here](https://github.com/GaloyMoney/galoy/pull/393#discussion_r680660465))~ **_Done https://github.com/GaloyMoney/galoy/pull/393/commits/be90463873ff2d36b64f55e03c72068638e79d95_**
- [x] ~Add description/type to `toThrow()` to fix integration tests ([see here](https://github.com/GaloyMoney/galoy/pull/393#discussion_r680106515) and fix [here](https://github.com/GaloyMoney/galoy/pull/393#discussion_r680527467))~ **_Done https://github.com/GaloyMoney/galoy/pull/393/commits/4e7ed7d55cf931b2aaa254c963b0fa1c473d04aa_**
- [x] _Remove `Limits` suffix for properties on the `config.limits` object_ (**[open question for reviewers](https://github.com/GaloyMoney/galoy/pull/393#discussion_r681091304)**)
