### PR TITLE
Reverse btc price list loop to prevent early break

### DIFF
--- a/src/graphql/root/query/btc-price-list.ts
+++ b/src/graphql/root/query/btc-price-list.ts
@@ -48,12 +48,12 @@ const BtcPriceListQuery = GT.Field({
 
     const prices: PricePointType[] = []
 
-    for (const price of hourlyPrices) {
+    for (const price of hourlyPrices.reverse()) {
       if (1000 * price.id < rangeStart) {
         break
       }
       const btcPriceInCents = price.o * 100 * 10 ** 8
-      prices.push({
+      prices.unshift({
         timestamp: price.id,
         price: {
           formattedAmount: btcPriceInCents.toString(),


### PR DESCRIPTION
For any price list whose rangeStart was after the first price returned in getHourlyPrice, the loop would break early and not push any of the dates after rangeStart into prices array. 