### PR TITLE
Add wallet public id

### DIFF
--- a/src/migrations/20210922002129-add-wallet-public-id.ts
+++ b/src/migrations/20210922002129-add-wallet-public-id.ts
@@ -1,0 +1,43 @@
+/* eslint @typescript-eslint/no-var-requires: "off" */
+const { randomUUID } = require("crypto")
+
+module.exports = {
+  async up(db) {
+    console.log("Begin to add wallet public id to users collection")
+    const users = db
+      .collection("users")
+      .aggregate([{ $group: { _id: "$_id" } }], { cursor: { batchSize: 100 } })
+
+    let progress = 0
+    for await (const user of users) {
+      progress++
+
+      await db
+        .collection("users")
+        .updateOne({ _id: user._id }, { $set: { walletPublicId: randomUUID() } })
+
+      if (progress % 1000 === 0) {
+        console.log(`${progress} users updated`)
+      }
+    }
+
+    console.log("Finish to add wallet public id to users collection")
+  },
+
+  async down(db) {
+    await removeAttributes(db.collection("users"), ["walletPublicId"])
+  },
+}
+
+const removeAttributes = (collection, attrs) => {
+  const unsets = attrs.reduce((obj, key) => {
+    return { ...obj, [key]: 1 }
+  }, {})
+
+  return collection.updateMany(
+    {},
+    {
+      $unset: unsets,
+    },
+  )
+}

--- a/src/migrations/migrate-mongo-config.js
+++ b/src/migrations/migrate-mongo-config.js
@@ -1,4 +1,3 @@
-// FIXME: copy from mongodb.ts
 const user = process.env.MONGODB_USER ?? "testGaloy"
 const password = process.env.MONGODB_PASSWORD
 const address = process.env.MONGODB_ADDRESS ?? "localhost"
@@ -8,9 +7,7 @@ const url = `mongodb://${user}:${password}@${address}/${db}`
 
 const config = {
   mongodb: {
-    // TODO Change (or review) the url to your MongoDB:
     url,
-
     options: {
       useNewUrlParser: true, // removes a deprecation warning when connecting
       useUnifiedTopology: true, // removes a deprecating warning when connecting
@@ -20,7 +17,7 @@ const config = {
   },
 
   // The migrations dir, can be an relative or absolute path. Only edit this when really necessary.
-  migrationsDir: "migrations",
+  migrationsDir: "./",
 
   // The mongodb collection where the applied changes are stored. Only edit this when really necessary.
   changelogCollectionName: "changelog",

--- a/src/services/mongoose/schema.ts
+++ b/src/services/mongoose/schema.ts
@@ -1,5 +1,6 @@
 import * as _ from "lodash"
 import * as mongoose from "mongoose"
+import crypto from "crypto"
 import {
   levels,
   getUserLimits,
@@ -258,6 +259,14 @@ const UserSchema = new Schema<UserType>({
       type: Number,
       default: twoFAConfig.threshold,
     },
+  },
+
+  walletPublicId: {
+    type: String,
+    index: true,
+    unique: true,
+    required: true,
+    default: () => crypto.randomUUID(),
   },
 })
 


### PR DESCRIPTION
- Add walletPublicId Migration
- Add walletPublicId to user schema
- Update migration config to support current folder structure

### How to test

1. Comment schema update 
```js
  // walletPublicId: {
  //   type: String,
  //   index: true,
  //   unique: true,
  //   required: true,
  //   default: () => crypto.randomUUID(),
  // }
```
2. Run tests `TEST="01|02" make reset-integration`
3. Check documents in `users` collection (should not have walletPublicId)
4. Run migrations
```bash
$ cd src/migrations/
$ npx migrate-mongo up # if this fail you must comment up function content in 20210726211641-simplify-accounting
```
5. Check documents in `users` collection (should have walletPublicId)
6. Restore user schema (uncomment code from item 1)
7. Run tests `TEST="01|02" make reset-integration`
8. Check documents in `users` collection (should have walletPublicId)