### PR TITLE
Add new `extendLock` method to Lock service

### DIFF
--- a/src/domain/lock/index.types.d.ts
+++ b/src/domain/lock/index.types.d.ts
@@ -8,10 +8,14 @@ type DistributedLock = RedLock & { [distributedLockSymbol]: never }
 interface ILockService {
   lockWalletId<Res>(
     args: { walletId: WalletId; logger: Logger; lock?: DistributedLock },
-    f: () => Promise<Res>,
+    f: (lock?: DistributedLock) => Promise<Res>,
   ): Promise<Res | LockServiceError>
   lockPaymentHash<Res>(
     args: { paymentHash: PaymentHash; logger: Logger; lock?: DistributedLock },
+    f: (lock?: DistributedLock) => Promise<Res>,
+  ): Promise<Res | LockServiceError>
+  extendLock<Res>(
+    args: { logger: Logger; lock?: DistributedLock },
     f: (lock?: DistributedLock) => Promise<Res>,
   ): Promise<Res | LockServiceError>
 }


### PR DESCRIPTION
## Description

This PR adds a new `extendLock` method to our Lock service to wrap the `lockExtendOrThrow` method in a safe way for our new code style.