### PR TITLE
Fix price proto path

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "eslint-fix": "eslint \"{src,test}/**/*.ts\" --fix",
     "prettier-check": "prettier --check .",
     "prettier-write": "prettier --write .",
-    "build": "tsc -p tsconfig-build.json --skipLibCheck && cp -R src/services/price/protos lib/services/ && cp src/graphql/old-schema.graphql lib/graphql/ && tscpaths -p tsconfig.json -s ./src -o ./lib",
+    "build": "tsc -p tsconfig-build.json --skipLibCheck && cp -R src/services/price/protos lib/services/price/ && cp src/graphql/old-schema.graphql lib/graphql/ && tscpaths -p tsconfig.json -s ./src -o ./lib",
     "start": "yarn build && source ./scripts/export-local.sh && node lib/servers/graphql-old-server.js | pino-pretty -c -l",
     "trigger": "yarn build && source ./scripts/export-local.sh && node lib/servers/trigger.js | pino-pretty -c -l",
     "watch": "nodemon -V -e ts,graphql -w ./src -x yarn run start",


### PR DESCRIPTION
This PR fix testflight issue.

How to reproduce it

- pull `main`
- run `yarn build`
- run old or new server from generated code  `. ./.envrc && node lib/servers/graphql-old-server.js` (this returns error in current main)

if you run these cmds in this branch should run the server successfully