### PR TITLE
Add new 'get balances' use case

### DIFF
--- a/src/app/wallets/get-balance-for-wallet.ts
+++ b/src/app/wallets/get-balance-for-wallet.ts
@@ -11,17 +11,19 @@ export const getBalanceForWallet = async ({
   lock?: DistributedLock
   logger: Logger
 }): Promise<Satoshis | ApplicationError> => {
-  Wallets.updatePendingInvoices({
-    walletId: walletId,
-    lock,
-    logger,
-  })
-  const result = await Wallets.updatePendingPayments({
-    walletId: walletId,
-    lock,
-    logger,
-  })
-  if (result instanceof Error) throw result
+  const [, updatePaymentsResult] = await Promise.all([
+    Wallets.updatePendingInvoices({
+      walletId: walletId,
+      lock,
+      logger,
+    }),
+    Wallets.updatePendingPayments({
+      walletId: walletId,
+      lock,
+      logger,
+    }),
+  ])
+  if (updatePaymentsResult instanceof Error) throw updatePaymentsResult
 
   const liabilitiesAccountId = toLiabilitiesAccountId(walletId)
   const balance = await LedgerService().getAccountBalance(liabilitiesAccountId)

--- a/src/app/wallets/get-balance-for-wallet.ts
+++ b/src/app/wallets/get-balance-for-wallet.ts
@@ -1,0 +1,31 @@
+import { toLiabilitiesAccountId } from "@domain/ledger"
+import { LedgerService } from "@services/ledger"
+import * as Wallets from "@app/wallets"
+
+export const getBalanceForWallet = async ({
+  walletId,
+  lock,
+  logger,
+}: {
+  walletId: WalletId
+  lock?: DistributedLock
+  logger: Logger
+}): Promise<Balances | ApplicationError> => {
+  Wallets.updatePendingInvoices({
+    walletId: walletId,
+    lock,
+    logger,
+  })
+  const result = await Wallets.updatePendingPayments({
+    walletId: walletId,
+    lock,
+    logger,
+  })
+  if (result instanceof Error) throw result
+
+  const liabilitiesAccountId = toLiabilitiesAccountId(walletId)
+  const balance = await LedgerService().getAccountBalance(liabilitiesAccountId)
+  if (balance instanceof Error) return balance
+
+  return { BTC: balance, totalInBtc: balance }
+}

--- a/src/app/wallets/get-balance-for-wallet.ts
+++ b/src/app/wallets/get-balance-for-wallet.ts
@@ -10,7 +10,7 @@ export const getBalanceForWallet = async ({
   walletId: WalletId
   lock?: DistributedLock
   logger: Logger
-}): Promise<Balances | ApplicationError> => {
+}): Promise<Satoshis | ApplicationError> => {
   Wallets.updatePendingInvoices({
     walletId: walletId,
     lock,
@@ -27,5 +27,5 @@ export const getBalanceForWallet = async ({
   const balance = await LedgerService().getAccountBalance(liabilitiesAccountId)
   if (balance instanceof Error) return balance
 
-  return { BTC: balance, totalInBtc: balance }
+  return balance
 }

--- a/src/app/wallets/index.ts
+++ b/src/app/wallets/index.ts
@@ -1,4 +1,5 @@
 export * from "./create-on-chain-address"
+export * from "./get-balance-for-wallet"
 export * from "./get-transactions-for-wallet"
 export * from "./get-last-on-chain-address"
 export * from "./update-on-chain-receipt"

--- a/src/core/lightning/index.ts
+++ b/src/core/lightning/index.ts
@@ -221,7 +221,11 @@ export const LightningMixin = (superclass) =>
       let feeKnownInAdvance
 
       return redlock({ path: this.user._id, logger: lightningLogger }, async (lock) => {
-        const balance = await this.getBalances(lock)
+        const balance = await Wallets.getBalanceForWallet({
+          walletId: this.user.id,
+          logger: lightningLogger,
+        })
+        if (balance instanceof Error) throw balance
 
         // On us transaction
         if (isMyNode({ pubkey: destination }) || isPushPayment) {
@@ -281,7 +285,7 @@ export const LightningMixin = (superclass) =>
           }
 
           // TODO: manage when paid fully in USD directly from USD balance to avoid conversion issue
-          if (balance.total_in_BTC < sats) {
+          if (balance.totalInBtc < sats) {
             throw new InsufficientBalanceError(undefined, {
               logger: lightningLoggerOnUs,
             })
@@ -438,7 +442,7 @@ export const LightningMixin = (superclass) =>
 
           // TODO usd management for balance
 
-          if (balance.total_in_BTC < sats) {
+          if (balance.totalInBtc < sats) {
             throw new InsufficientBalanceError(undefined, { logger: lightningLogger })
           }
 

--- a/src/core/lightning/index.ts
+++ b/src/core/lightning/index.ts
@@ -221,11 +221,11 @@ export const LightningMixin = (superclass) =>
       let feeKnownInAdvance
 
       return redlock({ path: this.user._id, logger: lightningLogger }, async (lock) => {
-        const balance = await Wallets.getBalanceForWallet({
+        const balanceSats = await Wallets.getBalanceForWallet({
           walletId: this.user.id,
           logger: lightningLogger,
         })
-        if (balance instanceof Error) throw balance
+        if (balanceSats instanceof Error) throw balanceSats
 
         // On us transaction
         if (isMyNode({ pubkey: destination }) || isPushPayment) {
@@ -285,7 +285,7 @@ export const LightningMixin = (superclass) =>
           }
 
           // TODO: manage when paid fully in USD directly from USD balance to avoid conversion issue
-          if (balance.totalInBtc < sats) {
+          if (balanceSats < sats) {
             throw new InsufficientBalanceError(undefined, {
               logger: lightningLoggerOnUs,
             })
@@ -438,11 +438,11 @@ export const LightningMixin = (superclass) =>
             ...UserWallet.getCurrencyEquivalent({ sats, fee }),
           }
 
-          lightningLogger = lightningLogger.child({ route, balance, ...metadata })
+          lightningLogger = lightningLogger.child({ route, balanceSats, ...metadata })
 
           // TODO usd management for balance
 
-          if (balance.totalInBtc < sats) {
+          if (balanceSats < sats) {
             throw new InsufficientBalanceError(undefined, { logger: lightningLogger })
           }
 
@@ -505,7 +505,7 @@ export const LightningMixin = (superclass) =>
 
               return "pending"
               // pending in-flight payment are being handled either by a cron job
-              // or payment update when the user query his balance
+              // or payment update when the user query his balanceSats
             }
 
             try {

--- a/src/core/on-chain/index.ts
+++ b/src/core/on-chain/index.ts
@@ -30,6 +30,7 @@ import { lockExtendOrThrow, redlock } from "../lock"
 import { UserWallet } from "../user-wallet"
 import { LoggedError } from "../utils"
 import { ONCHAIN_LOOK_BACK, ONCHAIN_LOOK_BACK_OUTGOING } from "@config/app"
+import * as Wallets from "@app/wallets"
 
 export const getOnChainTransactions = async ({
   lnd,
@@ -134,15 +135,21 @@ export const OnChainMixin = (superclass) =>
       // when sendAll the amount should be 0
       else {
         assert(amount === 0)
-        /// TODO: unable to check balance.total_in_BTC vs this.dustThreshold at this point...
+        /// TODO: unable to check balance.totalInBtc vs this.dustThreshold at this point...
       }
 
       return redlock({ path: this.user._id, logger: onchainLogger }, async (lock) => {
-        const balance = await this.getBalances(lock)
+        const balance = await Wallets.getBalanceForWallet({
+          walletId: this.user.id,
+          logger: onchainLogger,
+          lock,
+        })
+        if (balance instanceof Error) throw balance
+
         onchainLogger = onchainLogger.child({ balance })
 
         // quit early if balance is not enough
-        if (balance.total_in_BTC < amount) {
+        if (balance.totalInBtc < amount) {
           throw new InsufficientBalanceError(undefined, { logger: onchainLogger })
         }
 
@@ -153,7 +160,7 @@ export const OnChainMixin = (superclass) =>
           let amountToSendPayeeUser = amount
           if (sendAll) {
             // when sendAll the amount to send payeeUser is the whole balance
-            amountToSendPayeeUser = balance.total_in_BTC
+            amountToSendPayeeUser = balance.totalInBtc
           }
 
           const remainingTwoFALimit = await this.user.remainingTwoFALimit()
@@ -224,9 +231,7 @@ export const OnChainMixin = (superclass) =>
         }
 
         /// when sendAll the amount is closer to the final one by deducting the withdrawFee
-        const checksAmount = sendAll
-          ? balance.total_in_BTC - this.user.withdrawFee
-          : amount
+        const checksAmount = sendAll ? balance.totalInBtc - this.user.withdrawFee : amount
 
         if (checksAmount < this.config.dustThreshold) {
           throw new DustAmountError(undefined, { logger: onchainLogger })
@@ -287,16 +292,13 @@ export const OnChainMixin = (superclass) =>
           }
 
           // case where the user doesn't have enough money
-          if (
-            balance.total_in_BTC <
-            amountToSend + estimatedFee + this.user.withdrawFee
-          ) {
+          if (balance.totalInBtc < amountToSend + estimatedFee + this.user.withdrawFee) {
             throw new InsufficientBalanceError(undefined, { logger: onchainLogger })
           }
         }
         // when sendAll the amount to sendToChainAddress is the whole balance minus the fees
         else {
-          amountToSend = balance.total_in_BTC - estimatedFee - this.user.withdrawFee
+          amountToSend = balance.totalInBtc - estimatedFee - this.user.withdrawFee
 
           // case where there is not enough money available within lnd on-chain wallet
           if (onChainBalance < amountToSend) {
@@ -349,7 +351,7 @@ export const OnChainMixin = (superclass) =>
             let sats = amount + fee
             if (sendAll) {
               // when sendAll the amount debited from the account is the whole balance
-              sats = balance.total_in_BTC
+              sats = balance.totalInBtc
             }
 
             const metadata = {

--- a/src/core/user-wallet.ts
+++ b/src/core/user-wallet.ts
@@ -261,7 +261,12 @@ export abstract class UserWallet {
   }
 
   sendBalance = async (): Promise<void> => {
-    const { BTC: balanceSats } = await this.getBalances()
+    const balances = await Wallets.getBalanceForWallet({
+      walletId: this.user.id as WalletId,
+      logger: this.logger,
+    })
+    if (balances instanceof Error) throw balances
+    const { BTC: balanceSats } = balances
 
     // Add commas to balancesats
     const balanceSatsPrettified = balanceSats.toLocaleString("en")

--- a/src/core/user-wallet.ts
+++ b/src/core/user-wallet.ts
@@ -261,12 +261,11 @@ export abstract class UserWallet {
   }
 
   sendBalance = async (): Promise<void> => {
-    const balances = await Wallets.getBalanceForWallet({
+    const balanceSats = await Wallets.getBalanceForWallet({
       walletId: this.user.id as WalletId,
       logger: this.logger,
     })
-    if (balances instanceof Error) throw balances
-    const { BTC: balanceSats } = balances
+    if (balanceSats instanceof Error) throw balanceSats
 
     // Add commas to balancesats
     const balanceSatsPrettified = balanceSats.toLocaleString("en")

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -97,6 +97,10 @@ interface ILedgerService {
     liabilitiesAccountId: LiabilitiesAccountId,
   ): Promise<number | LedgerServiceError>
 
+  getAccountBalance(
+    liabilitiesAccountId: LiabilitiesAccountId,
+  ): Promise<Satoshis | LedgerServiceError>
+
   isOnChainTxRecorded(
     liabilitiesAccountId: LiabilitiesAccountId,
     txId: TxId,

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -5,6 +5,11 @@ type SettlementMethod =
 type TxStatus =
   typeof import("./tx-status").TxStatus[keyof typeof import("./tx-status").TxStatus]
 
+type Balances = {
+  BTC: Satoshis
+  totalInBtc: Satoshis
+}
+
 // Fields only needed to support the old schema
 type Deprecated = {
   readonly description: string

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -5,12 +5,6 @@ type SettlementMethod =
 type TxStatus =
   typeof import("./tx-status").TxStatus[keyof typeof import("./tx-status").TxStatus]
 
-type Balances = {
-  BTC: Satoshis
-  totalInBtc: Satoshis
-}
-
-// Fields only needed to support the old schema
 type Deprecated = {
   readonly description: string
   readonly type: LedgerTransactionType

--- a/src/graphql/types/object/btc-wallet.ts
+++ b/src/graphql/types/object/btc-wallet.ts
@@ -22,7 +22,14 @@ const BTCWallet = new GT.Object({
     },
     balance: {
       type: GT.NonNull(SignedAmount),
-      resolve: async (_, __, { wallet }) => (await wallet.getBalances())["BTC"],
+      resolve: async (_, __, { wallet, logger }) => {
+        const balances = await Wallets.getBalanceForWallet({
+          walletId: wallet.user.id as WalletId,
+          logger,
+        })
+        if (balances instanceof Error) throw balances
+        return balances.BTC
+      },
     },
 
     transactions: {

--- a/src/graphql/types/object/btc-wallet.ts
+++ b/src/graphql/types/object/btc-wallet.ts
@@ -23,12 +23,12 @@ const BTCWallet = new GT.Object({
     balance: {
       type: GT.NonNull(SignedAmount),
       resolve: async (_, __, { wallet, logger }) => {
-        const balances = await Wallets.getBalanceForWallet({
+        const balanceSats = await Wallets.getBalanceForWallet({
           walletId: wallet.user.id as WalletId,
           logger,
         })
-        if (balances instanceof Error) throw balances
-        return balances.BTC
+        if (balanceSats instanceof Error) throw balanceSats
+        return balanceSats
       },
     },
 

--- a/src/servers/exporter.ts
+++ b/src/servers/exporter.ts
@@ -111,13 +111,13 @@ const main = async () => {
     for (const role of roles) {
       try {
         const wallet = await getWalletFromRole({ role, logger })
-        const balances = await Wallets.getBalanceForWallet({
+        const balanceSats = await Wallets.getBalanceForWallet({
           walletId: wallet.user.id as WalletId,
           logger,
         })
-        if (balances instanceof Error) throw balances
+        if (balanceSats instanceof Error) throw balanceSats
 
-        wallet_roles[role].set(balances.BTC)
+        wallet_roles[role].set(balanceSats)
       } catch (err) {
         baseLogger.error({ role }, `can't fetch balance for role`)
       }

--- a/src/servers/graphql-old-server.ts
+++ b/src/servers/graphql-old-server.ts
@@ -78,13 +78,13 @@ const resolvers = {
         id: "BTC",
         currency: "BTC",
         balance: async () => {
-          const balances = await Wallets.getBalanceForWallet({
+          const balanceSats = await Wallets.getBalanceForWallet({
             walletId: wallet.user.id as WalletId,
             logger,
           })
-          if (balances instanceof Error) throw balances
+          if (balanceSats instanceof Error) throw balanceSats
 
-          return balances.BTC
+          return balanceSats
         },
         transactions: async () => {
           const { result: txs, error } = await Wallets.getTransactionsForWalletId({

--- a/src/servers/graphql-old-server.ts
+++ b/src/servers/graphql-old-server.ts
@@ -73,11 +73,19 @@ const resolvers = {
     },
 
     // legacy, before handling multi currency account
-    wallet: (_, __, { wallet }) => [
+    wallet: (_, __, { wallet, logger }) => [
       {
         id: "BTC",
         currency: "BTC",
-        balance: async () => (await wallet.getBalances())["BTC"],
+        balance: async () => {
+          const balances = await Wallets.getBalanceForWallet({
+            walletId: wallet.user.id as WalletId,
+            logger,
+          })
+          if (balances instanceof Error) throw balances
+
+          return balances.BTC
+        },
         transactions: async () => {
           const { result: txs, error } = await Wallets.getTransactionsForWalletId({
             walletId: wallet.user.id,

--- a/src/services/ledger/index.ts
+++ b/src/services/ledger/index.ts
@@ -3,9 +3,22 @@
  * https://en.wikipedia.org/wiki/Double-entry_bookkeeping
  */
 
+// we have to import schema before medici
+import { Transaction } from "./schema"
+
 import * as accounts from "./accounts"
 import * as queries from "./query"
 import * as transactions from "./transaction"
+
+import {
+  UnknownLedgerError,
+  LedgerError,
+  LedgerServiceError,
+} from "@domain/ledger/errors"
+import { MainBook } from "./books"
+import { toSats } from "@domain/bitcoin"
+import { LedgerTransactionType } from "@domain/ledger"
+import { lndAccountingPath, bankOwnerAccountPath } from "./accounts"
 
 type LoadLedgerParams = {
   bankOwnerAccountResolver: () => Promise<string>
@@ -24,17 +37,6 @@ export const loadLedger = ({
     ...transactions,
   }
 }
-
-import {
-  UnknownLedgerError,
-  LedgerError,
-  LedgerServiceError,
-} from "@domain/ledger/errors"
-import { MainBook } from "./books"
-import { Transaction } from "./schema"
-import { toSats } from "@domain/bitcoin"
-import { LedgerTransactionType } from "@domain/ledger"
-import { lndAccountingPath, bankOwnerAccountPath } from "./accounts"
 
 export const LedgerService = (): ILedgerService => {
   const getLiabilityTransactions = async (
@@ -85,7 +87,7 @@ export const LedgerService = (): ILedgerService => {
       })
       return toSats(balance)
     } catch (err) {
-      return new UnknownLedgerError()
+      return new UnknownLedgerError(err)
     }
   }
 

--- a/src/services/ledger/index.ts
+++ b/src/services/ledger/index.ts
@@ -75,6 +75,20 @@ export const LedgerService = (): ILedgerService => {
     })
   }
 
+  const getAccountBalance = async (
+    liabilitiesAccountId: LiabilitiesAccountId,
+  ): Promise<Satoshis | LedgerError> => {
+    try {
+      const { balance } = await MainBook.balance({
+        account: liabilitiesAccountId,
+        currency: "BTC",
+      })
+      return toSats(balance)
+    } catch (err) {
+      return new UnknownLedgerError()
+    }
+  }
+
   const isOnChainTxRecorded = async (
     liabilitiesAccountId: LiabilitiesAccountId,
     txId: TxId,
@@ -239,6 +253,7 @@ export const LedgerService = (): ILedgerService => {
     getLiabilityTransactions,
     listPendingPayments,
     getPendingPaymentsCount,
+    getAccountBalance,
     isOnChainTxRecorded,
     isLnTxRecorded,
     receiveOnChainTx,

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -7,6 +7,7 @@ export * from "./bitcoin-core"
 export * from "./lightning"
 export * from "./user"
 export * from "./redis"
+export * from "./wallet"
 
 export const amountAfterFeeDeduction = ({ amount, depositFeeRatio }) =>
   Math.round(btc2sat(amount) * (1 - depositFeeRatio))

--- a/test/helpers/wallet.ts
+++ b/test/helpers/wallet.ts
@@ -1,0 +1,11 @@
+import * as Wallets from "@app/wallets"
+import { baseLogger } from "@services/logger"
+
+export const getBTCBalance = async (walletId: WalletId): Promise<Satoshis> => {
+  const balances = await Wallets.getBalanceForWallet({
+    walletId,
+    logger: baseLogger,
+  })
+  if (balances instanceof Error) throw balances
+  return balances.BTC
+}

--- a/test/helpers/wallet.ts
+++ b/test/helpers/wallet.ts
@@ -2,10 +2,10 @@ import * as Wallets from "@app/wallets"
 import { baseLogger } from "@services/logger"
 
 export const getBTCBalance = async (walletId: WalletId): Promise<Satoshis> => {
-  const balances = await Wallets.getBalanceForWallet({
+  const balanceSats = await Wallets.getBalanceForWallet({
     walletId,
     logger: baseLogger,
   })
-  if (balances instanceof Error) throw balances
-  return balances.BTC
+  if (balanceSats instanceof Error) throw balanceSats
+  return balanceSats
 }

--- a/test/integration/02-user-wallet/02-receive-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-lightning.spec.ts
@@ -1,7 +1,13 @@
 import { ledger } from "@services/mongodb"
 import { baseLogger } from "@services/logger"
 import { getHash } from "@core/utils"
-import { checkIsBalanced, getUserWallet, lndOutside1, pay } from "test/helpers"
+import {
+  checkIsBalanced,
+  getUserWallet,
+  lndOutside1,
+  pay,
+  getBTCBalance,
+} from "test/helpers"
 import { MEMO_SHARING_SATS_THRESHOLD } from "@config/app"
 import * as Wallets from "@app/wallets"
 import { PaymentInitiationMethod } from "@domain/wallets"
@@ -20,7 +26,7 @@ beforeAll(async () => {
 })
 
 beforeEach(async () => {
-  ;({ BTC: initBalance1 } = await userWallet1.getBalances())
+  initBalance1 = await getBTCBalance(userWallet1.user.id)
 })
 
 afterEach(async () => {
@@ -90,7 +96,7 @@ describe("UserWallet - Lightning", () => {
     ) as WalletTransaction
     expect(noSpamTxn.deprecated.description).toBe(memo)
 
-    const { BTC: finalBalance } = await userWallet1.getBalances()
+    const finalBalance = await getBTCBalance(userWallet1.user.id)
     expect(finalBalance).toBe(initBalance1 + sats)
   })
 
@@ -126,7 +132,7 @@ describe("UserWallet - Lightning", () => {
     expect(dbTx.memo).toBe("")
     expect(dbTx.pending).toBe(false)
 
-    const { BTC: finalBalance } = await userWallet1.getBalances()
+    const finalBalance = await getBTCBalance(userWallet1.user.id)
     expect(finalBalance).toBe(initBalance1 + sats)
   })
 
@@ -176,7 +182,7 @@ describe("UserWallet - Lightning", () => {
     expect(spamTxn.deprecated.description).toBe(dbTx.type)
 
     // confirm expected final balance
-    const { BTC: finalBalance } = await userWallet1.getBalances()
+    const finalBalance = await getBTCBalance(userWallet1.user.id)
     expect(finalBalance).toBe(initBalance1 + sats)
   })
 })

--- a/test/integration/02-user-wallet/02-receive-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-onchain.spec.ts
@@ -22,6 +22,7 @@ import {
 import { getWalletFromRole } from "@core/wallet-factory"
 import * as Wallets from "@app/wallets"
 import { TxStatus } from "@domain/wallets"
+import { getBTCBalance } from "test/helpers/wallet"
 
 jest.mock("@services/realtime-price", () => require("test/mocks/realtime-price"))
 jest.mock("@services/phone-provider", () => require("test/mocks/phone-provider"))
@@ -103,8 +104,8 @@ describe("UserWallet - On chain", () => {
     const address4 = await Wallets.createOnChainAddress(walletUser4.user.id)
     if (address4 instanceof Error) throw address4
 
-    const { BTC: initialBalanceUser0 } = await walletUser0.getBalances()
-    const { BTC: initBalanceUser4 } = await walletUser4.getBalances()
+    const initialBalanceUser0 = await getBTCBalance(walletUser0.user.id)
+    const initBalanceUser4 = await getBTCBalance(walletUser4.user.id)
 
     const output0 = {}
     output0[address0] = 1
@@ -135,8 +136,8 @@ describe("UserWallet - On chain", () => {
     }
 
     {
-      const { BTC: balance0 } = await walletUser0.getBalances()
-      const { BTC: balance4 } = await walletUser4.getBalances()
+      const balance0 = await getBTCBalance(walletUser0.user.id)
+      const balance4 = await getBTCBalance(walletUser4.user.id)
 
       expect(balance0).toBe(
         initialBalanceUser0 +
@@ -223,9 +224,9 @@ describe("UserWallet - On chain", () => {
     walletUser2 = await getUserWallet(2)
     walletUser2.user.depositFeeRatio = 0
     await walletUser2.user.save()
-    const { BTC: initBalanceUser2 } = await walletUser2.getBalances()
+    const initBalanceUser2 = await getBTCBalance(walletUser2.user.id)
     await sendToWallet({ walletDestination: walletUser2 })
-    const { BTC: finalBalanceUser2 } = await walletUser2.getBalances()
+    const finalBalanceUser2 = await getBTCBalance(walletUser2.user.id)
     expect(finalBalanceUser2).toBe(initBalanceUser2 + btc2sat(amountBTC))
   })
 })
@@ -234,7 +235,7 @@ describe("UserWallet - On chain", () => {
 async function sendToWallet({ walletDestination }) {
   const lnd = lndonchain
 
-  const { BTC: initialBalance } = await walletDestination.getBalances()
+  const initialBalance = await getBTCBalance(walletDestination.user.id)
   const { result: initTransactions, error } = await Wallets.getTransactionsForWalletId({
     walletId: walletDestination.user.id,
   })
@@ -263,7 +264,7 @@ async function sendToWallet({ walletDestination }) {
       throw result
     }
 
-    const { BTC: balance } = await walletDestination.getBalances()
+    const balance = await getBTCBalance(walletDestination.user.id)
     expect(balance).toBe(
       initialBalance +
         amountAfterFeeDeduction({

--- a/test/integration/02-user-wallet/02-receive-rewards.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-rewards.spec.ts
@@ -1,6 +1,7 @@
 import { find, difference } from "lodash"
 import { MS_PER_DAY, onboardingEarn } from "@config/app"
 import { checkIsBalanced, getUserWallet } from "test/helpers"
+import { getBTCBalance } from "test/helpers/wallet"
 
 jest.mock("@services/realtime-price", () => require("test/mocks/realtime-price"))
 jest.mock("@services/phone-provider", () => require("test/mocks/phone-provider"))
@@ -29,11 +30,11 @@ afterAll(() => {
 
 describe("UserWallet - addEarn", () => {
   it("adds balance only once", async () => {
-    const { BTC: initialBalance } = await userWallet1.getBalances()
+    const initialBalance = await getBTCBalance(userWallet1.user.id)
 
     const getAndVerifyRewards = async () => {
       await userWallet1.addEarn(onBoardingEarnIds)
-      const { BTC: finalBalance } = await userWallet1.getBalances()
+      const finalBalance = await getBTCBalance(userWallet1.user.id)
       let rewards = onBoardingEarnAmt
       if (difference(onBoardingEarnIds, userWallet1.user.earn).length === 0) {
         rewards = 0

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -418,21 +418,13 @@ describe("UserWallet - Lightning Pay", () => {
           tokens: amountInvoice,
         })
         await fn(userWallet1)({ invoice: request })
-        const intermediateBalance = await Wallets.getBalanceForWallet({
-          walletId: userWallet1.user.id,
-          logger: baseLogger,
-        })
-        if (intermediateBalance instanceof Error) throw intermediateBalance
+        const intermediateBalanceSats = await getBTCBalance(userWallet1.user.id)
 
         const result = await fn(userWallet1)({ invoice: request })
         expect(result).toBe("already_paid")
 
-        const finalBalance = await Wallets.getBalanceForWallet({
-          walletId: userWallet1.user.id,
-          logger: baseLogger,
-        })
-        if (finalBalance instanceof Error) throw finalBalance
-        expect(finalBalance).toStrictEqual(intermediateBalance)
+        const finalBalanceSats = await getBTCBalance(userWallet1.user.id)
+        expect(finalBalanceSats).toEqual(intermediateBalanceSats)
       })
 
       it("pay invoice with High CLTV Delta", async () => {
@@ -762,11 +754,7 @@ describe("UserWallet - Lightning Pay", () => {
 
     // await sleep(1000)
 
-    const _ = await Wallets.getBalanceForWallet({
-      walletId: userWallet1.user.id,
-      logger: baseLogger,
-    })
-    if (_ instanceof Error) throw _
+    await getBTCBalance(userWallet1.user.id)
 
     // FIXME: test is failing.
     // lnd doens't always delete invoice just after they have expired

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -754,7 +754,7 @@ describe("UserWallet - Lightning Pay", () => {
 
     // await sleep(1000)
 
-    await getBTCBalance(userWallet1.user.id)
+    // await getBTCBalance(userWallet1.user.id)
 
     // FIXME: test is failing.
     // lnd doens't always delete invoice just after they have expired

--- a/test/integration/servers/trigger.spec.ts
+++ b/test/integration/servers/trigger.spec.ts
@@ -24,6 +24,7 @@ import { ledger } from "@services/mongodb"
 import { getTitle } from "@services/notifications/payment"
 import { getCurrentPrice } from "@services/realtime-price"
 import { TxStatus } from "@domain/wallets"
+import { getBTCBalance } from "test/helpers/wallet"
 
 jest.mock("@services/notifications/notification")
 jest.mock("@services/realtime-price", () => require("test/mocks/realtime-price"))
@@ -46,7 +47,7 @@ afterAll(async () => {
 })
 
 const getWalletState = async (wallet) => {
-  const { BTC: balance } = await wallet.getBalances()
+  const balance = await getBTCBalance(wallet.user.id)
   const { result: transactions, error } = await Wallets.getTransactionsForWalletId({
     walletId: wallet.user.id as WalletId,
   })


### PR DESCRIPTION
### Description

This PR adds the re-implemented `getBalanceForWallet` method to take the place of the old `getBalances` method.

The re-implementation only focuses on BTC balances. There are two outstanding places where USD balances are used, so the old `getBalances` method hasn't been removed as yet:
- `wallet2` endpoint in `graphql-old-server.ts` file
- `rebalancePortfolio` method in `src/services/ledger/transaction.ts` (with related integration tests)