### PR TITLE
Add new RateLimit service & implement invoice rate limits

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -92,6 +92,14 @@ limits:
     points: 30
     duration: 21600 # 60 * 60 * 6 s
     blockDuration: 86400 # 60 * 60 * 24 s
+  invoiceCreateAttempt:
+    points: 5
+    duration: 60
+    blockDuration: 60
+  invoiceCreateForRecipientAttempt:
+    points: 10
+    duration: 60
+    blockDuration: 300
   memoSharingSatsThreshold: 1000
   oldEnoughForWithdrawal: 172800000 # 1000 * 60 * 60 * 24 * 2, in ms # 2 days
   withdrawal:

--- a/src/app/errors.ts
+++ b/src/app/errors.ts
@@ -5,6 +5,7 @@ import * as LightningErrors from "@domain/bitcoin/lightning/errors"
 import * as PriceServiceErrors from "@domain/price/errors"
 import * as TwoFAErrors from "@domain/twoFA/errors"
 import * as LockServiceErrors from "@domain/lock/errors"
+import * as RateLimitServiceErrors from "@domain/rate-limit/errors"
 import * as IpFetcherErrors from "@domain/ipfetcher/errors"
 import * as AccountErrors from "@domain/accounts/errors"
 import * as NotificationsErrors from "@domain/notifications/errors"
