### PR TITLE
Pass domain user in context

### DIFF
--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -149,7 +149,8 @@ export const getSpecterWalletConfig = (): SpecterWalletConfig => {
 export const PROXY_CHECK_APIKEY = yamlConfig?.PROXY_CHECK_APIKEY
 
 export const getIpConfig = (config = yamlConfig): IpConfig => ({
-  ipRecordingEnabled: config.ipRecording?.enabled,
+  ipRecordingEnabled:
+    process.env.NODE_ENV === "test" ? false : config.ipRecording?.enabled,
   proxyCheckingEnabled: config.ipRecording?.proxyChecking?.enabled,
   blacklistedIPTypes: config.blacklistedIPTypes ? config.blacklistedIPTypes : [],
   blacklistedIPs: config.blacklistedIPs ? config.blacklistedIPs : [],

--- a/src/domain/ipfetcher/errors.ts
+++ b/src/domain/ipfetcher/errors.ts
@@ -1,0 +1,6 @@
+export class IpFetcherError extends Error {
+  name = this.constructor.name
+}
+
+export class IpFetcherServiceError extends IpFetcherError {}
+export class UnknownIpFetcherServiceError extends IpFetcherError {}

--- a/src/domain/ipfetcher/index.ts
+++ b/src/domain/ipfetcher/index.ts
@@ -1,0 +1,1 @@
+export * from "./errors"

--- a/src/domain/ipfetcher/index.types.d.ts
+++ b/src/domain/ipfetcher/index.types.d.ts
@@ -1,0 +1,14 @@
+type IpFetcherServiceError = import("./errors").IpFetcherServiceError
+
+type IPInfo = {
+  provider: string
+  country: string
+  region: string
+  city: string
+  type: string
+  status: string
+}
+
+interface IIpFetcherService {
+  fetchIPInfo(ip: string): Promise<IPInfo | IpFetcherServiceError>
+}

--- a/src/domain/primitives/index.types.d.ts
+++ b/src/domain/primitives/index.types.d.ts
@@ -4,9 +4,6 @@ type UsdPerSat = number & { [usdPerSatSymbol]: never }
 declare const userIdSymbol: unique symbol
 type UserId = string & { [userIdSymbol]: never }
 
-declare const usernameSymbol: unique symbol
-type Username = string & { [usernameSymbol]: never }
-
 declare const pubkeySymbol: unique symbol
 type Pubkey = string & { [pubkeySymbol]: never }
 

--- a/src/domain/users/index.types.d.ts
+++ b/src/domain/users/index.types.d.ts
@@ -5,7 +5,7 @@ type UserLanguage =
   typeof import("./index").UserLanguage[keyof typeof import("./index").UserLanguage]
 
 declare const deviceTokenSymbol: unique symbol
-type DeviceToken = number & { [deviceTokenSymbol]: never }
+type DeviceToken = string & { [deviceTokenSymbol]: never }
 
 declare const contactAliasSymbol: unique symbol
 type ContactAlias = string & { [contactAliasSymbol]: never }
@@ -38,7 +38,6 @@ type User = {
   quizQuestions: UserQuizQuestion[]
   defaultAccountId: AccountId
   deviceTokens: DeviceToken[]
-  createdAt: Date
 }
 
 interface IUsersRepository {

--- a/src/domain/users/index.types.d.ts
+++ b/src/domain/users/index.types.d.ts
@@ -14,30 +14,31 @@ declare const quizQuestionIdSymbol: unique symbol
 type QuizQuestionId = string & { [quizQuestionIdSymbol]: never }
 
 type WalletContact = {
-  walletName: WalletName
+  readonly walletName: WalletName
   alias: ContactAlias
   transactionsCount: number
 }
 
 type QuizQuestion = {
-  id: QuizQuestionId
-  earnAmount: Satoshis
+  readonly id: QuizQuestionId
+  readonly earnAmount: Satoshis
 }
 
 type UserQuizQuestion = {
-  question: QuizQuestion
+  readonly question: QuizQuestion
   completed: boolean
 }
 
 type User = {
-  id: UserId
-  username: Username | null
+  readonly id: UserId
+  readonly contacts: WalletContact[]
+  readonly quizQuestions: UserQuizQuestion[]
+  readonly defaultAccountId: AccountId
+  readonly deviceTokens: DeviceToken[]
+  readonly lastIPs: IPType[]
   phone: PhoneNumber
   language: UserLanguage
-  contacts: WalletContact[]
-  quizQuestions: UserQuizQuestion[]
-  defaultAccountId: AccountId
-  deviceTokens: DeviceToken[]
+  lastConnection: Date
 }
 
 interface IUsersRepository {

--- a/src/services/ipfetcher/index.ts
+++ b/src/services/ipfetcher/index.ts
@@ -1,0 +1,19 @@
+import axios from "axios"
+import { UnknownIpFetcherServiceError } from "@domain/ipfetcher"
+import { PROXY_CHECK_APIKEY } from "@config/app"
+
+export const IpFetcher = (): IIpFetcherService => {
+  const fetchIPInfo = async (ip: string): Promise<IPInfo | IpFetcherServiceError> => {
+    try {
+      const { data } = await axios.get(
+        `http://proxycheck.io/v2/${ip}?key=${PROXY_CHECK_APIKEY}&vpn=1&asn=1`,
+      )
+      return { ...data[ip], status: data.status }
+    } catch (err) {
+      return new UnknownIpFetcherServiceError(err)
+    }
+  }
+  return {
+    fetchIPInfo,
+  }
+}

--- a/src/services/mongoose/schema.types.d.ts
+++ b/src/services/mongoose/schema.types.d.ts
@@ -58,8 +58,8 @@ interface UserType {
   earn?: string[]
   deviceToken?: string[]
   excludeCashback?: boolean
-  contacts: ConcatObjectForUser
-  created_at?: string
+  contacts: ConcatObjectForUser[]
+  created_at: string
   currencies: CurrenceyObjectForUser[]
   lastIPs?: IPType[]
   onchain?: OnChainObjectForUser[]

--- a/src/services/mongoose/schema.types.d.ts
+++ b/src/services/mongoose/schema.types.d.ts
@@ -5,8 +5,8 @@ type IPType = {
   region: string
   city: string
   Type: string
-  firstConnection: string
-  lastConnection: string
+  firstConnection: Date
+  lastConnection: Date
 }
 
 type TwoFA = {
@@ -63,7 +63,7 @@ interface UserType {
   currencies: CurrenceyObjectForUser[]
   lastIPs?: IPType[]
   onchain?: OnChainObjectForUser[]
-  lastConnection?: string
+  lastConnection: Date
   twoFA: TwoFA
 
   // business:


### PR DESCRIPTION
Currently our new use cases always need to first load the user in order to update it.
This PR exposes the `domainUser` in the GQL context so subsequent operations can access it directly.
Accessing the `domainUser` out of scope of this PR.