### PR TITLE
Make .envrc docker-compose v2 compatible

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -8,7 +8,7 @@ export TLSOUTSIDE1=$(base64 dev/lnd/tls.cert | tr -d '\n\r')
 export TLSOUTSIDE2=$(base64 dev/lnd/tls.cert | tr -d '\n\r')
 
 fetch_macaroon() {
-  local container_id=$(docker ps -q -f status=running -f name="${PWD##*/}_$1_")
+  local container_id=$(docker ps -q -f status=running -f name="${PWD##*/}-$1-")
   if [ ! -z "${container_id}" ]; then
     # On Arch Linux `docker-compose up` appears to complete before the lnd containers have initialized the macaroons.
     # Here we retry for 10 seconds until we can copy the macroon successfully
@@ -30,7 +30,7 @@ export MACAROONOUTSIDE1=$(fetch_macaroon lnd-outside-1)
 export MACAROONOUTSIDE2=$(fetch_macaroon lnd-outside-2)
 
 fetch_pubkey() {
-  local container_id=$(docker ps -q -f status=running -f name="${PWD##*/}_$1_")
+  local container_id=$(docker ps -q -f status=running -f name="${PWD##*/}-$1-")
   if [ ! -z "${container_id}" ]; then
     for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
       docker exec ${container_id} lncli -n $NETWORK getinfo > /dev/null 2>&1


### PR DESCRIPTION
Fixes https://github.com/GaloyMoney/galoy/issues/689 but NOT backwards compatible. When we merge this everyone needs to use docker-compose v2. Including GitHub actions and concourse... not sure if we're ready for it.

Alternatively you can run:
```
docker-compose disable-v2
```

cc @nicolasburtey 