### PR TITLE
Wallet invoice validator

### DIFF
--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -14,3 +14,5 @@ export class PersistError extends RepositoryError {}
 export class ValidationError extends DomainError {}
 export class InvalidSatoshiAmount extends ValidationError {}
 export class InvalidWalletName extends ValidationError {}
+export class AlreadyPaidError extends ValidationError {}
+export class SelfPaymentError extends ValidationError {}

--- a/src/domain/wallet-invoices/index.ts
+++ b/src/domain/wallet-invoices/index.ts
@@ -1,0 +1,1 @@
+export * from "./wallet-invoice-validator"

--- a/src/domain/wallet-invoices/index.types.d.ts
+++ b/src/domain/wallet-invoices/index.types.d.ts
@@ -6,6 +6,10 @@ type WalletInvoice = {
   paid: boolean
 }
 
+type WalletInvoiceValidator = {
+  validateToSend({ fromWalletId: WalletId }): void | Error
+}
+
 interface IWalletInvoicesRepository {
   persistNew: (invoice: WalletInvoice) => Promise<WalletInvoice | RepositoryError>
 

--- a/src/domain/wallet-invoices/index.types.d.ts
+++ b/src/domain/wallet-invoices/index.types.d.ts
@@ -7,7 +7,7 @@ type WalletInvoice = {
 }
 
 type WalletInvoiceValidator = {
-  validateToSend({ fromWalletId: WalletId }): void | Error
+  validateToSend({ fromWalletId: WalletId }): true | Error
 }
 
 interface IWalletInvoicesRepository {

--- a/src/domain/wallet-invoices/wallet-invoice-validator.ts
+++ b/src/domain/wallet-invoices/wallet-invoice-validator.ts
@@ -1,0 +1,19 @@
+import { AlreadyPaidError, SelfPaymentError } from "@domain/errors"
+
+export const WalletInvoiceValidator = (
+  walletInvoice: WalletInvoice,
+): WalletInvoiceValidator => {
+  const validateToSend = ({
+    fromWalletId,
+  }: {
+    fromWalletId: WalletId
+  }): void | ApplicationError => {
+    if (walletInvoice.paid) return new AlreadyPaidError()
+
+    if (walletInvoice.walletId === fromWalletId) return new SelfPaymentError()
+  }
+
+  return {
+    validateToSend,
+  }
+}

--- a/src/domain/wallet-invoices/wallet-invoice-validator.ts
+++ b/src/domain/wallet-invoices/wallet-invoice-validator.ts
@@ -7,10 +7,10 @@ export const WalletInvoiceValidator = (
     fromWalletId,
   }: {
     fromWalletId: WalletId
-  }): void | ApplicationError => {
+  }): true | ApplicationError => {
     if (walletInvoice.paid) return new AlreadyPaidError()
-
     if (walletInvoice.walletId === fromWalletId) return new SelfPaymentError()
+    return true
   }
 
   return {

--- a/test/unit/domain/wallet-invoices/wallet-invoice-validator.spec.ts
+++ b/test/unit/domain/wallet-invoices/wallet-invoice-validator.spec.ts
@@ -1,0 +1,39 @@
+import { AlreadyPaidError, SelfPaymentError } from "@domain/errors"
+import { WalletInvoiceValidator } from "@domain/wallet-invoices"
+
+describe("WalletInvoiceValidator", () => {
+  const walletInvoice: WalletInvoice = {
+    paymentHash: "paymentHash" as PaymentHash,
+    walletId: "toWalletId" as WalletId,
+    selfGenerated: false,
+    pubkey: "pubkey" as Pubkey,
+    paid: false,
+  }
+  const fromWalletId = "fromWalletId" as WalletId
+
+  it("passes for unpaid invoice and valid recipient wallet", () => {
+    walletInvoice.paid = false
+    const walletInvoiceValidator = WalletInvoiceValidator(walletInvoice)
+
+    const validatorResult = walletInvoiceValidator.validateToSend({ fromWalletId })
+    expect(validatorResult).not.toBeInstanceOf(Error)
+  })
+
+  it("fails for self recipient wallet", () => {
+    walletInvoice.paid = false
+    const walletInvoiceValidator = WalletInvoiceValidator(walletInvoice)
+
+    const validatorResult = walletInvoiceValidator.validateToSend({
+      fromWalletId: walletInvoice.walletId,
+    })
+    expect(validatorResult).toBeInstanceOf(SelfPaymentError)
+  })
+
+  it("fails for non-pending invoice and valid recipient wallet", () => {
+    walletInvoice.paid = true
+    const walletInvoiceValidator = WalletInvoiceValidator(walletInvoice)
+
+    const validatorResult = walletInvoiceValidator.validateToSend({ fromWalletId })
+    expect(validatorResult).toBeInstanceOf(AlreadyPaidError)
+  })
+})


### PR DESCRIPTION
## Description

This PR adds a `walletInvoiceValidator` to check wallet invoices for lightning initiated payments that will be settled intraledger.

_**Note:** This was not swapped into any parts of the existing codebase because the logic implemented here is strung out across multiple `if` blocks and relies on objects that are poorly typed. We will have to be mindful of capturing the existing errors when using this in the new `send-payment` use-case._