### PR TITLE
Safer translation of lnds returned tx objects to SubmittedTransaction

### DIFF
--- a/src/domain/bitcoin/onchain/errors.ts
+++ b/src/domain/bitcoin/onchain/errors.ts
@@ -3,5 +3,7 @@ export class OnChainError extends Error {
 }
 
 export class TransactionDecodeError extends OnChainError {}
-export class UnknownOnChainServiceError extends OnChainError {}
-export class OnChainServiceUnavailableError extends OnChainError {}
+
+export class OnChainServiceError extends OnChainError {}
+export class UnknownOnChainServiceError extends OnChainServiceError {}
+export class OnChainServiceUnavailableError extends OnChainServiceError {}

--- a/src/domain/bitcoin/onchain/index.types.d.ts
+++ b/src/domain/bitcoin/onchain/index.types.d.ts
@@ -24,7 +24,6 @@ type OnChainTransaction = {
 
 type SubmittedTransaction = {
   confirmations: number
-  fee: Satoshis
   id: TxId
   outputAddresses: OnChainAddress[]
   tokens: Satoshis

--- a/src/domain/bitcoin/onchain/index.types.d.ts
+++ b/src/domain/bitcoin/onchain/index.types.d.ts
@@ -25,8 +25,6 @@ type OnChainTransaction = {
 type SubmittedTransaction = {
   confirmations: number
   id: TxId
-  outputAddresses: OnChainAddress[]
-  tokens: Satoshis
   rawTx: OnChainTransaction
   createdAt: Date
 }

--- a/src/domain/bitcoin/onchain/index.types.d.ts
+++ b/src/domain/bitcoin/onchain/index.types.d.ts
@@ -25,6 +25,7 @@ type OnChainTransaction = {
 type SubmittedTransaction = {
   confirmations: number
   rawTx: OnChainTransaction
+  fee: Satoshis
   createdAt: Date
 }
 

--- a/src/domain/bitcoin/onchain/index.types.d.ts
+++ b/src/domain/bitcoin/onchain/index.types.d.ts
@@ -24,7 +24,6 @@ type OnChainTransaction = {
 
 type SubmittedTransaction = {
   confirmations: number
-  id: TxId
   rawTx: OnChainTransaction
   createdAt: Date
 }

--- a/src/domain/bitcoin/onchain/index.types.d.ts
+++ b/src/domain/bitcoin/onchain/index.types.d.ts
@@ -33,7 +33,7 @@ type SubmittedTransaction = {
 }
 
 type TxDecoder = {
-  decode(txHex: string): OnChainTransaction | TransactionDecodeError
+  decode(txHex: string): OnChainTransaction
 }
 
 type TxFilterArgs = {

--- a/src/domain/bitcoin/onchain/index.types.d.ts
+++ b/src/domain/bitcoin/onchain/index.types.d.ts
@@ -44,7 +44,7 @@ type TxFilter = {
 }
 
 interface IOnChainService {
-  getIncomingTransactions({
+  getIncomingTransactions(
     scanDepth: number,
-  }): Promise<SubmittedTransaction[] | OnChainServiceError>
+  ): Promise<SubmittedTransaction[] | OnChainServiceError>
 }

--- a/src/domain/bitcoin/onchain/tx-filter.ts
+++ b/src/domain/bitcoin/onchain/tx-filter.ts
@@ -16,7 +16,7 @@ export const TxFilter = ({
       }
       if (
         !!addresses &&
-        !outs.some((out) => out.address != null && addresses.includes(out.address))
+        !outs.some((out) => out.address !== null && addresses.includes(out.address))
       ) {
         return false
       }

--- a/src/domain/bitcoin/onchain/tx-filter.ts
+++ b/src/domain/bitcoin/onchain/tx-filter.ts
@@ -4,7 +4,7 @@ export const TxFilter = ({
   addresses,
 }: TxFilterArgs): TxFilter => {
   const apply = (txs: SubmittedTransaction[]): SubmittedTransaction[] => {
-    return txs.filter(({ confirmations, outputAddresses }) => {
+    return txs.filter(({ confirmations, rawTx: { outs } }) => {
       if (
         !!confirmationsGreaterThanOrEqual &&
         confirmations < confirmationsGreaterThanOrEqual
@@ -14,7 +14,10 @@ export const TxFilter = ({
       if (!!confirmationsLessThan && confirmations >= confirmationsLessThan) {
         return false
       }
-      if (!!addresses && !outputAddresses.some((addr) => addresses.includes(addr))) {
+      if (
+        !!addresses &&
+        !outs.some((out) => out.address != null && addresses.includes(out.address))
+      ) {
         return false
       }
       return true

--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -9,11 +9,11 @@ const filterPendingIncoming = (
   usdPerSat: UsdPerSat,
 ): WalletTransaction[] => {
   const walletTransactions: WalletTransaction[] = []
-  pendingTransactions.forEach(({ id, rawTx, createdAt }) => {
+  pendingTransactions.forEach(({ rawTx, createdAt }) => {
     rawTx.outs.forEach(({ sats, address }) => {
       if (address && addresses.includes(address)) {
         walletTransactions.push({
-          id,
+          id: rawTx.id,
           initiationVia: PaymentInitiationMethod.OnChain,
           settlementVia: SettlementMethod.OnChain,
           deprecated: {

--- a/src/services/lnd/onchain-service.ts
+++ b/src/services/lnd/onchain-service.ts
@@ -31,7 +31,7 @@ export const OnChainService = (
       })
 
       return transactions
-        .filter((tx) => !tx.is_outgoing || !!tx.transaction || !!tx.fee)
+        .filter((tx) => !tx.is_outgoing && !!tx.transaction && !!tx.fee && tx.fee >= 0)
         .map((tx): SubmittedTransaction => {
           return {
             confirmations: tx.confirmation_count || 0,

--- a/src/services/lnd/onchain-service.ts
+++ b/src/services/lnd/onchain-service.ts
@@ -32,17 +32,18 @@ export const OnChainService = (
 
       return transactions
         .filter((tx) => !tx.is_outgoing || !!tx.transaction)
-        .map((tx): SubmittedTransaction => {
-          return {
-            confirmations: tx.confirmation_count || 0,
-            fee: toSats(tx.fee as number),
-            id: tx.id as TxId,
-            outputAddresses: tx.output_addresses as OnChainAddress[],
-            tokens: toSats(tx.tokens),
-            rawTx: decoder.decode(tx.transaction as string),
-            createdAt: new Date(tx.created_at),
-          }
-        })
+        .map(
+          (tx): SubmittedTransaction => {
+            return {
+              confirmations: tx.confirmation_count || 0,
+              id: tx.id as TxId,
+              outputAddresses: tx.output_addresses as OnChainAddress[],
+              tokens: toSats(tx.tokens),
+              rawTx: decoder.decode(tx.transaction as string),
+              createdAt: new Date(tx.created_at),
+            }
+          },
+        )
     } catch (err) {
       return new UnknownOnChainServiceError(err)
     }

--- a/src/services/lnd/onchain-service.ts
+++ b/src/services/lnd/onchain-service.ts
@@ -36,7 +36,6 @@ export const OnChainService = (
           (tx): SubmittedTransaction => {
             return {
               confirmations: tx.confirmation_count || 0,
-              id: tx.id as TxId,
               rawTx: decoder.decode(tx.transaction as string),
               createdAt: new Date(tx.created_at),
             }

--- a/src/services/lnd/onchain-service.ts
+++ b/src/services/lnd/onchain-service.ts
@@ -17,11 +17,9 @@ export const OnChainService = (
     return new OnChainServiceUnavailableError(err)
   }
 
-  const getIncomingTransactions = async ({
-    scanDepth,
-  }: {
-    scanDepth: number
-  }): Promise<SubmittedTransaction[] | OnChainServiceError> => {
+  const getIncomingTransactions = async (
+    scanDepth: number,
+  ): Promise<SubmittedTransaction[] | OnChainServiceError> => {
     try {
       const { current_block_height } = await getHeight({ lnd })
 

--- a/src/services/lnd/onchain-service.ts
+++ b/src/services/lnd/onchain-service.ts
@@ -31,7 +31,7 @@ export const OnChainService = (
       })
 
       return transactions
-        .filter((tx) => !tx.is_outgoing || !!tx.transaction)
+        .filter((tx) => !tx.is_outgoing || !!tx.transaction || !!tx.fee)
         .map(
           (tx): SubmittedTransaction => {
             return {

--- a/src/services/lnd/onchain-service.ts
+++ b/src/services/lnd/onchain-service.ts
@@ -37,8 +37,6 @@ export const OnChainService = (
             return {
               confirmations: tx.confirmation_count || 0,
               id: tx.id as TxId,
-              outputAddresses: tx.output_addresses as OnChainAddress[],
-              tokens: toSats(tx.tokens),
               rawTx: decoder.decode(tx.transaction as string),
               createdAt: new Date(tx.created_at),
             }

--- a/src/services/lnd/onchain-service.ts
+++ b/src/services/lnd/onchain-service.ts
@@ -32,15 +32,14 @@ export const OnChainService = (
 
       return transactions
         .filter((tx) => !tx.is_outgoing || !!tx.transaction || !!tx.fee)
-        .map(
-          (tx): SubmittedTransaction => {
-            return {
-              confirmations: tx.confirmation_count || 0,
-              rawTx: decoder.decode(tx.transaction as string),
-              createdAt: new Date(tx.created_at),
-            }
-          },
-        )
+        .map((tx): SubmittedTransaction => {
+          return {
+            confirmations: tx.confirmation_count || 0,
+            rawTx: decoder.decode(tx.transaction as string),
+            fee: toSats(tx.fee as number),
+            createdAt: new Date(tx.created_at),
+          }
+        })
     } catch (err) {
       return new UnknownOnChainServiceError(err)
     }

--- a/src/services/lnd/onchain-service.ts
+++ b/src/services/lnd/onchain-service.ts
@@ -28,13 +28,12 @@ export const OnChainService = (
       // this is necessary for tests, otherwise after may be negative
       const after = Math.max(0, current_block_height - scanDepth)
 
-      return extractIncomingTransactions(
-        decoder,
-        await getChainTransactions({
-          lnd,
-          after,
-        }),
-      )
+      const result = await getChainTransactions({
+        lnd,
+        after,
+      })
+
+      return extractIncomingTransactions(decoder, result)
     } catch (err) {
       return new UnknownOnChainServiceError(err)
     }

--- a/test/unit/domain/bitcoin/onchain/tx-filter.spec.ts
+++ b/test/unit/domain/bitcoin/onchain/tx-filter.spec.ts
@@ -7,6 +7,7 @@ describe("TxFilter", () => {
     const filteredTxs = filter.apply([
       {
         confirmations: 0,
+        fee: toSats(1000),
         rawTx: {
           id: "id1" as TxId,
           outs: [
@@ -20,6 +21,7 @@ describe("TxFilter", () => {
       },
       {
         confirmations: 2,
+        fee: toSats(1000),
         rawTx: {
           id: "id2" as TxId,
           outs: [
@@ -41,6 +43,7 @@ describe("TxFilter", () => {
     const filteredTxs = filter.apply([
       {
         confirmations: 2,
+        fee: toSats(1000),
         rawTx: {
           id: "id1" as TxId,
           outs: [
@@ -54,6 +57,7 @@ describe("TxFilter", () => {
       },
       {
         confirmations: 3,
+        fee: toSats(1000),
         rawTx: {
           id: "id2" as TxId,
           outs: [
@@ -75,6 +79,7 @@ describe("TxFilter", () => {
     const filteredTxs = filter.apply([
       {
         confirmations: 2,
+        fee: toSats(1000),
         rawTx: {
           id: "id1" as TxId,
           outs: [
@@ -88,6 +93,7 @@ describe("TxFilter", () => {
       },
       {
         confirmations: 3,
+        fee: toSats(1000),
         rawTx: {
           id: "id2" as TxId,
           outs: [

--- a/test/unit/domain/bitcoin/onchain/tx-filter.spec.ts
+++ b/test/unit/domain/bitcoin/onchain/tx-filter.spec.ts
@@ -7,18 +7,32 @@ describe("TxFilter", () => {
     const filteredTxs = filter.apply([
       {
         confirmations: 0,
-        id: "id" as TxId,
-        outputAddresses: ["address"],
-        tokens: toSats(10000),
+        id: "id1" as TxId,
+        rawTx: {
+          id: "id1" as TxId,
+          outs: [
+            {
+              sats: toSats(1),
+              address: "address1" as OnChainAddress,
+            },
+          ],
+        },
         createdAt: new Date(),
-      } as SubmittedTransaction,
+      },
       {
         confirmations: 2,
-        id: "id" as TxId,
-        outputAddresses: ["address"],
-        tokens: toSats(10000),
+        id: "id2" as TxId,
+        rawTx: {
+          id: "id2" as TxId,
+          outs: [
+            {
+              sats: toSats(1),
+              address: "address2" as OnChainAddress,
+            },
+          ],
+        },
         createdAt: new Date(),
-      } as SubmittedTransaction,
+      },
     ])
 
     expect(filteredTxs.length).toEqual(1)
@@ -29,18 +43,32 @@ describe("TxFilter", () => {
     const filteredTxs = filter.apply([
       {
         confirmations: 2,
-        id: "id" as TxId,
-        outputAddresses: ["address"],
-        tokens: toSats(10000),
+        id: "id1" as TxId,
+        rawTx: {
+          id: "id1" as TxId,
+          outs: [
+            {
+              sats: toSats(1),
+              address: "address1" as OnChainAddress,
+            },
+          ],
+        },
         createdAt: new Date(),
-      } as SubmittedTransaction,
+      },
       {
         confirmations: 3,
-        id: "id" as TxId,
-        outputAddresses: ["address"],
-        tokens: toSats(10000),
+        id: "id2" as TxId,
+        rawTx: {
+          id: "id2" as TxId,
+          outs: [
+            {
+              sats: toSats(1),
+              address: "address2" as OnChainAddress,
+            },
+          ],
+        },
         createdAt: new Date(),
-      } as SubmittedTransaction,
+      },
     ])
 
     expect(filteredTxs[0].confirmations).toEqual(2)
@@ -51,20 +79,34 @@ describe("TxFilter", () => {
     const filteredTxs = filter.apply([
       {
         confirmations: 2,
-        id: "id" as TxId,
-        outputAddresses: ["address1"],
-        tokens: toSats(10000),
+        id: "id1" as TxId,
+        rawTx: {
+          id: "id1" as TxId,
+          outs: [
+            {
+              sats: toSats(1),
+              address: "address1" as OnChainAddress,
+            },
+          ],
+        },
         createdAt: new Date(),
-      } as SubmittedTransaction,
+      },
       {
         confirmations: 3,
-        id: "id" as TxId,
-        outputAddresses: ["address2"],
-        tokens: toSats(10000),
+        id: "id2" as TxId,
+        rawTx: {
+          id: "id2" as TxId,
+          outs: [
+            {
+              sats: toSats(1),
+              address: "address2" as OnChainAddress,
+            },
+          ],
+        },
         createdAt: new Date(),
-      } as SubmittedTransaction,
+      },
     ])
 
-    expect(filteredTxs[0].outputAddresses[0]).toEqual("address1")
+    expect(filteredTxs[0].id).toEqual("id1")
   })
 })

--- a/test/unit/domain/bitcoin/onchain/tx-filter.spec.ts
+++ b/test/unit/domain/bitcoin/onchain/tx-filter.spec.ts
@@ -7,7 +7,6 @@ describe("TxFilter", () => {
     const filteredTxs = filter.apply([
       {
         confirmations: 0,
-        fee: toSats(10),
         id: "id" as TxId,
         outputAddresses: ["address"],
         tokens: toSats(10000),
@@ -15,7 +14,6 @@ describe("TxFilter", () => {
       } as SubmittedTransaction,
       {
         confirmations: 2,
-        fee: toSats(10),
         id: "id" as TxId,
         outputAddresses: ["address"],
         tokens: toSats(10000),
@@ -31,7 +29,6 @@ describe("TxFilter", () => {
     const filteredTxs = filter.apply([
       {
         confirmations: 2,
-        fee: toSats(10),
         id: "id" as TxId,
         outputAddresses: ["address"],
         tokens: toSats(10000),
@@ -39,7 +36,6 @@ describe("TxFilter", () => {
       } as SubmittedTransaction,
       {
         confirmations: 3,
-        fee: toSats(10),
         id: "id" as TxId,
         outputAddresses: ["address"],
         tokens: toSats(10000),
@@ -55,7 +51,6 @@ describe("TxFilter", () => {
     const filteredTxs = filter.apply([
       {
         confirmations: 2,
-        fee: toSats(10),
         id: "id" as TxId,
         outputAddresses: ["address1"],
         tokens: toSats(10000),
@@ -63,7 +58,6 @@ describe("TxFilter", () => {
       } as SubmittedTransaction,
       {
         confirmations: 3,
-        fee: toSats(10),
         id: "id" as TxId,
         outputAddresses: ["address2"],
         tokens: toSats(10000),

--- a/test/unit/domain/bitcoin/onchain/tx-filter.spec.ts
+++ b/test/unit/domain/bitcoin/onchain/tx-filter.spec.ts
@@ -7,7 +7,6 @@ describe("TxFilter", () => {
     const filteredTxs = filter.apply([
       {
         confirmations: 0,
-        id: "id1" as TxId,
         rawTx: {
           id: "id1" as TxId,
           outs: [
@@ -21,7 +20,6 @@ describe("TxFilter", () => {
       },
       {
         confirmations: 2,
-        id: "id2" as TxId,
         rawTx: {
           id: "id2" as TxId,
           outs: [
@@ -43,7 +41,6 @@ describe("TxFilter", () => {
     const filteredTxs = filter.apply([
       {
         confirmations: 2,
-        id: "id1" as TxId,
         rawTx: {
           id: "id1" as TxId,
           outs: [
@@ -57,7 +54,6 @@ describe("TxFilter", () => {
       },
       {
         confirmations: 3,
-        id: "id2" as TxId,
         rawTx: {
           id: "id2" as TxId,
           outs: [
@@ -79,7 +75,6 @@ describe("TxFilter", () => {
     const filteredTxs = filter.apply([
       {
         confirmations: 2,
-        id: "id1" as TxId,
         rawTx: {
           id: "id1" as TxId,
           outs: [
@@ -93,7 +88,6 @@ describe("TxFilter", () => {
       },
       {
         confirmations: 3,
-        id: "id2" as TxId,
         rawTx: {
           id: "id2" as TxId,
           outs: [
@@ -107,6 +101,6 @@ describe("TxFilter", () => {
       },
     ])
 
-    expect(filteredTxs[0].id).toEqual("id1")
+    expect(filteredTxs[0].rawTx.id).toEqual("id1")
   })
 })

--- a/test/unit/domain/wallets/tx-history.spec.ts
+++ b/test/unit/domain/wallets/tx-history.spec.ts
@@ -198,6 +198,7 @@ describe("ConfirmedTransactionHistory.addPendingIncoming", () => {
     const submittedTransactions: SubmittedTransaction[] = [
       {
         confirmations: 1,
+        fee: toSats(1000),
         rawTx: {
           id: "id" as TxId,
           outs: [
@@ -264,6 +265,7 @@ describe("ConfirmedTransactionHistory.addPendingIncoming", () => {
     const submittedTransactions: SubmittedTransaction[] = [
       {
         confirmations: 1,
+        fee: toSats(1000),
         rawTx: {
           id: "id" as TxId,
           outs: [

--- a/test/unit/domain/wallets/tx-history.spec.ts
+++ b/test/unit/domain/wallets/tx-history.spec.ts
@@ -199,8 +199,6 @@ describe("ConfirmedTransactionHistory.addPendingIncoming", () => {
       {
         confirmations: 1,
         id: "id" as TxId,
-        outputAddresses: ["userAddress1", "userAddress2", "address3"] as OnChainAddress[],
-        tokens: toSats(100000),
         rawTx: {
           id: "id" as TxId,
           outs: [
@@ -268,8 +266,6 @@ describe("ConfirmedTransactionHistory.addPendingIncoming", () => {
       {
         confirmations: 1,
         id: "id" as TxId,
-        outputAddresses: ["userAddress1"] as OnChainAddress[],
-        tokens: toSats(100000),
         rawTx: {
           id: "id" as TxId,
           outs: [

--- a/test/unit/domain/wallets/tx-history.spec.ts
+++ b/test/unit/domain/wallets/tx-history.spec.ts
@@ -198,7 +198,6 @@ describe("ConfirmedTransactionHistory.addPendingIncoming", () => {
     const submittedTransactions: SubmittedTransaction[] = [
       {
         confirmations: 1,
-        id: "id" as TxId,
         rawTx: {
           id: "id" as TxId,
           outs: [
@@ -265,7 +264,6 @@ describe("ConfirmedTransactionHistory.addPendingIncoming", () => {
     const submittedTransactions: SubmittedTransaction[] = [
       {
         confirmations: 1,
-        id: "id" as TxId,
         rawTx: {
           id: "id" as TxId,
           outs: [

--- a/test/unit/domain/wallets/tx-history.spec.ts
+++ b/test/unit/domain/wallets/tx-history.spec.ts
@@ -198,7 +198,6 @@ describe("ConfirmedTransactionHistory.addPendingIncoming", () => {
     const submittedTransactions: SubmittedTransaction[] = [
       {
         confirmations: 1,
-        fee: toSats(1000),
         id: "id" as TxId,
         outputAddresses: ["userAddress1", "userAddress2", "address3"] as OnChainAddress[],
         tokens: toSats(100000),
@@ -268,7 +267,6 @@ describe("ConfirmedTransactionHistory.addPendingIncoming", () => {
     const submittedTransactions: SubmittedTransaction[] = [
       {
         confirmations: 1,
-        fee: toSats(1000),
         id: "id" as TxId,
         outputAddresses: ["userAddress1"] as OnChainAddress[],
         tokens: toSats(100000),

--- a/test/unit/services/lnd/onchain-service.spec.ts
+++ b/test/unit/services/lnd/onchain-service.spec.ts
@@ -1,0 +1,79 @@
+import { toSats } from "@domain/bitcoin"
+import { TxDecoder } from "@domain/bitcoin/onchain"
+import { extractIncomingTransactions } from "@services/lnd/onchain-service"
+
+jest.mock("@config/app.ts", () => {
+  const config = jest.requireActual("@config/app.ts")
+  config.yamlConfig.lnds = []
+  return config
+})
+
+describe("extractIncomingTransactions", () => {
+  const validTxHex =
+    "0100000001bcc1db7faba3226e49bf4b78c70433a5afa0b0c88b2f546d0eee07b40bdf70bc010000006a4730440220378952a9acd4fc40dfafba799be975f545793cc679a01c0d552dbb3e4c29556402205b50a6c5b9a541de3cde7519cbb5a8ebfa1bc49488be1ccf898f888ee5105691012102195646c22ab419c14599106960cc8587266cc0ad2189861c44c5eb3dfa771d3cffffffff0260b10a00000000001976a9145ace538e7c29931c5645e233d327af544dfcfa2f88ac1ef6ee19000000001976a9147452552d6ca38bbfc20f3d95dd3dbb4849a33f7d88ac00000000"
+  const created_at = "2000-01-01T00:00:00.000Z"
+  const decoder = TxDecoder("mainnet" as BtcNetwork)
+  it("only returns incoming transactions", () => {
+    const txs = extractIncomingTransactions(decoder, {
+      transactions: [
+        {
+          id: "outgoing",
+          is_outgoing: true,
+          transaction: validTxHex,
+          fee: toSats(1),
+          created_at,
+          is_confirmed: false,
+          output_addresses: ["address1"],
+          tokens: toSats(1000),
+        },
+        {
+          id: "incoming",
+          is_outgoing: false,
+          transaction: validTxHex,
+          fee: toSats(10),
+          created_at,
+          is_confirmed: false,
+          output_addresses: ["address1"],
+          tokens: toSats(1000),
+        },
+      ],
+    })
+    expect(txs.length).toEqual(1)
+    expect(txs[0].fee).toEqual(toSats(10))
+  })
+
+  it("filters txs with no valid hex", () => {
+    const txs = extractIncomingTransactions(decoder, {
+      transactions: [
+        {
+          id: "incoming",
+          is_outgoing: false,
+          fee: toSats(1),
+          created_at,
+          is_confirmed: false,
+          output_addresses: ["address1"],
+          tokens: toSats(1000),
+        },
+      ],
+    })
+    expect(txs.length).toEqual(0)
+  })
+
+  it("it defaults fee to 0 (only has fee set on outgoing tx)", () => {
+    const txs = extractIncomingTransactions(decoder, {
+      transactions: [
+        {
+          id: "incoming",
+          is_outgoing: false,
+          transaction: validTxHex,
+          created_at,
+          is_confirmed: false,
+          output_addresses: ["address1"],
+          tokens: toSats(1000),
+        },
+      ],
+    })
+    expect(txs.length).toEqual(1)
+    expect(txs[0].fee).toEqual(toSats(0))
+  })
+})


### PR DESCRIPTION
The `createdAt` field was not being set correctly due to usage of casting.

This has triggered me to:
- remove all unused fields of SubmittedTransaction
- add unit tests around the conversion