### PR TITLE
Add jq in DEV.md

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -10,6 +10,8 @@ $ yarn --version
 1.22.10
 $ direnv --version
 2.28.0
+$ jq --version
+jq-1.6
 $ docker --version
 Docker version 20.10.7, build f0df350
 $ docker-compose --version


### PR DESCRIPTION
jq is not installed by default on linux.
Adding it in the tool list could be useful for people setting up their development environment.