### PR TITLE
Add expected createdAt property to User model

### DIFF
--- a/src/domain/users/index.types.d.ts
+++ b/src/domain/users/index.types.d.ts
@@ -36,6 +36,7 @@ type User = {
   readonly defaultAccountId: AccountId
   readonly deviceTokens: DeviceToken[]
   readonly lastIPs: IPType[]
+  readonly createdAt: Date
   phone: PhoneNumber
   language: UserLanguage
   lastConnection: Date

--- a/src/services/mongoose/users.ts
+++ b/src/services/mongoose/users.ts
@@ -96,5 +96,6 @@ const userFromRaw = (result: UserType): User => {
     deviceTokens: (result.deviceToken || []) as DeviceToken[],
     lastConnection: result.lastConnection,
     lastIPs: (result.lastIPs || []) as IPType[],
+    createdAt: new Date(result.created_at),
   }
 }


### PR DESCRIPTION
## Description

The `UserDetails` object in graphql expects a `createdAt` property which currently isn't being translated from the user database object into our model. It results in things like the `userContactUpdateAlias` breaking in PR #602 if `createdAt` is included in the query.

This PR addresses that.