### PR TITLE
chore: run github workflows on main branch

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -1,5 +1,7 @@
 name: "Check code"
 on:
+  push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 jobs:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,6 +1,8 @@
 name: "Integration test"
 
 on:
+  push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,6 +1,8 @@
 name: "Unit test"
 
 on:
+  push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
This is somewhat redundant as all commits that land on main were already tested with the merged result of their respective PR - but this way ppl can see the current result of the tests on main GitHub page.