### PR TITLE
Add user default values in first insert to collection

### DIFF
--- a/src/core/text.ts
+++ b/src/core/text.ts
@@ -178,7 +178,11 @@ export const login = async ({
     if (user) {
       subLogger.info({ phone }, "user logged in")
     } else {
-      user = await User.findOneAndUpdate({ phone }, {}, { upsert: true, new: true })
+      user = await User.findOneAndUpdate(
+        { phone },
+        {},
+        { upsert: true, new: true, setDefaultsOnInsert: true },
+      )
       subLogger.info({ phone }, "a new user has register")
     }
 


### PR DESCRIPTION
Fix default values not saved in first login.

- Is not a problem in staging or production
- Only happens in local environment or when twilio credentials are not setup 

Problem

- https://stackoverflow.com/questions/26865357/default-value-not-set-while-using-update-with-upsert-as-true
- Here https://github.com/GaloyMoney/galoy/blob/main/src/core/text.ts#L181 user is only created with phone number and id (in db) but the user in memory has the default values generated by mongoose
- if twilio attr is not setup then we get carrier info and save the whole user https://github.com/GaloyMoney/galoy/blob/main/src/core/text.ts#L195 (including the default values generated in line 181)
- `getCarrier` can throw an exception (in local env is because twilio env variables are not setup) and if that happen then the default values are not saved (error reported by @fiatjaf)
- Integration tests work because we use a mock for `getCarrier`


