### PR TITLE
fix: send push notification only to the last registered device token

### DIFF
--- a/src/services/notifications/notification.ts
+++ b/src/services/notifications/notification.ts
@@ -57,16 +57,15 @@ export const sendNotification = async ({
   logger.info({ message, user }, "sending notification")
 
   try {
-    const response = await admin.messaging().sendToDevice(
-      user.deviceToken.filter((token) => token.length === 163),
-      message,
-      {
-        // Required for background/quit data-only messages on iOS
-        // contentAvailable: true,
-        // Required for background/quit data-only messages on Android
-        // priority: 'high',
-      },
-    )
+    const token = user.deviceToken.reverse().find((token) => token.length === 163)
+    if (!token) return
+
+    const response = await admin.messaging().sendToDevice(token, message, {
+      // Required for background/quit data-only messages on iOS
+      // contentAvailable: true,
+      // Required for background/quit data-only messages on Android
+      // priority: 'high',
+    })
 
     logger.info(
       { response, user, title, body, data },


### PR DESCRIPTION
- Only send push notifications to the last registered device
- Partial fix to https://github.com/GaloyMoney/galoy/issues/783
- Needs to be tested in staging (important before prod deployment)