### PR TITLE
Fix ip array validation

### DIFF
--- a/src/app/users/index.ts
+++ b/src/app/users/index.ts
@@ -54,13 +54,13 @@ export const getUserForLogin = async ({
 
   // IP tracking logic could be extracted into domain
   const ipConfig = getIpConfig()
-  if (ipConfig.ipRecordingEnabled) {
+  if (ip && ipConfig.ipRecordingEnabled) {
     const lastIP: IPType | undefined = user.lastIPs.find(
       (ipObject: IPType) => ipObject.ip === ip,
     )
     if (lastIP) {
       lastIP.lastConnection = user.lastConnection
-    } else if (ip && ipConfig.proxyCheckingEnabled) {
+    } else if (ipConfig.proxyCheckingEnabled) {
       const ipFetcher = IpFetcher()
       const ipInfo = await ipFetcher.fetchIPInfo(ip as IpAddress)
       if (!(ipInfo instanceof Error)) {

--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -51,14 +51,13 @@ export const startApolloServer = async ({
       const token = context.req?.token ?? null
       const uid = token?.uid ?? null
       const ips = context.req?.headers["x-real-ip"]
-      let ip: string | undefined
-      if (ips && ips.length) {
+      let ip: string | undefined = ips as string | undefined
+
+      if (ips && Array.isArray(ips) && ips.length) {
         ip = ips[0]
-      } else {
-        ip = ips as string | undefined
       }
 
-      if (isIPBlacklisted({ ip })) {
+      if (ip && isIPBlacklisted({ ip })) {
         throw new IPBlacklistedError("IP Blacklisted", { logger: graphqlLogger, ip })
       }
 


### PR DESCRIPTION
- this validation `ips && ips.length` is also true for strings (so we were assigning the first number as ip)
-  before deploy to prod, please do a `requestPhoneCode` query, search for `RequestPhoneCode called` in the log and check the ip param