### PR TITLE
Use lockPaymentHash to update pending payments

### DIFF
--- a/src/app/wallets/update-pending-payments.ts
+++ b/src/app/wallets/update-pending-payments.ts
@@ -15,10 +15,6 @@ export const updatePendingPayments = async ({
   logger: Logger
   lock?: DistributedLock
 }): Promise<void | ApplicationError> => {
-  // we only lock the account if there is some pending payment transaction, which would typically be unlikely
-  // we're doing the the Transaction.find after the lock to make sure there is no race condition
-  // note: there might be another design that doesn't requiere a lock at the uid level but only at the hash level,
-  // but will need to dig more into the cursor aspect of mongodb to see if there is a concurrency-safe way to do it.
   const liabilitiesAccountId = toLiabilitiesAccountId(walletId)
   const ledgerService = LedgerService()
   const count = await ledgerService.getPendingPaymentsCount(liabilitiesAccountId)


### PR DESCRIPTION
- Move the lock until needed
- Change wallet lock to payment hash lock

this reduce the risk of lock walletId when users query their balance

Refs: https://galoymoney-workspace.slack.com/archives/C025NSXHME3/p1635380466032500