### PR TITLE
activate failed htlc payment pruning

### DIFF
--- a/src/servers/cron.ts
+++ b/src/servers/cron.ts
@@ -2,7 +2,7 @@ import { getSpecterWalletConfig } from "@config/app"
 
 import {
   deleteExpiredInvoiceUser,
-  deleteFailedPaymentsAllLnds,
+  deleteFailedPaymentsAttemptAllLnds,
   updateEscrows,
   updateRoutingFees,
 } from "@services/lnd/utils"
@@ -22,7 +22,7 @@ const main = async () => {
   await updatePendingLightningTransactions()
 
   await deleteExpiredInvoiceUser()
-  await deleteFailedPaymentsAllLnds()
+  await deleteFailedPaymentsAttemptAllLnds()
 
   const specterWalletConfig = getSpecterWalletConfig()
   const specterWallet = new SpecterWallet({

--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -1,19 +1,19 @@
 import { toSats } from "@domain/bitcoin"
 import {
-  decodeInvoice,
   CouldNotDecodeReturnedPaymentRequest,
-  UnknownLightningServiceError,
-  LightningServiceError,
+  decodeInvoice,
   InvoiceNotFoundError,
+  LightningServiceError,
   PaymentStatus,
+  UnknownLightningServiceError,
 } from "@domain/bitcoin/lightning"
 import {
+  cancelHodlInvoice,
   createInvoice,
+  deleteFailedPayAttempts,
   getInvoice,
   getPayment,
-  cancelHodlInvoice,
   GetPaymentResult,
-  deleteFailedPayAttempts,
 } from "lightning"
 import { getActiveLnd, getLndFromPubkey, getLnds } from "./utils"
 

--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -13,6 +13,7 @@ import {
   getPayment,
   cancelHodlInvoice,
   GetPaymentResult,
+  deleteFailedPayAttempts,
 } from "lightning"
 import { getActiveLnd, getLndFromPubkey, getLnds } from "./utils"
 
@@ -137,5 +138,6 @@ export const LndService = (): ILightningService | LightningServiceError => {
     lookupInvoice,
     lookupPayment,
     cancelInvoice,
+    deleteFailedPayAttempts,
   }
 }

--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -1,18 +1,17 @@
 import { toSats } from "@domain/bitcoin"
 import {
-  CouldNotDecodeReturnedPaymentRequest,
   decodeInvoice,
-  InvoiceNotFoundError,
-  LightningServiceError,
-  PaymentStatus,
+  CouldNotDecodeReturnedPaymentRequest,
   UnknownLightningServiceError,
+  LightningServiceError,
+  InvoiceNotFoundError,
+  PaymentStatus,
 } from "@domain/bitcoin/lightning"
 import {
-  cancelHodlInvoice,
   createInvoice,
-  deleteFailedPayAttempts,
   getInvoice,
   getPayment,
+  cancelHodlInvoice,
   GetPaymentResult,
 } from "lightning"
 import { getActiveLnd, getLndFromPubkey, getLnds } from "./utils"
@@ -138,6 +137,5 @@ export const LndService = (): ILightningService | LightningServiceError => {
     lookupInvoice,
     lookupPayment,
     cancelInvoice,
-    deleteFailedPayAttempts,
   }
 }

--- a/src/services/lnd/utils.ts
+++ b/src/services/lnd/utils.ts
@@ -1,39 +1,32 @@
+import {
+  getGaloyInstanceName,
+  MS_PER_DAY,
+  ONCHAIN_LOOK_BACK_CHANNEL_UPDATE
+} from "@config/app"
+import { DbError, LndOfflineError, ValidationInternalError } from "@core/error"
+import { LoggedError } from "@core/utils"
+import { LnFeeCalculator } from "@domain/bitcoin/lightning"
+import { baseLogger } from "@services/logger"
+import { ledger } from "@services/mongodb"
+import { WalletInvoicesRepository } from "@services/mongoose"
+import { DbMetadata } from "@services/mongoose/schema"
 import assert from "assert"
 import { default as axios } from "axios"
 import { parsePaymentRequest } from "invoices"
 import {
-  getChainBalance,
+  deleteFailedPayAttempts, getChainBalance,
   getChainTransactions,
   getChannelBalance,
   getChannels,
   getClosedChannels,
   getForwards,
-  getHeight,
-  getPendingChainBalance,
-  getInvoice,
-  getWalletInfo,
+  getHeight, getInvoice, getPendingChainBalance, getWalletInfo,
   SubscribeToChannelsChannelClosedEvent,
-  SubscribeToChannelsChannelOpenedEvent,
+  SubscribeToChannelsChannelOpenedEvent
 } from "lightning"
 import _ from "lodash"
 import { Logger } from "pino"
-
-import {
-  getGaloyInstanceName,
-  MS_PER_DAY,
-  ONCHAIN_LOOK_BACK_CHANNEL_UPDATE,
-} from "@config/app"
-
-import { baseLogger } from "@services/logger"
-import { ledger } from "@services/mongodb"
-import { DbMetadata } from "@services/mongoose/schema"
-
-import { DbError, LndOfflineError, ValidationInternalError } from "@core/error"
-import { LoggedError } from "@core/utils"
-
 import { params } from "./auth"
-import { WalletInvoicesRepository } from "@services/mongoose"
-import { LnFeeCalculator } from "@domain/bitcoin/lightning"
 
 export const deleteExpiredInvoiceUser = async () => {
   const walletInvoicesRepo = WalletInvoicesRepository()
@@ -53,17 +46,17 @@ export const deleteExpiredInvoiceUser = async () => {
   return result
 }
 
-export const deleteFailedPaymentsAllLnds = async () => {
-  baseLogger.warn("only run deleteFailedPayments on lnd 0.13")
-  return Promise.resolve()
-  // try {
-  //   const lnds = offchainLnds
-  //   for (const { lnd } of lnds)
-  //     await deleteFailedPayments({lnd})
-  //   }
-  // } catch (err) {
-  //   baseLogger.warn({ err }, "error deleting failed payment")
-  // }
+export const deleteFailedPaymentsAttemptAllLnds = async () => {
+  const lnds = offchainLnds
+  for (const { lnd, socket } of lnds)
+  
+  try {
+    baseLogger.info({socket}, "running deleteFailedPayments")
+      await deleteFailedPayAttempts({lnd})
+    } catch (err) {
+      baseLogger.warn({ err }, "error deleting failed payment")
+    }
+  }
 }
 
 export const lndsBalances = async () => {

--- a/src/services/lnd/utils.ts
+++ b/src/services/lnd/utils.ts
@@ -1,7 +1,7 @@
 import {
   getGaloyInstanceName,
   MS_PER_DAY,
-  ONCHAIN_LOOK_BACK_CHANNEL_UPDATE
+  ONCHAIN_LOOK_BACK_CHANNEL_UPDATE,
 } from "@config/app"
 import { DbError, LndOfflineError, ValidationInternalError } from "@core/error"
 import { LoggedError } from "@core/utils"
@@ -14,15 +14,19 @@ import assert from "assert"
 import { default as axios } from "axios"
 import { parsePaymentRequest } from "invoices"
 import {
-  deleteFailedPayAttempts, getChainBalance,
+  deleteFailedPayAttempts,
+  getChainBalance,
   getChainTransactions,
   getChannelBalance,
   getChannels,
   getClosedChannels,
   getForwards,
-  getHeight, getInvoice, getPendingChainBalance, getWalletInfo,
+  getHeight,
+  getInvoice,
+  getPendingChainBalance,
+  getWalletInfo,
   SubscribeToChannelsChannelClosedEvent,
-  SubscribeToChannelsChannelOpenedEvent
+  SubscribeToChannelsChannelOpenedEvent,
 } from "lightning"
 import _ from "lodash"
 import { Logger } from "pino"
@@ -48,11 +52,10 @@ export const deleteExpiredInvoiceUser = async () => {
 
 export const deleteFailedPaymentsAttemptAllLnds = async () => {
   const lnds = offchainLnds
-  for (const { lnd, socket } of lnds)
-  
-  try {
-    baseLogger.info({socket}, "running deleteFailedPayments")
-      await deleteFailedPayAttempts({lnd})
+  for (const { lnd, socket } of lnds) {
+    try {
+      baseLogger.info({ socket }, "running deleteFailedPaymentsAttempt")
+      await deleteFailedPayAttempts({ lnd })
     } catch (err) {
       baseLogger.warn({ err }, "error deleting failed payment")
     }


### PR DESCRIPTION
fix #573 (at least the failed htlc). 

we might want to dive more into the use of the `deletefailedpayments` (instead of `deleteFailedPayAttempts`), because it's possible we need the data about failed payments for support purpose. ie: when we need to do a refund.

the htlc part are safe to delete, and would likely already free the database significantly. 