### PR TITLE
Remove getCurrentPrice from transactionNotification

### DIFF
--- a/src/app/wallets/update-on-chain-receipt.ts
+++ b/src/app/wallets/update-on-chain-receipt.ts
@@ -76,10 +76,9 @@ const processTxForWallet = async (
 
   const walletAddresses = wallet.onChainAddresses()
 
-  const price = await PriceService().getCurrentPrice()
-  if (price instanceof Error) {
-    return price
-  }
+  const usdPerSat = await PriceService().getCurrentPrice()
+  if (usdPerSat instanceof Error) return usdPerSat
+
   const liabilitiesAccountId = toLiabilitiesAccountId(wallet.id)
 
   const lockService = LockService()
@@ -97,8 +96,8 @@ const processTxForWallet = async (
             amount: sats,
             ratio: wallet.depositFeeRatio,
           })
-          const usd = sats * price
-          const usdFee = fee * price
+          const usd = sats * usdPerSat
+          const usdFee = fee * usdPerSat
 
           const result = await ledger.addOnChainTxReceive({
             liabilitiesAccountId,
@@ -118,6 +117,7 @@ const processTxForWallet = async (
             walletId: wallet.id,
             amount: sats,
             txId: tx.rawTx.id,
+            usdPerSat,
           })
         }
       }

