### PR TITLE
Add make unit-in-ci to exit correctly on failure

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -13,4 +13,4 @@ jobs:
     - uses: actions/setup-node@v2
     - run: yarn install
     - name: Run unit tests
-      run: make unit
+      run: make unit-in-ci

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,10 @@ integration-in-ci:
 	. ./.envrc && \
 		LOGLEVEL=error $(BIN_DIR)/jest --config ./test/jest-integration.config.js --bail --runInBand --ci --reporters=default --reporters=jest-junit
 
+unit-in-ci:
+	. ./.envrc && \
+		LOGLEVEL=warn $(BIN_DIR)/jest --config ./test/jest-unit.config.js --ci --bail
+
 check-code:
 	yarn tsc-check
 	yarn eslint-check

--- a/ci/tasks/test-unit.sh
+++ b/ci/tasks/test-unit.sh
@@ -8,4 +8,4 @@ unpack_deps
 
 pushd repo
 
-make unit
+make unit-in-ci


### PR DESCRIPTION
The `yarn test:unit` task was not exiting correctly due to its pipe to `| yarn pino-pretty` which eats the exit code.
Here I've introducedd `make unit-in-ci` (similar to `make integration-in-ci`) which will exit correctly (`!= 0`) on a test failing.