### PR TITLE
Re-organize cron jobs order

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -169,3 +169,22 @@ export const isIPTypeBlacklisted = ({ type }) =>
   yamlConfig.blacklistedIPTypes?.includes(type)
 
 export const isIPBlacklisted = ({ ip }) => yamlConfig.blacklistedIPs?.includes(ip)
+
+/**
+ * Process an iterator with N workers
+ * @method async
+ * @param  iterator iterator to process
+ * @param  processor async function that process each item
+ * @param  workers  number of workers to use. 5 by default
+ * @return       Promise with all workers
+ */
+export const runInParallel = ({ iterator, processor, workers = 5 }) => {
+  const runWorkerInParallel = async (items, index) => {
+    for await (const item of items) {
+      await processor(item, index)
+    }
+  }
+  // starts N workers sharing the same iterator, i.e. process N items in parallel
+  const jobWorkers = new Array(workers).fill(iterator).map(runWorkerInParallel)
+  return Promise.allSettled(jobWorkers)
+}

--- a/src/servers/cron.ts
+++ b/src/servers/cron.ts
@@ -9,14 +9,17 @@ import {
 import { baseLogger } from "@services/logger"
 import { setupMongoConnection } from "@services/mongodb"
 
-import { updateUsersPendingPayment } from "@core/balance-sheet"
+import {
+  updatePendingLightningTransactions,
+  updateUsersPendingPayment,
+} from "@core/balance-sheet"
 import { SpecterWallet } from "@core/specter-wallet"
 
 const main = async () => {
   const mongoose = await setupMongoConnection()
 
   await updateEscrows()
-  await updateUsersPendingPayment()
+  await updatePendingLightningTransactions()
 
   await deleteExpiredInvoiceUser()
   await deleteFailedPaymentsAllLnds()
@@ -29,6 +32,8 @@ const main = async () => {
   await specterWallet.tentativelyRebalance()
 
   await updateRoutingFees()
+
+  await updateUsersPendingPayment({ onchainOnly: true })
 
   await mongoose.connection.close()
 


### PR DESCRIPTION
- Refactor runInParallel code
- Add workers to onchain receipt
- Reorganize execution to allow to run the other jobs (this is temporal while we push the onchain PR)

```js
await deleteExpiredInvoiceUser()
await deleteFailedPaymentsAllLnds()
await specterWallet.tentativelyRebalance()
await updateRoutingFees()
```
