### PR TITLE
Add on chain payment mutations/query to walletId middleware

### DIFF
--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -18,8 +18,8 @@ const assertUnreachable = (x: never): never => {
 }
 
 export const mapError = (error: ApplicationError): CustomApolloError => {
-  let message = ""
   const errorName = error.constructor.name as ApplicationErrorKey
+  let message = error.message || errorName || ""
   switch (errorName) {
     case "WithdrawalLimitsExceededError":
       message = error.message

--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -821,6 +821,7 @@ input OnChainAddressCurrentInput {
 }
 
 input OnChainPaymentSendInput {
+  walletId: WalletId!
   address: OnChainAddress!
   amount: SatAmount!
   memo: Memo
@@ -828,6 +829,7 @@ input OnChainPaymentSendInput {
 }
 
 input OnChainPaymentSendAllInput {
+  walletId: WalletId!
   address: OnChainAddress!
   memo: Memo
   targetConfirmations: TargetConfirmations = 1

--- a/src/graphql/root/mutation/onchain-payment-send-all.ts
+++ b/src/graphql/root/mutation/onchain-payment-send-all.ts
@@ -1,6 +1,6 @@
 import { GT } from "@graphql/index"
-
 import Memo from "@graphql/types/scalar/memo"
+import WalletId from "@graphql/types/scalar/wallet-id"
 import OnChainAddress from "@graphql/types/scalar/on-chain-address"
 import PaymentSendPayload from "@graphql/types/payload/payment-send"
 import TargetConfirmations from "@graphql/types/scalar/target-confirmations"
@@ -8,6 +8,7 @@ import TargetConfirmations from "@graphql/types/scalar/target-confirmations"
 const OnChainPaymentSendAllInput = new GT.Input({
   name: "OnChainPaymentSendAllInput",
   fields: () => ({
+    walletId: { type: GT.NonNull(WalletId) },
     address: { type: GT.NonNull(OnChainAddress) },
     memo: { type: Memo },
     targetConfirmations: { type: TargetConfirmations, defaultValue: 1 },
@@ -20,9 +21,9 @@ const OnChainPaymentSendAllMutation = GT.Field({
     input: { type: GT.NonNull(OnChainPaymentSendAllInput) },
   },
   resolve: async (_, args, { wallet }) => {
-    const { address, memo, targetConfirmations } = args.input
+    const { walletId, address, memo, targetConfirmations } = args.input
 
-    for (const input of [memo, address, targetConfirmations]) {
+    for (const input of [walletId, memo, address, targetConfirmations]) {
       if (input instanceof Error) {
         return { errors: [{ message: input.message }] }
       }

--- a/src/graphql/root/mutation/onchain-payment-send.ts
+++ b/src/graphql/root/mutation/onchain-payment-send.ts
@@ -1,14 +1,15 @@
 import { GT } from "@graphql/index"
-
 import Memo from "@graphql/types/scalar/memo"
+import WalletId from "@graphql/types/scalar/wallet-id"
+import SatAmount from "@graphql/types/scalar/sat-amount"
 import OnChainAddress from "@graphql/types/scalar/on-chain-address"
 import PaymentSendPayload from "@graphql/types/payload/payment-send"
-import SatAmount from "@graphql/types/scalar/sat-amount"
 import TargetConfirmations from "@graphql/types/scalar/target-confirmations"
 
 const OnChainPaymentSendInput = new GT.Input({
   name: "OnChainPaymentSendInput",
   fields: () => ({
+    walletId: { type: GT.NonNull(WalletId) },
     address: { type: GT.NonNull(OnChainAddress) },
     amount: { type: GT.NonNull(SatAmount) },
     memo: { type: Memo },
@@ -22,9 +23,9 @@ const OnChainPaymentSendMutation = GT.Field({
     input: { type: GT.NonNull(OnChainPaymentSendInput) },
   },
   resolve: async (_, args, { wallet }) => {
-    const { address, amount, memo, targetConfirmations } = args.input
+    const { walletId, address, amount, memo, targetConfirmations } = args.input
 
-    for (const input of [memo, amount, address, targetConfirmations]) {
+    for (const input of [walletId, memo, amount, address, targetConfirmations]) {
       if (input instanceof Error) {
         return { errors: [{ message: input.message }] }
       }

--- a/src/graphql/root/query/on-chain-tx-fee-query.ts
+++ b/src/graphql/root/query/on-chain-tx-fee-query.ts
@@ -1,13 +1,11 @@
 import { GT } from "@graphql/index"
+import * as Wallets from "@app/wallets"
+import { mapError } from "@graphql/error-map"
+import WalletId from "@graphql/types/scalar/wallet-id"
 import SatAmount from "@graphql/types/scalar/sat-amount"
 import OnChainTxFee from "@graphql/types/object/onchain-tx-fee"
 import OnChainAddress from "@graphql/types/scalar/on-chain-address"
 import TargetConfirmations from "@graphql/types/scalar/target-confirmations"
-import WalletId from "@graphql/types/scalar/wallet-id"
-
-import { ApolloError } from "apollo-server-errors"
-import * as Wallets from "@app/wallets"
-import * as Accounts from "@app/accounts"
 
 const OnChainTxFeeQuery = GT.Field({
   type: GT.NonNull(OnChainTxFee),
@@ -17,44 +15,20 @@ const OnChainTxFeeQuery = GT.Field({
     amount: { type: GT.NonNull(SatAmount) },
     targetConfirmations: { type: TargetConfirmations, defaultValue: 1 },
   },
-  resolve: async (_, args, { domainUser }) => {
+  resolve: async (_, args) => {
     const { walletId, address, amount, targetConfirmations } = args
 
     for (const input of [walletId, address, amount, targetConfirmations]) {
       if (input instanceof Error) throw input
     }
 
-    let fee: Satoshis | Error | null = null
-    if (walletId) {
-      const hasPermissions = await Accounts.hasPermissions(domainUser.id, walletId)
-      if (hasPermissions instanceof Error) throw new ApolloError(hasPermissions.message)
-
-      if (!hasPermissions) throw new ApolloError("Invalid walletId")
-
-      fee = await Wallets.getOnChainFeeByWalletPublicId({
-        walletPublicId: walletId,
-        amount,
-        address,
-        targetConfirmations,
-      })
-    }
-
-    if (!fee) {
-      const account = await Accounts.getAccount(domainUser.defaultAccountId)
-      if (account instanceof Error) throw account
-
-      if (!account.walletIds.length)
-        throw new Error("Account does not have a default wallet")
-
-      fee = await Wallets.getOnChainFeeByWalletId({
-        walletId: account.walletIds[0],
-        amount,
-        address,
-        targetConfirmations,
-      })
-    }
-
-    if (fee instanceof Error) throw fee
+    const fee = await Wallets.getOnChainFeeByWalletPublicId({
+      walletPublicId: walletId,
+      amount,
+      address,
+      targetConfirmations,
+    })
+    if (fee instanceof Error) throw mapError(fee)
 
     return {
       amount: fee,

--- a/src/servers/graphql-middlewares/wallet-id.ts
+++ b/src/servers/graphql-middlewares/wallet-id.ts
@@ -18,5 +18,7 @@ export const walletIdMiddleware = {
   Mutation: {
     onChainAddressCreate: validateWalletId,
     onChainAddressCurrent: validateWalletId,
+    onChainPaymentSend: validateWalletId,
+    onChainPaymentSendAll: validateWalletId,
   },
 }

--- a/src/servers/graphql-middlewares/wallet-id.ts
+++ b/src/servers/graphql-middlewares/wallet-id.ts
@@ -17,5 +17,6 @@ const validateWalletId = async (resolve, parent, args, context, info) => {
 export const walletIdMiddleware = {
   Mutation: {
     onChainAddressCreate: validateWalletId,
+    onChainAddressCurrent: validateWalletId,
   },
 }

--- a/src/services/mongoose/accounts.ts
+++ b/src/services/mongoose/accounts.ts
@@ -49,7 +49,7 @@ export const AccountsRepository = (): IAccountsRepository => {
       const result: UserType = await User.findOne({
         walletPublicId,
       })
-      if (!result) return new CouldNotFindError("Invalid walletName")
+      if (!result) return new CouldNotFindError("Invalid wallet")
       return translateToAccount(result)
     } catch (err) {
       return new UnknownRepositoryError(err)


### PR DESCRIPTION
- Does not include on chain pay use case migration for `onChainPaymentSend` and `onChainPaymentSendAll`
- Fix `onChainAddressCurrent` mutation and `onChainTxFee` query logic
- Includes `onChainAddressCurrent`, `onChainPaymentSend` and `onChainPaymentSendAll` in walletId middleware
- Fix empty error message for old app errors