### PR TITLE
Refactor 'ApplicationError' type to derive from union of all app errors

### DIFF
--- a/src/app/errors.ts
+++ b/src/app/errors.ts
@@ -1,0 +1,23 @@
+import * as DomainErrors from "@domain/errors"
+import * as LedgerErrors from "@domain/ledger/errors"
+import * as OnChainErrors from "@domain/bitcoin/onchain/errors"
+import * as LightningErrors from "@domain/bitcoin/lightning/errors"
+import * as PriceServiceErrors from "@domain/price/errors"
+import * as TwoFAErrors from "@domain/twoFA/errors"
+import * as LockServiceErrors from "@domain/lock/errors"
+import * as IpFetcherErrors from "@domain/ipfetcher/errors"
+import * as AccountErrors from "@domain/accounts/errors"
+import * as NotificationsErrors from "@domain/notifications/errors"
+
+export const ApplicationErrors = {
+  ...DomainErrors,
+  ...LedgerErrors,
+  ...OnChainErrors,
+  ...LightningErrors,
+  ...PriceServiceErrors,
+  ...TwoFAErrors,
+  ...LockServiceErrors,
+  ...IpFetcherErrors,
+  ...AccountErrors,
+  ...NotificationsErrors,
+} as const

--- a/src/app/index.types.d.ts
+++ b/src/app/index.types.d.ts
@@ -3,16 +3,8 @@ type PartialResult<T> = {
   error?: ApplicationError
 }
 
-type ApplicationError =
-  | AuthorizationError
-  | RepositoryError
-  | ValidationError
-  | LedgerError
-  | OnChainError
-  | LightningError
-  | PriceServiceError
-  | TwoFAError
-  | LockServiceError
-  | IpFetcherError
-  | AccountError
-  | NotificationsError
+type ApplicationErrors = typeof import("./errors").ApplicationErrors
+type ApplicationErrorKey = keyof ApplicationErrors
+
+type ExtractInstanceType<T> = T extends new () => infer R ? R : never
+type ApplicationError = ExtractInstanceType<ApplicationErrors[ApplicationErrorKey]>

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -10,32 +10,7 @@ import {
   InvoiceDecodeError,
   ValidationInternalError,
 } from "@graphql/error"
-
-import * as DomainErrors from "@domain/errors"
-import * as LedgerErrors from "@domain/ledger/errors"
-import * as OnChainErrors from "@domain/bitcoin/onchain/errors"
-import * as LightningErrors from "@domain/bitcoin/lightning/errors"
-import * as PriceServiceErrors from "@domain/price/errors"
-import * as TwoFAErrors from "@domain/twoFA/errors"
-import * as LockServiceErrors from "@domain/lock/errors"
-import * as IpFetcherErrors from "@domain/ipfetcher/errors"
-import * as AccountErrors from "@domain/accounts/errors"
-import * as NotificationsErrors from "@domain/notifications/errors"
-
 import { baseLogger } from "@services/logger"
-
-const AllApplicationErrors = {
-  ...DomainErrors,
-  ...LedgerErrors,
-  ...OnChainErrors,
-  ...LightningErrors,
-  ...PriceServiceErrors,
-  ...TwoFAErrors,
-  ...LockServiceErrors,
-  ...IpFetcherErrors,
-  ...AccountErrors,
-  ...NotificationsErrors,
-}
 
 const assertUnreachable = (x: never): never => {
   throw new Error(`This should never compile with ${x}`)
@@ -43,7 +18,7 @@ const assertUnreachable = (x: never): never => {
 
 export const mapError = (error: ApplicationError): CustomApolloError => {
   let message = ""
-  const errorName = error.constructor.name as keyof typeof AllApplicationErrors
+  const errorName = error.constructor.name as ApplicationErrorKey
   switch (errorName) {
     case "WithdrawalLimitsExceededError":
       message = error.message


### PR DESCRIPTION
### Description

This is part of ongoing work to get type-safe exhaustive error checking at our application layer.

In the current implementation of our `mapError` switching function, the arg type of the error passed in (`ApplicationError`) isn't coupled at all at the type-checker level to the set of errors we check for in the switch (`AllApplicationErrors`) which could eventually lead to things slipping by the type-checker and causing runtime errors.

This PR changes the definition of the `ApplicationError` type to derive directly from the set of all errors we feed into the switch, to more tightly couple these two checks.