### PR TITLE
Fix onchain-address graphql validation

### DIFF
--- a/src/graphql/types/scalar/on-chain-address.ts
+++ b/src/graphql/types/scalar/on-chain-address.ts
@@ -16,11 +16,17 @@ const OnChainAddress = new GT.Scalar({
 })
 
 function validOnChainAddressValue(value) {
-  // TODO: verify/improve. Use bc1/tb1 prefixes?
-  if (value.match(/^[A-Z0-9]+$/i)) {
-    return value.toLowerCase()
-  }
-  return new UserInputError("Invalid value for OnChainAddress")
+  // Regex patterns: https://regexland.com/regex-bitcoin-addresses/
+  const regexes = [
+    /^[13]{1}[a-km-zA-HJ-NP-Z1-9]{26,34}$/, // mainnet non-segwit
+    /^bc1[a-z0-9]{39,59}$/i, // mainnet segwit
+    /^[mn2]{1}[a-km-zA-HJ-NP-Z1-9]{26,34}$/, // testnet non-segwit
+    /^tb1[a-z0-9]{39,59}$/i, // testnet segwit
+  ]
+
+  return regexes.some((r) => value.match(r))
+    ? value
+    : new UserInputError("Invalid value for OnChainAddress")
 }
 
 export default OnChainAddress


### PR DESCRIPTION
### Description

The new API currently lowercases all addresses which invalidates any non-Segwit address since those are case sensitive. This PR adds new regexes to more tightly check for different address formats and removes the 'toLowerCase' step that invalidates non-Segwit addresses.

Sources for formatting:
- https://regexland.com/regex-bitcoin-addresses/
- https://allprivatekeys.com/bitcoin-address-format