### PR TITLE
Add ln fee probe to wallet id middleware

### DIFF
--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -722,6 +722,7 @@ type SatAmountPayload {
 }
 
 input LnInvoiceFeeProbeInput {
+  walletId: WalletId!
   paymentRequest: LnPaymentRequest!
 }
 
@@ -731,6 +732,7 @@ BOLT11 lightning invoice payment request with the amount included
 scalar LnPaymentRequest
 
 input LnNoAmountInvoiceFeeProbeInput {
+  walletId: WalletId!
   paymentRequest: LnPaymentRequest!
   amount: SatAmount!
 }

--- a/src/graphql/root/mutation/ln-invoice-fee-probe.ts
+++ b/src/graphql/root/mutation/ln-invoice-fee-probe.ts
@@ -1,11 +1,12 @@
 import { GT } from "@graphql/index"
-
-import LnPaymentRequest from "@graphql/types/scalar/ln-payment-request"
+import WalletId from "@graphql/types/scalar/wallet-id"
 import SatAmountPayload from "@graphql/types/payload/sat-amount"
+import LnPaymentRequest from "@graphql/types/scalar/ln-payment-request"
 
 const LnInvoiceFeeProbeInput = new GT.Input({
   name: "LnInvoiceFeeProbeInput",
   fields: () => ({
+    walletId: { type: GT.NonNull(WalletId) },
     paymentRequest: { type: GT.NonNull(LnPaymentRequest) },
   }),
 })
@@ -16,10 +17,12 @@ const LnInvoiceFeeProbeMutation = GT.Field({
     input: { type: GT.NonNull(LnInvoiceFeeProbeInput) },
   },
   resolve: async (_, args, { wallet }) => {
-    const { paymentRequest } = args.input
+    const { walletId, paymentRequest } = args.input
 
-    if (paymentRequest instanceof Error) {
-      return { errors: [{ message: paymentRequest.message }] }
+    for (const input of [walletId, paymentRequest]) {
+      if (input instanceof Error) {
+        return { errors: [{ message: input.message }] }
+      }
     }
 
     try {

--- a/src/graphql/root/mutation/ln-noamount-invoice-fee-probe.ts
+++ b/src/graphql/root/mutation/ln-noamount-invoice-fee-probe.ts
@@ -1,12 +1,13 @@
 import { GT } from "@graphql/index"
-
-import LnPaymentRequest from "@graphql/types/scalar/ln-payment-request"
-import SatAmountPayload from "@graphql/types/payload/sat-amount"
+import WalletId from "@graphql/types/scalar/wallet-id"
 import SatAmount from "@graphql/types/scalar/sat-amount"
+import SatAmountPayload from "@graphql/types/payload/sat-amount"
+import LnPaymentRequest from "@graphql/types/scalar/ln-payment-request"
 
 const LnNoAmountInvoiceFeeProbeInput = new GT.Input({
   name: "LnNoAmountInvoiceFeeProbeInput",
   fields: () => ({
+    walletId: { type: GT.NonNull(WalletId) },
     paymentRequest: { type: GT.NonNull(LnPaymentRequest) },
     amount: { type: GT.NonNull(SatAmount) },
   }),
@@ -18,9 +19,9 @@ const LnNoAmountInvoiceFeeProbeMutation = GT.Field({
     input: { type: GT.NonNull(LnNoAmountInvoiceFeeProbeInput) },
   },
   resolve: async (_, args, { wallet }) => {
-    const { paymentRequest, amount } = args.input
+    const { walletId, paymentRequest, amount } = args.input
 
-    for (const input of [paymentRequest, amount]) {
+    for (const input of [walletId, paymentRequest, amount]) {
       if (input instanceof Error) {
         return { errors: [{ message: input.message }] }
       }

--- a/src/servers/graphql-middlewares/wallet-id.ts
+++ b/src/servers/graphql-middlewares/wallet-id.ts
@@ -31,6 +31,8 @@ export const walletIdMiddleware = {
   },
   Mutation: {
     intraLedgerPaymentSend: validateWalletIdMutation,
+    lnInvoiceFeeProbe: validateWalletIdMutation,
+    lnNoAmountInvoiceFeeProbe: validateWalletIdMutation,
     lnInvoiceCreate: validateWalletIdMutation,
     lnNoAmountInvoiceCreate: validateWalletIdMutation,
     lnInvoicePaymentSend: validateWalletIdMutation,

--- a/test/integration/servers/graphql-main-server/auth-requests.spec.ts
+++ b/test/integration/servers/graphql-main-server/auth-requests.spec.ts
@@ -137,7 +137,7 @@ describe("graphql", () => {
         tokens: 1001,
       })
 
-      const input = { paymentRequest }
+      const input = { walletId, paymentRequest }
       const result = await mutate(mutation, { variables: { input } })
       const { amount, errors } = result.data.lnInvoiceFeeProbe
       expect(errors).toHaveLength(0)
@@ -151,7 +151,7 @@ describe("graphql", () => {
         tokens: 10010000000,
       })
 
-      const input = { paymentRequest }
+      const input = { walletId, paymentRequest }
       const result = await mutate(mutation, { variables: { input } })
       const { amount, errors } = result.data.lnInvoiceFeeProbe
       expect(errors).toHaveLength(1)
@@ -170,7 +170,7 @@ describe("graphql", () => {
         lnd: lndOutside2,
       })
 
-      const input = { amount: 1013, paymentRequest }
+      const input = { walletId, amount: 1013, paymentRequest }
       const result = await mutate(mutation, { variables: { input } })
       const { amount, errors } = result.data.lnNoAmountInvoiceFeeProbe
       expect(errors).toHaveLength(0)
@@ -183,7 +183,7 @@ describe("graphql", () => {
         lnd: lndOutside2,
       })
 
-      const input = { amount: 10010000000, paymentRequest }
+      const input = { walletId, amount: 10010000000, paymentRequest }
       const result = await mutate(mutation, { variables: { input } })
       const { amount, errors } = result.data.lnNoAmountInvoiceFeeProbe
       expect(errors).toHaveLength(1)


### PR DESCRIPTION
- Does not include use case clean up.
- Wallet id is only used to validate ownership but after use case migration balance check validation should be added