@@ -17,6 +18,7 @@ export const ApplicationErrors = {
   ...PriceServiceErrors,
   ...TwoFAErrors,
   ...LockServiceErrors,
+  ...RateLimitServiceErrors,
   ...IpFetcherErrors,
   ...AccountErrors,
   ...NotificationsErrors,

--- a/src/app/wallets/add-invoice-for-wallet.ts
+++ b/src/app/wallets/add-invoice-for-wallet.ts
@@ -132,7 +132,7 @@ const walletIdFromPublicId = async (
   return wallet.id
 }
 
-const checkSelfWalletIdLimits = async (
+export const checkSelfWalletIdLimits = async (
   walletId: WalletId,
 ): Promise<true | RateLimiterExceededError> => {
   const invoiceCreateAttemptLimits = getInvoiceCreateAttemptLimits()
@@ -146,7 +146,7 @@ const checkSelfWalletIdLimits = async (
   return limitOk
 }
 
-const checkRecipientWalletIdLimits = async (
+export const checkRecipientWalletIdLimits = async (
   walletId: WalletId,
 ): Promise<true | RateLimiterExceededError> => {
   const invoiceCreateForRecipientAttempt = getInvoiceCreateForRecipientAttemptLimits()

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -108,7 +108,7 @@ export const getTwoFALimits = (): TwoFALimits => ({
   threshold: yamlConfig.twoFA.threshold,
 })
 
-const getRateLimits = (config): IRateLimits => {
+const getRateLimits = (config): RateLimitOptions => {
   /**
    * Returns a subset of the required parameters for the
    * 'rate-limiter-flexible.RateLimiterRedis' object.

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -131,6 +131,12 @@ export const getLoginAttemptLimits = () => getRateLimits(yamlConfig.limits.login
 export const getFailedAttemptPerIpLimits = () =>
   getRateLimits(yamlConfig.limits.failedAttemptPerIp)
 
+export const getInvoiceCreateAttemptLimits = () =>
+  getRateLimits(yamlConfig.limits.invoiceCreateAttempt)
+
+export const getInvoiceCreateForRecipientAttemptLimits = () =>
+  getRateLimits(yamlConfig.limits.invoiceCreateForRecipientAttempt)
+
 export const getOnChainWalletConfig = () => ({
   dustThreshold: yamlConfig.onChainWallet.dustThreshold,
 })

--- a/src/core/types.d.ts
+++ b/src/core/types.d.ts
@@ -37,12 +37,6 @@ interface ITransactionLimits extends IUserLimits {
   oldEnoughForWithdrawalHours: number
 }
 
-interface IRateLimits {
-  points: number
-  duration: number
-  blockDuration: number
-}
-
 type onChainWalletConfig = {
   dustThreshold: number
 }

--- a/src/core/wallets.ts
+++ b/src/core/wallets.ts
@@ -1,4 +1,4 @@
-import { registerAndPersistInvoice } from "@app/wallets"
+import { checkRecipientWalletIdLimits, registerAndPersistInvoice } from "@app/wallets"
 
 import { checkedToSats, toSats } from "@domain/bitcoin"
 import { checkedToUsername } from "@domain/users"
@@ -25,11 +25,13 @@ export const addInvoiceForUsername = async ({
 }): Promise<LnInvoice | ApplicationError> => {
   const checkedUsername = checkedToUsername(username)
   if (checkedUsername instanceof Error) return checkedUsername
-  const sats = checkedToSats(amount)
-  if (sats instanceof Error) return sats
-
   const walletId = await walletIdFromUsername(checkedUsername)
   if (walletId instanceof Error) return walletId
+
+  const limitOk = await checkRecipientWalletIdLimits(walletId)
+  if (limitOk instanceof Error) return limitOk
+  const sats = checkedToSats(amount)
+  if (sats instanceof Error) return sats
 
   const walletInvoiceFactory = WalletInvoiceFactory(walletId)
   return registerAndPersistInvoice({
@@ -46,9 +48,11 @@ export const addInvoiceNoAmountForUsername = async ({
 }): Promise<LnInvoice | ApplicationError> => {
   const checkedUsername = checkedToUsername(username)
   if (checkedUsername instanceof Error) return checkedUsername
-
   const walletId = await walletIdFromUsername(checkedUsername)
   if (walletId instanceof Error) return walletId
+
+  const limitOk = await checkRecipientWalletIdLimits(walletId)
+  if (limitOk instanceof Error) return limitOk
 
   const walletInvoiceFactory = WalletInvoiceFactory(walletId)
   return registerAndPersistInvoice({

--- a/src/domain/rate-limit/errors.ts
+++ b/src/domain/rate-limit/errors.ts
@@ -1,0 +1,9 @@
+export class RateLimitError extends Error {
+  name = this.constructor.name
+}
+
+export class RateLimitServiceError extends RateLimitError {}
+export class UnknownRateLimitServiceError extends RateLimitServiceError {}
+
+export class RateLimiterExceededError extends RateLimitServiceError {}
+export class InvoiceCreateRateLimiterExceededError extends RateLimiterExceededError {}

--- a/src/domain/rate-limit/index.ts
+++ b/src/domain/rate-limit/index.ts
@@ -1,0 +1,8 @@
+export const RateLimitPrefix = {
+  requestPhoneCode: "request_phone_code",
+  requestPhoneCodeIp: "request_phone_code_ip",
+  login: "login",
+  failedAttemptIp: "failed_attempt_ip",
+  invoiceCreate: "invoice_create",
+  invoiceCreateForRecipient: "invoice_create_for_recipient",
+} as const

--- a/src/domain/rate-limit/index.types.d.ts
+++ b/src/domain/rate-limit/index.types.d.ts
@@ -1,0 +1,14 @@
+type RateLimitServiceError = import("./errors").RateLimitServiceError
+
+type RateLimitPrefix =
+  typeof import("./index").RateLimitPrefix[keyof typeof import("./index").RateLimitPrefix]
+
+type RateLimitOptions = {
+  points: number
+  duration: Seconds
+  blockDuration: Seconds
+}
+
+interface IRateLimitService {
+  consume(key: string | number): Promise<true | RateLimitServiceError>
+}

--- a/src/domain/rate-limit/index.types.d.ts
+++ b/src/domain/rate-limit/index.types.d.ts
@@ -11,4 +11,5 @@ type RateLimitOptions = {
 
 interface IRateLimitService {
   consume(key: string | number): Promise<true | RateLimitServiceError>
+  reset(key: string | number): Promise<true | RateLimitServiceError>
 }

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -9,6 +9,7 @@ import {
   UnknownClientError,
   InvoiceDecodeError,
   ValidationInternalError,
+  TooManyRequestError,
 } from "@graphql/error"
 import { baseLogger } from "@services/logger"
 
@@ -83,6 +84,11 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       message = "Invoice must be a zero-amount invoice"
       return new ValidationInternalError({ message, logger: baseLogger })
 
+    case "InvoiceCreateRateLimiterExceededError":
+      message =
+        "User tried to create too many invoices, please wait for a while and try again."
+      return new TooManyRequestError({ message, logger: baseLogger })
+
     case "UnknownLnInvoiceDecodeError":
       return new InvoiceDecodeError({ message, logger: baseLogger })
 
@@ -101,7 +107,10 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     // ----------
     // Unhandled below here
     // ----------
-
+    case "RateLimiterExceededError":
+    case "RateLimitError":
+    case "RateLimitServiceError":
+    case "UnknownRateLimitServiceError":
     case "CouldNotFindUserError":
     case "TwoFAError":
     case "LedgerError":

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -76,6 +76,10 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       message = "An amount is required to complete payment"
       return new ValidationInternalError({ message, logger: baseLogger })
 
+    case "InvalidSatoshiAmount":
+      message = "A valid satoshi amount is required"
+      return new ValidationInternalError({ message, logger: baseLogger })
+
     case "LnPaymentRequestNonZeroAmountRequiredError":
       message = "Invoice does not have a valid amount to pay"
       return new ValidationInternalError({ message, logger: baseLogger })
@@ -131,7 +135,6 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "DuplicateError":
     case "CouldNotFindError":
     case "ValidationError":
-    case "InvalidSatoshiAmount":
     case "InvalidUsername":
     case "InvalidPublicWalletId":
     case "LessThanDustThresholdError":

--- a/src/graphql/root/mutation/ln-invoice-create-on-behalf-of-recipient.ts
+++ b/src/graphql/root/mutation/ln-invoice-create-on-behalf-of-recipient.ts
@@ -1,4 +1,5 @@
 import { addInvoiceForRecipient } from "@app/wallets"
+import { mapError } from "@graphql/error-map"
 import { GT } from "@graphql/index"
 
 import LnInvoicePayload from "@graphql/types/payload/ln-invoice"
@@ -35,7 +36,8 @@ const LnInvoiceCreateOnBehalfOfRecipientMutation = GT.Field({
     })
 
     if (result instanceof Error) {
-      return { errors: [{ message: result.message || result.name }] } // TODO: refine error
+      const appErr = mapError(result)
+      return { errors: [{ message: appErr.message || appErr.name }] } // TODO: refine error
     }
 
     const { paymentRequest, paymentHash, paymentSecret } = result

--- a/src/graphql/root/mutation/ln-invoice-create.ts
+++ b/src/graphql/root/mutation/ln-invoice-create.ts
@@ -4,6 +4,7 @@ import LnInvoicePayload from "@graphql/types/payload/ln-invoice"
 import Memo from "@graphql/types/scalar/memo"
 import { addInvoice } from "@app/wallets/add-invoice-for-wallet"
 import SatAmount from "@graphql/types/scalar/sat-amount"
+import { mapError } from "@graphql/error-map"
 
 const LnInvoiceCreateInput = new GT.Input({
   name: "LnInvoiceCreateInput",
@@ -34,7 +35,8 @@ const LnInvoiceCreateMutation = GT.Field({
     })
 
     if (lnInvoice instanceof Error) {
-      return { errors: [{ message: lnInvoice.message || lnInvoice.name }] } // TODO: refine error
+      const appErr = mapError(lnInvoice)
+      return { errors: [{ message: appErr.message || appErr.name }] } // TODO: refine error
     }
 
     return {

--- a/src/graphql/root/mutation/ln-noamount-invoice-create-on-behalf-of-recipient.ts
+++ b/src/graphql/root/mutation/ln-noamount-invoice-create-on-behalf-of-recipient.ts
@@ -1,4 +1,5 @@
 import { addInvoiceNoAmountForRecipient } from "@app/wallets"
+import { mapError } from "@graphql/error-map"
 import { GT } from "@graphql/index"
 
 import LnNoAmountInvoicePayload from "@graphql/types/payload/ln-noamount-invoice"
@@ -33,7 +34,8 @@ const LnNoAmountInvoiceCreateOnBehalfOfRecipientMutation = GT.Field({
     })
 
     if (result instanceof Error) {
-      return { errors: [{ message: result.message || result.name }] } // TODO: refine error
+      const appErr = mapError(result)
+      return { errors: [{ message: appErr.message || appErr.name }] } // TODO: refine error
     }
 
     const { paymentRequest, paymentHash, paymentSecret } = result

--- a/src/graphql/root/mutation/ln-noamount-invoice-create.ts
+++ b/src/graphql/root/mutation/ln-noamount-invoice-create.ts
@@ -3,6 +3,7 @@ import { GT } from "@graphql/index"
 import LnNoAmountInvoicePayload from "@graphql/types/payload/ln-noamount-invoice"
 import Memo from "@graphql/types/scalar/memo"
 import { addInvoiceNoAmount } from "@app/wallets/add-invoice-for-wallet"
+import { mapError } from "@graphql/error-map"
 
 const LnNoAmountInvoiceCreateInput = new GT.Input({
   name: "LnNoAmountInvoiceCreateInput",
@@ -29,7 +30,8 @@ const LnNoAmountInvoiceCreateMutation = GT.Field({
     })
 
     if (lnInvoice instanceof Error) {
-      return { errors: [{ message: lnInvoice.message || lnInvoice.name }] } // TODO: refine error
+      const appErr = mapError(lnInvoice)
+      return { errors: [{ message: appErr.message || appErr.name }] } // TODO: refine error
     }
 
     return {

--- a/src/servers/graphql-old-server.ts
+++ b/src/servers/graphql-old-server.ts
@@ -269,7 +269,7 @@ const resolvers = {
           : await addInvoiceNoAmountForUsername({
               username,
             })
-      if (lnInvoice instanceof Error) throw lnInvoice
+      if (lnInvoice instanceof Error) throw mapError(lnInvoice)
       return lnInvoice.paymentRequest
     },
     invoice: (_, __, { wallet, logger }) => ({
@@ -285,7 +285,7 @@ const resolvers = {
                 walletId: wallet.user.id,
                 memo,
               })
-        if (lnInvoice instanceof Error) throw lnInvoice
+        if (lnInvoice instanceof Error) throw mapError(lnInvoice)
         return lnInvoice.paymentRequest
       },
       // FIXME: move to query

--- a/src/services/rate-limit/index.ts
+++ b/src/services/rate-limit/index.ts
@@ -1,0 +1,25 @@
+import { RateLimiterRedis } from "rate-limiter-flexible"
+import { redis } from "@services/redis"
+
+import { RateLimiterExceededError } from "@domain/rate-limit/errors"
+
+export const RedisRateLimitService = ({
+  keyPrefix,
+  limitOptions,
+}: {
+  keyPrefix: RateLimitPrefix
+  limitOptions: RateLimitOptions
+}): IRateLimitService => {
+  const limiter = new RateLimiterRedis({ storeClient: redis, keyPrefix, ...limitOptions })
+
+  const consume = async (key) => {
+    try {
+      await limiter.consume(key)
+      return true
+    } catch (err) {
+      return new RateLimiterExceededError()
+    }
+  }
+
+  return { consume }
+}

--- a/src/services/rate-limit/index.ts
+++ b/src/services/rate-limit/index.ts
@@ -1,7 +1,10 @@
 import { RateLimiterRedis } from "rate-limiter-flexible"
 import { redis } from "@services/redis"
 
-import { RateLimiterExceededError } from "@domain/rate-limit/errors"
+import {
+  RateLimiterExceededError,
+  UnknownRateLimitServiceError,
+} from "@domain/rate-limit/errors"
 
 export const RedisRateLimitService = ({
   keyPrefix,
@@ -21,5 +24,14 @@ export const RedisRateLimitService = ({
     }
   }
 
-  return { consume }
+  const reset = async (key) => {
+    try {
+      await limiter.delete(key)
+      return true
+    } catch (err) {
+      return new UnknownRateLimitServiceError()
+    }
+  }
+
+  return { consume, reset }
 }

--- a/test/helpers/rate-limit.ts
+++ b/test/helpers/rate-limit.ts
@@ -1,0 +1,14 @@
+import { getInvoiceCreateAttemptLimits } from "@config/app"
+import { RateLimitPrefix } from "@domain/rate-limit"
+import { RedisRateLimitService } from "@services/rate-limit"
+
+export const resetSelfWalletIdLimits = async (
+  walletId: WalletId,
+): Promise<true | RateLimitServiceError> => {
+  const invoiceCreateAttemptLimits = getInvoiceCreateAttemptLimits()
+  const limiter = RedisRateLimitService({
+    keyPrefix: RateLimitPrefix.invoiceCreate,
+    limitOptions: invoiceCreateAttemptLimits,
+  })
+  return limiter.reset(walletId)
+}

--- a/test/helpers/rate-limit.ts
+++ b/test/helpers/rate-limit.ts
@@ -1,4 +1,7 @@
-import { getInvoiceCreateAttemptLimits } from "@config/app"
+import {
+  getInvoiceCreateAttemptLimits,
+  getInvoiceCreateForRecipientAttemptLimits,
+} from "@config/app"
 import { RateLimitPrefix } from "@domain/rate-limit"
 import { RedisRateLimitService } from "@services/rate-limit"
 
@@ -9,6 +12,18 @@ export const resetSelfWalletIdLimits = async (
   const limiter = RedisRateLimitService({
     keyPrefix: RateLimitPrefix.invoiceCreate,
     limitOptions: invoiceCreateAttemptLimits,
+  })
+  return limiter.reset(walletId)
+}
+
+export const resetRecipientWalletIdLimits = async (
+  walletId: WalletId,
+): Promise<true | RateLimitServiceError> => {
+  const invoiceCreateForRecipientAttemptLimits =
+    getInvoiceCreateForRecipientAttemptLimits()
+  const limiter = RedisRateLimitService({
+    keyPrefix: RateLimitPrefix.invoiceCreateForRecipient,
+    limitOptions: invoiceCreateForRecipientAttemptLimits,
   })
   return limiter.reset(walletId)
 }

--- a/test/helpers/redis.ts
+++ b/test/helpers/redis.ts
@@ -1,3 +1,4 @@
+import { RateLimitPrefix } from "@domain/rate-limit"
 import { redis } from "@services/redis"
 
 export const clearKeys = async (prefix) => {
@@ -12,8 +13,7 @@ export const clearAccountLocks = async () => {
 }
 
 export const clearLimiters = async () => {
-  await clearKeys("login")
-  await clearKeys("failed_attempt_ip")
-  await clearKeys("request_phone_code")
-  await clearKeys("request_phone_code_ip")
+  for (const limiter in RateLimitPrefix) {
+    await clearKeys(RateLimitPrefix[limiter])
+  }
 }

--- a/test/integration/02-user-wallet/02-invoice.spec.ts
+++ b/test/integration/02-user-wallet/02-invoice.spec.ts
@@ -1,12 +1,17 @@
 import {
   addInvoice,
-  addInvoiceNoAmountForRecipient,
   addInvoiceNoAmount,
-} from "@app/wallets/add-invoice-for-wallet"
+  addInvoiceForRecipient,
+  addInvoiceNoAmountForRecipient,
+} from "@app/wallets"
+
+import { getInvoiceCreateAttemptLimits } from "@config/app"
 import { getHash } from "@core/utils"
 import { toSats } from "@domain/bitcoin"
+import { InvoiceCreateRateLimiterExceededError } from "@domain/rate-limit/errors"
 import { InvoiceUser } from "@services/mongoose/schema"
 import { getUserWallet } from "test/helpers"
+import { resetSelfWalletIdLimits } from "test/helpers/rate-limit"
 
 jest.mock("@services/realtime-price", () => require("test/mocks/realtime-price"))
 jest.mock("@services/phone-provider", () => require("test/mocks/phone-provider"))
@@ -40,6 +45,107 @@ describe("UserWallet - addInvoice", () => {
 
     const { uid } = await InvoiceUser.findById(getHash(request))
     expect(String(uid)).toBe(String(userWallet1.user._id))
+  })
+
+  it("fails to add invoice past rate limit", async () => {
+    // Reset limits before starting
+    let resetOk = await resetSelfWalletIdLimits(userWallet1.user.id)
+    expect(resetOk).not.toBeInstanceOf(Error)
+    if (resetOk instanceof Error) throw resetOk
+
+    // Create max number of invoices
+    const limitsNum = getInvoiceCreateAttemptLimits().points
+    const promises: Promise<LnInvoice | ApplicationError>[] = []
+    for (let i = 0; i < limitsNum; i++) {
+      const lnInvoicePromise = addInvoice({
+        walletId: userWallet1.user.id as WalletId,
+        amount: toSats(1000),
+      })
+      promises.push(lnInvoicePromise)
+    }
+    const lnInvoices = await Promise.all(promises)
+    const isNotError = (item) => !(item instanceof Error)
+    expect(lnInvoices.every(isNotError)).toBe(true)
+
+    // Test that first invoice past the limit fails
+    const lnInvoice = await addInvoice({
+      walletId: userWallet1.user.id as WalletId,
+      amount: toSats(1000),
+    })
+    expect(lnInvoice).toBeInstanceOf(InvoiceCreateRateLimiterExceededError)
+
+    const lnNoAmountInvoice = await addInvoiceNoAmount({
+      walletId: userWallet1.user.id as WalletId,
+    })
+    expect(lnNoAmountInvoice).toBeInstanceOf(InvoiceCreateRateLimiterExceededError)
+
+    // Test that recipient invoices still work
+    const lnRecipientInvoice = await addInvoiceForRecipient({
+      recipientWalletPublicId: userWallet1.user.walletPublicId,
+      amount: toSats(1000),
+    })
+    expect(lnRecipientInvoice).not.toBeInstanceOf(Error)
+    expect(lnRecipientInvoice).toHaveProperty("paymentRequest")
+
+    const lnNoAmountRecipientInvoice = await addInvoiceNoAmountForRecipient({
+      recipientWalletPublicId: userWallet1.user.walletPublicId,
+    })
+    expect(lnNoAmountRecipientInvoice).not.toBeInstanceOf(Error)
+    expect(lnNoAmountRecipientInvoice).toHaveProperty("paymentRequest")
+
+    // Reset limits when done for other tests
+    resetOk = await resetSelfWalletIdLimits(userWallet1.user.id)
+    expect(resetOk).not.toBeInstanceOf(Error)
+  })
+
+  it("fails to add no amount invoice past rate limit", async () => {
+    // Reset limits before starting
+    let resetOk = await resetSelfWalletIdLimits(userWallet1.user.id)
+    expect(resetOk).not.toBeInstanceOf(Error)
+    if (resetOk instanceof Error) throw resetOk
+
+    // Create max number of invoices
+    const limitsNum = getInvoiceCreateAttemptLimits().points
+    const promises: Promise<LnInvoice | ApplicationError>[] = []
+    for (let i = 0; i < limitsNum; i++) {
+      const lnInvoicePromise = addInvoiceNoAmount({
+        walletId: userWallet1.user.id as WalletId,
+      })
+      promises.push(lnInvoicePromise)
+    }
+    const lnInvoices = await Promise.all(promises)
+    const isNotError = (item) => !(item instanceof Error)
+    expect(lnInvoices.every(isNotError)).toBe(true)
+
+    // Test that first invoice past the limit fails
+    const lnInvoice = await addInvoice({
+      walletId: userWallet1.user.id as WalletId,
+      amount: toSats(1000),
+    })
+    expect(lnInvoice).toBeInstanceOf(InvoiceCreateRateLimiterExceededError)
+
+    const lnNoAmountInvoice = await addInvoiceNoAmount({
+      walletId: userWallet1.user.id as WalletId,
+    })
+    expect(lnNoAmountInvoice).toBeInstanceOf(InvoiceCreateRateLimiterExceededError)
+
+    // Test that recipient invoices still work
+    const lnRecipientInvoice = await addInvoiceForRecipient({
+      recipientWalletPublicId: userWallet1.user.walletPublicId,
+      amount: toSats(1000),
+    })
+    expect(lnRecipientInvoice).not.toBeInstanceOf(Error)
+    expect(lnRecipientInvoice).toHaveProperty("paymentRequest")
+
+    const lnNoAmountRecipientInvoice = await addInvoiceNoAmountForRecipient({
+      recipientWalletPublicId: userWallet1.user.walletPublicId,
+    })
+    expect(lnNoAmountRecipientInvoice).not.toBeInstanceOf(Error)
+    expect(lnNoAmountRecipientInvoice).toHaveProperty("paymentRequest")
+
+    // Reset limits when done for other tests
+    resetOk = await resetSelfWalletIdLimits(userWallet1.user.id)
+    expect(resetOk).not.toBeInstanceOf(Error)
   })
 
   it("adds a public invoice", async () => {

--- a/test/integration/02-user-wallet/02-receive-rewards.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-rewards.spec.ts
@@ -2,6 +2,7 @@ import { find, difference } from "lodash"
 import { MS_PER_DAY, onboardingEarn } from "@config/app"
 import { checkIsBalanced, getUserWallet } from "test/helpers"
 import { getBTCBalance } from "test/helpers/wallet"
+import { resetSelfWalletIdLimits } from "test/helpers/rate-limit"
 
 jest.mock("@services/realtime-price", () => require("test/mocks/realtime-price"))
 jest.mock("@services/phone-provider", () => require("test/mocks/phone-provider"))
@@ -30,6 +31,10 @@ afterAll(() => {
 
 describe("UserWallet - addEarn", () => {
   it("adds balance only once", async () => {
+    const resetOk = await resetSelfWalletIdLimits(userWallet1.user.id)
+    expect(resetOk).not.toBeInstanceOf(Error)
+    if (resetOk instanceof Error) throw resetOk
+
     const initialBalance = await getBTCBalance(userWallet1.user.id)
 
     const getAndVerifyRewards = async () => {

--- a/test/integration/servers/graphql-main-server/auth-requests.spec.ts
+++ b/test/integration/servers/graphql-main-server/auth-requests.spec.ts
@@ -112,7 +112,7 @@ describe("graphql", () => {
     })
 
     it("returns an error if amount is zero", async () => {
-      const message = "InvalidSatoshiAmount"
+      const message = "A valid satoshi amount is required"
       const input = { amount: 0, memo: "This is a lightning invoice" }
       const result = await mutate(mutation, { variables: { input } })
       const { invoice, errors } = result.data.lnInvoiceCreate


### PR DESCRIPTION
### Description

Adds a redis rate limiter check for the `addInvoice` and `addInvoiceNoAmount` methods used by both old and new graphql endpoints.