### PR TITLE
Run `yarn install` before tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ reset-deps: clean-deps start-deps
 test: unit integration
 
 unit:
+	yarn install
 	yarn test:unit
 
 watch-unit:
@@ -48,6 +49,7 @@ watch-compile:
 	$(BIN_DIR)/tsc --watch  --noEmit --skipLibCheck
 
 integration:
+	yarn install
 	yarn test:integration
 
 reset-integration: reset-deps integration


### PR DESCRIPTION
Ensures that tests will work when switching branches.