--- a/src/app/wallets/update-pending-invoices.ts
+++ b/src/app/wallets/update-pending-invoices.ts
@@ -116,14 +116,14 @@ const updatePendingInvoice = async ({
       const updatedWalletInvoice = await walletInvoicesRepo.update(invoiceToUpdate)
       if (updatedWalletInvoice instanceof Error) return updatedWalletInvoice
 
-      const price = await PriceService().getCurrentPrice()
-      if (price instanceof Error) return price
+      const usdPerSat = await PriceService().getCurrentPrice()
+      if (usdPerSat instanceof Error) return usdPerSat
 
       const { description, received } = lnInvoiceLookup
       const fee = DepositFeeCalculator().lnDepositFee()
 
-      const usd = received * price
-      const usdFee = fee * price
+      const usd = received * usdPerSat
+      const usdFee = fee * usdPerSat
 
       const liabilitiesAccountId = toLiabilitiesAccountId(walletId)
       const ledgerService = LedgerService()
@@ -143,6 +143,7 @@ const updatePendingInvoice = async ({
         amount: received,
         walletId: walletInvoice.walletId,
         paymentHash,
+        usdPerSat,
       })
 
       const eventName = lnPaymentStatusEvent(paymentHash)

--- a/src/domain/notifications/index.ts
+++ b/src/domain/notifications/index.ts
@@ -1,1 +1,8 @@
 export * from "./errors"
+
+export const NotificationType = {
+  OnchainReceipt: "onchain_receipt",
+  OnchainReceiptPending: "onchain_receipt_pending",
+  OnchainPayment: "onchain_payment",
+  LnInvoicePaid: "paid-invoice",
+} as const

--- a/src/domain/notifications/index.types.d.ts
+++ b/src/domain/notifications/index.types.d.ts
@@ -1,21 +1,36 @@
 type NotificationsError = import("./errors").NotificationsError
 type NotificationsServiceError = import("./errors").NotificationsServiceError
 
-type OnChainTxReceivedArgs = {
+type NotificationType =
+  typeof import("./index").NotificationType[keyof typeof import("./index").NotificationType]
+
+type OnChainTxBaseArgs = {
   walletId: WalletId
   amount: Satoshis
   txId: TxId
+  usdPerSat?: UsdPerSat
 }
+
+type OnChainTxReceivedArgs = OnChainTxBaseArgs
+type OnChainTxReceivedPendingArgs = OnChainTxBaseArgs
+type OnChainTxPaymentArgs = OnChainTxBaseArgs
 
 type LnPaymentReceivedArgs = {
   walletId: WalletId
   amount: Satoshis
   paymentHash: PaymentHash
+  usdPerSat?: UsdPerSat
 }
 
 interface INotificationsService {
   onChainTransactionReceived(
     args: OnChainTxReceivedArgs,
+  ): Promise<void | NotificationsServiceError>
+  onChainTransactionReceivedPending(
+    args: OnChainTxReceivedPendingArgs,
+  ): Promise<void | NotificationsServiceError>
+  onChainTransactionPayment(
+    args: OnChainTxPaymentArgs,
   ): Promise<void | NotificationsServiceError>
   lnPaymentReceived(
     args: LnPaymentReceivedArgs,

--- a/src/services/notifications/payment.ts
+++ b/src/services/notifications/payment.ts
@@ -1,5 +1,3 @@
-import { getCurrentPrice } from "@services/realtime-price"
-
 import { sendNotification } from "./notification"
 
 export const getTitle = {
@@ -23,13 +21,12 @@ export const transactionNotification = async ({
   logger,
   hash,
   txid,
+  usdPerSat,
 }: IPaymentNotification) => {
-  const satsPrice = await getCurrentPrice()
-
   let title
 
-  if (satsPrice) {
-    const usd = (amount * satsPrice).toFixed(2)
+  if (usdPerSat) {
+    const usd = (amount * usdPerSat).toFixed(2)
     title = getTitle[type]({ usd, amount })
   } else {
     title = getTitleNoUsd[type]({ amount })

--- a/src/services/notifications/payment.types.d.ts
+++ b/src/services/notifications/payment.types.d.ts
@@ -5,4 +5,5 @@ interface IPaymentNotification {
   logger: Logger
   hash?: string
   txid?: string
+  usdPerSat?: UsdPerSat
 }

--- a/test/integration/02-user-wallet/02-receive-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-onchain.spec.ts
@@ -25,6 +25,7 @@ import { TxStatus } from "@domain/wallets"
 import { getBTCBalance } from "test/helpers/wallet"
 import { resetOnChainAddressWalletIdLimits } from "test/helpers/rate-limit"
 import { OnChainAddressCreateRateLimiterExceededError } from "@domain/rate-limit/errors"
+import { NotificationType } from "@domain/notifications"
 
 jest.mock("@services/realtime-price", () => require("test/mocks/realtime-price"))
 jest.mock("@services/phone-provider", () => require("test/mocks/phone-provider"))
@@ -215,7 +216,9 @@ describe("UserWallet - On chain", () => {
     await sleep(1000)
 
     expect(sendNotification.mock.calls.length).toBe(1)
-    expect(sendNotification.mock.calls[0][0].data.type).toBe("onchain_receipt_pending")
+    expect(sendNotification.mock.calls[0][0].data.type).toBe(
+      NotificationType.OnchainReceiptPending,
+    )
 
     const satsPrice = await getCurrentPrice()
     if (!satsPrice) {
@@ -224,7 +227,10 @@ describe("UserWallet - On chain", () => {
     const usd = (btc2sat(amountBTC) * satsPrice).toFixed(2)
 
     expect(sendNotification.mock.calls[0][0].title).toBe(
-      getTitle["onchain_receipt_pending"]({ usd, amount: btc2sat(amountBTC) }),
+      getTitle[NotificationType.OnchainReceiptPending]({
+        usd,
+        amount: btc2sat(amountBTC),
+      }),
     )
 
     await Promise.all([
@@ -243,7 +249,7 @@ describe("UserWallet - On chain", () => {
     // to not replay if it has already been handled?
     //
     // expect(notification.sendNotification.mock.calls.length).toBe(2)
-    // expect(notification.sendNotification.mock.calls[1][0].data.type).toBe("onchain_receipt")
+    // expect(notification.sendNotification.mock.calls[1][0].data.type).toBe(NotificationType.OnchainReceipt)
     // expect(notification.sendNotification.mock.calls[1][0].title).toBe(
     //   `Your wallet has been credited with ${btc2sat(amountBTC)} sats`)
   })

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -31,6 +31,7 @@ import { PaymentInitiationMethod, TxStatus } from "@domain/wallets"
 import * as Wallets from "@app/wallets"
 import { TwoFAError, TransactionRestrictedError } from "@core/error"
 import { getBTCBalance, getRemainingTwoFALimit } from "test/helpers/wallet"
+import { NotificationType } from "@domain/notifications"
 
 jest.mock("@services/realtime-price", () => require("test/mocks/realtime-price"))
 jest.mock("@services/phone-provider", () => require("test/mocks/phone-provider"))
@@ -88,7 +89,7 @@ describe("UserWallet - onChainPay", () => {
 
     // we don't send a notification for send transaction for now
     // expect(sendNotification.mock.calls.length).toBe(1)
-    // expect(sendNotification.mock.calls[0][0].data.type).toBe("onchain_payment")
+    // expect(sendNotification.mock.calls[0][0].data.type).toBe(NotificationType.OnchainPayment)
     // expect(sendNotification.mock.calls[0][0].data.title).toBe(`Your transaction has been sent. It may takes some time before it is confirmed`)
 
     // FIXME: does this syntax always take the first match item in the array? (which is waht we want, items are return as newest first)
@@ -125,10 +126,12 @@ describe("UserWallet - onChainPay", () => {
     // expect(sendNotification.mock.calls.length).toBe(2)  // FIXME: should be 1
 
     expect(sendNotification.mock.calls[0][0].title).toBe(
-      getTitle["onchain_payment"]({ amount }),
+      getTitle[NotificationType.OnchainPayment]({ amount }),
     )
     expect(sendNotification.mock.calls[0][0].user._id).toStrictEqual(userWallet0.user._id)
-    expect(sendNotification.mock.calls[0][0].data.type).toBe("onchain_payment")
+    expect(sendNotification.mock.calls[0][0].data.type).toBe(
+      NotificationType.OnchainPayment,
+    )
 
     const {
       results: [{ pending, fee, feeUsd }],
@@ -179,7 +182,7 @@ describe("UserWallet - onChainPay", () => {
 
     // we don't send a notification for send transaction for now
     // expect(sendNotification.mock.calls.length).toBe(1)
-    // expect(sendNotification.mock.calls[0][0].data.type).toBe("onchain_payment")
+    // expect(sendNotification.mock.calls[0][0].data.type).toBe(NotificationType.OnchainPayment)
     // expect(sendNotification.mock.calls[0][0].data.title).toBe(`Your transaction has been sent. It may takes some time before it is confirmed`)
 
     // FIXME: does this syntax always take the first match item in the array? (which is waht we want, items are return as newest first)
@@ -217,9 +220,11 @@ describe("UserWallet - onChainPay", () => {
 
     /// TODO Still showing amount, find where this happens...
     // expect(sendNotification.mock.calls[0][0].title).toBe(
-    //   getTitle["onchain_payment"]({ amount: initialBalanceUser1 }),
+    //   getTitle[NotificationType.OnchainPayment]({ amount: initialBalanceUser1 }),
     // )
-    expect(sendNotification.mock.calls[0][0].data.type).toBe("onchain_payment")
+    expect(sendNotification.mock.calls[0][0].data.type).toBe(
+      NotificationType.OnchainPayment,
+    )
 
     const {
       results: [{ pending, fee, feeUsd }],

--- a/test/integration/servers/trigger.spec.ts
+++ b/test/integration/servers/trigger.spec.ts
@@ -25,6 +25,7 @@ import { getTitle } from "@services/notifications/payment"
 import { getCurrentPrice } from "@services/realtime-price"
 import { TxStatus } from "@domain/wallets"
 import { getBTCBalance } from "test/helpers/wallet"
+import { NotificationType } from "@domain/notifications"
 
 jest.mock("@services/notifications/notification")
 jest.mock("@services/realtime-price", () => require("test/mocks/realtime-price"))
@@ -159,9 +160,11 @@ describe("onchainBlockEventhandler", () => {
     const satsPrice = (await getCurrentPrice()) || 1
     const usd = (sats * satsPrice).toFixed(2)
     expect(sendNotification.mock.calls[0][0].title).toBe(
-      getTitle["paid-invoice"]({ usd, amount: sats }),
+      getTitle[NotificationType.LnInvoicePaid]({ usd, amount: sats }),
     )
     expect(sendNotification.mock.calls[0][0].user._id).toStrictEqual(wallet.user._id)
-    expect(sendNotification.mock.calls[0][0].data.type).toBe("paid-invoice")
+    expect(sendNotification.mock.calls[0][0].data.type).toBe(
+      NotificationType.LnInvoicePaid,
+    )
   })
 })


### PR DESCRIPTION
Reviewing https://github.com/GaloyMoney/galoy/pull/662 and pairing with Arvin, we decided to split it in different PRs

- The main purpose of this PR is remove getCurrentPrice from transactionNotification
- Remove direct calls to transactionNotification
- Although we have some tests for notifications, we need to do final tests in staging