### PR TITLE
Add walletId middleware

### DIFF
--- a/src/graphql/root/mutation/on-chain-address-create.ts
+++ b/src/graphql/root/mutation/on-chain-address-create.ts
@@ -1,6 +1,5 @@
 import { GT } from "@graphql/index"
 import * as Wallets from "@app/wallets"
-import * as Accounts from "@app/accounts"
 import OnChainAddressPayload from "@graphql/types/payload/on-chain-address"
 import WalletId from "@graphql/types/scalar/wallet-id"
 import { mapError } from "@graphql/error-map"
@@ -17,18 +16,10 @@ const OnChainAddressCreateMutation = GT.Field({
   args: {
     input: { type: GT.NonNull(OnChainAddressCreateInput) },
   },
-  resolve: async (_, args, { domainUser }) => {
+  resolve: async (_, args) => {
     const { walletId } = args.input
     if (walletId instanceof Error) {
       return { errors: [{ message: walletId.message }] }
-    }
-
-    const hasPermissions = await Accounts.hasPermissions(domainUser.id, walletId)
-    if (hasPermissions instanceof Error) {
-      return { errors: [{ message: hasPermissions.message }] }
-    }
-    if (!hasPermissions) {
-      return { errors: [{ message: "Invalid wallet" }] }
     }
 
     const address = await Wallets.createOnChainAddressByWalletPublicId(walletId)

--- a/src/servers/graphql-main-server.ts
+++ b/src/servers/graphql-main-server.ts
@@ -11,6 +11,7 @@ import {
   startApolloServer,
 } from "./graphql-server"
 import { gqlMainSchema } from "../graphql"
+import { walletIdMiddleware } from "./graphql-middlewares/wallet-id"
 
 const graphqlLogger = baseLogger.child({ module: "graphql" })
 
@@ -59,7 +60,7 @@ export async function startApolloServerForCoreSchema() {
     { allowExternalErrors: true },
   )
 
-  const schema = applyMiddleware(gqlMainSchema, permissions)
+  const schema = applyMiddleware(gqlMainSchema, permissions, walletIdMiddleware)
   return startApolloServer({ schema, port: 4002, startSubscriptionServer: true })
 }
 

--- a/src/servers/graphql-middlewares/wallet-id.ts
+++ b/src/servers/graphql-middlewares/wallet-id.ts
@@ -1,0 +1,21 @@
+import * as Accounts from "@app/accounts"
+
+const InvalidWalletError = (message: string) => ({ errors: [{ message }] })
+
+const validateWalletId = async (resolve, parent, args, context, info) => {
+  const { walletId } = args.input || {}
+  if (!walletId) return InvalidWalletError("Invalid wallet")
+  if (walletId instanceof Error) return InvalidWalletError(walletId.message)
+
+  const hasPermissions = await Accounts.hasPermissions(context.domainUser.id, walletId)
+  if (hasPermissions instanceof Error) return InvalidWalletError(hasPermissions.message)
+  if (!hasPermissions) return InvalidWalletError("Invalid wallet")
+
+  return resolve(parent, args, context, info)
+}
+
+export const walletIdMiddleware = {
+  Mutation: {
+    onChainAddressCreate: validateWalletId,
+  },
+}


### PR DESCRIPTION
Add walledId middleware. 

- This PR only includes refactor for `onChainAddressCreate` mutation
- Once this is approved will be added to other related payment mutations

How to test:

**Query**
```
mutation OnChainAddressCreate($input: OnChainAddressCreateInput!) {
  onChainAddressCreate(input: $input) {
    errors {
      message
    }
    address
  }
}
```

**Variables** 
```
// please test changing walletId to other existing wallet (from db)
{ 
  "input": { "walletId": "31bfa4ac-fff9-43e3-ad73-dcd3834aa2c5" } 
}
```