### PR TITLE
Switch username to walletname in new code

### DIFF
--- a/src/app/wallets/add-invoice-for-wallet.ts
+++ b/src/app/wallets/add-invoice-for-wallet.ts
@@ -1,7 +1,7 @@
 import { checkedToSats, toSats } from "@domain/bitcoin"
 import { invoiceExpirationForCurrency } from "@domain/bitcoin/lightning"
 import { WalletInvoiceFactory } from "@domain/wallet-invoices/wallet-invoice-factory"
-import { checkedToWalletname } from "@domain/wallets"
+import { checkedToWalletName } from "@domain/wallets"
 import { LndService } from "@services/lnd"
 import { WalletInvoicesRepository, WalletsRepository } from "@services/mongoose"
 
@@ -38,12 +38,12 @@ export const addInvoiceForRecipient = async ({
   amount,
   memo = "",
 }: AddInvoiceForRecipientArgs): Promise<LnInvoice | ApplicationError> => {
-  const walletname = checkedToWalletname(recipient)
-  if (walletname instanceof Error) return walletname
+  const walletName = checkedToWalletName(recipient)
+  if (walletName instanceof Error) return walletName
   const sats = checkedToSats(amount)
   if (sats instanceof Error) return sats
 
-  const walletId = await walletIdFromWalletname(walletname)
+  const walletId = await walletIdFromWalletName(walletName)
   if (walletId instanceof Error) return walletId
 
   const walletInvoiceFactory = WalletInvoiceFactory(walletId)
@@ -58,10 +58,10 @@ export const addInvoiceNoAmountForRecipient = async ({
   recipient,
   memo = "",
 }: AddInvoiceNoAmountForRecipientArgs): Promise<LnInvoice | ApplicationError> => {
-  const walletname = checkedToWalletname(recipient)
-  if (walletname instanceof Error) return walletname
+  const walletName = checkedToWalletName(recipient)
+  if (walletName instanceof Error) return walletName
 
-  const walletId = await walletIdFromWalletname(walletname)
+  const walletId = await walletIdFromWalletName(walletName)
   if (walletId instanceof Error) return walletId
 
   const walletInvoiceFactory = WalletInvoiceFactory(walletId)
@@ -102,11 +102,11 @@ const registerAndPersistInvoice = async ({
   return invoice
 }
 
-const walletIdFromWalletname = async (
-  walletname: Walletname,
+const walletIdFromWalletName = async (
+  walletName: WalletName,
 ): Promise<WalletId | RepositoryError> => {
   const walletsRepo = WalletsRepository()
-  const wallet = await walletsRepo.findByWalletname(walletname)
+  const wallet = await walletsRepo.findByWalletName(walletName)
   if (wallet instanceof Error) return wallet
 
   return wallet.id

--- a/src/app/wallets/index.types.d.ts
+++ b/src/app/wallets/index.types.d.ts
@@ -10,12 +10,12 @@ type AddInvoiceNoAmountArgs = {
 }
 
 type AddInvoiceForRecipientArgs = {
-  recipient: Walletname
+  recipient: WalletName
   amount: number
   memo?: string
 }
 
 type AddInvoiceNoAmountForRecipientArgs = {
-  recipient: Walletname
+  recipient: WalletName
   memo?: string
 }

--- a/src/app/wallets/index.types.d.ts
+++ b/src/app/wallets/index.types.d.ts
@@ -10,12 +10,12 @@ type AddInvoiceNoAmountArgs = {
 }
 
 type AddInvoiceForRecipientArgs = {
-  recipient: Username
+  recipient: Walletname
   amount: number
   memo?: string
 }
 
 type AddInvoiceNoAmountForRecipientArgs = {
-  recipient: Username
+  recipient: Walletname
   memo?: string
 }

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -12,3 +12,4 @@ export class CouldNotFindError extends DomainError {}
 export class ValidationError extends DomainError {}
 export class InvalidSatoshiAmount extends ValidationError {}
 export class InvalidUsername extends ValidationError {}
+export class InvalidWalletname extends ValidationError {}

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -11,4 +11,4 @@ export class CouldNotFindError extends DomainError {}
 
 export class ValidationError extends DomainError {}
 export class InvalidSatoshiAmount extends ValidationError {}
-export class InvalidWalletname extends ValidationError {}
+export class InvalidWalletName extends ValidationError {}

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -11,5 +11,4 @@ export class CouldNotFindError extends DomainError {}
 
 export class ValidationError extends DomainError {}
 export class InvalidSatoshiAmount extends ValidationError {}
-export class InvalidUsername extends ValidationError {}
 export class InvalidWalletname extends ValidationError {}

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -29,7 +29,7 @@ type LedgerTransaction = {
   readonly feeUsd: number
 
   // for IntraLedger
-  readonly walletname?: Walletname
+  readonly walletName?: WalletName
   readonly memoFromPayer?: string
 
   // for ln

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -29,7 +29,7 @@ type LedgerTransaction = {
   readonly feeUsd: number
 
   // for IntraLedger
-  readonly username?: Username
+  readonly username?: Walletname
   readonly memoFromPayer?: string
 
   // for ln

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -29,7 +29,7 @@ type LedgerTransaction = {
   readonly feeUsd: number
 
   // for IntraLedger
-  readonly username?: Walletname
+  readonly walletname?: Walletname
   readonly memoFromPayer?: string
 
   // for ln

--- a/src/domain/primitives/index.types.d.ts
+++ b/src/domain/primitives/index.types.d.ts
@@ -13,8 +13,8 @@ type Pubkey = string & { [pubkeySymbol]: never }
 declare const walletIdSymbol: unique symbol
 type WalletId = string & { [walletIdSymbol]: never }
 
-declare const walletnameSymbol: unique symbol
-type Walletname = string & { [walletnameSymbol]: never }
+declare const walletNameSymbol: unique symbol
+type WalletName = string & { [walletNameSymbol]: never }
 
 declare const accountIdSymbol: unique symbol
 type AccountId = string & { [accountIdSymbol]: never }

--- a/src/domain/primitives/index.types.d.ts
+++ b/src/domain/primitives/index.types.d.ts
@@ -13,6 +13,9 @@ type Pubkey = string & { [pubkeySymbol]: never }
 declare const walletIdSymbol: unique symbol
 type WalletId = string & { [walletIdSymbol]: never }
 
+declare const walletnameSymbol: unique symbol
+type Walletname = string & { [walletnameSymbol]: never }
+
 declare const accountIdSymbol: unique symbol
 type AccountId = string & { [accountIdSymbol]: never }
 

--- a/src/domain/users/index.ts
+++ b/src/domain/users/index.ts
@@ -1,15 +1,4 @@
-import { InvalidUsername } from "@domain/errors"
-
 export const UserLanguage = {
   EN_US: "en",
   ES_SV: "es",
 } as const
-
-export const UsernameRegex = /(?!^(1|3|bc1|lnbc1))^[0-9a-z_]+$/i
-
-export const checkedToUsername = (username): Username | ValidationError => {
-  if (!username.match(UsernameRegex)) {
-    return new InvalidUsername(username)
-  }
-  return username as Username
-}

--- a/src/domain/users/index.types.d.ts
+++ b/src/domain/users/index.types.d.ts
@@ -19,5 +19,4 @@ type User = {
 
 interface IUsersRepository {
   findById(userId: UserId): Promise<User | RepositoryError>
-  findByUsername(username: Username): Promise<User | RepositoryError>
 }

--- a/src/domain/wallets/index.ts
+++ b/src/domain/wallets/index.ts
@@ -1,2 +1,13 @@
+import { InvalidWalletname } from "@domain/errors"
+
 export { WalletTransactionHistory } from "./tx-history"
 export * from "./tx-methods"
+
+export const WalletnameRegex = /(?!^(1|3|bc1|lnbc1))^[0-9a-z_]+$/i
+
+export const checkedToWalletname = (walletname): Walletname | ValidationError => {
+  if (!walletname.match(WalletnameRegex)) {
+    return new InvalidWalletname(walletname)
+  }
+  return walletname as Walletname
+}

--- a/src/domain/wallets/index.ts
+++ b/src/domain/wallets/index.ts
@@ -1,13 +1,13 @@
-import { InvalidWalletname } from "@domain/errors"
+import { InvalidWalletName } from "@domain/errors"
 
 export { WalletTransactionHistory } from "./tx-history"
 export * from "./tx-methods"
 
-export const WalletnameRegex = /(?!^(1|3|bc1|lnbc1))^[0-9a-z_]+$/i
+export const WalletNameRegex = /(?!^(1|3|bc1|lnbc1))^[0-9a-z_]+$/i
 
-export const checkedToWalletname = (walletname): Walletname | ValidationError => {
-  if (!walletname.match(WalletnameRegex)) {
-    return new InvalidWalletname(walletname)
+export const checkedToWalletName = (walletName): WalletName | ValidationError => {
+  if (!walletName.match(WalletNameRegex)) {
+    return new InvalidWalletName(walletName)
   }
-  return walletname as Walletname
+  return walletName as WalletName
 }

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -72,7 +72,7 @@ type DepositFeeRatio = number & { [depositFeeRatioSymbol]: never }
 type Wallet = {
   readonly id: WalletId
   readonly depositFeeRatio: DepositFeeRatio
-  readonly walletname: Walletname
+  readonly walletname: Walletname | null
   readonly onChainAddressIdentifiers: OnChainAddressIdentifier[]
   onChainAddresses(): OnChainAddress[]
 }

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -26,20 +26,20 @@ type BaseWalletTransaction = {
 type UsernameTransaction = BaseWalletTransaction & {
   readonly initiationVia: "username"
   readonly settlementVia: "intraledger"
-  readonly recipientId: Username
+  readonly recipientId: Walletname
 }
 
 type WalletOnChainTransaction = BaseWalletTransaction & {
   readonly initiationVia: "onchain"
   readonly settlementVia: "onchain" | "intraledger"
-  readonly recipientId: Username | null
+  readonly recipientId: Walletname | null
   readonly addresses: OnChainAddress[]
 }
 
 type WalletLnTransaction = BaseWalletTransaction & {
   readonly initiationVia: "lightning"
   readonly settlementVia: "lightning" | "intraledger"
-  readonly recipientId: Username | null
+  readonly recipientId: Walletname | null
   readonly paymentHash: PaymentHash
 }
 

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -26,20 +26,20 @@ type BaseWalletTransaction = {
 type UsernameTransaction = BaseWalletTransaction & {
   readonly initiationVia: "username"
   readonly settlementVia: "intraledger"
-  readonly recipientId: Walletname
+  readonly recipientId: WalletName
 }
 
 type WalletOnChainTransaction = BaseWalletTransaction & {
   readonly initiationVia: "onchain"
   readonly settlementVia: "onchain" | "intraledger"
-  readonly recipientId: Walletname | null
+  readonly recipientId: WalletName | null
   readonly addresses: OnChainAddress[]
 }
 
 type WalletLnTransaction = BaseWalletTransaction & {
   readonly initiationVia: "lightning"
   readonly settlementVia: "lightning" | "intraledger"
-  readonly recipientId: Walletname | null
+  readonly recipientId: WalletName | null
   readonly paymentHash: PaymentHash
 }
 
@@ -72,12 +72,12 @@ type DepositFeeRatio = number & { [depositFeeRatioSymbol]: never }
 type Wallet = {
   readonly id: WalletId
   readonly depositFeeRatio: DepositFeeRatio
-  readonly walletname: Walletname | null
+  readonly walletName: WalletName | null
   readonly onChainAddressIdentifiers: OnChainAddressIdentifier[]
   onChainAddresses(): OnChainAddress[]
 }
 
 interface IWalletsRepository {
   findById(walletId: WalletId): Promise<Wallet | RepositoryError>
-  findByWalletname(walletname: Walletname): Promise<Wallet | RepositoryError>
+  findByWalletName(walletName: WalletName): Promise<Wallet | RepositoryError>
 }

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -72,10 +72,12 @@ type DepositFeeRatio = number & { [depositFeeRatioSymbol]: never }
 type Wallet = {
   readonly id: WalletId
   readonly depositFeeRatio: DepositFeeRatio
+  readonly walletname: Walletname
   readonly onChainAddressIdentifiers: OnChainAddressIdentifier[]
   onChainAddresses(): OnChainAddress[]
 }
 
 interface IWalletsRepository {
   findById(walletId: WalletId): Promise<Wallet | RepositoryError>
+  findByWalletname(walletname: Walletname): Promise<Wallet | RepositoryError>
 }

--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -50,7 +50,7 @@ export const fromLedger = (
       usd,
       feeUsd,
       paymentHash,
-      username,
+      walletname,
       addresses,
       pendingConfirmation,
       timestamp,
@@ -61,7 +61,7 @@ export const fromLedger = (
         memoFromPayer,
         lnMemo,
         credit,
-        username,
+        walletname,
       })
       if (addresses && addresses.length > 0) {
         return {
@@ -78,7 +78,7 @@ export const fromLedger = (
             feeUsd,
             type,
           },
-          recipientId: username || null,
+          recipientId: walletname || null,
           settlementAmount,
           settlementFee: toSats(fee || 0),
           pendingConfirmation,
@@ -102,7 +102,7 @@ export const fromLedger = (
           settlementAmount,
           settlementFee: toSats(fee || 0),
           paymentHash: paymentHash as PaymentHash,
-          recipientId: username || null,
+          recipientId: walletname || null,
           pendingConfirmation,
           createdAt: timestamp,
         }
@@ -119,7 +119,7 @@ export const fromLedger = (
         },
         settlementAmount,
         settlementFee: toSats(fee || 0),
-        recipientId: username || null,
+        recipientId: walletname || null,
         pendingConfirmation,
         createdAt: timestamp,
       } as UsernameTransaction
@@ -147,13 +147,13 @@ const shouldDisplayMemo = (credit: number) => {
 export const translateDescription = ({
   memoFromPayer,
   lnMemo,
-  username,
+  walletname,
   type,
   credit,
 }: {
   memoFromPayer?: string
   lnMemo?: string
-  username?: string
+  walletname?: string
   type: LedgerTransactionType
   credit: number
 }): string => {
@@ -166,15 +166,15 @@ export const translateDescription = ({
     }
   }
 
-  let usernameDescription
-  if (username) {
-    usernameDescription = `to ${username}`
+  let walletnameDescription
+  if (walletname) {
+    walletnameDescription = `to ${walletname}`
     if (credit > 0) {
-      usernameDescription = `from ${username}`
+      walletnameDescription = `from ${walletname}`
     }
   }
 
-  return usernameDescription || type
+  return walletnameDescription || type
 }
 
 export const WalletTransactionHistory = {

--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -50,7 +50,7 @@ export const fromLedger = (
       usd,
       feeUsd,
       paymentHash,
-      walletname,
+      walletName,
       addresses,
       pendingConfirmation,
       timestamp,
@@ -61,7 +61,7 @@ export const fromLedger = (
         memoFromPayer,
         lnMemo,
         credit,
-        walletname,
+        walletName,
       })
       if (addresses && addresses.length > 0) {
         return {
@@ -78,7 +78,7 @@ export const fromLedger = (
             feeUsd,
             type,
           },
-          recipientId: walletname || null,
+          recipientId: walletName || null,
           settlementAmount,
           settlementFee: toSats(fee || 0),
           pendingConfirmation,
@@ -102,14 +102,14 @@ export const fromLedger = (
           settlementAmount,
           settlementFee: toSats(fee || 0),
           paymentHash: paymentHash as PaymentHash,
-          recipientId: walletname || null,
+          recipientId: walletName || null,
           pendingConfirmation,
           createdAt: timestamp,
         }
       }
       return {
         id,
-        initiationVia: PaymentInitiationMethod.Walletname,
+        initiationVia: PaymentInitiationMethod.WalletName,
         settlementVia: SettlementMethod.IntraLedger,
         deprecated: {
           description,
@@ -119,7 +119,7 @@ export const fromLedger = (
         },
         settlementAmount,
         settlementFee: toSats(fee || 0),
-        recipientId: walletname || null,
+        recipientId: walletName || null,
         pendingConfirmation,
         createdAt: timestamp,
       } as UsernameTransaction
@@ -147,13 +147,13 @@ const shouldDisplayMemo = (credit: number) => {
 export const translateDescription = ({
   memoFromPayer,
   lnMemo,
-  walletname,
+  walletName,
   type,
   credit,
 }: {
   memoFromPayer?: string
   lnMemo?: string
-  walletname?: string
+  walletName?: string
   type: LedgerTransactionType
   credit: number
 }): string => {
@@ -166,15 +166,15 @@ export const translateDescription = ({
     }
   }
 
-  let walletnameDescription
-  if (walletname) {
-    walletnameDescription = `to ${walletname}`
+  let walletNameDescription
+  if (walletName) {
+    walletNameDescription = `to ${walletName}`
     if (credit > 0) {
-      walletnameDescription = `from ${walletname}`
+      walletNameDescription = `from ${walletName}`
     }
   }
 
-  return walletnameDescription || type
+  return walletNameDescription || type
 }
 
 export const WalletTransactionHistory = {

--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -109,7 +109,7 @@ export const fromLedger = (
       }
       return {
         id,
-        initiationVia: PaymentInitiationMethod.Username,
+        initiationVia: PaymentInitiationMethod.Walletname,
         settlementVia: SettlementMethod.IntraLedger,
         deprecated: {
           description,

--- a/src/domain/wallets/tx-methods.ts
+++ b/src/domain/wallets/tx-methods.ts
@@ -5,7 +5,7 @@ export const SettlementMethod = {
 } as const
 
 export const PaymentInitiationMethod = {
-  Username: "username",
+  Walletname: "username",
   OnChain: "onchain",
   Lightning: "lightning",
 } as const

--- a/src/domain/wallets/tx-methods.ts
+++ b/src/domain/wallets/tx-methods.ts
@@ -5,7 +5,7 @@ export const SettlementMethod = {
 } as const
 
 export const PaymentInitiationMethod = {
-  Walletname: "username",
+  WalletName: "username",
   OnChain: "onchain",
   Lightning: "lightning",
 } as const

--- a/src/services/ledger/index.ts
+++ b/src/services/ledger/index.ts
@@ -52,7 +52,7 @@ export const LedgerService = (): ILedgerService => {
           timestamp: tx.timestamp,
           pendingConfirmation: tx.pending,
           lnMemo: tx.memo,
-          username: tx.username,
+          walletname: tx.username,
           memoFromPayer: tx.memoPayer,
           paymentHash: tx.hash,
           addresses: tx.payee_addresses,

--- a/src/services/ledger/index.ts
+++ b/src/services/ledger/index.ts
@@ -52,7 +52,7 @@ export const LedgerService = (): ILedgerService => {
           timestamp: tx.timestamp,
           pendingConfirmation: tx.pending,
           lnMemo: tx.memo,
-          walletname: tx.username,
+          walletName: tx.username,
           memoFromPayer: tx.memoPayer,
           paymentHash: tx.hash,
           addresses: tx.payee_addresses,

--- a/src/services/mongoose/schema.ts
+++ b/src/services/mongoose/schema.ts
@@ -15,7 +15,7 @@ import { accountPath } from "@services/ledger/accounts"
 import { Transaction } from "@services/ledger/schema"
 import { baseLogger } from "../logger"
 import { caseInsensitiveRegex } from "./users"
-import { UsernameRegex } from "@domain/users"
+import { WalletnameRegex } from "@domain/wallets"
 
 export { Transaction }
 
@@ -164,7 +164,7 @@ const UserSchema = new Schema<UserType>({
 
   username: {
     type: String,
-    match: [UsernameRegex, "Username can only have alphabets, numbers and underscores"],
+    match: [WalletnameRegex, "Username can only have alphabets, numbers and underscores"],
     minlength: 3,
     maxlength: 50,
     index: {
@@ -413,7 +413,7 @@ UserSchema.statics.getUserByPhone = async function (phone: string) {
 }
 
 UserSchema.statics.getUserByUsername = async function (username: string) {
-  if (!username.match(UsernameRegex)) {
+  if (!username.match(WalletnameRegex)) {
     return null
   }
 

--- a/src/services/mongoose/schema.ts
+++ b/src/services/mongoose/schema.ts
@@ -15,7 +15,7 @@ import { accountPath } from "@services/ledger/accounts"
 import { Transaction } from "@services/ledger/schema"
 import { baseLogger } from "../logger"
 import { caseInsensitiveRegex } from "./users"
-import { WalletnameRegex } from "@domain/wallets"
+import { WalletNameRegex } from "@domain/wallets"
 
 export { Transaction }
 
@@ -164,7 +164,7 @@ const UserSchema = new Schema<UserType>({
 
   username: {
     type: String,
-    match: [WalletnameRegex, "Username can only have alphabets, numbers and underscores"],
+    match: [WalletNameRegex, "Username can only have alphabets, numbers and underscores"],
     minlength: 3,
     maxlength: 50,
     index: {
@@ -413,7 +413,7 @@ UserSchema.statics.getUserByPhone = async function (phone: string) {
 }
 
 UserSchema.statics.getUserByUsername = async function (username: string) {
-  if (!username.match(WalletnameRegex)) {
+  if (!username.match(WalletNameRegex)) {
     return null
   }
 

--- a/src/services/mongoose/users.ts
+++ b/src/services/mongoose/users.ts
@@ -32,29 +32,7 @@ export const UsersRepository = (): IUsersRepository => {
     }
   }
 
-  const findByUsername = async (username: Username): Promise<User | RepositoryError> => {
-    try {
-      const result = await User.findOne({ username: caseInsensitiveRegex(username) })
-      if (!result) {
-        return new CouldNotFindError()
-      }
-
-      return {
-        id: result.id as UserId,
-        username,
-        phone: result.phone as PhoneNumber,
-        language: result.language || UserLanguage.EN_US,
-        defaultAccountId: result.id as AccountId,
-        deviceToken: result.deviceToken || [],
-        createdAt: result.created_at,
-      }
-    } catch (err) {
-      return new UnknownRepositoryError(err)
-    }
-  }
-
   return {
     findById,
-    findByUsername,
   }
 }

--- a/src/services/mongoose/wallets.ts
+++ b/src/services/mongoose/wallets.ts
@@ -43,9 +43,7 @@ export const WalletsRepository = (): IWalletsRepository => {
 const resultToWallet = (result: UserType): Wallet => {
   const walletId = result.id as WalletId
 
-  const walletname: Walletname = result.username
-    ? (result.username as Walletname)
-    : ("" as Walletname)
+  const walletname = result.username ? (result.username as Walletname) : null
 
   const depositFeeRatio = result.depositFeeRatio as DepositFeeRatio
 

--- a/src/services/mongoose/wallets.ts
+++ b/src/services/mongoose/wallets.ts
@@ -4,6 +4,7 @@ import {
   RepositoryError,
 } from "@domain/errors"
 import { User } from "@services/mongoose/schema"
+import { caseInsensitiveRegex } from "./users"
 
 export const WalletsRepository = (): IWalletsRepository => {
   const findById = async (walletId: WalletId): Promise<Wallet | RepositoryError> => {
@@ -12,21 +13,22 @@ export const WalletsRepository = (): IWalletsRepository => {
       if (!result) {
         return new CouldNotFindError()
       }
-      const onChainAddressIdentifiers = result.onchain.map(({ pubkey, address }) => {
-        return {
-          pubkey: pubkey as Pubkey,
-          address: address as OnChainAddress,
-        }
-      })
-      const onChainAddresses = () =>
-        onChainAddressIdentifiers.map(({ address }) => address)
+      return resultToWallet(result)
+    } catch (err) {
+      return new UnknownRepositoryError(err)
+    }
+  }
 
-      return {
-        id: walletId,
-        depositFeeRatio: result.depositFeeRatio,
-        onChainAddresses,
-        onChainAddressIdentifiers,
+  const findByWalletname = async (
+    username: Walletname,
+  ): Promise<Wallet | RepositoryError> => {
+    try {
+      const result = await User.findOne({ username: caseInsensitiveRegex(username) })
+      if (!result) {
+        return new CouldNotFindError()
       }
+
+      return resultToWallet(result)
     } catch (err) {
       return new UnknownRepositoryError(err)
     }
@@ -34,5 +36,34 @@ export const WalletsRepository = (): IWalletsRepository => {
 
   return {
     findById,
+    findByWalletname,
+  }
+}
+
+const resultToWallet = (result: UserType): Wallet => {
+  const walletId = result.id as WalletId
+
+  const walletname: Walletname = result.username
+    ? (result.username as Walletname)
+    : ("" as Walletname)
+
+  const depositFeeRatio = result.depositFeeRatio as DepositFeeRatio
+
+  const onChainAddressIdentifiers = result.onchain
+    ? result.onchain.map(({ pubkey, address }) => {
+        return {
+          pubkey: pubkey as Pubkey,
+          address: address as OnChainAddress,
+        }
+      })
+    : []
+  const onChainAddresses = () => onChainAddressIdentifiers.map(({ address }) => address)
+
+  return {
+    id: walletId,
+    depositFeeRatio,
+    walletname,
+    onChainAddressIdentifiers,
+    onChainAddresses,
   }
 }

--- a/src/services/mongoose/wallets.ts
+++ b/src/services/mongoose/wallets.ts
@@ -19,8 +19,8 @@ export const WalletsRepository = (): IWalletsRepository => {
     }
   }
 
-  const findByWalletname = async (
-    username: Walletname,
+  const findByWalletName = async (
+    username: WalletName,
   ): Promise<Wallet | RepositoryError> => {
     try {
       const result = await User.findOne({ username: caseInsensitiveRegex(username) })
@@ -36,14 +36,14 @@ export const WalletsRepository = (): IWalletsRepository => {
 
   return {
     findById,
-    findByWalletname,
+    findByWalletName,
   }
 }
 
 const resultToWallet = (result: UserType): Wallet => {
   const walletId = result.id as WalletId
 
-  const walletname = result.username ? (result.username as Walletname) : null
+  const walletName = result.username ? (result.username as WalletName) : null
 
   const depositFeeRatio = result.depositFeeRatio as DepositFeeRatio
 
@@ -60,7 +60,7 @@ const resultToWallet = (result: UserType): Wallet => {
   return {
     id: walletId,
     depositFeeRatio,
-    walletname,
+    walletName,
     onChainAddressIdentifiers,
     onChainAddresses,
   }

--- a/test/integration/02-user-wallet/02-invoice.spec.ts
+++ b/test/integration/02-user-wallet/02-invoice.spec.ts
@@ -44,7 +44,7 @@ describe("UserWallet - addInvoice", () => {
 
   it("adds a public invoice", async () => {
     const lnInvoice = await addInvoiceNoAmountForRecipient({
-      recipient: "user1" as Username,
+      recipient: "user1" as Walletname,
     })
     if (lnInvoice instanceof Error) return lnInvoice
     const { paymentRequest: request } = lnInvoice

--- a/test/integration/02-user-wallet/02-invoice.spec.ts
+++ b/test/integration/02-user-wallet/02-invoice.spec.ts
@@ -44,7 +44,7 @@ describe("UserWallet - addInvoice", () => {
 
   it("adds a public invoice", async () => {
     const lnInvoice = await addInvoiceNoAmountForRecipient({
-      recipient: "user1" as Walletname,
+      recipient: "user1" as WalletName,
     })
     if (lnInvoice instanceof Error) return lnInvoice
     const { paymentRequest: request } = lnInvoice

--- a/test/unit/domain/wallets/checked-to-username.spec.ts
+++ b/test/unit/domain/wallets/checked-to-username.spec.ts
@@ -1,35 +1,35 @@
-import { checkedToWalletname } from "@domain/wallets"
+import { checkedToWalletName } from "@domain/wallets"
 
 describe("username-check", () => {
   it("Passes alphanumeric username", () => {
-    const username = checkedToWalletname("alice_12")
+    const username = checkedToWalletName("alice_12")
     expect(username).toEqual("alice_12")
   })
 
   it("Fails legacy address", () => {
-    const username = checkedToWalletname("1LKvxGL8ejTsgBjRVUNCGi7adiwaVnM9cn")
+    const username = checkedToWalletName("1LKvxGL8ejTsgBjRVUNCGi7adiwaVnM9cn")
     expect(username).toBeInstanceOf(Error)
   })
 
   it("Fails wrapped segwit address", () => {
-    const username = checkedToWalletname("32ksNi7zSt3t2aesvoEWhGMUEwCFg9UCCG")
+    const username = checkedToWalletName("32ksNi7zSt3t2aesvoEWhGMUEwCFg9UCCG")
     expect(username).toBeInstanceOf(Error)
   })
 
   it("Fails segwit address", () => {
-    const username = checkedToWalletname("bc1qpl8ehyzu44yhwu92w892uxwxdfp9dhu3d0zj2g")
+    const username = checkedToWalletName("bc1qpl8ehyzu44yhwu92w892uxwxdfp9dhu3d0zj2g")
     expect(username).toBeInstanceOf(Error)
   })
 
   it("Fails lightning payment request", () => {
-    const username = checkedToWalletname(
+    const username = checkedToWalletName(
       "lnbc1500n1ps36h3rpp5qtgvy47pu6n3t2ggf47vahl3kdjql0d68egtaschvd34atvu5eysdpa2fjkzep6ypyx7aeqw3hjqct4w3hk6ct5d93kzmrv0ys82uryv96x2greda6hycqzpgxqr23ssp5makumjtdy54vz80ayytgld7420uuw5m6pdtq5x2n38gg7z5gd9ms9qyyssq64faagqrfa6qp45jsx8enwgs62fquqfejxk0gmtuf67z7v7d9364c5tw679cd635nmllfwzur348whvrgnf94sx6w40n6ttwa4x8grcqa0ms0d",
     )
     expect(username).toBeInstanceOf(Error)
   })
 
   it("Fails non-underscore special characters", () => {
-    const username = checkedToWalletname("alice-12")
+    const username = checkedToWalletName("alice-12")
     expect(username).toBeInstanceOf(Error)
   })
 })

--- a/test/unit/domain/wallets/checked-to-username.spec.ts
+++ b/test/unit/domain/wallets/checked-to-username.spec.ts
@@ -1,35 +1,35 @@
-import { checkedToUsername } from "@domain/users"
+import { checkedToWalletname } from "@domain/wallets"
 
 describe("username-check", () => {
   it("Passes alphanumeric username", () => {
-    const username = checkedToUsername("alice_12")
+    const username = checkedToWalletname("alice_12")
     expect(username).toEqual("alice_12")
   })
 
   it("Fails legacy address", () => {
-    const username = checkedToUsername("1LKvxGL8ejTsgBjRVUNCGi7adiwaVnM9cn")
+    const username = checkedToWalletname("1LKvxGL8ejTsgBjRVUNCGi7adiwaVnM9cn")
     expect(username).toBeInstanceOf(Error)
   })
 
   it("Fails wrapped segwit address", () => {
-    const username = checkedToUsername("32ksNi7zSt3t2aesvoEWhGMUEwCFg9UCCG")
+    const username = checkedToWalletname("32ksNi7zSt3t2aesvoEWhGMUEwCFg9UCCG")
     expect(username).toBeInstanceOf(Error)
   })
 
   it("Fails segwit address", () => {
-    const username = checkedToUsername("bc1qpl8ehyzu44yhwu92w892uxwxdfp9dhu3d0zj2g")
+    const username = checkedToWalletname("bc1qpl8ehyzu44yhwu92w892uxwxdfp9dhu3d0zj2g")
     expect(username).toBeInstanceOf(Error)
   })
 
   it("Fails lightning payment request", () => {
-    const username = checkedToUsername(
+    const username = checkedToWalletname(
       "lnbc1500n1ps36h3rpp5qtgvy47pu6n3t2ggf47vahl3kdjql0d68egtaschvd34atvu5eysdpa2fjkzep6ypyx7aeqw3hjqct4w3hk6ct5d93kzmrv0ys82uryv96x2greda6hycqzpgxqr23ssp5makumjtdy54vz80ayytgld7420uuw5m6pdtq5x2n38gg7z5gd9ms9qyyssq64faagqrfa6qp45jsx8enwgs62fquqfejxk0gmtuf67z7v7d9364c5tw679cd635nmllfwzur348whvrgnf94sx6w40n6ttwa4x8grcqa0ms0d",
     )
     expect(username).toBeInstanceOf(Error)
   })
 
   it("Fails non-underscore special characters", () => {
-    const username = checkedToUsername("alice-12")
+    const username = checkedToWalletname("alice-12")
     expect(username).toBeInstanceOf(Error)
   })
 })

--- a/test/unit/domain/wallets/tx-history.spec.ts
+++ b/test/unit/domain/wallets/tx-history.spec.ts
@@ -32,7 +32,7 @@ describe("WalletTransactionHistory.fromLedger", () => {
         id: "id" as LedgerTransactionId,
         type: LedgerTransactionType.IntraLedger,
         paymentHash: "paymentHash" as PaymentHash,
-        username: "username" as Walletname,
+        walletname: "walletname" as Walletname,
         debit: toSats(0),
         fee: toSats(0),
         credit: toSats(100000),
@@ -93,12 +93,12 @@ describe("WalletTransactionHistory.fromLedger", () => {
         id: "id" as LedgerTransactionId,
         initiationVia: PaymentInitiationMethod.Lightning,
         settlementVia: SettlementMethod.IntraLedger,
-        recipientId: "username",
+        recipientId: "walletname",
         settlementAmount: toSats(100000),
         settlementFee: toSats(0),
         paymentHash: "paymentHash" as PaymentHash,
         deprecated: {
-          description: "from username",
+          description: "from walletname",
           usd: 10,
           feeUsd: 0.1,
           type: LedgerTransactionType.IntraLedger,
@@ -164,13 +164,13 @@ describe("translateDescription", () => {
     expect(result).toEqual("some memo")
   })
 
-  it("returns username description for any amount", () => {
+  it("returns walletname description for any amount", () => {
     const result = translateDescription({
-      username: "username",
+      walletname: "walletname",
       credit: MEMO_SHARING_SATS_THRESHOLD - 1,
       type: "invoice",
     })
-    expect(result).toEqual("from username")
+    expect(result).toEqual("from walletname")
   })
 
   it("defaults to type under spam threshdeprecated", () => {

--- a/test/unit/domain/wallets/tx-history.spec.ts
+++ b/test/unit/domain/wallets/tx-history.spec.ts
@@ -32,7 +32,7 @@ describe("WalletTransactionHistory.fromLedger", () => {
         id: "id" as LedgerTransactionId,
         type: LedgerTransactionType.IntraLedger,
         paymentHash: "paymentHash" as PaymentHash,
-        username: "username" as Username,
+        username: "username" as Walletname,
         debit: toSats(0),
         fee: toSats(0),
         credit: toSats(100000),

--- a/test/unit/domain/wallets/tx-history.spec.ts
+++ b/test/unit/domain/wallets/tx-history.spec.ts
@@ -32,7 +32,7 @@ describe("WalletTransactionHistory.fromLedger", () => {
         id: "id" as LedgerTransactionId,
         type: LedgerTransactionType.IntraLedger,
         paymentHash: "paymentHash" as PaymentHash,
-        walletname: "walletname" as Walletname,
+        walletName: "walletName" as WalletName,
         debit: toSats(0),
         fee: toSats(0),
         credit: toSats(100000),
@@ -93,12 +93,12 @@ describe("WalletTransactionHistory.fromLedger", () => {
         id: "id" as LedgerTransactionId,
         initiationVia: PaymentInitiationMethod.Lightning,
         settlementVia: SettlementMethod.IntraLedger,
-        recipientId: "walletname",
+        recipientId: "walletName",
         settlementAmount: toSats(100000),
         settlementFee: toSats(0),
         paymentHash: "paymentHash" as PaymentHash,
         deprecated: {
-          description: "from walletname",
+          description: "from walletName",
           usd: 10,
           feeUsd: 0.1,
           type: LedgerTransactionType.IntraLedger,
@@ -164,13 +164,13 @@ describe("translateDescription", () => {
     expect(result).toEqual("some memo")
   })
 
-  it("returns walletname description for any amount", () => {
+  it("returns walletName description for any amount", () => {
     const result = translateDescription({
-      walletname: "walletname",
+      walletName: "walletName",
       credit: MEMO_SHARING_SATS_THRESHOLD - 1,
       type: "invoice",
     })
-    expect(result).toEqual("from walletname")
+    expect(result).toEqual("from walletName")
   })
 
   it("defaults to type under spam threshdeprecated", () => {


### PR DESCRIPTION
## Description

We will be moving the naming reference from the user level to the wallet level. This PR is to switch all references of `username` to `walletname` in the new code, but to leave the old code intact for now so that now functionality changes or migrations are needed.

_**Note:** I didnt remove the `Username` type and `username` property our `User` type because that one goes all the way through to the new graphql schema._