### PR TITLE
Add `LimitsChecker` object

### DIFF
--- a/src/app/accounts/get-limits-checker.ts
+++ b/src/app/accounts/get-limits-checker.ts
@@ -1,0 +1,31 @@
+import { getTwoFALimits, getUserLimits, MS_PER_DAY } from "@config/app"
+import { LimitsChecker } from "@domain/accounts"
+import { toLiabilitiesAccountId } from "@domain/ledger"
+import { LedgerService } from "@services/ledger"
+import { AccountsRepository } from "@services/mongoose"
+
+export const getLimitsChecker = async (
+  walletId: WalletId,
+): Promise<LimitsChecker | ApplicationError> => {
+  const ledgerService = LedgerService()
+
+  const liabilitiesAccountId = toLiabilitiesAccountId(walletId)
+  const timestamp1Day = (Date.now() - MS_PER_DAY) as UnixTimeMs
+  const walletVolume = await ledgerService.txVolumeSince({
+    liabilitiesAccountId,
+    timestamp: timestamp1Day,
+  })
+  if (walletVolume instanceof Error) return walletVolume
+
+  const account = await AccountsRepository().findByWalletId(walletId)
+  if (account instanceof Error) return account
+  const { level } = account
+
+  const userLimits = getUserLimits({ level })
+  const twoFALimits = getTwoFALimits()
+  return LimitsChecker({
+    walletVolume,
+    userLimits,
+    twoFALimits,
+  })
+}

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -97,6 +97,10 @@ export const getUserLimits = ({
   }
 }
 
