### PR TITLE
Track IP if its of type string

### DIFF
--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -82,6 +82,8 @@ export const startApolloServer = async ({
 
       if (ips && Array.isArray(ips) && ips.length) {
         ip = ips[0]
+      } else if (typeof ips === "string") {
+        ip = ips
       }
 
       let wallet, user


### PR DESCRIPTION
`context.req.header` can be an array or a string - need to capture it in both cases.