### PR TITLE
no need for looping through invoices for admin panel

### DIFF
--- a/src/app/lightning/lookup-invoice-by-hash.ts
+++ b/src/app/lightning/lookup-invoice-by-hash.ts
@@ -1,13 +1,21 @@
 import { LndService } from "@services/lnd"
+import { WalletInvoicesRepository } from "@services/mongoose"
+import { RepositoryError } from "@domain/errors"
 
-export const lookupInvoiceByHashAndPubkey = async ({
+export const lookupInvoiceByHash = async ({
   paymentHash,
-  pubkey,
 }: {
   paymentHash: PaymentHash
-  pubkey: Pubkey
 }): Promise<LnInvoiceLookup | ApplicationError> => {
   const lndService = LndService()
   if (lndService instanceof Error) return lndService
+
+  const invoicesRepo = WalletInvoicesRepository()
+  const walletInvoice = await invoicesRepo.findByPaymentHash(paymentHash)
+
+  if (walletInvoice instanceof RepositoryError) return walletInvoice
+
+  const { pubkey } = walletInvoice
+
   return lndService.lookupInvoice({ paymentHash, pubkey })
 }

--- a/src/app/lightning/lookup-invoice-by-hash.ts
+++ b/src/app/lightning/lookup-invoice-by-hash.ts
@@ -1,9 +1,13 @@
 import { LndService } from "@services/lnd"
 
-export const lookupInvoiceByHash = async (
-  paymentHash: PaymentHash,
-): Promise<LnInvoiceLookup | ApplicationError> => {
+export const lookupInvoiceByHashAndPubkey = async ({
+  paymentHash,
+  pubkey,
+}: {
+  paymentHash: PaymentHash
+  pubkey: Pubkey
+}): Promise<LnInvoiceLookup | ApplicationError> => {
   const lndService = LndService()
   if (lndService instanceof Error) return lndService
-  return lndService.lookupInvoice({ paymentHash })
+  return lndService.lookupInvoice({ paymentHash, pubkey })
 }

--- a/src/app/lightning/lookup-invoice-by-hash.ts
+++ b/src/app/lightning/lookup-invoice-by-hash.ts
@@ -2,11 +2,9 @@ import { LndService } from "@services/lnd"
 import { WalletInvoicesRepository } from "@services/mongoose"
 import { RepositoryError } from "@domain/errors"
 
-export const lookupInvoiceByHash = async ({
-  paymentHash,
-}: {
-  paymentHash: PaymentHash
-}): Promise<LnInvoiceLookup | ApplicationError> => {
+export const lookupInvoiceByHash = async (
+  paymentHash: PaymentHash,
+): Promise<LnInvoiceLookup | ApplicationError> => {
   const lndService = LndService()
   if (lndService instanceof Error) return lndService
 

--- a/src/domain/bitcoin/lightning/index.types.d.ts
+++ b/src/domain/bitcoin/lightning/index.types.d.ts
@@ -111,7 +111,7 @@ interface ILightningService {
     pubkey,
     paymentHash,
   }: {
-    pubkey?: Pubkey
+    pubkey: Pubkey
     paymentHash: PaymentHash
   }): Promise<LnInvoiceLookup | LightningServiceError>
 

--- a/src/graphql/admin/root/query/lightning-invoice.ts
+++ b/src/graphql/admin/root/query/lightning-invoice.ts
@@ -1,9 +1,7 @@
 import { GT } from "@graphql/index"
-import { lookupInvoiceByHashAndPubkey } from "@app/lightning"
+import { lookupInvoiceByHash } from "@app/lightning"
 import PaymentHash from "@graphql/types/scalar/payment-hash"
 import LightningInvoice from "@graphql/admin/types/object/lightning-invoice"
-import { WalletInvoicesRepository } from "@services/mongoose"
-import { RepositoryError } from "@domain/errors"
 
 const LightningInvoiceQuery = GT.Field({
   type: GT.NonNull(LightningInvoice),
@@ -13,19 +11,10 @@ const LightningInvoiceQuery = GT.Field({
   resolve: async (_, { hash }) => {
     if (hash instanceof Error) throw hash
 
-    const invoicesRepo = WalletInvoicesRepository()
-    const walletInvoice = await invoicesRepo.findByPaymentHash(hash)
-
-    if (walletInvoice instanceof RepositoryError) return walletInvoice
-
-    const { pubkey } = walletInvoice
-
-    const paymentHash = hash as PaymentHash /* FIXME */
-
-    const lightningInvoice = await lookupInvoiceByHashAndPubkey({
-      paymentHash,
-      pubkey,
+    const lightningInvoice = await lookupInvoiceByHash({
+      paymentHash: hash,
     })
+
     if (lightningInvoice instanceof Error) throw lightningInvoice
 
     return lightningInvoice

--- a/src/graphql/admin/root/query/lightning-invoice.ts
+++ b/src/graphql/admin/root/query/lightning-invoice.ts
@@ -11,9 +11,7 @@ const LightningInvoiceQuery = GT.Field({
   resolve: async (_, { hash }) => {
     if (hash instanceof Error) throw hash
 
-    const lightningInvoice = await lookupInvoiceByHash({
-      paymentHash: hash,
-    })
+    const lightningInvoice = await lookupInvoiceByHash(hash)
 
     if (lightningInvoice instanceof Error) throw lightningInvoice
 

--- a/src/graphql/admin/root/query/lightning-invoice.ts
+++ b/src/graphql/admin/root/query/lightning-invoice.ts
@@ -1,7 +1,9 @@
 import { GT } from "@graphql/index"
-import { lookupInvoiceByHash } from "@app/lightning"
+import { lookupInvoiceByHashAndPubkey } from "@app/lightning"
 import PaymentHash from "@graphql/types/scalar/payment-hash"
 import LightningInvoice from "@graphql/admin/types/object/lightning-invoice"
+import { WalletInvoicesRepository } from "@services/mongoose"
+import { RepositoryError } from "@domain/errors"
 
 const LightningInvoiceQuery = GT.Field({
   type: GT.NonNull(LightningInvoice),
@@ -11,7 +13,19 @@ const LightningInvoiceQuery = GT.Field({
   resolve: async (_, { hash }) => {
     if (hash instanceof Error) throw hash
 
-    const lightningInvoice = await lookupInvoiceByHash(hash)
+    const invoicesRepo = WalletInvoicesRepository()
+    const walletInvoice = await invoicesRepo.findByPaymentHash(hash)
+
+    if (walletInvoice instanceof RepositoryError) return walletInvoice
+
+    const { pubkey } = walletInvoice
+
+    const paymentHash = hash as PaymentHash /* FIXME */
+
+    const lightningInvoice = await lookupInvoiceByHashAndPubkey({
+      paymentHash,
+      pubkey,
+    })
     if (lightningInvoice instanceof Error) throw lightningInvoice
 
     return lightningInvoice


### PR DESCRIPTION
this is different for payments.

note: there are a aside case for payment not covered here

if we were to have 2 lnd, and the payment would have been sent through the first lnd, and failed. then send again with the second lnd and succeed.

we may only show the failed payment where in fact the payment would have succeed.

I think we should rely on medici also for the payments