### PR TITLE
Fix error response in fee probe mutations

### DIFF
--- a/src/graphql/root/mutation/ln-invoice-fee-probe.ts
+++ b/src/graphql/root/mutation/ln-invoice-fee-probe.ts
@@ -23,7 +23,7 @@ const LnInvoiceFeeProbeMutation = GT.Field({
     }
 
     try {
-      const feeSatAmount = wallet.getLightningFee({
+      const feeSatAmount = await wallet.getLightningFee({
         invoice: paymentRequest,
       })
       // TODO: validate feeSatAmount

--- a/src/graphql/root/mutation/ln-noamount-invoice-fee-probe.ts
+++ b/src/graphql/root/mutation/ln-noamount-invoice-fee-probe.ts
@@ -27,7 +27,7 @@ const LnNoAmountInvoiceFeeProbeMutation = GT.Field({
     }
 
     try {
-      const feeSatAmount = wallet.getLightningFee({
+      const feeSatAmount = await wallet.getLightningFee({
         amount,
         invoice: paymentRequest,
       })


### PR DESCRIPTION
without `await` fee probe methods return an invalid error response: 
```json
{
  "errors": [
    {
      "message": "Invoice contains non-zero amount, but amount was also passed separately",
      "code": "INVALID_INPUT"
    }
  ],
  "data": {
    "lnNoAmountInvoiceFeeProbe": {
      "errors": [],
      "amount": null
    }
  }
}
```