### PR TITLE
Invoices repo

### DIFF
--- a/src/domain/invoices.types.d.ts
+++ b/src/domain/invoices.types.d.ts
@@ -1,0 +1,17 @@
+type RepositoryErrorType = "RepositoryError"
+type RepositoryError = ErrorWithMessage<RepositoryErrorType>
+
+declare const walletIdSymbol: unique symbol
+type WalletId = string & { [walletIdSymbol]: never }
+
+type WalletInvoice = {
+  paymentHash: PaymentHash
+  walletId: WalletId
+  selfGenerated: boolean
+  pubkey: Pubkey
+  paid: boolean
+}
+
+interface IInvoices {
+  persist: (invoice: WalletInvoice) => ResultAsync<WalletInvoice, RepositoryError>
+}

--- a/src/domain/primitives/crypto.types.d.ts
+++ b/src/domain/primitives/crypto.types.d.ts
@@ -1,0 +1,2 @@
+declare const pubKeySymbol: unique symbol
+type Pubkey = string & { [walletIdSymbol]: never }

--- a/src/services/mongoose/invoices.ts
+++ b/src/services/mongoose/invoices.ts
@@ -1,0 +1,39 @@
+import { fromPromise, ResultAsync } from "neverthrow"
+import { toTypedError } from "@domain/utils"
+import { InvoiceUser } from "./schema"
+
+const toRepositoryError = toTypedError<RepositoryErrorType>({
+  _type: "RepositoryError",
+  unknownMessage: "Unknown RepositoryError",
+})
+
+export const MakeInvoicesRepo = () => {
+  const persist = ({
+    paymentHash,
+    walletId,
+    selfGenerated,
+    pubkey,
+    paid,
+  }: WalletInvoice): ResultAsync<WalletInvoice, RepositoryError> => {
+    return fromPromise(
+      new InvoiceUser({
+        _id: paymentHash,
+        uid: walletId,
+        selfGenerated,
+        pubkey,
+        paid,
+      }).save(),
+      toRepositoryError,
+    ).map((_result) => {
+      return {
+        paymentHash,
+        walletId,
+        selfGenerated,
+        pubkey,
+        paid,
+      } as WalletInvoice
+    })
+  }
+
+  return { persist }
+}

--- a/test/integration/services/mongoose/invoices.spec.ts
+++ b/test/integration/services/mongoose/invoices.spec.ts
@@ -1,0 +1,16 @@
+import { MakeInvoicesRepo } from "@services/mongoose/invoices"
+
+describe("Invoices", () => {
+  it("persits invoices", async () => {
+    const randomPaymentHash = Math.random().toString(36)
+    const repo = MakeInvoicesRepo()
+    const persistResult = await repo.persist({
+      paymentHash: randomPaymentHash as PaymentHash,
+      walletId: "walletId" as WalletId,
+      selfGenerated: false,
+      pubkey: "pubkey" as Pubkey,
+      paid: false,
+    })
+    expect(persistResult.isOk()).toEqual(true)
+  })
+})


### PR DESCRIPTION
This PR builds on top of the [LightningService PR](https://github.com/GaloyMoney/galoy/pull/426) and continues the work of introducing patterns for key domain concepts that should be type safe.

Here the `Repository` pattern is introduced.
The `InvoicesRepo` persists a `WalletInvoice`.