### PR TITLE
Add intraLedgerPaymentSend mutation to walletId middleware

### DIFF
--- a/src/app/wallets/index.ts
+++ b/src/app/wallets/index.ts
@@ -21,3 +21,10 @@ export const getWallet = async (walletId: WalletId) => {
   const wallets = WalletsRepository()
   return wallets.findById(walletId)
 }
+
+export const getWalletByPublicId = async (
+  walletPublicId: WalletPublicId,
+): Promise<Wallet | ApplicationError> => {
+  const wallets = WalletsRepository()
+  return wallets.findByPublicId(walletPublicId)
+}

--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -802,6 +802,7 @@ input LnNoAmountInvoicePaymentInput {
 }
 
 input IntraLedgerPaymentSendInput {
+  walletId: WalletId!
   recipientWalletId: WalletId!
   amount: SatAmount!
   memo: Memo

--- a/src/servers/graphql-middlewares/wallet-id.ts
+++ b/src/servers/graphql-middlewares/wallet-id.ts
@@ -30,6 +30,7 @@ export const walletIdMiddleware = {
     onChainTxFee: validateWalletIdQuery,
   },
   Mutation: {
+    intraLedgerPaymentSend: validateWalletIdMutation,
     onChainAddressCreate: validateWalletIdMutation,
     onChainAddressCurrent: validateWalletIdMutation,
     onChainPaymentSend: validateWalletIdMutation,


### PR DESCRIPTION
- Add walletId to intraLedgerPaymentSend
- Fix error mapping 
- The use case was not changed to use wallet public id because this will need to be updated when we implement the new authorization system.