### PR TITLE
Revert "upgrade last mongodb version docker-compose"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     - ALLOW_EMPTY_PASSWORD=yes
     - REDIS_DISABLE_COMMANDS=FLUSHDB,FLUSHALL
   mongodb:
-    image: bitnami/mongodb:4.4.10-debian-10-r20
+    image: bitnami/mongodb:4.4.6-debian-10-r0
     ports:
     - "27017:27017"
     environment:


### PR DESCRIPTION
There is an issue rolling out the MongoDB upgrade to production (see https://github.com/GaloyMoney/charts/pull/192 to reproduce the issue locally).

Until we are able to roll this out to production we should keep the local dev env in sync with what we are currently running!