### PR TITLE
Convert 'address' in graphql to allow null

### DIFF
--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -108,6 +108,8 @@ export const fromLedger = (
         txType = ExtendedLedgerTransactionType.LnIntraLedger
       }
 
+      const defaultOnChainAddress = "<no-address>" as OnChainAddress
+
       let walletTransaction: WalletTransaction
       switch (txType) {
         case ExtendedLedgerTransactionType.IntraLedger:
@@ -131,7 +133,7 @@ export const fromLedger = (
             ...baseTransaction,
             initiationVia: {
               type: PaymentInitiationMethod.OnChain,
-              address,
+              address: address || defaultOnChainAddress,
             },
             settlementVia: {
               type: SettlementMethod.IntraLedger,
@@ -147,7 +149,7 @@ export const fromLedger = (
             ...baseTransaction,
             initiationVia: {
               type: PaymentInitiationMethod.OnChain,
-              address,
+              address: address || defaultOnChainAddress,
             },
             settlementVia: {
               type: SettlementMethod.OnChain,


### PR DESCRIPTION
### Description

We have a "legacy" type for onchain transaction where the 'address' property wasn't previously recorded in the database. This means that at the graphql level this property can't be non-null until we either figure out a way to backfill this data or place a non-null placeholder value in there instead.

_**Note:** We have similar issues with `counterPartyWalletId` and `paymentSecret` properties where these have also been made non-null for now until we migrate the db, see #759._