### PR TITLE
Fix price image in dev setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   price:
-    image: gcr.io/galoyapp/price
+    image: us.gcr.io/galoy-org/price:edge
     ports:
     - "50051:50051"
     - "9464:9464"


### PR DESCRIPTION
Previous price image was hosted in the project with the old prod cluster which is now decommissioned.