### PR TITLE
 trying to resolve local dev issue with tsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "galoy",
   "scripts": {
-    "tsc-check": "tsc --noEmit -p tsconfig.d.json && tsc --noEmit --skipLibCheck",
+    "tsc-check": "tsc --noEmit -p tsconfig.d.json --skipLibCheck && tsc --noEmit --skipLibCheck",
     "eslint-check": "eslint \"{src,test}/**/*.ts\"",
     "eslint-fix": "eslint \"{src,test}/**/*.ts\" --fix",
     "prettier-check": "prettier --check .",


### PR DESCRIPTION
 without the `--skipLibCheck`, I have some error. This doesn't seem to be the case on the ci server, and can't necessarily figure out why.

here is the error I have:

```
node_modules/typescript/lib/lib.dom.d.ts:1899:11 - error TS2300: Duplicate identifier 'AbortController'.

1899 interface AbortController {
               ~~~~~~~~~~~~~~~

  ../node_modules/@types/react-native/globals.d.ts:389:15
    389 declare class AbortController {
                      ~~~~~~~~~~~~~~~
    'AbortController' was also declared here.

node_modules/typescript/lib/lib.dom.d.ts:1910:13 - error TS2300: Duplicate identifier 'AbortController'.

1910 declare var AbortController: {
                 ~~~~~~~~~~~~~~~

  ../node_modules/@types/react-native/globals.d.ts:389:15
    389 declare class AbortController {
                      ~~~~~~~~~~~~~~~
    'AbortController' was also declared here.

node_modules/typescript/lib/lib.dom.d.ts:1920:11 - error TS2300: Duplicate identifier 'AbortSignal'.

1920 interface AbortSignal extends EventTarget {
               ~~~~~~~~~~~

  ../node_modules/@types/react-native/globals.d.ts:376:15
    376 declare class AbortSignal {
                      ~~~~~~~~~~~
    'AbortSignal' was also declared here.

node_modules/typescript/lib/lib.dom.d.ts:1932:13 - error TS2300: Duplicate identifier 'AbortSignal'.

1932 declare var AbortSignal: {
                 ~~~~~~~~~~~

  ../node_modules/@types/react-native/globals.d.ts:376:15
    376 declare class AbortSignal {
                      ~~~~~~~~~~~
    'AbortSignal' was also declared here.

node_modules/typescript/lib/lib.dom.d.ts:5431:11 - error TS2300: Duplicate identifier 'FormData'.

5431 interface FormData {
               ~~~~~~~~

  ../node_modules/@types/react-native/globals.d.ts:54:15
    54 declare class FormData {
                     ~~~~~~~~
    'FormData' was also declared here.

node_modules/typescript/lib/lib.dom.d.ts:5441:13 - error TS2300: Duplicate identifier 'FormData'.

5441 declare var FormData: {
                 ~~~~~~~~

  ../node_modules/@types/react-native/globals.d.ts:54:15
    54 declare class FormData {
                     ~~~~~~~~
    'FormData' was also declared here.

node_modules/typescript/lib/lib.dom.d.ts:14919:11 - error TS2300: Duplicate identifier 'URL'.

14919 interface URL {
                ~~~

  ../node_modules/@types/react-native/globals.d.ts:287:15
    287 declare class URL {
                      ~~~
    'URL' was also declared here.

node_modules/typescript/lib/lib.dom.d.ts:14936:13 - error TS2300: Duplicate identifier 'URL'.

14936 declare var URL: {
                  ~~~

  ../node_modules/@types/react-native/globals.d.ts:287:15
    287 declare class URL {
                      ~~~
    'URL' was also declared here.

node_modules/typescript/lib/lib.dom.d.ts:14946:11 - error TS2300: Duplicate identifier 'URLSearchParams'.

14946 interface URLSearchParams {
                ~~~~~~~~~~~~~~~

  ../node_modules/@types/react-native/globals.d.ts:312:15
    312 declare class URLSearchParams {
                      ~~~~~~~~~~~~~~~
    'URLSearchParams' was also declared here.

node_modules/typescript/lib/lib.dom.d.ts:14979:13 - error TS2300: Duplicate identifier 'URLSearchParams'.

14979 declare var URLSearchParams: {
                  ~~~~~~~~~~~~~~~

  ../node_modules/@types/react-native/globals.d.ts:312:15
    312 declare class URLSearchParams {
                      ~~~~~~~~~~~~~~~
    'URLSearchParams' was also declared here.

node_modules/typescript/lib/lib.dom.d.ts:18772:6 - error TS2300: Duplicate identifier 'RequestInfo'.

18772 type RequestInfo = Request | string;
           ~~~~~~~~~~~

  ../node_modules/@types/react-native/globals.d.ts:137:14
    137 declare type RequestInfo = Request | string;
                     ~~~~~~~~~~~
    'RequestInfo' was also declared here.

node_modules/typescript/lib/lib.dom.d.ts:18924:6 - error TS2300: Duplicate identifier 'XMLHttpRequestResponseType'.

18924 type XMLHttpRequestResponseType = "" | "arraybuffer" | "blob" | "document" | "json" | "text";
           ~~~~~~~~~~~~~~~~~~~~~~~~~~

  ../node_modules/@types/react-native/globals.d.ts:280:14
    280 declare type XMLHttpRequestResponseType = '' | 'arraybuffer' | 'blob' | 'document' | 'json' | 'text';
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~
    'XMLHttpRequestResponseType' was also declared here.

node_modules/typescript/lib/lib.dom.iterable.d.ts:79:11 - error TS2300: Duplicate identifier 'FormData'.

79 interface FormData {
             ~~~~~~~~

  ../node_modules/@types/react-native/globals.d.ts:54:15
    54 declare class FormData {
                     ~~~~~~~~
    'FormData' was also declared here.

node_modules/typescript/lib/lib.dom.iterable.d.ts:284:11 - error TS2300: Duplicate identifier 'URLSearchParams'.

284 interface URLSearchParams {
              ~~~~~~~~~~~~~~~

  ../node_modules/@types/react-native/globals.d.ts:312:15
    312 declare class URLSearchParams {
                      ~~~~~~~~~~~~~~~
    'URLSearchParams' was also declared here.

../node_modules/@types/react-native/globals.d.ts:49:13 - error TS2403: Subsequent variable declarations must have the same type.  Variable 'Blob' must be of type '{ new (blobParts?: BlobPart[] | undefined, options?: BlobPropertyBag | undefined): Blob; prototype: Blob; }', but here has type '{ new (blobParts?: (string | Blob)[] | undefined, options?: BlobOptions | undefined): Blob; prototype: Blob; }'.

49 declare var Blob: {
               ~~~~

  node_modules/typescript/lib/lib.dom.d.ts:2428:13
    2428 declare var Blob: {
                     ~~~~
    'Blob' was also declared here.

../node_modules/@types/react-native/globals.d.ts:54:15 - error TS2300: Duplicate identifier 'FormData'.

54 declare class FormData {
                 ~~~~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:5431:11
    5431 interface FormData {
                   ~~~~~~~~
    'FormData' was also declared here.
  node_modules/typescript/lib/lib.dom.d.ts:5441:13
    5441 declare var FormData: {
                     ~~~~~~~~
    and here.
  node_modules/typescript/lib/lib.dom.iterable.d.ts:79:11
    79 interface FormData {
                 ~~~~~~~~
    and here.

../node_modules/@types/react-native/globals.d.ts:110:5 - error TS2717: Subsequent property declarations must have the same type.  Property 'body' must be of type 'BodyInit | null | undefined', but here has type 'BodyInit_ | undefined'.

110     body?: BodyInit_;
        ~~~~

  node_modules/typescript/lib/lib.dom.d.ts:1481:5
    1481     body?: BodyInit | null;
             ~~~~
    'body' was also declared here.

../node_modules/@types/react-native/globals.d.ts:119:5 - error TS2717: Subsequent property declarations must have the same type.  Property 'signal' must be of type 'AbortSignal | null | undefined', but here has type 'AbortSignal | undefined'.

119     signal?: AbortSignal;
        ~~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:1525:5
    1525     signal?: AbortSignal | null;
             ~~~~~~
    'signal' was also declared here.

../node_modules/@types/react-native/globals.d.ts:137:14 - error TS2300: Duplicate identifier 'RequestInfo'.

137 declare type RequestInfo = Request | string;
                 ~~~~~~~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:18772:6
    18772 type RequestInfo = Request | string;
               ~~~~~~~~~~~
    'RequestInfo' was also declared here.

../node_modules/@types/react-native/globals.d.ts:156:13 - error TS2403: Subsequent variable declarations must have the same type.  Variable 'Response' must be of type '{ new (body?: BodyInit | null | undefined, init?: ResponseInit | undefined): Response; prototype: Response; error(): Response; redirect(url: string | URL, status?: number | undefined): Response; }', but here has type '{ new (body?: BodyInit_ | undefined, init?: ResponseInit | undefined): Response; prototype: Response; error: () => Response; redirect: (url: string, status?: number | undefined) => Response; }'.

156 declare var Response: {
                ~~~~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:12153:13
    12153 declare var Response: {
                      ~~~~~~~~
    'Response' was also declared here.

../node_modules/@types/react-native/globals.d.ts:233:5 - error TS2717: Subsequent property declarations must have the same type.  Property 'abort' must be of type 'ProgressEvent<XMLHttpRequestEventTarget>', but here has type 'ProgressEvent<EventTarget>'.

233     abort: ProgressEvent;
        ~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:17639:5
    17639     "abort": ProgressEvent<XMLHttpRequestEventTarget>;
              ~~~~~~~
    'abort' was also declared here.

../node_modules/@types/react-native/globals.d.ts:234:5 - error TS2717: Subsequent property declarations must have the same type.  Property 'error' must be of type 'ProgressEvent<XMLHttpRequestEventTarget>', but here has type 'ProgressEvent<EventTarget>'.

234     error: ProgressEvent;
        ~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:17640:5
    17640     "error": ProgressEvent<XMLHttpRequestEventTarget>;
              ~~~~~~~
    'error' was also declared here.

../node_modules/@types/react-native/globals.d.ts:235:5 - error TS2717: Subsequent property declarations must have the same type.  Property 'load' must be of type 'ProgressEvent<XMLHttpRequestEventTarget>', but here has type 'ProgressEvent<EventTarget>'.

235     load: ProgressEvent;
        ~~~~

  node_modules/typescript/lib/lib.dom.d.ts:17641:5
    17641     "load": ProgressEvent<XMLHttpRequestEventTarget>;
              ~~~~~~
    'load' was also declared here.

../node_modules/@types/react-native/globals.d.ts:236:5 - error TS2717: Subsequent property declarations must have the same type.  Property 'loadend' must be of type 'ProgressEvent<XMLHttpRequestEventTarget>', but here has type 'ProgressEvent<EventTarget>'.

236     loadend: ProgressEvent;
        ~~~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:17642:5
    17642     "loadend": ProgressEvent<XMLHttpRequestEventTarget>;
              ~~~~~~~~~
    'loadend' was also declared here.

../node_modules/@types/react-native/globals.d.ts:237:5 - error TS2717: Subsequent property declarations must have the same type.  Property 'loadstart' must be of type 'ProgressEvent<XMLHttpRequestEventTarget>', but here has type 'ProgressEvent<EventTarget>'.

237     loadstart: ProgressEvent;
        ~~~~~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:17643:5
    17643     "loadstart": ProgressEvent<XMLHttpRequestEventTarget>;
              ~~~~~~~~~~~
    'loadstart' was also declared here.

../node_modules/@types/react-native/globals.d.ts:238:5 - error TS2717: Subsequent property declarations must have the same type.  Property 'progress' must be of type 'ProgressEvent<XMLHttpRequestEventTarget>', but here has type 'ProgressEvent<EventTarget>'.

238     progress: ProgressEvent;
        ~~~~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:17644:5
    17644     "progress": ProgressEvent<XMLHttpRequestEventTarget>;
              ~~~~~~~~~~
    'progress' was also declared here.

../node_modules/@types/react-native/globals.d.ts:239:5 - error TS2717: Subsequent property declarations must have the same type.  Property 'timeout' must be of type 'ProgressEvent<XMLHttpRequestEventTarget>', but here has type 'ProgressEvent<EventTarget>'.

239     timeout: ProgressEvent;
        ~~~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:17645:5
    17645     "timeout": ProgressEvent<XMLHttpRequestEventTarget>;
              ~~~~~~~~~
    'timeout' was also declared here.

../node_modules/@types/react-native/globals.d.ts:280:14 - error TS2300: Duplicate identifier 'XMLHttpRequestResponseType'.

280 declare type XMLHttpRequestResponseType = '' | 'arraybuffer' | 'blob' | 'document' | 'json' | 'text';
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:18924:6
    18924 type XMLHttpRequestResponseType = "" | "arraybuffer" | "blob" | "document" | "json" | "text";
               ~~~~~~~~~~~~~~~~~~~~~~~~~~
    'XMLHttpRequestResponseType' was also declared here.

../node_modules/@types/react-native/globals.d.ts:287:15 - error TS2300: Duplicate identifier 'URL'.

287 declare class URL {
                  ~~~

  node_modules/typescript/lib/lib.dom.d.ts:14919:11
    14919 interface URL {
                    ~~~
    'URL' was also declared here.
  node_modules/typescript/lib/lib.dom.d.ts:14936:13
    14936 declare var URL: {
                      ~~~
    and here.

../node_modules/@types/react-native/globals.d.ts:312:15 - error TS2300: Duplicate identifier 'URLSearchParams'.

312 declare class URLSearchParams {
                  ~~~~~~~~~~~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:14946:11
    14946 interface URLSearchParams {
                    ~~~~~~~~~~~~~~~
    'URLSearchParams' was also declared here.
  node_modules/typescript/lib/lib.dom.d.ts:14979:13
    14979 declare var URLSearchParams: {
                      ~~~~~~~~~~~~~~~
    and here.
  node_modules/typescript/lib/lib.dom.iterable.d.ts:284:11
    284 interface URLSearchParams {
                  ~~~~~~~~~~~~~~~
    and here.

../node_modules/@types/react-native/globals.d.ts:346:5 - error TS2717: Subsequent property declarations must have the same type.  Property 'onopen' must be of type '((this: WebSocket, ev: Event) => any) | null', but here has type '(() => void) | null'.

346     onopen: (() => void) | null;
        ~~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:17141:5
    17141     onopen: ((this: WebSocket, ev: Event) => any) | null;
              ~~~~~~
    'onopen' was also declared here.

../node_modules/@types/react-native/globals.d.ts:347:5 - error TS2717: Subsequent property declarations must have the same type.  Property 'onmessage' must be of type '((this: WebSocket, ev: MessageEvent<any>) => any) | null', but here has type '((event: WebSocketMessageEvent) => void) | null'.

347     onmessage: ((event: WebSocketMessageEvent) => void) | null;
        ~~~~~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:17140:5
    17140     onmessage: ((this: WebSocket, ev: MessageEvent) => any) | null;
              ~~~~~~~~~
    'onmessage' was also declared here.

../node_modules/@types/react-native/globals.d.ts:348:5 - error TS2717: Subsequent property declarations must have the same type.  Property 'onerror' must be of type '((this: WebSocket, ev: Event) => any) | null', but here has type '((event: WebSocketErrorEvent) => void) | null'.

348     onerror: ((event: WebSocketErrorEvent) => void) | null;
        ~~~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:17139:5
    17139     onerror: ((this: WebSocket, ev: Event) => any) | null;
              ~~~~~~~
    'onerror' was also declared here.

../node_modules/@types/react-native/globals.d.ts:349:5 - error TS2717: Subsequent property declarations must have the same type.  Property 'onclose' must be of type '((this: WebSocket, ev: CloseEvent) => any) | null', but here has type '((event: WebSocketCloseEvent) => void) | null'.

349     onclose: ((event: WebSocketCloseEvent) => void) | null;
        ~~~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:17138:5
    17138     onclose: ((this: WebSocket, ev: CloseEvent) => any) | null;
              ~~~~~~~
    'onclose' was also declared here.

../node_modules/@types/react-native/globals.d.ts:352:13 - error TS2403: Subsequent variable declarations must have the same type.  Variable 'WebSocket' must be of type '{ new (url: string | URL, protocols?: string | string[] | undefined): WebSocket; prototype: WebSocket; readonly CLOSED: number; readonly CLOSING: number; readonly CONNECTING: number; readonly OPEN: number; }', but here has type '{ new (uri: string, protocols?: string | string[] | null | undefined, options?: { [optionName: string]: any; headers: { [headerName: string]: string; }; } | null | undefined): WebSocket; ... 4 more ...; readonly OPEN: number; }'.

352 declare var WebSocket: {
                ~~~~~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:17172:13
    17172 declare var WebSocket: {
                      ~~~~~~~~~
    'WebSocket' was also declared here.

../node_modules/@types/react-native/globals.d.ts:376:15 - error TS2300: Duplicate identifier 'AbortSignal'.

376 declare class AbortSignal {
                  ~~~~~~~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:1920:11
    1920 interface AbortSignal extends EventTarget {
                   ~~~~~~~~~~~
    'AbortSignal' was also declared here.
  node_modules/typescript/lib/lib.dom.d.ts:1932:13
    1932 declare var AbortSignal: {
                     ~~~~~~~~~~~
    and here.

../node_modules/@types/react-native/globals.d.ts:389:15 - error TS2300: Duplicate identifier 'AbortController'.

389 declare class AbortController {
                  ~~~~~~~~~~~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:1899:11
    1899 interface AbortController {
                   ~~~~~~~~~~~~~~~
    'AbortController' was also declared here.
  node_modules/typescript/lib/lib.dom.d.ts:1910:13
    1910 declare var AbortController: {
                     ~~~~~~~~~~~~~~~
    and here.

../node_modules/@types/react-native/globals.d.ts:414:14 - error TS2717: Subsequent property declarations must have the same type.  Property 'error' must be of type 'DOMException | null', but here has type 'Error | null'.

414     readonly error: Error | null;
                 ~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:5271:14
    5271     readonly error: DOMException | null;
                      ~~~~~
    'error' was also declared here.

../node_modules/@types/react-native/globals.d.ts:422:14 - error TS2717: Subsequent property declarations must have the same type.  Property 'result' must be of type 'string | ArrayBuffer | null', but here has type 'string | ArrayBuffer'.

422     readonly result: string | ArrayBuffer;
                 ~~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:5279:14
    5279     readonly result: string | ArrayBuffer | null;
                      ~~~~~~
    'result' was also declared here.


Found 39 errors.
```