### PR TITLE
Add new `send...Tx` methods to Ledger service

### DIFF
--- a/src/app/wallets/reimburse-fee.ts
+++ b/src/app/wallets/reimburse-fee.ts
@@ -47,7 +47,7 @@ export const reimburseFee = async ({
   const usd = feeDifference * price
 
   const ledgerService = LedgerService()
-  const result = await ledgerService.receiveLnFeeReimbursement({
+  const result = await ledgerService.addLnFeeReimbursementReceive({
     liabilitiesAccountId,
     paymentHash,
     sats: feeDifference,

--- a/src/app/wallets/update-on-chain-receipt.ts
+++ b/src/app/wallets/update-on-chain-receipt.ts
@@ -100,7 +100,7 @@ const processTxForWallet = async (
           const usd = sats * price
           const usdFee = fee * price
 
-          const result = await ledger.receiveOnChainTx({
+          const result = await ledger.addOnChainTxReceive({
             liabilitiesAccountId,
             txId: tx.rawTx.id,
             sats,

--- a/src/app/wallets/update-pending-invoices.ts
+++ b/src/app/wallets/update-pending-invoices.ts
@@ -127,7 +127,7 @@ const updatePendingInvoice = async ({
 
       const liabilitiesAccountId = toLiabilitiesAccountId(walletId)
       const ledgerService = LedgerService()
-      const result = await ledgerService.receiveLnTx({
+      const result = await ledgerService.addLnTxReceive({
         liabilitiesAccountId,
         paymentHash,
         description,

--- a/src/core/lightning/index.ts
+++ b/src/core/lightning/index.ts
@@ -5,7 +5,7 @@ import { verifyToken } from "node-2fa"
 
 import * as Wallets from "@app/wallets"
 import { TIMEOUT_PAYMENT } from "@services/lnd/auth"
-import { WalletInvoicesRepository } from "@services/mongoose"
+import { WalletInvoicesRepository, WalletsRepository } from "@services/mongoose"
 import { getActiveLnd, getLndFromPubkey, validate } from "@services/lnd/utils"
 import { ledger } from "@services/mongodb"
 import { redis } from "@services/redis"
@@ -29,6 +29,11 @@ import { addContact, isInvoiceAlreadyPaidError, timeout } from "../utils"
 import { lnPaymentStatusEvent } from "@config/app"
 import pubsub from "@services/pubsub"
 import { LndService } from "@services/lnd"
+import { PriceService } from "@services/price"
+import { LedgerService } from "@services/ledger"
+import { toSats } from "@domain/bitcoin"
+import { toLiabilitiesAccountId } from "@domain/ledger"
+import { CouldNotFindError } from "@domain/errors"
 
 export type ITxType =
   | "invoice"
@@ -298,19 +303,40 @@ export const LightningMixin = (superclass) =>
             })
           }
 
-          await lockExtendOrThrow({ lock, logger: lightningLoggerOnUs }, async () => {
-            const tx = await ledger.addOnUsPayment({
-              description: memoInvoice,
-              sats,
-              metadata,
-              payerUser: this.user,
-              payeeUser,
-              memoPayer,
-              shareMemoWithPayee: isPushPayment,
-              lastPrice: UserWallet.lastPrice,
-            })
-            return tx
-          })
+          const price = await PriceService().getCurrentPrice()
+          if (price instanceof Error) throw price
+          const lnFee = toSats(0)
+          const usd = sats * price
+          const usdFee = lnFee * price
+
+          const payerWallet = await WalletsRepository().findById(this.user.id)
+          if (payerWallet instanceof CouldNotFindError) throw payerWallet
+          if (payerWallet instanceof Error) throw payerWallet
+          const recipientWallet = await WalletsRepository().findById(payeeUser.id)
+          if (recipientWallet instanceof CouldNotFindError) throw recipientWallet
+          if (recipientWallet instanceof Error) throw recipientWallet
+
+          const journal = await lockExtendOrThrow(
+            { lock, logger: lightningLoggerOnUs },
+            async () => {
+              return LedgerService().sendLnIntraledgerTx({
+                liabilitiesAccountId: toLiabilitiesAccountId(this.user.id),
+                paymentHash: id,
+                description: memoInvoice,
+                sats,
+                fee: lnFee,
+                usd,
+                usdFee,
+                pubkey,
+                recipientLiabilitiesAccountId: toLiabilitiesAccountId(payeeUser.id),
+                payerWalletName: payerWallet.walletName,
+                recipientWalletName: recipientWallet.walletName,
+                memoPayer: memoPayer || null,
+                shareMemoWithPayee: isPushPayment,
+              })
+            },
+          )
+          if (journal instanceof Error) throw journal
 
           transactionNotification({
             amount: sats,

--- a/src/core/lightning/index.ts
+++ b/src/core/lightning/index.ts
@@ -319,7 +319,7 @@ export const LightningMixin = (superclass) =>
           const journal = await lockExtendOrThrow(
             { lock, logger: lightningLoggerOnUs },
             async () => {
-              return LedgerService().sendLnIntraledgerTx({
+              return LedgerService().addLnIntraledgerTxSend({
                 liabilitiesAccountId: toLiabilitiesAccountId(this.user.id),
                 paymentHash: id,
                 description: memoInvoice,
@@ -494,7 +494,7 @@ export const LightningMixin = (superclass) =>
 
           entry = await lockExtendOrThrow({ lock, logger: lightningLogger }, async () => {
             // reduce balance from customer first
-            return LedgerService().sendLnTx({
+            return LedgerService().addLnTxSend({
               liabilitiesAccountId: toLiabilitiesAccountId(this.user.id),
               paymentHash: id,
               description: memoInvoice,

--- a/src/core/on-chain/index.ts
+++ b/src/core/on-chain/index.ts
@@ -181,7 +181,7 @@ export const OnChainMixin = (superclass) =>
           const journal = await lockExtendOrThrow(
             { lock, logger: onchainLoggerOnUs },
             async () => {
-              return LedgerService().sendOnChainIntraledgerTx({
+              return LedgerService().addOnChainIntraledgerTxSend({
                 liabilitiesAccountId: toLiabilitiesAccountId(this.user.id),
                 description: "",
                 sats: toSats(sats),

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -16,6 +16,12 @@ type LedgerAccountId = string & { [ledgerAccountIdSymbol]: never }
 type LedgerTransactionType =
   typeof import("./index").LedgerTransactionType[keyof typeof import("./index").LedgerTransactionType]
 
+type LedgerJournal = {
+  readonly journalId: LedgerJournalId
+  readonly voided: boolean
+  readonly transactionIds: LedgerTransactionId[]
+}
+
 // Differentiate fields depending on what 'type' we have (see domain/wallets/index.types.d.ts)
 type LedgerTransaction = {
   readonly id: LedgerTransactionId
@@ -138,15 +144,17 @@ interface ILedgerService {
 
   isLnTxRecorded(paymentHash: PaymentHash): Promise<boolean | LedgerServiceError>
 
-  receiveOnChainTx(args: ReceiveOnChainTxArgs): Promise<void | LedgerServiceError>
+  receiveOnChainTx(
+    args: ReceiveOnChainTxArgs,
+  ): Promise<LedgerJournal | LedgerServiceError>
 
-  receiveLnTx(args: ReceiveLnTxArgs): Promise<void | LedgerServiceError>
+  receiveLnTx(args: ReceiveLnTxArgs): Promise<LedgerJournal | LedgerServiceError>
 
   receiveLnFeeReimbursement(
     args: ReceiveLnFeeReeimbursementArgs,
-  ): Promise<void | LedgerServiceError>
+  ): Promise<LedgerJournal | LedgerServiceError>
 
-  sendLnTx(args: SendLnTxArgs): Promise<void | LedgerServiceError>
+  sendLnTx(args: SendLnTxArgs): Promise<LedgerJournal | LedgerServiceError>
 
   settlePendingLiabilityTransactions(
     paymentHash: PaymentHash,

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -67,6 +67,36 @@ type ReceiveLnTxArgs = {
   usdFee: number
 }
 
+type SendLnTxArgs = ReceiveLnTxArgs & {
+  recipientLiabilitiesAccountId: LiabilitiesAccountId | null
+  type: LedgerTransactionType
+  pending: boolean
+  pubkey: Pubkey
+  feeKnownInAdvance: boolean
+  payerWalletName?: WalletName
+  recipientWalletName?: WalletName
+  memoPayer?: string | null
+  isPushPayment?: boolean
+}
+
+type ReceiveLnTxMetadata = {
+  type: LedgerTransactionType
+  pending: boolean
+  hash: PaymentHash
+  fee: Satoshis
+  feeUsd: number
+  sats: Satoshis
+  usd: number
+  currency: Currency
+}
+
+type SendLnTxMetadata = ReceiveLnTxMetadata & {
+  pubkey: Pubkey
+  feeKnownInAdvance: boolean
+  memoPayer?: string | null
+  username?: WalletName
+}
+
 type ReceiveLnFeeReeimbursementArgs = {
   liabilitiesAccountId: LiabilitiesAccountId
   paymentHash: PaymentHash
@@ -115,6 +145,8 @@ interface ILedgerService {
   receiveLnFeeReimbursement(
     args: ReceiveLnFeeReeimbursementArgs,
   ): Promise<void | LedgerServiceError>
+
+  sendLnTx(args: SendLnTxArgs): Promise<void | LedgerServiceError>
 
   settlePendingLiabilityTransactions(
     paymentHash: PaymentHash,

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -74,15 +74,17 @@ type ReceiveLnTxArgs = {
 }
 
 type SendLnTxArgs = ReceiveLnTxArgs & {
-  recipientLiabilitiesAccountId: LiabilitiesAccountId | null
-  type: LedgerTransactionType
-  pending: boolean
   pubkey: Pubkey
   feeKnownInAdvance: boolean
-  payerWalletName?: WalletName
-  recipientWalletName?: WalletName
-  memoPayer?: string | null
-  isPushPayment?: boolean
+}
+
+type SendIntraledgerTxArgs = ReceiveLnTxArgs & {
+  pubkey: Pubkey
+  recipientLiabilitiesAccountId: LiabilitiesAccountId | null
+  payerWalletName: WalletName | null
+  recipientWalletName: WalletName | null
+  memoPayer: string | null
+  isPushPayment: boolean
 }
 
 type ReceiveLnTxMetadata = {
@@ -99,8 +101,12 @@ type ReceiveLnTxMetadata = {
 type SendLnTxMetadata = ReceiveLnTxMetadata & {
   pubkey: Pubkey
   feeKnownInAdvance: boolean
-  memoPayer?: string | null
-  username?: WalletName
+}
+
+type SendIntraledgerTxMetadata = ReceiveLnTxMetadata & {
+  pubkey: Pubkey
+  memoPayer: string | null
+  username: WalletName | null
 }
 
 type ReceiveLnFeeReeimbursementArgs = {
@@ -155,6 +161,10 @@ interface ILedgerService {
   ): Promise<LedgerJournal | LedgerServiceError>
 
   sendLnTx(args: SendLnTxArgs): Promise<LedgerJournal | LedgerServiceError>
+
+  sendIntraledgerTx(
+    args: SendIntraledgerTxArgs,
+  ): Promise<LedgerJournal | LedgerServiceError>
 
   settlePendingLiabilityTransactions(
     paymentHash: PaymentHash,

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -76,9 +76,9 @@ type LnTxArgs = TxArgs & {
   paymentHash: PaymentHash
 }
 
-type ReceiveLnTxArgs = LnTxArgs
+type AddLnTxReceiveArgs = LnTxArgs
 
-type SendLnTxArgs = LnTxArgs & {
+type AddLnTxSendArgs = LnTxArgs & {
   pubkey: Pubkey
   feeKnownInAdvance: boolean
 }
@@ -94,7 +94,7 @@ type IntraledgerTxArgs = {
   shareMemoWithPayee: boolean
 }
 
-type SendLnIntraledgerTxArgs = IntraledgerTxArgs & {
+type AddLnIntraledgerTxSendArgs = IntraledgerTxArgs & {
   paymentHash: PaymentHash
   fee: Satoshis
   usd: number
@@ -102,7 +102,7 @@ type SendLnIntraledgerTxArgs = IntraledgerTxArgs & {
   pubkey: Pubkey
 }
 
-type SendOnChainIntraledgerTxArgs = IntraledgerTxArgs & {
+type AddOnChainIntraledgerTxSendArgs = IntraledgerTxArgs & {
   fee: Satoshis
   usd: number
   usdFee: number
@@ -110,7 +110,7 @@ type SendOnChainIntraledgerTxArgs = IntraledgerTxArgs & {
   sendAll: boolean
 }
 
-type ReceiveLnFeeReeimbursementArgs = {
+type AddLnFeeReeimbursementReceiveArgs = {
   liabilitiesAccountId: LiabilitiesAccountId
   paymentHash: PaymentHash
   sats: Satoshis
@@ -151,24 +151,24 @@ interface ILedgerService {
 
   isLnTxRecorded(paymentHash: PaymentHash): Promise<boolean | LedgerServiceError>
 
-  receiveOnChainTx(
+  addOnChainTxReceive(
     args: ReceiveOnChainTxArgs,
   ): Promise<LedgerJournal | LedgerServiceError>
 
-  receiveLnTx(args: ReceiveLnTxArgs): Promise<LedgerJournal | LedgerServiceError>
+  addLnTxReceive(args: AddLnTxReceiveArgs): Promise<LedgerJournal | LedgerServiceError>
 
-  receiveLnFeeReimbursement(
-    args: ReceiveLnFeeReeimbursementArgs,
+  addLnFeeReimbursementReceive(
+    args: AddLnFeeReeimbursementReceiveArgs,
   ): Promise<LedgerJournal | LedgerServiceError>
 
-  sendLnTx(args: SendLnTxArgs): Promise<LedgerJournal | LedgerServiceError>
+  addLnTxSend(args: AddLnTxSendArgs): Promise<LedgerJournal | LedgerServiceError>
 
-  sendLnIntraledgerTx(
-    args: SendLnIntraledgerTxArgs,
+  addLnIntraledgerTxSend(
+    args: AddLnIntraledgerTxSendArgs,
   ): Promise<LedgerJournal | LedgerServiceError>
 
-  sendOnChainIntraledgerTx(
-    args: SendOnChainIntraledgerTxArgs,
+  addOnChainIntraledgerTxSend(
+    args: AddOnChainIntraledgerTxSendArgs,
   ): Promise<LedgerJournal | LedgerServiceError>
 
   settlePendingLiabilityTransactions(

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -63,9 +63,8 @@ type ReceiveOnChainTxArgs = {
   receivingAddress: OnChainAddress
 }
 
-type ReceiveLnTxArgs = {
+type TxArgs = {
   liabilitiesAccountId: LiabilitiesAccountId
-  paymentHash: PaymentHash
   description: string
   sats: Satoshis
   fee: Satoshis
@@ -73,24 +72,51 @@ type ReceiveLnTxArgs = {
   usdFee: number
 }
 
-type SendLnTxArgs = ReceiveLnTxArgs & {
+type LnTxArgs = TxArgs & {
+  paymentHash: PaymentHash
+}
+
+type ReceiveLnTxArgs = LnTxArgs
+
+type SendLnTxArgs = LnTxArgs & {
   pubkey: Pubkey
   feeKnownInAdvance: boolean
 }
 
-type SendIntraledgerTxArgs = ReceiveLnTxArgs & {
-  pubkey: Pubkey
+type IntraledgerTxArgs = {
+  liabilitiesAccountId: LiabilitiesAccountId
+  description: string
+  sats: Satoshis
   recipientLiabilitiesAccountId: LiabilitiesAccountId | null
   payerWalletName: WalletName | null
   recipientWalletName: WalletName | null
   memoPayer: string | null
-  isPushPayment: boolean
+  shareMemoWithPayee: boolean
 }
 
-type ReceiveLnTxMetadata = {
+type SendIntraledgerTxArgs = IntraledgerTxArgs & {
+  metadata: SendLnIntraledgerTxMetadata | SendOnChainIntraledgerTxMetadata
+}
+
+type SendLnIntraledgerTxArgs = IntraledgerTxArgs & {
+  paymentHash: PaymentHash
+  fee: Satoshis
+  usd: number
+  usdFee: number
+  pubkey: Pubkey
+}
+
+type SendOnChainIntraledgerTxArgs = IntraledgerTxArgs & {
+  fee: Satoshis
+  usd: number
+  usdFee: number
+  payeeAddresses: OnChainAddress[]
+  sendAll: boolean
+}
+
+type TxMetadata = {
   type: LedgerTransactionType
   pending: boolean
-  hash: PaymentHash
   fee: Satoshis
   feeUsd: number
   sats: Satoshis
@@ -98,13 +124,26 @@ type ReceiveLnTxMetadata = {
   currency: Currency
 }
 
-type SendLnTxMetadata = ReceiveLnTxMetadata & {
+type ReceiveLnTxMetadata = TxMetadata & {
+  hash: PaymentHash
+}
+
+type SendLnTxMetadata = TxMetadata & {
+  hash: PaymentHash
   pubkey: Pubkey
   feeKnownInAdvance: boolean
 }
 
-type SendIntraledgerTxMetadata = ReceiveLnTxMetadata & {
+type SendLnIntraledgerTxMetadata = TxMetadata & {
+  hash: PaymentHash
   pubkey: Pubkey
+  memoPayer: string | null
+  username: WalletName | null
+}
+
+type SendOnChainIntraledgerTxMetadata = TxMetadata & {
+  payee_addresses: OnChainAddress[]
+  sendAll: boolean
   memoPayer: string | null
   username: WalletName | null
 }
@@ -162,8 +201,12 @@ interface ILedgerService {
 
   sendLnTx(args: SendLnTxArgs): Promise<LedgerJournal | LedgerServiceError>
 
-  sendIntraledgerTx(
-    args: SendIntraledgerTxArgs,
+  sendLnIntraledgerTx(
+    args: SendLnIntraledgerTxArgs,
+  ): Promise<LedgerJournal | LedgerServiceError>
+
+  sendOnChainIntraledgerTx(
+    args: SendOnChainIntraledgerTxArgs,
   ): Promise<LedgerJournal | LedgerServiceError>
 
   settlePendingLiabilityTransactions(

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -94,10 +94,6 @@ type IntraledgerTxArgs = {
   shareMemoWithPayee: boolean
 }
 
-type SendIntraledgerTxArgs = IntraledgerTxArgs & {
-  metadata: SendLnIntraledgerTxMetadata | SendOnChainIntraledgerTxMetadata
-}
-
 type SendLnIntraledgerTxArgs = IntraledgerTxArgs & {
   paymentHash: PaymentHash
   fee: Satoshis
@@ -112,40 +108,6 @@ type SendOnChainIntraledgerTxArgs = IntraledgerTxArgs & {
   usdFee: number
   payeeAddresses: OnChainAddress[]
   sendAll: boolean
-}
-
-type TxMetadata = {
-  type: LedgerTransactionType
-  pending: boolean
-  fee: Satoshis
-  feeUsd: number
-  sats: Satoshis
-  usd: number
-  currency: Currency
-}
-
-type ReceiveLnTxMetadata = TxMetadata & {
-  hash: PaymentHash
-}
-
-type SendLnTxMetadata = TxMetadata & {
-  hash: PaymentHash
-  pubkey: Pubkey
-  feeKnownInAdvance: boolean
-}
-
-type SendLnIntraledgerTxMetadata = TxMetadata & {
-  hash: PaymentHash
-  pubkey: Pubkey
-  memoPayer: string | null
-  username: WalletName | null
-}
-
-type SendOnChainIntraledgerTxMetadata = TxMetadata & {
-  payee_addresses: OnChainAddress[]
-  sendAll: boolean
-  memoPayer: string | null
-  username: WalletName | null
 }
 
 type ReceiveLnFeeReeimbursementArgs = {

--- a/src/services/ledger/index.ts
+++ b/src/services/ledger/index.ts
@@ -142,7 +142,7 @@ export const LedgerService = (): ILedgerService => {
     usd,
     usdFee,
     receivingAddress,
-  }: ReceiveOnChainTxArgs) => {
+  }: ReceiveOnChainTxArgs): Promise<LedgerJournal | LedgerError> => {
     try {
       const metadata = {
         currency: "BTC",
@@ -165,9 +165,12 @@ export const LedgerService = (): ILedgerService => {
         entry.credit(bankOwnerPath, fee, metadata)
       }
 
-      await entry.commit()
-
-      return
+      const savedEntry = await entry.commit()
+      return {
+        journalId: savedEntry._id.toString(),
+        voided: savedEntry.voided,
+        transactionIds: savedEntry._transactions.map((id) => id.toString()),
+      }
     } catch (err) {
       return new UnknownLedgerError(err)
     }
@@ -181,7 +184,7 @@ export const LedgerService = (): ILedgerService => {
     fee,
     usd,
     usdFee,
-  }: ReceiveLnTxArgs): Promise<void | LedgerError> => {
+  }: ReceiveLnTxArgs): Promise<LedgerJournal | LedgerError> => {
     let metadata: ReceiveLnTxMetadata
     try {
       metadata = {
@@ -205,7 +208,12 @@ export const LedgerService = (): ILedgerService => {
         entry.credit(bankOwnerPath, fee, metadata)
       }
 
-      await entry.commit()
+      const savedEntry = await entry.commit()
+      return {
+        journalId: savedEntry._id.toString(),
+        voided: savedEntry.voided,
+        transactionIds: savedEntry._transactions.map((id) => id.toString()),
+      }
     } catch (err) {
       return new UnknownLedgerError(err)
     }
@@ -217,7 +225,7 @@ export const LedgerService = (): ILedgerService => {
     sats,
     usd,
     journalId,
-  }: ReceiveLnFeeReeimbursementArgs): Promise<void | LedgerError> => {
+  }: ReceiveLnFeeReeimbursementArgs): Promise<LedgerJournal | LedgerError> => {
     try {
       const metadata = {
         type: LedgerTransactionType.LnFeeReimbursement,
@@ -234,7 +242,12 @@ export const LedgerService = (): ILedgerService => {
         .credit(liabilitiesAccountId, sats, metadata)
         .debit(lndAccountingPath, sats, metadata)
 
-      await entry.commit()
+      const savedEntry = await entry.commit()
+      return {
+        journalId: savedEntry._id.toString(),
+        voided: savedEntry.voided,
+        transactionIds: savedEntry._transactions.map((id) => id.toString()),
+      }
     } catch (err) {
       return new UnknownLedgerError(err)
     }
@@ -257,7 +270,7 @@ export const LedgerService = (): ILedgerService => {
     recipientWalletName,
     memoPayer,
     isPushPayment,
-  }: SendLnTxArgs): Promise<void | LedgerError> => {
+  }: SendLnTxArgs): Promise<LedgerJournal | LedgerError> => {
     let metadata: SendLnTxMetadata
     try {
       metadata = {
@@ -292,7 +305,12 @@ export const LedgerService = (): ILedgerService => {
         .credit(creditAccountingPath, sats, creditMetadata)
         .debit(liabilitiesAccountId, sats, debitMetadata)
 
-      await entry.commit()
+      const savedEntry = await entry.commit()
+      return {
+        journalId: savedEntry._id.toString(),
+        voided: savedEntry.voided,
+        transactionIds: savedEntry._transactions.map((id) => id.toString()),
+      }
     } catch (err) {
       return new UnknownLedgerError(err)
     }

--- a/src/services/ledger/index.ts
+++ b/src/services/ledger/index.ts
@@ -134,7 +134,7 @@ export const LedgerService = (): ILedgerService => {
     }
   }
 
-  const receiveOnChainTx = async ({
+  const addOnChainTxReceive = async ({
     liabilitiesAccountId,
     txId,
     sats,
@@ -172,7 +172,7 @@ export const LedgerService = (): ILedgerService => {
     }
   }
 
-  const receiveLnTx = async ({
+  const addLnTxReceive = async ({
     liabilitiesAccountId,
     paymentHash,
     description,
@@ -180,8 +180,8 @@ export const LedgerService = (): ILedgerService => {
     fee,
     usd,
     usdFee,
-  }: ReceiveLnTxArgs): Promise<LedgerJournal | LedgerError> => {
-    let metadata: ReceiveLnTxMetadata
+  }: AddLnTxReceiveArgs): Promise<LedgerJournal | LedgerError> => {
+    let metadata: AddLnTxReceiveMetadata
     try {
       metadata = {
         type: LedgerTransactionType.Invoice,
@@ -211,13 +211,13 @@ export const LedgerService = (): ILedgerService => {
     }
   }
 
-  const receiveLnFeeReimbursement = async ({
+  const addLnFeeReimbursementReceive = async ({
     liabilitiesAccountId,
     paymentHash,
     sats,
     usd,
     journalId,
-  }: ReceiveLnFeeReeimbursementArgs): Promise<LedgerJournal | LedgerError> => {
+  }: AddLnFeeReeimbursementReceiveArgs): Promise<LedgerJournal | LedgerError> => {
     try {
       const metadata = {
         type: LedgerTransactionType.LnFeeReimbursement,
@@ -241,7 +241,7 @@ export const LedgerService = (): ILedgerService => {
     }
   }
 
-  const sendLnTx = async ({
+  const addLnTxSend = async ({
     liabilitiesAccountId,
     paymentHash,
     description,
@@ -251,8 +251,8 @@ export const LedgerService = (): ILedgerService => {
     usdFee,
     pubkey,
     feeKnownInAdvance,
-  }: SendLnTxArgs): Promise<LedgerJournal | LedgerError> => {
-    let metadata: SendLnTxMetadata
+  }: AddLnTxSendArgs): Promise<LedgerJournal | LedgerError> => {
+    let metadata: AddLnTxSendMetadata
     try {
       metadata = {
         type: LedgerTransactionType.Payment,
@@ -280,7 +280,7 @@ export const LedgerService = (): ILedgerService => {
     }
   }
 
-  const sendLnIntraledgerTx = async ({
+  const addLnIntraledgerTxSend = async ({
     liabilitiesAccountId,
     paymentHash,
     description,
@@ -294,8 +294,8 @@ export const LedgerService = (): ILedgerService => {
     recipientWalletName,
     memoPayer,
     shareMemoWithPayee,
-  }: SendLnIntraledgerTxArgs): Promise<LedgerJournal | LedgerError> => {
-    const metadata: SendLnIntraledgerTxMetadata = {
+  }: AddLnIntraledgerTxSendArgs): Promise<LedgerJournal | LedgerError> => {
+    const metadata: AddLnIntraledgerTxSendMetadata = {
       type: LedgerTransactionType.IntraLedger,
       pending: false,
       hash: paymentHash,
@@ -309,7 +309,7 @@ export const LedgerService = (): ILedgerService => {
       currency: "BTC",
     }
 
-    return sendIntraledgerTx({
+    return addIntraledgerTxSend({
       liabilitiesAccountId,
       description,
       sats,
@@ -322,7 +322,7 @@ export const LedgerService = (): ILedgerService => {
     })
   }
 
-  const sendOnChainIntraledgerTx = async ({
+  const addOnChainIntraledgerTxSend = async ({
     liabilitiesAccountId,
     description,
     sats,
@@ -336,8 +336,8 @@ export const LedgerService = (): ILedgerService => {
     recipientWalletName,
     memoPayer,
     shareMemoWithPayee,
-  }: SendOnChainIntraledgerTxArgs): Promise<LedgerJournal | LedgerError> => {
-    const metadata: SendOnChainIntraledgerTxMetadata = {
+  }: AddOnChainIntraledgerTxSendArgs): Promise<LedgerJournal | LedgerError> => {
+    const metadata: AddOnChainIntraledgerTxSendMetadata = {
       type: LedgerTransactionType.OnchainIntraLedger,
       pending: false,
       fee,
@@ -351,7 +351,7 @@ export const LedgerService = (): ILedgerService => {
       currency: "BTC",
     }
 
-    return sendIntraledgerTx({
+    return addIntraledgerTxSend({
       liabilitiesAccountId,
       description,
       sats,
@@ -364,7 +364,7 @@ export const LedgerService = (): ILedgerService => {
     })
   }
 
-  const sendIntraledgerTx = async ({
+  const addIntraledgerTxSend = async ({
     liabilitiesAccountId,
     description,
     sats,
@@ -429,12 +429,12 @@ export const LedgerService = (): ILedgerService => {
     getAccountBalance,
     isOnChainTxRecorded,
     isLnTxRecorded,
-    receiveOnChainTx,
-    receiveLnTx,
-    receiveLnFeeReimbursement,
-    sendLnTx,
-    sendLnIntraledgerTx,
-    sendOnChainIntraledgerTx,
+    addOnChainTxReceive,
+    addLnTxReceive,
+    addLnFeeReimbursementReceive,
+    addLnTxSend,
+    addLnIntraledgerTxSend,
+    addOnChainIntraledgerTxSend,
     settlePendingLiabilityTransactions,
     voidLedgerTransactionsForJournal,
   }

--- a/src/services/ledger/index.ts
+++ b/src/services/ledger/index.ts
@@ -166,11 +166,7 @@ export const LedgerService = (): ILedgerService => {
       }
 
       const savedEntry = await entry.commit()
-      return {
-        journalId: savedEntry._id.toString(),
-        voided: savedEntry.voided,
-        transactionIds: savedEntry._transactions.map((id) => id.toString()),
-      }
+      return translateToLedgerJournal(savedEntry)
     } catch (err) {
       return new UnknownLedgerError(err)
     }
@@ -209,11 +205,7 @@ export const LedgerService = (): ILedgerService => {
       }
 
       const savedEntry = await entry.commit()
-      return {
-        journalId: savedEntry._id.toString(),
-        voided: savedEntry.voided,
-        transactionIds: savedEntry._transactions.map((id) => id.toString()),
-      }
+      return translateToLedgerJournal(savedEntry)
     } catch (err) {
       return new UnknownLedgerError(err)
     }
@@ -243,11 +235,7 @@ export const LedgerService = (): ILedgerService => {
         .debit(lndAccountingPath, sats, metadata)
 
       const savedEntry = await entry.commit()
-      return {
-        journalId: savedEntry._id.toString(),
-        voided: savedEntry.voided,
-        transactionIds: savedEntry._transactions.map((id) => id.toString()),
-      }
+      return translateToLedgerJournal(savedEntry)
     } catch (err) {
       return new UnknownLedgerError(err)
     }
@@ -255,27 +243,20 @@ export const LedgerService = (): ILedgerService => {
 
   const sendLnTx = async ({
     liabilitiesAccountId,
-    recipientLiabilitiesAccountId,
     paymentHash,
     description,
     sats,
     fee,
     usd,
     usdFee,
-    type,
-    pending,
     pubkey,
     feeKnownInAdvance,
-    payerWalletName,
-    recipientWalletName,
-    memoPayer,
-    isPushPayment,
   }: SendLnTxArgs): Promise<LedgerJournal | LedgerError> => {
     let metadata: SendLnTxMetadata
     try {
       metadata = {
-        type,
-        pending,
+        type: LedgerTransactionType.Payment,
+        pending: true,
         hash: paymentHash,
         fee,
         feeUsd: usdFee,
@@ -286,6 +267,48 @@ export const LedgerService = (): ILedgerService => {
         currency: "BTC",
       }
 
+      const entry = MainBook.entry(description)
+
+      entry
+        .credit(lndAccountingPath, sats, metadata)
+        .debit(liabilitiesAccountId, sats, metadata)
+
+      const savedEntry = await entry.commit()
+      return translateToLedgerJournal(savedEntry)
+    } catch (err) {
+      return new UnknownLedgerError(err)
+    }
+  }
+
+  const sendIntraledgerTx = async ({
+    liabilitiesAccountId,
+    paymentHash,
+    description,
+    sats,
+    fee,
+    usd,
+    usdFee,
+    pubkey,
+    recipientLiabilitiesAccountId,
+    payerWalletName,
+    recipientWalletName,
+    memoPayer,
+    isPushPayment,
+  }: SendIntraledgerTxArgs): Promise<LedgerJournal | LedgerError> => {
+    const metadata: SendIntraledgerTxMetadata = {
+      type: LedgerTransactionType.IntraLedger,
+      pending: false,
+      hash: paymentHash,
+      fee,
+      feeUsd: usdFee,
+      sats,
+      usd,
+      pubkey,
+      memoPayer: null,
+      username: null,
+      currency: "BTC",
+    }
+    try {
       const creditMetadata = { ...metadata }
       if (payerWalletName) {
         creditMetadata.memoPayer = isPushPayment ? memoPayer : null
@@ -298,19 +321,13 @@ export const LedgerService = (): ILedgerService => {
       }
 
       const entry = MainBook.entry(description)
-      const creditAccountingPath =
-        recipientLiabilitiesAccountId || (lndAccountingPath as LiabilitiesAccountId)
 
       entry
-        .credit(creditAccountingPath, sats, creditMetadata)
+        .credit(recipientLiabilitiesAccountId, sats, creditMetadata)
         .debit(liabilitiesAccountId, sats, debitMetadata)
 
       const savedEntry = await entry.commit()
-      return {
-        journalId: savedEntry._id.toString(),
-        voided: savedEntry.voided,
-        transactionIds: savedEntry._transactions.map((id) => id.toString()),
-      }
+      return translateToLedgerJournal(savedEntry)
     } catch (err) {
       return new UnknownLedgerError(err)
     }
@@ -353,6 +370,7 @@ export const LedgerService = (): ILedgerService => {
     receiveLnTx,
     receiveLnFeeReimbursement,
     sendLnTx,
+    sendIntraledgerTx,
     settlePendingLiabilityTransactions,
     voidLedgerTransactionsForJournal,
   }
@@ -378,4 +396,10 @@ const translateToLedgerTx = (tx): LedgerTransaction => ({
   addresses: tx.payee_addresses,
   txId: tx.hash,
   feeKnownInAdvance: tx.feeKnownInAdvance || false,
+})
+
+const translateToLedgerJournal = (savedEntry): LedgerJournal => ({
+  journalId: savedEntry._id.toString(),
+  voided: savedEntry.voided,
+  transactionIds: savedEntry._transactions.map((id) => id.toString()),
 })

--- a/src/services/ledger/index.types.d.ts
+++ b/src/services/ledger/index.types.d.ts
@@ -1,0 +1,37 @@
+type TxMetadata = {
+  type: LedgerTransactionType
+  pending: boolean
+  fee: Satoshis
+  feeUsd: number
+  sats: Satoshis
+  usd: number
+  currency: Currency
+}
+
+type ReceiveLnTxMetadata = TxMetadata & {
+  hash: PaymentHash
+}
+
+type SendLnTxMetadata = TxMetadata & {
+  hash: PaymentHash
+  pubkey: Pubkey
+  feeKnownInAdvance: boolean
+}
+
+type SendLnIntraledgerTxMetadata = TxMetadata & {
+  hash: PaymentHash
+  pubkey: Pubkey
+  memoPayer: string | null
+  username: WalletName | null
+}
+
+type SendOnChainIntraledgerTxMetadata = TxMetadata & {
+  payee_addresses: OnChainAddress[]
+  sendAll: boolean
+  memoPayer: string | null
+  username: WalletName | null
+}
+
+type SendIntraledgerTxArgs = IntraledgerTxArgs & {
+  metadata: SendLnIntraledgerTxMetadata | SendOnChainIntraledgerTxMetadata
+}

--- a/src/services/ledger/index.types.d.ts
+++ b/src/services/ledger/index.types.d.ts
@@ -8,24 +8,24 @@ type TxMetadata = {
   currency: Currency
 }
 
-type ReceiveLnTxMetadata = TxMetadata & {
+type AddLnTxReceiveMetadata = TxMetadata & {
   hash: PaymentHash
 }
 
-type SendLnTxMetadata = TxMetadata & {
+type AddLnTxSendMetadata = TxMetadata & {
   hash: PaymentHash
   pubkey: Pubkey
   feeKnownInAdvance: boolean
 }
 
-type SendLnIntraledgerTxMetadata = TxMetadata & {
+type AddLnIntraledgerTxSendMetadata = TxMetadata & {
   hash: PaymentHash
   pubkey: Pubkey
   memoPayer: string | null
   username: WalletName | null
 }
 
-type SendOnChainIntraledgerTxMetadata = TxMetadata & {
+type AddOnChainIntraledgerTxSendMetadata = TxMetadata & {
   payee_addresses: OnChainAddress[]
   sendAll: boolean
   memoPayer: string | null
@@ -33,5 +33,5 @@ type SendOnChainIntraledgerTxMetadata = TxMetadata & {
 }
 
 type SendIntraledgerTxArgs = IntraledgerTxArgs & {
-  metadata: SendLnIntraledgerTxMetadata | SendOnChainIntraledgerTxMetadata
+  metadata: AddLnIntraledgerTxSendMetadata | AddOnChainIntraledgerTxSendMetadata
 }


### PR DESCRIPTION
## Description

Add new ledger service methods:
- `sendLnTx` to replace `addLnPayment`
- `sendIntraledgerTx` to replace `addOnUsPayment`

### Open `TODO`s:
- [x] Add/confirm support for `onChainPay` usage
- [x] swap into places that use `addLnPayment` and `addOnUsPayment`