### PR TITLE
Add target confirmations to onChainPay

### DIFF
--- a/src/core/on-chain/index.ts
+++ b/src/core/on-chain/index.ts
@@ -79,6 +79,7 @@ export const OnChainMixin = (superclass) =>
       memo,
       sendAll = false,
       twoFAToken,
+      targetConfirmations,
     }: IOnChainPayment): Promise<ISuccess> {
       let onchainLogger = this.logger.child({
         topic: "payment",
@@ -262,12 +263,13 @@ export const OnChainMixin = (superclass) =>
         let estimatedFee, id, amountToSend
 
         const sendTo = [{ address, tokens: checksAmount }]
+        const targetConfs = targetConfirmations > 0 ? targetConfirmations : 1
 
         try {
           ;({ fee: estimatedFee } = await getChainFeeEstimate({
             lnd,
             send_to: sendTo,
-            target_confirmations: 1,
+            target_confirmations: targetConfs,
           }))
         } catch (err) {
           const error = `Unable to estimate fee for on-chain transaction`
@@ -329,7 +331,7 @@ export const OnChainMixin = (superclass) =>
               lnd,
               tokens: amountToSend,
               utxo_confirmations: 0,
-              target_confirmations: 1,
+              target_confirmations: targetConfs,
             }))
           } catch (err) {
             onchainLogger.error(

--- a/src/core/on-chain/index.types.d.ts
+++ b/src/core/on-chain/index.types.d.ts
@@ -45,4 +45,5 @@ interface IOnChainPayment {
   memo?: string
   sendAll?: boolean
   twoFAToken?: string
+  targetConfirmations: TargetConfirmations
 }

--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -726,11 +726,13 @@ input OnChainPaymentSendInput {
   address: OnChainAddress!
   amount: SatAmount!
   memo: Memo
+  targetConfirmations: TargetConfirmations = 1
 }
 
 input OnChainPaymentSendAllInput {
   address: OnChainAddress!
   memo: Memo
+  targetConfirmations: TargetConfirmations = 1
 }
 
 type CaptchaCreateChallengePayload {

--- a/src/graphql/root/mutation/onchain-payment-send-all.ts
+++ b/src/graphql/root/mutation/onchain-payment-send-all.ts
@@ -3,12 +3,14 @@ import { GT } from "@graphql/index"
 import Memo from "@graphql/types/scalar/memo"
 import OnChainAddress from "@graphql/types/scalar/on-chain-address"
 import PaymentSendPayload from "@graphql/types/payload/payment-send"
+import TargetConfirmations from "@graphql/types/scalar/target-confirmations"
 
 const OnChainPaymentSendAllInput = new GT.Input({
   name: "OnChainPaymentSendAllInput",
   fields: () => ({
     address: { type: GT.NonNull(OnChainAddress) },
     memo: { type: Memo },
+    targetConfirmations: { type: TargetConfirmations, defaultValue: 1 },
   }),
 })
 
@@ -18,16 +20,22 @@ const OnChainPaymentSendAllMutation = GT.Field({
     input: { type: GT.NonNull(OnChainPaymentSendAllInput) },
   },
   resolve: async (_, args, { wallet }) => {
-    const { address, memo } = args.input
+    const { address, memo, targetConfirmations } = args.input
 
-    for (const input of [memo, address]) {
+    for (const input of [memo, address, targetConfirmations]) {
       if (input instanceof Error) {
         return { errors: [{ message: input.message }] }
       }
     }
 
     try {
-      const status = await wallet.onChainPay({ address, amount: 0, memo, sendAll: true })
+      const status = await wallet.onChainPay({
+        address,
+        amount: 0,
+        memo,
+        sendAll: true,
+        targetConfirmations,
+      })
       return {
         errors: [],
         status,

--- a/src/graphql/root/mutation/onchain-payment-send.ts
+++ b/src/graphql/root/mutation/onchain-payment-send.ts
@@ -4,6 +4,7 @@ import Memo from "@graphql/types/scalar/memo"
 import OnChainAddress from "@graphql/types/scalar/on-chain-address"
 import PaymentSendPayload from "@graphql/types/payload/payment-send"
 import SatAmount from "@graphql/types/scalar/sat-amount"
+import TargetConfirmations from "@graphql/types/scalar/target-confirmations"
 
 const OnChainPaymentSendInput = new GT.Input({
   name: "OnChainPaymentSendInput",
@@ -11,6 +12,7 @@ const OnChainPaymentSendInput = new GT.Input({
     address: { type: GT.NonNull(OnChainAddress) },
     amount: { type: GT.NonNull(SatAmount) },
     memo: { type: Memo },
+    targetConfirmations: { type: TargetConfirmations, defaultValue: 1 },
   }),
 })
 
@@ -20,16 +22,21 @@ const OnChainPaymentSendMutation = GT.Field({
     input: { type: GT.NonNull(OnChainPaymentSendInput) },
   },
   resolve: async (_, args, { wallet }) => {
-    const { address, amount, memo } = args.input
+    const { address, amount, memo, targetConfirmations } = args.input
 
-    for (const input of [memo, amount, address]) {
+    for (const input of [memo, amount, address, targetConfirmations]) {
       if (input instanceof Error) {
         return { errors: [{ message: input.message }] }
       }
     }
 
     try {
-      const status = await wallet.onChainPay({ address, amount, memo })
+      const status = await wallet.onChainPay({
+        address,
+        amount,
+        memo,
+        targetConfirmations,
+      })
 
       return {
         errors: [],

--- a/src/servers/graphql-old-server.ts
+++ b/src/servers/graphql-old-server.ts
@@ -372,10 +372,16 @@ const resolvers = {
         return address
       },
       pay: ({ address, amount, memo }) => ({
-        success: wallet.onChainPay({ address, amount, memo }),
+        success: wallet.onChainPay({ address, amount, memo, targetConfirmations: 1 }),
       }),
       payAll: ({ address, memo }) => ({
-        success: wallet.onChainPay({ address, amount: 0, memo, sendAll: true }),
+        success: wallet.onChainPay({
+          address,
+          amount: 0,
+          memo,
+          sendAll: true,
+          targetConfirmations: 1,
+        }),
       }),
       getFee: async ({ address, amount }) => {
         const fee = await Wallets.getOnChainFeeByWalletId({


### PR DESCRIPTION
The main purpose of this PR is to add targetConfirmations for OnChainPaymentSend in V2

this is not a use case refactor but "fix" consistency between OnChainPaymentSend mutation and OnChainTxFee query 