### PR TITLE
Validate block subscription height

### DIFF
--- a/test/integration/servers/trigger.spec.ts
+++ b/test/integration/servers/trigger.spec.ts
@@ -85,8 +85,10 @@ describe("onchainBlockEventhandler", () => {
     const initialBlock = await bitcoindClient.getBlockCount()
     const subBlocks = subscribeToBlocks({ lnd: lnd1 })
     subBlocks.on("block", async ({ height }) => {
-      await onchainBlockEventhandler({ height })
-      lastHeight = height > lastHeight ? height : lastHeight
+      if (height > lastHeight) {
+        lastHeight = height
+        await onchainBlockEventhandler({ height })
+      }
       isFinalBlock = lastHeight >= initialBlock + blocksToMine
     })
 


### PR DESCRIPTION
avoid lock in wallet id when same onchain block event is triggered multiple times