### PR TITLE
App tracing

### DIFF
--- a/src/app/users/get-user.ts
+++ b/src/app/users/get-user.ts
@@ -1,4 +1,8 @@
-import { SemanticAttributes, asyncRunInSpan } from "@services/tracing"
+import {
+  SemanticAttributes,
+  asyncRunInSpan,
+  addAttributesToCurrentSpan,
+} from "@services/tracing"
 import { UsersRepository } from "@services/mongoose"
 import { IpFetcher } from "@services/ipfetcher"
 import { getIpConfig } from "@config/app"
@@ -25,6 +29,9 @@ export const getUserForLogin = async ({
       if (user instanceof Error) {
         return user
       }
+      addAttributesToCurrentSpan({
+        ENDUSER_ALIAS: user.username,
+      })
       user.lastConnection = new Date()
 
       // IP tracking logic could be extracted into domain

--- a/src/app/users/get-user.ts
+++ b/src/app/users/get-user.ts
@@ -2,6 +2,7 @@ import {
   SemanticAttributes,
   asyncRunInSpan,
   addAttributesToCurrentSpan,
+  ENDUSER_ALIAS,
 } from "@services/tracing"
 import { UsersRepository } from "@services/mongoose"
 import { IpFetcher } from "@services/ipfetcher"
@@ -16,21 +17,17 @@ export const getUserForLogin = async ({
 }: {
   userId: string
   ip?: string
-}): Promise<User | ApplicationError> => {
-  return asyncRunInSpan(
+}): Promise<User | ApplicationError> =>
+  asyncRunInSpan(
     "app.getUserForLogin",
-    {
-      [SemanticAttributes.ENDUSER_ID]: userId,
-      [SemanticAttributes.CODE_FUNCTION]: "getUserForLogin",
-      [SemanticAttributes.HTTP_CLIENT_IP]: ip,
-    },
+    { [SemanticAttributes.CODE_FUNCTION]: "getUserForLogin" },
     async () => {
       const user = await users.findById(userId as UserId)
       if (user instanceof Error) {
         return user
       }
       addAttributesToCurrentSpan({
-        ENDUSER_ALIAS: user.username,
+        [ENDUSER_ALIAS]: user.username,
       })
       user.lastConnection = new Date()
 
@@ -65,7 +62,6 @@ export const getUserForLogin = async ({
       return user
     },
   )
-}
 
 export const getUsernameFromWalletPublicId = async (
   walletPublicId: WalletPublicId,

--- a/src/app/users/get-user.ts
+++ b/src/app/users/get-user.ts
@@ -6,10 +6,6 @@ import { RepositoryError } from "@domain/errors"
 
 const users = UsersRepository()
 
-export const getUser = async (userId: UserId): Promise<User | ApplicationError> => {
-  return users.findById(userId)
-}
-
 export const getUserForLogin = async ({
   userId,
   ip,

--- a/src/app/wallets/ln-send-payment.ts
+++ b/src/app/wallets/ln-send-payment.ts
@@ -56,6 +56,9 @@ export const lnInvoicePaymentSendWithTwoFA = async ({
     "app.lnInvoicePaymentSendWithTwoFA",
     {
       [SemanticAttributes.CODE_FUNCTION]: "lnInvoicePaymentSendWithTwoFA",
+      "payment.initiation_method": PaymentInitiationMethod.Lightning,
+      "payment.wallet_id": walletId,
+      "payment.request": paymentRequest,
     },
     async () => {
       const decodedInvoice = decodeInvoice(paymentRequest)
@@ -102,6 +105,9 @@ export const lnInvoicePaymentSend = async ({
     "app.lnInvoicePaymentSend",
     {
       [SemanticAttributes.CODE_FUNCTION]: "lnInvoicePaymentSend",
+      "payment.initiation_method": PaymentInitiationMethod.Lightning,
+      "payment.wallet_id": walletId,
+      "payment.request": paymentRequest,
     },
     async () => {
       const decodedInvoice = decodeInvoice(paymentRequest)
@@ -141,6 +147,10 @@ export const lnNoAmountInvoicePaymentSendWithTwoFA = async ({
     "app.lnNoAmountInvoicePaymentSendWithTwoFA",
     {
       [SemanticAttributes.CODE_FUNCTION]: "lnNoAmountInvoicePaymentSendWithTwoFA",
+      "payment.initiation_method": PaymentInitiationMethod.Lightning,
+      "payment.wallet_id": walletId,
+      "payment.request": paymentRequest,
+      "payment.amount": amount,
     },
     async () => {
       const decodedInvoice = decodeInvoice(paymentRequest)
@@ -192,6 +202,10 @@ export const lnNoAmountInvoicePaymentSend = async ({
     "app.lnNoAmountInvoicePaymentSend",
     {
       [SemanticAttributes.CODE_FUNCTION]: "lnNoAmountInvoicePaymentSend",
+      "payment.initiation_method": PaymentInitiationMethod.Lightning,
+      "payment.wallet_id": walletId,
+      "payment.request": paymentRequest,
+      "payment.amount": amount,
     },
     async () => {
       const decodedInvoice = decodeInvoice(paymentRequest)
@@ -236,7 +250,10 @@ const lnSendPayment = async ({
   logger: Logger
 }): Promise<PaymentSendStatus | ApplicationError> => {
   addAttributesToCurrentSpan({
-    "payment.initiation_method": PaymentInitiationMethod.Lightning,
+    "payment.amount": amount,
+    "payment.request.destination": decodedInvoice.destination,
+    "payment.request.hash": decodedInvoice.paymentHash,
+    "payment.request.description": decodedInvoice.description,
   })
   const lndService = LndService()
   if (lndService instanceof Error) return lndService

--- a/src/graphql/root/mutation/ln-invoice-payment-send.ts
+++ b/src/graphql/root/mutation/ln-invoice-payment-send.ts
@@ -4,6 +4,7 @@ import { GT } from "@graphql/index"
 import PaymentSendPayload from "@graphql/types/payload/payment-send"
 import LnPaymentRequest from "@graphql/types/scalar/ln-payment-request"
 import Memo from "@graphql/types/scalar/memo"
+import { addToEverySpan, SemanticAttributes, ENDUSER_ALIAS } from "@services/tracing"
 
 const LnInvoicePaymentInput = new GT.Input({
   name: "LnInvoicePaymentInput",
@@ -18,31 +19,39 @@ const LnInvoicePaymentSendMutation = GT.Field({
   args: {
     input: { type: GT.NonNull(LnInvoicePaymentInput) },
   },
-  resolve: async (_, args, { user, wallet, logger }) => {
-    const { paymentRequest, memo } = args.input
+  resolve: async (_, args, { ip, domainUser, wallet, logger }) =>
+    addToEverySpan(
+      {
+        [SemanticAttributes.ENDUSER_ID]: domainUser?.id,
+        [ENDUSER_ALIAS]: domainUser?.username,
+        [SemanticAttributes.HTTP_CLIENT_IP]: ip,
+      },
+      async () => {
+        const { paymentRequest, memo } = args.input
 
-    for (const input of [memo, paymentRequest]) {
-      if (input instanceof Error) {
-        return { errors: [{ message: input.message }] }
-      }
-    }
+        for (const input of [memo, paymentRequest]) {
+          if (input instanceof Error) {
+            return { errors: [{ message: input.message }] }
+          }
+        }
 
-    const status = await lnInvoicePaymentSend({
-      paymentRequest,
-      memo,
-      walletId: wallet.user.id as WalletId,
-      userId: user.id as UserId,
-      logger,
-    })
-    if (status instanceof Error) {
-      const appErr = mapError(status)
-      return { status: "failed", errors: [{ message: appErr.message }] }
-    }
-    return {
-      errors: [],
-      status: status.value,
-    }
-  },
+        const status = await lnInvoicePaymentSend({
+          paymentRequest,
+          memo,
+          walletId: wallet.user.id as WalletId,
+          userId: domainUser.id,
+          logger,
+        })
+        if (status instanceof Error) {
+          const appErr = mapError(status)
+          return { status: "failed", errors: [{ message: appErr.message }] }
+        }
+        return {
+          errors: [],
+          status: status.value,
+        }
+      },
+    ),
 })
 
 export default LnInvoicePaymentSendMutation

--- a/src/graphql/root/mutation/ln-invoice-payment-send.ts
+++ b/src/graphql/root/mutation/ln-invoice-payment-send.ts
@@ -4,7 +4,11 @@ import { GT } from "@graphql/index"
 import PaymentSendPayload from "@graphql/types/payload/payment-send"
 import LnPaymentRequest from "@graphql/types/scalar/ln-payment-request"
 import Memo from "@graphql/types/scalar/memo"
-import { addToEverySpan, SemanticAttributes, ENDUSER_ALIAS } from "@services/tracing"
+import {
+  addAttributesToCurrentSpanAndPropagate,
+  SemanticAttributes,
+  ENDUSER_ALIAS,
+} from "@services/tracing"
 
 const LnInvoicePaymentInput = new GT.Input({
   name: "LnInvoicePaymentInput",
@@ -20,7 +24,7 @@ const LnInvoicePaymentSendMutation = GT.Field({
     input: { type: GT.NonNull(LnInvoicePaymentInput) },
   },
   resolve: async (_, args, { ip, domainUser, wallet, logger }) =>
-    addToEverySpan(
+    addAttributesToCurrentSpanAndPropagate(
       {
         [SemanticAttributes.ENDUSER_ID]: domainUser?.id,
         [ENDUSER_ALIAS]: domainUser?.username,

--- a/src/graphql/root/query/me.ts
+++ b/src/graphql/root/query/me.ts
@@ -1,4 +1,8 @@
-import { addToEverySpan, SemanticAttributes, ENDUSER_ALIAS } from "@services/tracing"
+import {
+  addAttributesToCurrentSpanAndPropagate,
+  SemanticAttributes,
+  ENDUSER_ALIAS,
+} from "@services/tracing"
 import { GT } from "@graphql/index"
 
 import { UserWithAccounts } from "@graphql/types/object/user"
@@ -6,7 +10,7 @@ import { UserWithAccounts } from "@graphql/types/object/user"
 const MeQuery = GT.Field({
   type: UserWithAccounts,
   resolve: async (_, __, { ip, domainUser }) =>
-    addToEverySpan(
+    addAttributesToCurrentSpanAndPropagate(
       {
         [SemanticAttributes.ENDUSER_ID]: domainUser?.id,
         [ENDUSER_ALIAS]: domainUser?.username,

--- a/src/graphql/root/query/me.ts
+++ b/src/graphql/root/query/me.ts
@@ -1,16 +1,11 @@
 import { GT } from "@graphql/index"
 
 import { UserWithAccounts } from "@graphql/types/object/user"
-import * as Users from "@app/users"
 
 const MeQuery = GT.Field({
   type: UserWithAccounts,
-  resolve: async (_, __, { uid }) => {
-    const user = await Users.getUser(uid)
-    if (user instanceof Error) {
-      throw user
-    }
-    return user
+  resolve: async (_, __, { domainUser }) => {
+    return domainUser
   },
 })
 

--- a/src/graphql/root/query/me.ts
+++ b/src/graphql/root/query/me.ts
@@ -1,12 +1,19 @@
+import { addToEverySpan, SemanticAttributes, ENDUSER_ALIAS } from "@services/tracing"
 import { GT } from "@graphql/index"
 
 import { UserWithAccounts } from "@graphql/types/object/user"
 
 const MeQuery = GT.Field({
   type: UserWithAccounts,
-  resolve: async (_, __, { domainUser }) => {
-    return domainUser
-  },
+  resolve: async (_, __, { ip, domainUser }) =>
+    addToEverySpan(
+      {
+        [SemanticAttributes.ENDUSER_ID]: domainUser?.id,
+        [ENDUSER_ALIAS]: domainUser?.username,
+        [SemanticAttributes.HTTP_CLIENT_IP]: ip,
+      },
+      () => domainUser,
+    ),
 })
 
 export default MeQuery

--- a/src/servers/graphql-old-server.ts
+++ b/src/servers/graphql-old-server.ts
@@ -37,7 +37,11 @@ import {
 } from "@app/wallets"
 import { decodeInvoice } from "@domain/bitcoin/lightning"
 import { mapError } from "@graphql/error-map"
-import { addToEverySpan, SemanticAttributes, ENDUSER_ALIAS } from "@services/tracing"
+import {
+  addAttributesToCurrentSpanAndPropagate,
+  SemanticAttributes,
+  ENDUSER_ALIAS,
+} from "@services/tracing"
 
 const graphqlLogger = baseLogger.child({ module: "graphql" })
 
@@ -81,7 +85,7 @@ const translateWalletTx = (txs: WalletTransaction[]) => {
 const resolvers = {
   Query: {
     me: (_, __, { uid, user, ip, domainUser }) =>
-      addToEverySpan(
+      addAttributesToCurrentSpanAndPropagate(
         {
           [SemanticAttributes.ENDUSER_ID]: domainUser?.id,
           [ENDUSER_ALIAS]: domainUser?.username,
@@ -307,7 +311,7 @@ const resolvers = {
         return result
       },
       payInvoice: async ({ invoice, amount, memo }, _, { ip, domainUser }) =>
-        addToEverySpan(
+        addAttributesToCurrentSpanAndPropagate(
           {
             [SemanticAttributes.ENDUSER_ID]: domainUser?.id,
             [ENDUSER_ALIAS]: domainUser?.username,

--- a/src/servers/graphql-old-server.ts
+++ b/src/servers/graphql-old-server.ts
@@ -37,6 +37,7 @@ import {
 } from "@app/wallets"
 import { decodeInvoice } from "@domain/bitcoin/lightning"
 import { mapError } from "@graphql/error-map"
+import { addToEverySpan, SemanticAttributes, ENDUSER_ALIAS } from "@services/tracing"
 
 const graphqlLogger = baseLogger.child({ module: "graphql" })
 
@@ -79,19 +80,27 @@ const translateWalletTx = (txs: WalletTransaction[]) => {
 
 const resolvers = {
   Query: {
-    me: (_, __, { uid, user }) => {
-      const { phone, username, contacts, language, level } = user
+    me: (_, __, { uid, user, ip, domainUser }) =>
+      addToEverySpan(
+        {
+          [SemanticAttributes.ENDUSER_ID]: domainUser?.id,
+          [ENDUSER_ALIAS]: domainUser?.username,
+          [SemanticAttributes.HTTP_CLIENT_IP]: ip,
+        },
+        async () => {
+          const { phone, username, contacts, language, level } = user
 
-      return {
-        id: uid,
-        level,
-        phone,
-        username,
-        contacts,
-        language,
-        twoFAEnabled: user.twoFAEnabled,
-      }
-    },
+          return {
+            id: uid,
+            level,
+            phone,
+            username,
+            contacts,
+            language,
+            twoFAEnabled: user.twoFAEnabled,
+          }
+        },
+      ),
 
     // legacy, before handling multi currency account
     wallet: (_, __, { wallet, logger }) => [
@@ -297,33 +306,41 @@ const resolvers = {
         if (result instanceof Error) throw result
         return result
       },
-      payInvoice: async ({ invoice, amount, memo }) => {
-        const decodedInvoice = await decodeInvoice(invoice)
-        if (decodedInvoice instanceof Error) throw decodedInvoice
+      payInvoice: async ({ invoice, amount, memo }, _, { ip, domainUser }) =>
+        addToEverySpan(
+          {
+            [SemanticAttributes.ENDUSER_ID]: domainUser?.id,
+            [ENDUSER_ALIAS]: domainUser?.username,
+            [SemanticAttributes.HTTP_CLIENT_IP]: ip,
+          },
+          async () => {
+            const decodedInvoice = decodeInvoice(invoice)
+            if (decodedInvoice instanceof Error) throw decodedInvoice
 
-        const { amount: lnInvoiceAmount } = decodedInvoice
-        if (lnInvoiceAmount && lnInvoiceAmount > 0) {
-          const status = await lnInvoicePaymentSend({
-            paymentRequest: invoice,
-            memo,
-            walletId: wallet.user.id as WalletId,
-            userId: wallet.user.id as UserId,
-            logger,
-          })
-          if (status instanceof Error) throw mapError(status)
-          return status.value
-        }
-        const status = await lnNoAmountInvoicePaymentSend({
-          paymentRequest: invoice,
-          memo,
-          amount,
-          walletId: wallet.user.id as WalletId,
-          userId: wallet.user.id as UserId,
-          logger,
-        })
-        if (status instanceof Error) throw mapError(status)
-        return status.value
-      },
+            const { amount: lnInvoiceAmount } = decodedInvoice
+            if (lnInvoiceAmount && lnInvoiceAmount > 0) {
+              const status = await lnInvoicePaymentSend({
+                paymentRequest: invoice,
+                memo,
+                walletId: wallet.user.id as WalletId,
+                userId: wallet.user.id as UserId,
+                logger,
+              })
+              if (status instanceof Error) throw mapError(status)
+              return status.value
+            }
+            const status = await lnNoAmountInvoicePaymentSend({
+              paymentRequest: invoice,
+              memo,
+              amount,
+              walletId: wallet.user.id as WalletId,
+              userId: wallet.user.id as UserId,
+              logger,
+            })
+            if (status instanceof Error) throw mapError(status)
+            return status.value
+          },
+        ),
       payKeysendUsername: async ({ username, amount, memo }) => {
         const status = await intraledgerPaymentSend({
           recipientUsername: username,

--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -24,6 +24,11 @@ import { WalletFactory } from "@core/wallet-factory"
 import { ApolloServerPluginUsageReporting } from "apollo-server-core"
 import GeeTest from "@services/geetest"
 import expressApiKeyAuth from "./graphql-middlewares/api-key-auth"
+import {
+  SemanticAttributes,
+  addAttributesToCurrentSpan,
+  ENDUSER_ALIAS,
+} from "@services/tracing"
 
 const graphqlLogger = baseLogger.child({
   module: "graphql",
@@ -115,6 +120,12 @@ export const startApolloServer = async ({
           })
         account = loggedInAccount
       }
+
+      addAttributesToCurrentSpan({
+        [SemanticAttributes.ENDUSER_ID]: uid,
+        [ENDUSER_ALIAS]: domainUser?.username,
+        [SemanticAttributes.HTTP_CLIENT_IP]: ip,
+      })
 
       return {
         ...context,

--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -26,6 +26,7 @@ import GeeTest from "@services/geetest"
 import expressApiKeyAuth from "./graphql-middlewares/api-key-auth"
 import {
   SemanticAttributes,
+  addToEverySpan,
   addAttributesToCurrentSpan,
   ENDUSER_ALIAS,
 } from "@services/tracing"
@@ -97,47 +98,56 @@ export const startApolloServer = async ({
       const logger = graphqlLogger.child({ token, id: uuidv4(), body: context.req?.body })
 
       let domainUser: User | null = null
-      if (uid) {
-        const loggedInUser = await Users.getUserForLogin({ userId: uid, ip })
-        if (loggedInUser instanceof Error)
-          throw new ApolloError("Invalid user authentication", "INVALID_AUTHENTICATION", {
-            reason: loggedInUser,
-          })
-        domainUser = loggedInUser
-        user = await User.findOne({ _id: uid })
-        wallet =
-          !!user && user.status === "active"
-            ? await WalletFactory({ user, logger })
-            : null
-      }
+      return addToEverySpan(
+        { [SemanticAttributes.ENDUSER_ID]: uid, [SemanticAttributes.HTTP_CLIENT_IP]: ip },
+        async () => {
+          if (uid) {
+            const loggedInUser = await Users.getUserForLogin({ userId: uid, ip })
+            if (loggedInUser instanceof Error)
+              throw new ApolloError(
+                "Invalid user authentication",
+                "INVALID_AUTHENTICATION",
+                {
+                  reason: loggedInUser,
+                },
+              )
+            domainUser = loggedInUser
+            user = await User.findOne({ _id: uid })
+            wallet =
+              !!user && user.status === "active"
+                ? await WalletFactory({ user, logger })
+                : null
+          }
 
-      let account: Account | null = null
-      if (apiSecret && apiSecret) {
-        const loggedInAccount = await Accounts.getAccountByApiKey(apiKey, apiSecret)
-        if (loggedInAccount instanceof Error)
-          throw new ApolloError("Invalid API authentication", "INVALID_AUTHENTICATION", {
-            reason: loggedInAccount,
-          })
-        account = loggedInAccount
-      }
+          let account: Account | null = null
+          if (apiSecret && apiSecret) {
+            const loggedInAccount = await Accounts.getAccountByApiKey(apiKey, apiSecret)
+            if (loggedInAccount instanceof Error)
+              throw new ApolloError(
+                "Invalid API authentication",
+                "INVALID_AUTHENTICATION",
+                {
+                  reason: loggedInAccount,
+                },
+              )
+            account = loggedInAccount
+          }
 
-      addAttributesToCurrentSpan({
-        [SemanticAttributes.ENDUSER_ID]: uid,
-        [ENDUSER_ALIAS]: domainUser?.username,
-        [SemanticAttributes.HTTP_CLIENT_IP]: ip,
-      })
+          addAttributesToCurrentSpan({ [ENDUSER_ALIAS]: domainUser?.username })
 
-      return {
-        ...context,
-        logger,
-        uid,
-        wallet,
-        domainUser,
-        user,
-        geetest,
-        account,
-        ip,
-      }
+          return {
+            ...context,
+            logger,
+            uid,
+            wallet,
+            domainUser,
+            user,
+            geetest,
+            account,
+            ip,
+          }
+        },
+      )
     },
     formatError: (err) => {
       const log = err.extensions?.exception?.log

--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -26,7 +26,7 @@ import GeeTest from "@services/geetest"
 import expressApiKeyAuth from "./graphql-middlewares/api-key-auth"
 import {
   SemanticAttributes,
-  addToEverySpan,
+  addAttributesToCurrentSpanAndPropagate,
   addAttributesToCurrentSpan,
   ENDUSER_ALIAS,
 } from "@services/tracing"
@@ -98,7 +98,7 @@ export const startApolloServer = async ({
       const logger = graphqlLogger.child({ token, id: uuidv4(), body: context.req?.body })
 
       let domainUser: User | null = null
-      return addToEverySpan(
+      return addAttributesToCurrentSpanAndPropagate(
         { [SemanticAttributes.ENDUSER_ID]: uid, [SemanticAttributes.HTTP_CLIENT_IP]: ip },
         async () => {
           if (uid) {

--- a/src/services/tracing.ts
+++ b/src/services/tracing.ts
@@ -166,7 +166,7 @@ export const asyncRunInSpan = <F extends () => ReturnType<F>>(
   return ret
 }
 
-export const addToEverySpan = <F extends () => ReturnType<F>>(
+export const addAttributesToCurrentSpanAndPropagate = <F extends () => ReturnType<F>>(
   attributes: { [key: string]: string | undefined },
   fn: F,
 ) => {

--- a/src/services/tracing.ts
+++ b/src/services/tracing.ts
@@ -154,3 +154,5 @@ export const asyncRunInSpan = <
 }
 
 export { SemanticAttributes, SemanticResourceAttributes }
+
+export const ENDUSER_ALIAS = "enduser.alias"


### PR DESCRIPTION
This PR begins to add some app-specific tracing.
In particular instrumentation is added to the pay-via-lightning use cases using helpers exposed in the `services/tracing.ts` module.

The diff is much smaller than it seems. Mostly code has just been indented und runs under a callback (similar like in the redis lock pattern we already have).

EDIT - a bit more context:
there are 2 _different_ helpers that 'wrap' functions - one sets attributes that should be added to _all_ child spans like:
```
 addAttributesToCurrentSpanAndPropagate(
      {
        [SemanticAttributes.ENDUSER_ID]: domainUser?.id,
        [ENDUSER_ALIAS]: domainUser?.username,
        [SemanticAttributes.HTTP_CLIENT_IP]: ip,
      },
```

This doesn't create its own span - it just makes sure it populates some context for all children to pick up. It should be called in _all_ GQL resolvers.


and then there is:
```
  asyncRunInSpan(
    "app.lnInvoicePaymentSendWithTwoFA",
    {
      [SemanticAttributes.CODE_FUNCTION]: "lnInvoicePaymentSendWithTwoFA",
    }
```
this is called from _within_ the app use case functions - and probably also from within the service functions when we get to that layer.