### PR TITLE
Add honeycomb config to local dev environment

### DIFF
--- a/dev/otel-agent-config.yaml
+++ b/dev/otel-agent-config.yaml
@@ -15,6 +15,11 @@ processors:
 exporters:
   logging:
     loglevel: debug
+  otlp:
+    endpoint: "api.honeycomb.io:443"
+    headers:
+      "x-honeycomb-team": ${HONEYCOMB_API_KEY}
+      "x-honeycomb-dataset": ${HONEYCOMB_DATASET}
 
 extensions:
   health_check:
@@ -27,5 +32,5 @@ service:
     traces:
       receivers: [jaeger]
       processors: [attributes, batch]
-      exporters: [logging]
+      exporters: [otlp, logging]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ services:
   otel-agent:
     image: otel/opentelemetry-collector-contrib:0.37.1
     command: ["--config=/etc/otel-agent-config.yaml", "--log-level=debug"]
+    environment:
+    - HONEYCOMB_DATASET=${HONEYCOMB_DATASET}
+    - HONEYCOMB_API_KEY=${HONEYCOMB_API_KEY}
     volumes:
       - ./dev/otel-agent-config.yaml:/etc/otel-agent-config.yaml
     ports:


### PR DESCRIPTION
By setting the following keys:

```
export HONEYCOMB_API_KEY=<api-key>
export HONEYCOMB_DATASET=<your-dataset>
```

in the terminal you run `make reset-deps` in you will get local traces in honeycomb.io