### PR TITLE
Fix 'tsnd' skipping files by adding explicit --files flag, and use tsconfig-paths for TS paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ start-deps:
 	direnv reload
 
 start: start-deps
-	. ./.envrc && yarn tsnd --respawn src/servers/graphql-main-server.ts | yarn pino-pretty -c -l
+	. ./.envrc && yarn tsnd --respawn --files src/servers/graphql-main-server.ts | yarn pino-pretty -c -l
 
 start-admin: start-deps
-	. ./.envrc && yarn tsnd --respawn src/servers/graphql-admin-server.ts | yarn pino-pretty -c -l
+	. ./.envrc && yarn tsnd --respawn --files src/servers/graphql-admin-server.ts | yarn pino-pretty -c -l
 
 watch:
 	yarn nodemon -V -e ts,graphql -w ./src -x make start

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ start-deps:
 	direnv reload
 
 start: start-deps
-	. ./.envrc && yarn tsnd --respawn --files src/servers/graphql-main-server.ts | yarn pino-pretty -c -l
+	. ./.envrc && yarn tsnd --respawn --files -r tsconfig-paths/register src/servers/graphql-main-server.ts | yarn pino-pretty -c -l
 
 start-admin: start-deps
-	. ./.envrc && yarn tsnd --respawn --files src/servers/graphql-admin-server.ts | yarn pino-pretty -c -l
+	. ./.envrc && yarn tsnd --respawn --files -r tsconfig-paths/register src/servers/graphql-admin-server.ts | yarn pino-pretty -c -l
 
 watch:
 	yarn nodemon -V -e ts,graphql -w ./src -x make start


### PR DESCRIPTION
### Description

**Fixes https://github.com/GaloyMoney/galoy/issues/399**

For more details on the problem and solution see: https://github.com/TypeStrong/ts-node#help-my-types-are-missing

These specific error messages would only pop up if you ran `$ yarn install` locally after we [switched](https://github.com/GaloyMoney/galoy/commit/6df62a4598d35d8a8f6e6b6fde89f7472a9ed514#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L6) from `node` to `ts-node` in the Makefile. It didn't get picked up in tests/checks because we still use `tsc` there I believe.