+export const getTwoFALimits = (): TwoFALimits => ({
+  threshold: yamlConfig.twoFA.threshold,
+})
+
 const getRateLimits = (config): IRateLimits => {
   /**
    * Returns a subset of the required parameters for the

--- a/src/core/accounts/helpers.ts
+++ b/src/core/accounts/helpers.ts
@@ -11,7 +11,7 @@ export const getLimitsChecker = async (
   const ledgerService = LedgerService()
 
   const liabilitiesAccountId = toLiabilitiesAccountId(walletId)
-  const timestamp1Day = (Date.now() - MS_PER_DAY) as UnixTimeMs
+  const timestamp1Day = new Date(Date.now() - MS_PER_DAY)
   const walletVolume = await ledgerService.txVolumeSince({
     liabilitiesAccountId,
     timestamp: timestamp1Day,

--- a/src/core/accounts/helpers.ts
+++ b/src/core/accounts/helpers.ts
@@ -38,7 +38,7 @@ export const checkAndVerifyTwoFA = async ({
   limitsChecker,
 }: {
   amount: Satoshis
-  twoFAToken: TwoFAToken
+  twoFAToken: TwoFAToken | null
   twoFASecret: TwoFASecret
   limitsChecker: LimitsChecker
 }): Promise<void | ApplicationError> => {
@@ -51,7 +51,7 @@ export const checkAndVerifyTwoFA = async ({
 
   const validTwoFA = TwoFA().verify({
     secret: twoFASecret,
-    token: twoFAToken as TwoFAToken,
+    token: twoFAToken,
   })
   if (validTwoFA instanceof Error) return validTwoFA
 }

--- a/src/core/accounts/helpers.ts
+++ b/src/core/accounts/helpers.ts
@@ -41,11 +41,11 @@ export const checkAndVerifyTwoFA = async ({
   twoFAToken: TwoFAToken | null
   twoFASecret: TwoFASecret
   limitsChecker: LimitsChecker
-}): Promise<void | ApplicationError> => {
+}): Promise<true | ApplicationError> => {
   const twoFALimitCheck = limitsChecker.checkTwoFA({
     amount,
   })
-  if (!(twoFALimitCheck instanceof Error)) return
+  if (!(twoFALimitCheck instanceof Error)) return true
 
   if (!twoFAToken) return new TwoFANewCodeNeededError()
 
@@ -54,4 +54,6 @@ export const checkAndVerifyTwoFA = async ({
     token: twoFAToken,
   })
   if (validTwoFA instanceof Error) return validTwoFA
+
+  return true
 }

--- a/src/core/lightning/index.ts
+++ b/src/core/lightning/index.ts
@@ -227,7 +227,7 @@ export const LightningMixin = (superclass) =>
       const twoFACheck = twoFA?.secret
         ? await checkAndVerifyTwoFA({
             amount: toSats(tokens),
-            twoFAToken: twoFAToken as TwoFAToken,
+            twoFAToken: twoFAToken ? (twoFAToken as TwoFAToken) : null,
             twoFASecret: twoFA.secret,
             limitsChecker: twoFALimitsChecker,
           })

--- a/src/core/lightning/index.ts
+++ b/src/core/lightning/index.ts
@@ -231,7 +231,7 @@ export const LightningMixin = (superclass) =>
             twoFASecret: twoFA.secret,
             limitsChecker: twoFALimitsChecker,
           })
-        : null
+        : true
       if (twoFACheck instanceof TwoFANewCodeNeededError)
         throw new TwoFAError("Need a 2FA code to proceed with the payment", {
           logger: lightningLogger,

--- a/src/core/lightning/index.ts
+++ b/src/core/lightning/index.ts
@@ -251,18 +251,22 @@ export const LightningMixin = (superclass) =>
         })
         if (balanceSats instanceof Error) throw balanceSats
 
+        const limitsChecker = await getLimitsChecker(this.user.id)
+        if (limitsChecker instanceof Error) throw limitsChecker
+
         // On us transaction
         const lndService = LndService()
         if (lndService instanceof Error) throw lndService
         if (lndService.isLocal(destination) || isPushPayment) {
           const lightningLoggerOnUs = lightningLogger.child({ onUs: true, fee: 0 })
 
-          const remainingOnUsLimit = await this.user.remainingOnUsLimit()
-
-          if (remainingOnUsLimit < tokens) {
-            const error = `Cannot transfer more than ${this.config.limits.onUsLimit} sats in 24 hours`
-            throw new TransactionRestrictedError(error, { logger: lightningLoggerOnUs })
-          }
+          const intraledgerLimitCheck = limitsChecker.checkIntraledger({
+            amount: tokens,
+          })
+          if (intraledgerLimitCheck instanceof Error)
+            throw new TransactionRestrictedError(intraledgerLimitCheck.message, {
+              logger: lightningLoggerOnUs,
+            })
 
           let payeeUser, pubkey, payeeInvoice
 
@@ -405,13 +409,13 @@ export const LightningMixin = (superclass) =>
           if (this.user.username) {
             await addContact({ uid: payeeUser._id, username: this.user.username })
           }
-
-          const remainingWithdrawalLimit = await this.user.remainingWithdrawalLimit()
-
-          if (remainingWithdrawalLimit < tokens) {
-            const error = `Cannot transfer more than ${this.config.limits.withdrawalLimit} sats in 24 hours`
-            throw new TransactionRestrictedError(error, { logger: lightningLogger })
-          }
+          const withdrawalLimitCheck = limitsChecker.checkWithdrawal({
+            amount: tokens,
+          })
+          if (withdrawalLimitCheck instanceof Error)
+            throw new TransactionRestrictedError(withdrawalLimitCheck.message, {
+              logger: lightningLogger,
+            })
 
           lightningLoggerOnUs.info(
             {
@@ -432,12 +436,13 @@ export const LightningMixin = (superclass) =>
           throw new NewAccountWithdrawalError(error, { logger: lightningLogger })
         }
 
-        const remainingWithdrawalLimit = await this.user.remainingWithdrawalLimit()
-
-        if (remainingWithdrawalLimit < tokens) {
-          const error = `Cannot withdraw more than ${this.config.limits.withdrawalLimit} sats in 24 hours`
-          throw new TransactionRestrictedError(error, { logger: lightningLogger })
-        }
+        const withdrawalLimitCheck = limitsChecker.checkWithdrawal({
+          amount: tokens,
+        })
+        if (withdrawalLimitCheck instanceof Error)
+          throw new TransactionRestrictedError(withdrawalLimitCheck.message, {
+            logger: lightningLogger,
+          })
 
         // TODO: fine tune those values:
         // const probe_timeout_ms

--- a/src/core/on-chain/index.ts
+++ b/src/core/on-chain/index.ts
@@ -141,7 +141,7 @@ export const OnChainMixin = (superclass) =>
           const twoFACheck = twoFA?.secret
             ? await checkAndVerifyTwoFA({
                 amount: toSats(amountToSendPayeeUser),
-                twoFAToken: twoFAToken as TwoFAToken,
+                twoFAToken: twoFAToken ? (twoFAToken as TwoFAToken) : null,
                 twoFASecret: twoFA.secret,
                 limitsChecker,
               })
@@ -245,7 +245,7 @@ export const OnChainMixin = (superclass) =>
         const twoFACheck = twoFA?.secret
           ? await checkAndVerifyTwoFA({
               amount: toSats(checksAmount),
-              twoFAToken: twoFAToken as TwoFAToken,
+              twoFAToken: twoFAToken ? (twoFAToken as TwoFAToken) : null,
               twoFASecret: twoFA.secret,
               limitsChecker,
             })

--- a/src/core/on-chain/index.ts
+++ b/src/core/on-chain/index.ts
@@ -145,7 +145,7 @@ export const OnChainMixin = (superclass) =>
                 twoFASecret: twoFA.secret,
                 limitsChecker,
               })
-            : null
+            : true
           if (twoFACheck instanceof TwoFANewCodeNeededError)
             throw new TwoFAError("Need a 2FA code to proceed with the payment", {
               logger: onchainLogger,
@@ -249,7 +249,7 @@ export const OnChainMixin = (superclass) =>
               twoFASecret: twoFA.secret,
               limitsChecker,
             })
-          : null
+          : true
         if (twoFACheck instanceof TwoFANewCodeNeededError)
           throw new TwoFAError("Need a 2FA code to proceed with the payment", {
             logger: onchainLogger,

--- a/src/core/types.d.ts
+++ b/src/core/types.d.ts
@@ -14,6 +14,10 @@ type GenericLimits = {
   oldEnoughForWithdrawalMicroseconds: number
 }
 
+type TwoFALimits = {
+  threshold: number
+}
+
 type FeeRates = {
   depositFeeVariable: number
   depositFeeFixed: number

--- a/src/domain/accounts/index.ts
+++ b/src/domain/accounts/index.ts
@@ -1,5 +1,6 @@
 export * from "./errors"
 export * from "./api-keys"
+export * from "./limits-checker"
 
 export const AccountLevel = {
   One: 1,

--- a/src/domain/accounts/index.types.d.ts
+++ b/src/domain/accounts/index.types.d.ts
@@ -38,9 +38,9 @@ type BusinessMapMarker = {
 }
 
 type LimitsChecker = {
-  checkTwoFA({ amount }: { amount: Satoshis }): void | LimitsExceededError
-  checkIntraledger({ amount }: { amount: Satoshis }): void | LimitsExceededError
-  checkWithdrawal({ amount }: { amount: Satoshis }): void | LimitsExceededError
+  checkTwoFA({ amount }: { amount: Satoshis }): true | LimitsExceededError
+  checkIntraledger({ amount }: { amount: Satoshis }): true | LimitsExceededError
+  checkWithdrawal({ amount }: { amount: Satoshis }): true | LimitsExceededError
 }
 interface IAccountsRepository {
   findById(accountId: AccountId): Promise<Account | RepositoryError>

--- a/src/domain/accounts/index.types.d.ts
+++ b/src/domain/accounts/index.types.d.ts
@@ -37,6 +37,11 @@ type BusinessMapMarker = {
   mapInfo: BusinessMapInfo
 }
 
+type LimitsChecker = {
+  checkTwoFA({ amount }: { amount: Satoshis }): void | LimitsExceededError
+  checkIntraledger({ amount }: { amount: Satoshis }): void | LimitsExceededError
+  checkWithdrawal({ amount }: { amount: Satoshis }): void | LimitsExceededError
+}
 interface IAccountsRepository {
   findById(accountId: AccountId): Promise<Account | RepositoryError>
   listByUserId(userId: UserId): Promise<Account[] | RepositoryError>

--- a/src/domain/accounts/index.types.d.ts
+++ b/src/domain/accounts/index.types.d.ts
@@ -8,10 +8,10 @@ type AccountStatus =
   typeof import("./index").AccountStatus[keyof typeof import("./index").AccountStatus]
 
 type Account = {
-  id: AccountId
-  level: AccountLevel
-  status: AccountStatus
-  walletIds: WalletId[]
+  readonly id: AccountId
+  readonly level: AccountLevel
+  readonly status: AccountStatus
+  readonly walletIds: WalletId[]
 }
 
 type Currencies = {
@@ -46,5 +46,6 @@ interface IAccountsRepository {
   findById(accountId: AccountId): Promise<Account | RepositoryError>
   listByUserId(userId: UserId): Promise<Account[] | RepositoryError>
   findByWalletName(walletName: WalletName): Promise<Account | RepositoryError>
+  findByWalletId(walletId: WalletId): Promise<Account | RepositoryError>
   listBusinessesForMap(): Promise<BusinessMapMarker[] | RepositoryError>
 }

--- a/src/domain/accounts/limits-checker.ts
+++ b/src/domain/accounts/limits-checker.ts
@@ -1,0 +1,50 @@
+import { LimitsExceededError, TwoFALimitsExceededError } from "@domain/errors"
+
+export const LimitsChecker = ({
+  walletVolume,
+  userLimits,
+  twoFALimits,
+}: {
+  walletVolume: TxVolume
+  userLimits: IUserLimits
+  twoFALimits: TwoFALimits
+}): LimitsChecker => {
+  const checkTwoFA = ({ amount }: { amount: Satoshis }): void | LimitsExceededError => {
+    const remainingTwoFALimit = twoFALimits.threshold - walletVolume.outgoingSats
+    if (remainingTwoFALimit < amount) {
+      return new TwoFALimitsExceededError("Need a 2FA code to proceed with the payment")
+    }
+  }
+
+  const checkIntraledger = ({
+    amount,
+  }: {
+    amount: Satoshis
+  }): void | LimitsExceededError => {
+    const remainingLimit = userLimits.onUsLimit - walletVolume.outgoingSats
+    if (remainingLimit < amount) {
+      return new LimitsExceededError(
+        `Cannot transfer more than ${userLimits.onUsLimit} sats in 24 hours`,
+      )
+    }
+  }
+
+  const checkWithdrawal = ({
+    amount,
+  }: {
+    amount: Satoshis
+  }): void | LimitsExceededError => {
+    const remainingLimit = userLimits.withdrawalLimit - walletVolume.outgoingSats
+    if (remainingLimit < amount) {
+      return new LimitsExceededError(
+        `Cannot transfer more than ${userLimits.withdrawalLimit} sats in 24 hours`,
+      )
+    }
+  }
+
+  return {
+    checkTwoFA,
+    checkIntraledger,
+    checkWithdrawal,
+  }
+}

--- a/src/domain/accounts/limits-checker.ts
+++ b/src/domain/accounts/limits-checker.ts
@@ -9,37 +9,40 @@ export const LimitsChecker = ({
   userLimits: IUserLimits
   twoFALimits: TwoFALimits
 }): LimitsChecker => {
-  const checkTwoFA = ({ amount }: { amount: Satoshis }): void | LimitsExceededError => {
+  const checkTwoFA = ({ amount }: { amount: Satoshis }): true | LimitsExceededError => {
     const remainingTwoFALimit = twoFALimits.threshold - walletVolume.outgoingSats
     if (remainingTwoFALimit < amount) {
       return new TwoFALimitsExceededError("Need a 2FA code to proceed with the payment")
     }
+    return true
   }
 
   const checkIntraledger = ({
     amount,
   }: {
     amount: Satoshis
-  }): void | LimitsExceededError => {
+  }): true | LimitsExceededError => {
     const remainingLimit = userLimits.onUsLimit - walletVolume.outgoingSats
     if (remainingLimit < amount) {
       return new LimitsExceededError(
         `Cannot transfer more than ${userLimits.onUsLimit} sats in 24 hours`,
       )
     }
+    return true
   }
 
   const checkWithdrawal = ({
     amount,
   }: {
     amount: Satoshis
-  }): void | LimitsExceededError => {
+  }): true | LimitsExceededError => {
     const remainingLimit = userLimits.withdrawalLimit - walletVolume.outgoingSats
     if (remainingLimit < amount) {
       return new LimitsExceededError(
         `Cannot transfer more than ${userLimits.withdrawalLimit} sats in 24 hours`,
       )
     }
+    return true
   }
 
   return {

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -20,3 +20,6 @@ export class SelfPaymentError extends ValidationError {}
 export class LessThanDustThresholdError extends ValidationError {}
 export class InsufficientBalanceError extends ValidationError {}
 export class InvalidTargetConfirmations extends ValidationError {}
+export class LimitsExceededError extends ValidationError {}
+
+export class TwoFALimitsExceededError extends LimitsExceededError {}

--- a/src/domain/errors.types.d.ts
+++ b/src/domain/errors.types.d.ts
@@ -1,3 +1,4 @@
 type RepositoryError = import("./errors").RepositoryError
-
 type ValidationError = import("./errors").ValidationError
+type LimitsExceededError = import("./errors").LimitsExceededError
+type TwoFALimitsExceededError = import("./errors").TwoFALimitsExceededError

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -122,6 +122,11 @@ type FeeReimbursement = {
   getReimbursement({ actualFee }: { actualFee: Satoshis }): Satoshis | null
 }
 
+type TxVolume = {
+  outgoingSats: Satoshis
+  incomingSats: Satoshis
+}
+
 interface ILedgerService {
   getLiabilityTransactions(
     liabilitiesAccountId: LiabilitiesAccountId,
@@ -143,6 +148,14 @@ interface ILedgerService {
   getAccountBalance(
     liabilitiesAccountId: LiabilitiesAccountId,
   ): Promise<Satoshis | LedgerServiceError>
+
+  txVolumeSince({
+    liabilitiesAccountId,
+    timestamp,
+  }: {
+    liabilitiesAccountId: LiabilitiesAccountId
+    timestamp: UnixTimeMs
+  }): Promise<TxVolume | LedgerServiceError>
 
   isOnChainTxRecorded(
     liabilitiesAccountId: LiabilitiesAccountId,

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -154,7 +154,7 @@ interface ILedgerService {
     timestamp,
   }: {
     liabilitiesAccountId: LiabilitiesAccountId
-    timestamp: UnixTimeMs
+    timestamp: Date
   }): Promise<TxVolume | LedgerServiceError>
 
   isOnChainTxRecorded(

--- a/src/domain/primitives/index.types.d.ts
+++ b/src/domain/primitives/index.types.d.ts
@@ -16,4 +16,7 @@ type WalletName = string & { [walletNameSymbol]: never }
 declare const accountIdSymbol: unique symbol
 type AccountId = string & { [accountIdSymbol]: never }
 
+declare const unixTimeMsSymbol: unique symbol
+type UnixTimeMs = number & { [unixTimeMsSymbol]: never }
+
 type TxDenominationCurrency = "USD" | "BTC"

--- a/src/domain/primitives/index.types.d.ts
+++ b/src/domain/primitives/index.types.d.ts
@@ -16,7 +16,4 @@ type WalletName = string & { [walletNameSymbol]: never }
 declare const accountIdSymbol: unique symbol
 type AccountId = string & { [accountIdSymbol]: never }
 
-declare const unixTimeMsSymbol: unique symbol
-type UnixTimeMs = number & { [unixTimeMsSymbol]: never }
-
 type TxDenominationCurrency = "USD" | "BTC"

--- a/src/domain/twoFA/errors.ts
+++ b/src/domain/twoFA/errors.ts
@@ -3,4 +3,5 @@ export class TwoFAError extends Error {
 }
 
 export class TwoFAValidationError extends TwoFAError {}
+export class TwoFANewCodeNeededError extends TwoFAError {}
 export class UnknownTwoFAError extends TwoFAError {}

--- a/src/domain/twoFA/errors.ts
+++ b/src/domain/twoFA/errors.ts
@@ -1,0 +1,6 @@
+export class TwoFAError extends Error {
+  name = this.constructor.name
+}
+
+export class TwoFAValidationError extends TwoFAError {}
+export class UnknownTwoFAError extends TwoFAError {}

--- a/src/domain/twoFA/index.ts
+++ b/src/domain/twoFA/index.ts
@@ -1,0 +1,26 @@
+import { TwoFAValidationError, UnknownTwoFAError } from "./errors"
+import { verifyToken } from "node-2fa"
+
+export * from "./errors"
+
+export const TwoFA = (): TwoFAComponent => {
+  const verify = ({
+    secret,
+    token,
+  }: {
+    secret: TwoFASecret
+    token: TwoFAToken
+  }): void | TwoFAError => {
+    try {
+      const result = verifyToken(secret, token)
+      if (!result) {
+        return new TwoFAValidationError()
+      }
+    } catch (err) {
+      return new UnknownTwoFAError()
+    }
+  }
+  return {
+    verify,
+  }
+}

--- a/src/domain/twoFA/index.ts
+++ b/src/domain/twoFA/index.ts
@@ -3,7 +3,7 @@ import { verifyToken } from "node-2fa"
 
 export * from "./errors"
 
-export const TwoFA = (): TwoFAComponent => {
+export const TwoFA = (): TwoFA => {
   const verify = ({
     secret,
     token,

--- a/src/domain/twoFA/index.ts
+++ b/src/domain/twoFA/index.ts
@@ -10,12 +10,13 @@ export const TwoFA = (): TwoFA => {
   }: {
     secret: TwoFASecret
     token: TwoFAToken
-  }): void | TwoFAError => {
+  }): true | TwoFAError => {
     try {
       const result = verifyToken(secret, token)
       if (!result) {
         return new TwoFAValidationError()
       }
+      return true
     } catch (err) {
       return new UnknownTwoFAError()
     }

--- a/src/domain/twoFA/index.types.d.ts
+++ b/src/domain/twoFA/index.types.d.ts
@@ -1,0 +1,11 @@
+declare const twoFASecretSymbol: unique symbol
+type TwoFASecret = string & { [twoFASecretSymbol]: never }
+
+declare const twoFATokenSymbol: unique symbol
+type TwoFAToken = string & { [twoFATokenSymbol]: never }
+
+type TwoFAError = import("./errors").TwoFAError
+
+interface TwoFAComponent {
+  verify({ secret, token }: { secret: TwoFASecret; token: TwoFAToken }): void | TwoFAError
+}

--- a/src/domain/twoFA/index.types.d.ts
+++ b/src/domain/twoFA/index.types.d.ts
@@ -7,5 +7,5 @@ type TwoFAToken = string & { [twoFATokenSymbol]: never }
 type TwoFAError = import("./errors").TwoFAError
 
 interface TwoFA {
-  verify({ secret, token }: { secret: TwoFASecret; token: TwoFAToken }): void | TwoFAError
+  verify({ secret, token }: { secret: TwoFASecret; token: TwoFAToken }): true | TwoFAError
 }

--- a/src/domain/twoFA/index.types.d.ts
+++ b/src/domain/twoFA/index.types.d.ts
@@ -6,6 +6,6 @@ type TwoFAToken = string & { [twoFATokenSymbol]: never }
 
 type TwoFAError = import("./errors").TwoFAError
 
-interface TwoFAComponent {
+interface TwoFA {
   verify({ secret, token }: { secret: TwoFASecret; token: TwoFAToken }): void | TwoFAError
 }

--- a/src/domain/users/index.types.d.ts
+++ b/src/domain/users/index.types.d.ts
@@ -7,6 +7,9 @@ type UserLanguage =
 declare const deviceTokenSymbol: unique symbol
 type DeviceToken = string & { [deviceTokenSymbol]: never }
 
+declare const twoFASecretSymbol: unique symbol
+type TwoFASecret = string & { [twoFASecretSymbol]: never }
+
 declare const contactAliasSymbol: unique symbol
 type ContactAlias = string & { [contactAliasSymbol]: never }
 

--- a/src/domain/users/index.types.d.ts
+++ b/src/domain/users/index.types.d.ts
@@ -7,9 +7,6 @@ type UserLanguage =
 declare const deviceTokenSymbol: unique symbol
 type DeviceToken = string & { [deviceTokenSymbol]: never }
 
-declare const twoFASecretSymbol: unique symbol
-type TwoFASecret = string & { [twoFASecretSymbol]: never }
-
 declare const contactAliasSymbol: unique symbol
 type ContactAlias = string & { [contactAliasSymbol]: never }
 

--- a/src/domain/users/index.types.d.ts
+++ b/src/domain/users/index.types.d.ts
@@ -39,7 +39,7 @@ type User = {
   phone: PhoneNumber
   language: UserLanguage
   lastConnection: Date
-  twoFA: TwoFA
+  twoFA: TwoFAForUser
 }
 
 interface IUsersRepository {

--- a/src/services/ledger/index.ts
+++ b/src/services/ledger/index.ts
@@ -109,7 +109,7 @@ export const LedgerService = (): ILedgerService => {
     timestamp,
   }: {
     liabilitiesAccountId: LiabilitiesAccountId
-    timestamp: UnixTimeMs
+    timestamp: Date
   }): Promise<TxVolume | LedgerServiceError> => {
     const txnTypes = [{ type: "on_us" }, { type: "onchain_on_us" }]
     try {
@@ -118,7 +118,7 @@ export const LedgerService = (): ILedgerService => {
           $match: {
             accounts: liabilitiesAccountId,
             $or: txnTypes,
-            $and: [{ timestamp: { $gte: new Date(timestamp) } }],
+            $and: [{ timestamp: { $gte: timestamp } }],
           },
         },
         {

--- a/src/services/ledger/index.ts
+++ b/src/services/ledger/index.ts
@@ -104,6 +104,41 @@ export const LedgerService = (): ILedgerService => {
     }
   }
 
+  const txVolumeSince = async ({
+    liabilitiesAccountId,
+    timestamp,
+  }: {
+    liabilitiesAccountId: LiabilitiesAccountId
+    timestamp: UnixTimeMs
+  }): Promise<TxVolume | LedgerServiceError> => {
+    const txnTypes = [{ type: "on_us" }, { type: "onchain_on_us" }]
+    try {
+      const [result]: (TxVolume & { _id: null })[] = await Transaction.aggregate([
+        {
+          $match: {
+            accounts: liabilitiesAccountId,
+            $or: txnTypes,
+            $and: [{ timestamp: { $gte: new Date(timestamp) } }],
+          },
+        },
+        {
+          $group: {
+            _id: null,
+            outgoingSats: { $sum: "$debit" },
+            incomingSats: { $sum: "$credit" },
+          },
+        },
+      ])
+
+      return {
+        outgoingSats: toSats(result?.outgoingSats ?? 0),
+        incomingSats: toSats(result?.incomingSats ?? 0),
+      }
+    } catch (err) {
+      return new UnknownLedgerError(err)
+    }
+  }
+
   const isOnChainTxRecorded = async (
     liabilitiesAccountId: LiabilitiesAccountId,
     txId: TxId,
@@ -427,6 +462,7 @@ export const LedgerService = (): ILedgerService => {
     listPendingPayments,
     getPendingPaymentsCount,
     getAccountBalance,
+    txVolumeSince,
     isOnChainTxRecorded,
     isLnTxRecorded,
     addOnChainTxReceive,

--- a/src/services/mongoose/schema.types.d.ts
+++ b/src/services/mongoose/schema.types.d.ts
@@ -10,7 +10,7 @@ type IPType = {
 }
 
 type TwoFA = {
-  secret: string | undefined
+  secret?: TwoFASecret
   threshold: number
 }
 

--- a/src/services/mongoose/schema.types.d.ts
+++ b/src/services/mongoose/schema.types.d.ts
@@ -9,7 +9,7 @@ type IPType = {
   lastConnection: Date
 }
 
-type TwoFA = {
+type TwoFAForUser = {
   secret?: TwoFASecret
   threshold: number
 }
@@ -64,7 +64,7 @@ interface UserType {
   lastIPs?: IPType[]
   onchain?: OnChainObjectForUser[]
   lastConnection: Date
-  twoFA: TwoFA
+  twoFA: TwoFAForUser
 
   // business:
   title?: string

--- a/src/services/mongoose/users.ts
+++ b/src/services/mongoose/users.ts
@@ -33,6 +33,7 @@ export const UsersRepository = (): IUsersRepository => {
     contacts,
     deviceTokens,
     lastConnection,
+    twoFA,
   }: User): Promise<User | RepositoryError> => {
     try {
       const data = {
@@ -44,6 +45,7 @@ export const UsersRepository = (): IUsersRepository => {
         })),
         deviceToken: deviceTokens,
         lastConnection,
+        twoFA,
       }
       const result = await User.findOneAndUpdate({ _id: id }, data)
       if (!result) {
@@ -66,7 +68,7 @@ const userFromRaw = (result: UserType): User => {
     id: result.id as UserId,
     phone: result.phone as PhoneNumber,
     language: (result.language || UserLanguage.EN_US) as UserLanguage,
-    twoFA: result.twoFA,
+    twoFA: result.twoFA as TwoFA,
     contacts: result.contacts.reduce(
       (res: WalletContact[], contact: ContactObjectForUser): WalletContact[] => {
         if (contact.id) {

--- a/src/services/mongoose/users.ts
+++ b/src/services/mongoose/users.ts
@@ -68,7 +68,7 @@ const userFromRaw = (result: UserType): User => {
     id: result.id as UserId,
     phone: result.phone as PhoneNumber,
     language: (result.language || UserLanguage.EN_US) as UserLanguage,
-    twoFA: result.twoFA as TwoFA,
+    twoFA: result.twoFA as TwoFAForUser,
     contacts: result.contacts.reduce(
       (res: WalletContact[], contact: ContactObjectForUser): WalletContact[] => {
         if (contact.id) {

--- a/test/unit/domain/accounts/limits-checker.spec.ts
+++ b/test/unit/domain/accounts/limits-checker.spec.ts
@@ -1,0 +1,102 @@
+import { getTwoFALimits, getUserLimits } from "@config/app"
+import { LimitsChecker } from "@domain/accounts"
+import { toSats } from "@domain/bitcoin"
+import { LimitsExceededError } from "@domain/errors"
+
+describe("LimitsChecker", () => {
+  let intraledgerLimitsChecker: LimitsChecker
+  let withdrawalLimitsChecker: LimitsChecker
+  let twoFALimitsChecker: LimitsChecker
+  let paymentAmount: Satoshis
+  beforeAll(() => {
+    const level: AccountLevel = 1
+    const userLimits = getUserLimits({ level })
+    const twoFALimits = getTwoFALimits()
+
+    paymentAmount = toSats(10_000)
+    const walletVolumeIntraledger: TxVolume = {
+      outgoingSats: toSats(userLimits.onUsLimit - paymentAmount),
+      incomingSats: toSats(0),
+    }
+    intraledgerLimitsChecker = LimitsChecker({
+      walletVolume: walletVolumeIntraledger,
+      userLimits,
+      twoFALimits,
+    })
+
+    const walletVolumeWithdrawal = {
+      outgoingSats: toSats(userLimits.withdrawalLimit - paymentAmount),
+      incomingSats: toSats(0),
+    }
+    withdrawalLimitsChecker = LimitsChecker({
+      walletVolume: walletVolumeWithdrawal,
+      userLimits,
+      twoFALimits,
+    })
+
+    const walletVolumeTwoFA = {
+      outgoingSats: toSats(twoFALimits.threshold - paymentAmount),
+      incomingSats: toSats(0),
+    }
+    twoFALimitsChecker = LimitsChecker({
+      walletVolume: walletVolumeTwoFA,
+      userLimits,
+      twoFALimits,
+    })
+  })
+
+  it("passes for exact limit amount", () => {
+    const intraledgerLimitCheck = intraledgerLimitsChecker.checkIntraledger({
+      amount: paymentAmount,
+    })
+    expect(intraledgerLimitCheck).not.toBeInstanceOf(Error)
+
+    const withdrawalLimitCheck = withdrawalLimitsChecker.checkWithdrawal({
+      amount: paymentAmount,
+    })
+    expect(withdrawalLimitCheck).not.toBeInstanceOf(Error)
+
+    const twoFALimitCheck = twoFALimitsChecker.checkTwoFA({
+      amount: paymentAmount,
+    })
+    expect(twoFALimitCheck).not.toBeInstanceOf(Error)
+  })
+
+  it("passes for amount below limit", () => {
+    const intraledgerLimitCheck = intraledgerLimitsChecker.checkIntraledger({
+      amount: toSats(paymentAmount - 1),
+    })
+    expect(intraledgerLimitCheck).not.toBeInstanceOf(Error)
+
+    const withdrawalLimitCheck = withdrawalLimitsChecker.checkWithdrawal({
+      amount: toSats(paymentAmount - 1),
+    })
+    expect(withdrawalLimitCheck).not.toBeInstanceOf(Error)
+
+    const twoFALimitCheck = twoFALimitsChecker.checkTwoFA({
+      amount: toSats(paymentAmount - 1),
+    })
+    expect(twoFALimitCheck).not.toBeInstanceOf(Error)
+  })
+
+  it("returns an error for exceeded intraledger amount", () => {
+    const intraledgerLimitCheck = intraledgerLimitsChecker.checkIntraledger({
+      amount: toSats(paymentAmount + 1),
+    })
+    expect(intraledgerLimitCheck).toBeInstanceOf(LimitsExceededError)
+  })
+
+  it("returns an error for exceeded withdrawal amount", () => {
+    const withdrawalLimitCheck = withdrawalLimitsChecker.checkWithdrawal({
+      amount: toSats(paymentAmount + 1),
+    })
+    expect(withdrawalLimitCheck).toBeInstanceOf(LimitsExceededError)
+  })
+
+  it("returns an error for exceeded 2FA amount", () => {
+    const twoFALimitCheck = twoFALimitsChecker.checkTwoFA({
+      amount: toSats(paymentAmount + 1),
+    })
+    expect(twoFALimitCheck).toBeInstanceOf(LimitsExceededError)
+  })
+})


### PR DESCRIPTION
## Description

This PR adds a `LimitChecker` to aggregate and replace the various limit checks we run in the existing code. It also implements a new `txVolumeFor` method in the Ledger service that can be used to fetch the TxVolume input for the checker methods.

Old methods being replaced:
- `remainingWithdrawalLimit`
- `remainingOnUsLimit`
- `remainingTwoFALimit`

### Open `TODO`s
- [x] swap into places that use the existing implementation