### PR TITLE
Increase no output timeout for install helm charts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,7 @@ jobs:
             kubectl create namespace $NAMESPACE
       - run:
           name: install helm charts
+          no_output_timeout: 20m
           command: ./scripts/init-local-test.sh
       - run:
           name: Run jest test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
             kubectl create namespace $NAMESPACE
       - run:
           name: install helm charts
-          no_output_timeout: 20m
+          no_output_timeout: 35m
           command: ./scripts/init-local-test.sh
       - run:
           name: Run jest test

--- a/scripts/init-local-test.sh
+++ b/scripts/init-local-test.sh
@@ -156,8 +156,8 @@ then
   kubectlLndDeletionWait
   helmUpgrade rtl -f $INFRADIR/configs/rtl/$NETWORK.yaml galoy/rtl
 else
-  helmUpgrade lnd-outside-1 --version=$lndVersion -f $INFRADIR/configs/lnd/$NETWORK.yaml $localdevpathOutside galoy/lnd & \
-  helmUpgrade lnd-outside-2 --version=$lndVersion -f $INFRADIR/configs/lnd/$NETWORK.yaml $localdevpathOutside galoy/lnd
+  helmUpgrade lnd-outside-1 --version=$lndVersion -f $INFRADIR/configs/lnd/$NETWORK.yaml $localdevpathOutside $INFRADIR/lnd & \
+  helmUpgrade lnd-outside-2 --version=$lndVersion -f $INFRADIR/configs/lnd/$NETWORK.yaml $localdevpathOutside $INFRADIR/lnd
 fi
 
 # # add extra sleep time... seems lnd is quite long to show up some time

--- a/scripts/init-local-test.sh
+++ b/scripts/init-local-test.sh
@@ -89,7 +89,7 @@ helmUpgradeDebug () {
 kubectlWait () {
   echo "waiting for -n=$NAMESPACE -l $@"
   sleep 6
-  kubectl wait -n=$NAMESPACE --for=condition=Ready --timeout=300s pod -l "$@"
+  kubectl wait -n=$NAMESPACE --for=condition=ready --timeout=1800s pod -l "$@"
 }
 
 kubectlLndDeletionWait () {
@@ -118,6 +118,7 @@ set -e
 helmUpgrade bitcoind $localdevpath -f $INFRADIR/configs/bitcoind/$NETWORK.yaml galoy/bitcoind --version=$bitcoindVersion
 helmUpgrade specter $localdevpath -f $INFRADIR/configs/specter/$NETWORK.yaml galoy/specter
 
+helm history -n=$NAMESPACE "bitcoind"
 # bug with --wait: https://github.com/helm/helm/issues/7139 ?
 kubectlWait app.kubernetes.io/name=bitcoind
 

--- a/scripts/init-local-test.sh
+++ b/scripts/init-local-test.sh
@@ -89,7 +89,7 @@ helmUpgradeDebug () {
 kubectlWait () {
   echo "waiting for -n=$NAMESPACE -l $@"
   sleep 6
-  kubectl wait -n=$NAMESPACE --for=condition=ready --timeout=1200s pod -l "$@"
+  kubectl wait -n=$NAMESPACE --for=condition=Ready --timeout=300s pod -l "$@"
 }
 
 kubectlLndDeletionWait () {


### PR DESCRIPTION
- kubectlWait has a timeout of 20 mins but circle ci default no output timeout is 10 mins