### PR TITLE
PaymentStatusChecker must check ledger

### DIFF
--- a/src/app/lightning/payment-status-checker.ts
+++ b/src/app/lightning/payment-status-checker.ts
@@ -1,6 +1,6 @@
 import { RepositoryError } from "@domain/errors"
 import { decodeInvoice } from "@domain/bitcoin/lightning"
-import { WalletInvoicesRepository } from "@services/mongoose"
+import { LedgerService } from "@services/ledger"
 
 export const PaymentStatusChecker = ({ paymentRequest }) => {
   const decodedInvoice = decodeInvoice(paymentRequest)
@@ -11,10 +11,10 @@ export const PaymentStatusChecker = ({ paymentRequest }) => {
 
   return {
     invoiceIsPaid: async (): Promise<boolean | RepositoryError> => {
-      const repo = WalletInvoicesRepository()
-      const walletInvoice = await repo.findByPaymentHash(paymentHash)
-      if (walletInvoice instanceof RepositoryError) return walletInvoice
-      return walletInvoice.paid
+      const ledger = LedgerService()
+      const recorded = await ledger.isLnTxRecorded(paymentHash)
+      if (recorded instanceof RepositoryError) return recorded
+      return recorded
     },
   }
 }

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -102,6 +102,8 @@ interface ILedgerService {
     txId: TxId,
   ): Promise<boolean | LedgerServiceError>
 
+  isLnTxRecorded(paymentHash: PaymentHash): Promise<boolean | LedgerServiceError>
+
   receiveOnChainTx(args: ReceiveOnChainTxArgs): Promise<void | LedgerServiceError>
 
   receiveLnTx(args: ReceiveLnTxArgs): Promise<void | LedgerServiceError>

--- a/src/services/ledger/index.ts
+++ b/src/services/ledger/index.ts
@@ -95,14 +95,16 @@ export const LedgerService = (): ILedgerService => {
     paymentHash: PaymentHash,
   ): Promise<boolean | LedgerServiceError> => {
     try {
-      const result = await Transaction.countDocuments({
+      const { total } = await MainBook.ledger({
+        pending: false,
         hash: paymentHash,
       })
-      return result > 0
+      return total > 0
     } catch (err) {
       return new UnknownLedgerError(err)
     }
   }
+
   const receiveOnChainTx = async ({
     liabilitiesAccountId,
     txId,

--- a/src/services/ledger/index.ts
+++ b/src/services/ledger/index.ts
@@ -90,6 +90,19 @@ export const LedgerService = (): ILedgerService => {
       return new UnknownLedgerError(err)
     }
   }
+
+  const isLnTxRecorded = async (
+    paymentHash: PaymentHash,
+  ): Promise<boolean | LedgerServiceError> => {
+    try {
+      const result = await Transaction.countDocuments({
+        hash: paymentHash,
+      })
+      return result > 0
+    } catch (err) {
+      return new UnknownLedgerError(err)
+    }
+  }
   const receiveOnChainTx = async ({
     liabilitiesAccountId,
     txId,
@@ -225,6 +238,7 @@ export const LedgerService = (): ILedgerService => {
     listPendingPayments,
     getPendingPaymentsCount,
     isOnChainTxRecorded,
+    isLnTxRecorded,
     receiveOnChainTx,
     receiveLnTx,
     receiveLnFeeReimbursement,


### PR DESCRIPTION
fixes https://github.com/GaloyMoney/galoy/issues/503

`PaymentStatusChecker` was checking `WalletInvoice` but this is not the point of reference to see if something has been paid or not. It is the ledger!