### PR TITLE
fix rate limit for min interval for phone code

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -75,10 +75,13 @@ test_accounts:
 
 limits:
   requestPhoneCodePerPhone:
-    msBeforeNext: 30000
     points: 4
     duration: 3600 # 60 * 60 s
     blockDuration: 10800 # 60 * 60 * 3 s
+  requestPhoneCodePerPhoneMinInterval:
+    points: 1
+    duration: 15
+    blockDuration: 15
   requestPhoneCodePerIp:
     points: 4
     duration: 3600 # 60 * 60 * 3 s

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -143,21 +143,18 @@ const getRateLimits = (config): RateLimitOptions => {
    * Returns a subset of the required parameters for the
    * 'rate-limiter-flexible.RateLimiterRedis' object.
    */
-  const rateLimitOptions: RateLimitOptions = {
+  return {
     points: config.points,
     duration: config.duration,
     blockDuration: config.blockDuration,
   }
-
-  if (config.msBeforeNext) {
-    rateLimitOptions.msBeforeNext = config.msBeforeNext
-  }
-
-  return rateLimitOptions
 }
 
 export const getRequestPhoneCodePerPhoneLimits = () =>
   getRateLimits(yamlConfig.limits.requestPhoneCodePerPhone)
+
+export const getRequestPhoneCodePerPhoneMinIntervalLimits = () =>
+  getRateLimits(yamlConfig.limits.requestPhoneCodePerPhoneMinInterval)
 
 export const getRequestPhoneCodePerIpLimits = () =>
   getRateLimits(yamlConfig.limits.requestPhoneCodePerIp)

--- a/src/domain/rate-limit/index.ts
+++ b/src/domain/rate-limit/index.ts
@@ -1,5 +1,7 @@
 export const RateLimitPrefix = {
   requestPhoneCodeAttemptPerPhone: "phone_code_attempt_phone_code",
+  requestPhoneCodeAttemptPerPhoneMinInterval:
+    "phone_code_attempt_phone_code_min_interval",
   requestPhoneCodeAttemptPerIp: "phone_code_attempt_ip",
   failedLoginAttemptPerIp: "login_attempt_ip",
   failedLoginAttemptPerPhone: "login_attempt_phone",

--- a/src/domain/rate-limit/index.types.d.ts
+++ b/src/domain/rate-limit/index.types.d.ts
@@ -7,7 +7,6 @@ type RateLimitOptions = {
   points: number
   duration: Seconds
   blockDuration: Seconds
-  msBeforeNext?: MilliSeconds
 }
 
 interface IRateLimitService {


### PR DESCRIPTION
I thought msBeforeNext was part of the API when calling the rate limit, but it's actually part of the response instead.

so adding a new rate limit to make the relevant effect