### PR TITLE
Add timeout to github actions integration-test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -9,6 +9,7 @@ jobs:
   integration:
     name: Integration test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2


### PR DESCRIPTION
Saw an integration test running for over an hour and [stopped](https://github.com/jotapea/galoy/actions/runs/1114999219) it manually. This adds an overall timeout for the integration test to avoid wasting pipeline minutes.