### PR TITLE
refactor: replace getOnChainTransactions dependency

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -142,9 +142,9 @@ lnds:
 onChainWallet:
   dustThreshold: 5000
   minConfirmations: 2
-  lookBack: 360
-  lookBackOutgoing: 2
-  lookBackChannelUpdate: 8
+  scanDepth: 360
+  scanDepthOutgoing: 2
+  scanDepthChannelUpdate: 8
 
 # TODO
 # carrierRegexFilter: ""

--- a/src/app/wallets/get-transactions-for-wallet.ts
+++ b/src/app/wallets/get-transactions-for-wallet.ts
@@ -4,7 +4,7 @@ import { WalletsRepository } from "@services/mongoose"
 import { LedgerService } from "@services/ledger"
 import { OnChainService } from "@services/lnd/onchain-service"
 import { toLiabilitiesAccountId, LedgerError } from "@domain/ledger"
-import { ONCHAIN_LOOK_BACK, ONCHAIN_MIN_CONFIRMATIONS, BTC_NETWORK } from "@config/app"
+import { ONCHAIN_SCAN_DEPTH, ONCHAIN_MIN_CONFIRMATIONS, BTC_NETWORK } from "@config/app"
 import { WalletTransactionHistory } from "@domain/wallets"
 import { PartialResult } from "@app/partial-result"
 import { getCurrentPrice } from "@app/prices"
@@ -36,7 +36,7 @@ export const getTransactionsForWallet = async (
     return PartialResult.partial(confirmedHistory.transactions, onChain)
   }
 
-  const onChainTxs = await onChain.listIncomingTransactions(ONCHAIN_LOOK_BACK)
+  const onChainTxs = await onChain.listIncomingTransactions(ONCHAIN_SCAN_DEPTH)
   if (onChainTxs instanceof OnChainError) {
     return PartialResult.partial(confirmedHistory.transactions, onChainTxs)
   }

--- a/src/app/wallets/get-transactions-for-wallet.ts
+++ b/src/app/wallets/get-transactions-for-wallet.ts
@@ -36,7 +36,7 @@ export const getTransactionsForWallet = async (
     return PartialResult.partial(confirmedHistory.transactions, onChain)
   }
 
-  const onChainTxs = await onChain.getIncomingTransactions(ONCHAIN_LOOK_BACK)
+  const onChainTxs = await onChain.listIncomingTransactions(ONCHAIN_LOOK_BACK)
   if (onChainTxs instanceof OnChainError) {
     return PartialResult.partial(confirmedHistory.transactions, onChainTxs)
   }

--- a/src/app/wallets/update-on-chain-receipt.ts
+++ b/src/app/wallets/update-on-chain-receipt.ts
@@ -6,14 +6,14 @@ import { OnChainError, TxDecoder } from "@domain/bitcoin/onchain"
 import { toLiabilitiesAccountId } from "@domain/ledger"
 import { DepositFeeCalculator } from "@domain/wallets"
 import { LockService } from "@services/lock"
-import { ONCHAIN_LOOK_BACK, ONCHAIN_MIN_CONFIRMATIONS, BTC_NETWORK } from "@config/app"
+import { ONCHAIN_SCAN_DEPTH, ONCHAIN_MIN_CONFIRMATIONS, BTC_NETWORK } from "@config/app"
 import { getCurrentPrice } from "@app/prices"
 
 export const updateOnChainReceipt = async ({
-  scanDepth = ONCHAIN_LOOK_BACK,
+  scanDepth = ONCHAIN_SCAN_DEPTH,
   logger,
 }: {
-  scanDepth?: number
+  scanDepth?: ScanDepth
   logger: Logger
 }): Promise<number | ApplicationError> => {
   const onChain = OnChainService(TxDecoder(BTC_NETWORK))

--- a/src/app/wallets/update-on-chain-receipt.ts
+++ b/src/app/wallets/update-on-chain-receipt.ts
@@ -21,7 +21,7 @@ export const updateOnChainReceipt = async ({
     return onChain
   }
 
-  const onChainTxs = await onChain.getIncomingTransactions(scanDepth)
+  const onChainTxs = await onChain.listIncomingTransactions(scanDepth)
   if (onChainTxs instanceof OnChainError) {
     return onChainTxs
   }

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -3,6 +3,7 @@ import yaml from "js-yaml"
 import merge from "lodash.merge"
 
 import { baseLogger } from "@services/logger"
+import { checkedToScanDepth } from "@domain/bitcoin/onchain"
 
 const defaultContent = fs.readFileSync("./default.yaml", "utf8")
 export const defaultConfig = yaml.load(defaultContent)
@@ -67,10 +68,18 @@ export const MEMO_SHARING_SATS_THRESHOLD = yamlConfig.limits.memoSharingSatsThre
 
 export const ONCHAIN_MIN_CONFIRMATIONS = yamlConfig.onChainWallet.minConfirmations
 // how many block are we looking back for getChainTransactions
-export const ONCHAIN_LOOK_BACK = yamlConfig.onChainWallet.lookBack
-export const ONCHAIN_LOOK_BACK_OUTGOING = yamlConfig.onChainWallet.lookBackOutgoing
-export const ONCHAIN_LOOK_BACK_CHANNEL_UPDATE =
-  yamlConfig.onChainWallet.lookBackChannelUpdate
+const getOnChainScanDepth = (val: number): ScanDepth => {
+  const scanDepth = checkedToScanDepth(val)
+  if (scanDepth instanceof Error) throw scanDepth
+  return scanDepth
+}
+export const ONCHAIN_SCAN_DEPTH = getOnChainScanDepth(yamlConfig.onChainWallet.scanDepth)
+export const ONCHAIN_SCAN_DEPTH_OUTGOING = getOnChainScanDepth(
+  yamlConfig.onChainWallet.scanDepthOutgoing,
+)
+export const ONCHAIN_SCAN_DEPTH_CHANNEL_UPDATE = getOnChainScanDepth(
+  yamlConfig.onChainWallet.scanDepthChannelUpdate,
+)
 
 export const USER_ACTIVENESS_MONTHLY_VOLUME_THRESHOLD =
   yamlConfig.userActivenessMonthlyVolumeThreshold

--- a/src/core/on-chain/index.ts
+++ b/src/core/on-chain/index.ts
@@ -18,7 +18,7 @@ import {
 import { redlock } from "../lock"
 import { UserWallet } from "../user-wallet"
 import { LoggedError } from "../utils"
-import { BTC_NETWORK, ONCHAIN_LOOK_BACK_OUTGOING } from "@config/app"
+import { BTC_NETWORK, ONCHAIN_SCAN_DEPTH_OUTGOING } from "@config/app"
 import * as Wallets from "@app/wallets"
 import { toSats } from "@domain/bitcoin"
 import { UsersRepository, WalletsRepository } from "@services/mongoose"
@@ -331,9 +331,9 @@ export const OnChainMixin = (superclass) =>
               return toSats(0)
             }
 
-            const onChainTxFee = await onChainService.findOnChainFee({
+            const onChainTxFee = await onChainService.lookupOnChainFee({
               txHash,
-              scanDepth: ONCHAIN_LOOK_BACK_OUTGOING,
+              scanDepth: ONCHAIN_SCAN_DEPTH_OUTGOING,
             })
             if (onChainTxFee instanceof Error) {
               onchainLogger.fatal({ err: onChainTxFee }, errMsg)

--- a/src/core/specter-wallet.ts
+++ b/src/core/specter-wallet.ts
@@ -8,7 +8,7 @@ import { ledger } from "@services/mongodb"
 
 import { UserWallet } from "./user-wallet"
 import { btc2sat, sat2btc } from "./utils"
-import { BTC_NETWORK, ONCHAIN_LOOK_BACK_OUTGOING } from "@config/app"
+import { BTC_NETWORK, ONCHAIN_SCAN_DEPTH_OUTGOING } from "@config/app"
 import { toSats } from "@domain/bitcoin"
 import { OnChainService } from "@services/lnd/onchain-service"
 import { TxDecoder } from "@domain/bitcoin/onchain"
@@ -208,9 +208,9 @@ export class SpecterWallet {
       const onChainService = OnChainService(TxDecoder(BTC_NETWORK))
       if (onChainService instanceof Error) return toSats(0)
 
-      const onChainTxFee = await onChainService.findOnChainFee({
+      const onChainTxFee = await onChainService.lookupOnChainFee({
         txHash,
-        scanDepth: ONCHAIN_LOOK_BACK_OUTGOING,
+        scanDepth: ONCHAIN_SCAN_DEPTH_OUTGOING,
       })
       if (onChainTxFee instanceof Error) return toSats(0)
 

--- a/src/debug/update-on-chain-receipt.ts
+++ b/src/debug/update-on-chain-receipt.ts
@@ -5,11 +5,14 @@
 
 import * as Wallets from "@app/wallets"
 import { baseLogger as logger } from "@services/logger"
+import { checkedToScanDepth } from "@domain/bitcoin/onchain"
 import { setupMongoConnectionSecondary } from "@services/mongodb"
 import { redis } from "@services/redis"
 
 const updateOnChainReceipt = async () => {
-  const scanDepth = 2160 // ~15 days
+  const scanDepth = checkedToScanDepth(2160) // ~15 days
+  if (scanDepth instanceof Error) throw scanDepth
+
   console.warn(`Updating onchain receipt for ${scanDepth} blocks`)
 
   const mongoose = await setupMongoConnectionSecondary()

--- a/src/domain/bitcoin/onchain/errors.ts
+++ b/src/domain/bitcoin/onchain/errors.ts
@@ -6,4 +6,5 @@ export class TransactionDecodeError extends OnChainError {}
 
 export class OnChainServiceError extends OnChainError {}
 export class UnknownOnChainServiceError extends OnChainServiceError {}
+export class CouldNotFindOnChainTransactionError extends OnChainServiceError {}
 export class OnChainServiceUnavailableError extends OnChainServiceError {}

--- a/src/domain/bitcoin/onchain/index.ts
+++ b/src/domain/bitcoin/onchain/index.ts
@@ -1,6 +1,36 @@
+import { InvalidScanDepthAmount } from "@domain/errors"
+
 export * from "./errors"
 export * from "./tx-filter"
 export * from "./tx-decoder"
+
+export const checkedToScanDepth = (value: number): ScanDepth | ValidationError => {
+  // 1 month as max scan depth
+  if (value && value > 0 && value <= 4380) return value as ScanDepth
+  return new InvalidScanDepthAmount()
+}
+
+export const BaseOnChainTransaction = ({
+  confirmations,
+  rawTx,
+  fee,
+  createdAt,
+}: {
+  confirmations: number
+  rawTx: OnChainTransaction
+  fee: Satoshis
+  createdAt: Date
+}): BaseOnChainTransaction => ({
+  confirmations,
+  rawTx,
+  fee,
+  createdAt,
+  uniqueAddresses: () =>
+    rawTx.outs.reduce<OnChainAddress[]>((a: OnChainAddress[], o: TxOut) => {
+      if (o.address && !a.includes(o.address)) a.push(o.address)
+      return a
+    }, []),
+})
 
 export const IncomingOnChainTransaction = ({
   confirmations,
@@ -12,14 +42,28 @@ export const IncomingOnChainTransaction = ({
   rawTx: OnChainTransaction
   fee: Satoshis
   createdAt: Date
-}): IncomingOnChainTransaction => ({
+}): IncomingOnChainTransaction =>
+  BaseOnChainTransaction({
+    confirmations,
+    rawTx,
+    fee,
+    createdAt,
+  })
+
+export const OutgoingOnChainTransaction = ({
   confirmations,
   rawTx,
   fee,
   createdAt,
-  uniqueAddresses: () =>
-    rawTx.outs.reduce<OnChainAddress[]>((a: OnChainAddress[], o: TxOut) => {
-      if (o.address && !a.includes(o.address)) a.push(o.address)
-      return a
-    }, []),
-})
+}: {
+  confirmations: number
+  rawTx: OnChainTransaction
+  fee: Satoshis
+  createdAt: Date
+}): OutgoingOnChainTransaction =>
+  BaseOnChainTransaction({
+    confirmations,
+    rawTx,
+    fee,
+    createdAt,
+  })

--- a/src/domain/bitcoin/onchain/index.types.d.ts
+++ b/src/domain/bitcoin/onchain/index.types.d.ts
@@ -44,10 +44,20 @@ type TxFilter = {
   apply(txs: IncomingOnChainTransaction[]): IncomingOnChainTransaction[]
 }
 
+type FindOnChainFeeArgs = {
+  txHash: OnChainTxHash
+  scanDepth: number
+}
+
 interface IOnChainService {
-  getIncomingTransactions(
+  listIncomingTransactions(
     scanDepth: number,
   ): Promise<IncomingOnChainTransaction[] | OnChainServiceError>
+
+  findOnChainFee({
+    txHash,
+    scanDepth,
+  }: FindOnChainFeeArgs): Promise<Satoshis | OnChainServiceError>
 
   createOnChainAddress(): Promise<OnChainAddressIdentifier | OnChainServiceError>
 

--- a/src/domain/bitcoin/onchain/index.types.d.ts
+++ b/src/domain/bitcoin/onchain/index.types.d.ts
@@ -11,6 +11,9 @@ type BlockId = string & { [blockIdSymbol]: never }
 declare const onChainTxHashSymbol: unique symbol
 type OnChainTxHash = string & { [onChainTxHashSymbol]: never }
 
+declare const ScanDepthSymbol: unique symbol
+type ScanDepth = number & { [ScanDepthSymbol]: never }
+
 type TxOut = {
   sats: Satoshis
   // OP_RETURN utxos don't have valid addresses associated with them
@@ -22,13 +25,16 @@ type OnChainTransaction = {
   outs: TxOut[]
 }
 
-type IncomingOnChainTransaction = {
+type BaseOnChainTransaction = {
   confirmations: number
   rawTx: OnChainTransaction
   fee: Satoshis
   createdAt: Date
   uniqueAddresses: () => OnChainAddress[]
 }
+
+type IncomingOnChainTransaction = BaseOnChainTransaction
+type OutgoingOnChainTransaction = BaseOnChainTransaction
 
 type TxDecoder = {
   decode(txHex: string): OnChainTransaction
@@ -44,20 +50,20 @@ type TxFilter = {
   apply(txs: IncomingOnChainTransaction[]): IncomingOnChainTransaction[]
 }
 
-type FindOnChainFeeArgs = {
+type LookupOnChainFeeArgs = {
   txHash: OnChainTxHash
-  scanDepth: number
+  scanDepth: ScanDepth
 }
 
 interface IOnChainService {
   listIncomingTransactions(
-    scanDepth: number,
+    scanDepth: ScanDepth,
   ): Promise<IncomingOnChainTransaction[] | OnChainServiceError>
 
-  findOnChainFee({
+  lookupOnChainFee({
     txHash,
     scanDepth,
-  }: FindOnChainFeeArgs): Promise<Satoshis | OnChainServiceError>
+  }: LookupOnChainFeeArgs): Promise<Satoshis | OnChainServiceError>
 
   createOnChainAddress(): Promise<OnChainAddressIdentifier | OnChainServiceError>
 

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -32,6 +32,7 @@ export class CouldNotFindAccountFromPhoneError extends CouldNotFindError {}
 
 export class ValidationError extends DomainError {}
 export class InvalidSatoshiAmount extends ValidationError {}
+export class InvalidScanDepthAmount extends ValidationError {}
 export class SatoshiAmountRequiredError extends ValidationError {}
 export class InvalidUsername extends ValidationError {}
 export class InvalidCoordinatesError extends ValidationError {}

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -207,6 +207,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "TransactionDecodeError":
     case "OnChainServiceError":
     case "UnknownOnChainServiceError":
+    case "CouldNotFindOnChainTransactionError":
     case "OnChainServiceUnavailableError":
     case "NotificationsError":
     case "NotificationsServiceError":

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -233,6 +233,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "PhoneProviderServiceError":
     case "UnknownPhoneProviderServiceError":
     case "InvalidAccountStatusError":
+    case "InvalidScanDepthAmount":
       message = `Unknown error occurred (code: ${error.name})`
       return new UnknownClientError({ message, logger: baseLogger })
 

--- a/src/services/lnd/utils.ts
+++ b/src/services/lnd/utils.ts
@@ -1,7 +1,7 @@
 import {
   getGaloyInstanceName,
   MS_PER_DAY,
-  ONCHAIN_LOOK_BACK_CHANNEL_UPDATE,
+  ONCHAIN_SCAN_DEPTH_CHANNEL_UPDATE,
 } from "@config/app"
 import { DbError, LndOfflineError, ValidationInternalError } from "@core/error"
 import { LoggedError } from "@core/utils"
@@ -291,7 +291,7 @@ export const onChannelUpdated = async ({
 
   // TODO: dedupe from onchain
   const { current_block_height } = await getHeight({ lnd })
-  const after = Math.max(0, current_block_height - ONCHAIN_LOOK_BACK_CHANNEL_UPDATE) // this is necessary for tests, otherwise after may be negative
+  const after = Math.max(0, current_block_height - ONCHAIN_SCAN_DEPTH_CHANNEL_UPDATE) // this is necessary for tests, otherwise after may be negative
   const { transactions } = await getChainTransactions({ lnd, after })
   // end dedupe
 

--- a/test/unit/services/lnd/onchain-service.spec.ts
+++ b/test/unit/services/lnd/onchain-service.spec.ts
@@ -1,6 +1,9 @@
 import { toSats } from "@domain/bitcoin"
 import { TxDecoder } from "@domain/bitcoin/onchain"
-import { extractIncomingTransactions } from "@services/lnd/onchain-service"
+import {
+  extractIncomingTransactions,
+  extractOutgoingTransactions,
+} from "@services/lnd/onchain-service"
 
 jest.mock("@config/app.ts", () => {
   const config = jest.requireActual("@config/app.ts")
@@ -18,66 +21,156 @@ describe("extractIncomingTransactions", () => {
   const created_at = "2000-01-01T00:00:00.000Z"
   const decoder = TxDecoder("mainnet" as BtcNetwork)
   it("only returns incoming transactions", () => {
-    const txs = extractIncomingTransactions(decoder, {
-      transactions: [
-        {
-          id: "outgoing",
-          is_outgoing: true,
-          transaction: validTxHex,
-          fee: toSats(1),
-          created_at,
-          is_confirmed: false,
-          output_addresses: ["address1"],
-          tokens: toSats(1000),
-        },
-        {
-          id: "incoming",
-          is_outgoing: false,
-          transaction: validTxHex,
-          fee: toSats(10),
-          created_at,
-          is_confirmed: false,
-          output_addresses: ["address1"],
-          tokens: toSats(1000),
-        },
-      ],
+    const txs = extractIncomingTransactions({
+      decoder,
+      txs: {
+        transactions: [
+          {
+            id: "outgoing",
+            is_outgoing: true,
+            transaction: validTxHex,
+            fee: toSats(1),
+            created_at,
+            is_confirmed: false,
+            output_addresses: ["address1"],
+            tokens: toSats(1000),
+          },
+          {
+            id: "incoming",
+            is_outgoing: false,
+            transaction: validTxHex,
+            fee: toSats(10),
+            created_at,
+            is_confirmed: false,
+            output_addresses: ["address1"],
+            tokens: toSats(1000),
+          },
+        ],
+      },
     })
     expect(txs.length).toEqual(1)
     expect(txs[0].fee).toEqual(toSats(10))
   })
 
   it("filters txs with no valid hex", () => {
-    const txs = extractIncomingTransactions(decoder, {
-      transactions: [
-        {
-          id: "incoming",
-          is_outgoing: false,
-          fee: toSats(1),
-          created_at,
-          is_confirmed: false,
-          output_addresses: ["address1"],
-          tokens: toSats(1000),
-        },
-      ],
+    const txs = extractIncomingTransactions({
+      decoder,
+      txs: {
+        transactions: [
+          {
+            id: "incoming",
+            is_outgoing: false,
+            fee: toSats(1),
+            created_at,
+            is_confirmed: false,
+            output_addresses: ["address1"],
+            tokens: toSats(1000),
+          },
+        ],
+      },
     })
     expect(txs.length).toEqual(0)
   })
 
   it("it defaults fee to 0 (only has fee set on outgoing tx)", () => {
-    const txs = extractIncomingTransactions(decoder, {
-      transactions: [
-        {
-          id: "incoming",
-          is_outgoing: false,
-          transaction: validTxHex,
-          created_at,
-          is_confirmed: false,
-          output_addresses: ["address1"],
-          tokens: toSats(1000),
-        },
-      ],
+    const txs = extractIncomingTransactions({
+      decoder,
+      txs: {
+        transactions: [
+          {
+            id: "incoming",
+            is_outgoing: false,
+            transaction: validTxHex,
+            created_at,
+            is_confirmed: false,
+            output_addresses: ["address1"],
+            tokens: toSats(1000),
+          },
+        ],
+      },
     })
     expect(txs.length).toEqual(1)
     expect(txs[0].fee).toEqual(toSats(0))
+  })
+})
+
+describe("extractOutgoingTransactions", () => {
+  const validTxHex =
+    "0100000001bcc1db7faba3226e49bf4b78c70433a5afa0b0c88b2f546d0eee07b40bdf70bc010000006a4730440220378952a9acd4fc40dfafba799be975f545793cc679a01c0d552dbb3e4c29556402205b50a6c5b9a541de3cde7519cbb5a8ebfa1bc49488be1ccf898f888ee5105691012102195646c22ab419c14599106960cc8587266cc0ad2189861c44c5eb3dfa771d3cffffffff0260b10a00000000001976a9145ace538e7c29931c5645e233d327af544dfcfa2f88ac1ef6ee19000000001976a9147452552d6ca38bbfc20f3d95dd3dbb4849a33f7d88ac00000000"
+  const created_at = "2000-01-01T00:00:00.000Z"
+  const decoder = TxDecoder("mainnet" as BtcNetwork)
+  it("only returns outgoing transactions", () => {
+    const txs = extractOutgoingTransactions({
+      decoder,
+      txs: {
+        transactions: [
+          {
+            id: "outgoing",
+            is_outgoing: false,
+            transaction: validTxHex,
+            fee: toSats(1),
+            created_at,
+            is_confirmed: false,
+            output_addresses: ["address1"],
+            tokens: toSats(1000),
+          },
+          {
+            id: "outgoing",
+            is_outgoing: true,
+            transaction: validTxHex,
+            fee: toSats(10),
+            created_at,
+            is_confirmed: false,
+            output_addresses: ["address1"],
+            tokens: toSats(1000),
+          },
+        ],
+      },
+    })
+    expect(txs.length).toEqual(1)
+    expect(txs[0].fee).toEqual(toSats(10))
+  })
+
+  it("filters txs with no valid hex", () => {
+    const txs = extractOutgoingTransactions({
+      decoder,
+      txs: {
+        transactions: [
+          {
+            id: "outgoing",
+            is_outgoing: true,
+            fee: toSats(1),
+            created_at,
+            is_confirmed: false,
+            output_addresses: ["address1"],
+            tokens: toSats(1000),
+          },
+        ],
+      },
+    })
+    expect(txs.length).toEqual(0)
+  })
+
+  it("it defaults fee to 0 (edge case)", () => {
+    const txs = extractOutgoingTransactions({
+      decoder,
+      txs: {
+        transactions: [
+          {
+            id: "outgoing",
+            is_outgoing: true,
+            transaction: validTxHex,
+            created_at,
+            is_confirmed: false,
+            output_addresses: ["19H8z5HQ4tuuGZRYJH5xbG2P64KimjnLFx"],
+            tokens: toSats(700768),
+          },
+        ],
+      },
+    })
+    expect(txs.length).toBe(1)
+    expect(txs[0].fee).toBe(toSats(0))
+    expect(txs[0].rawTx.outs[0].address).toBe("19H8z5HQ4tuuGZRYJH5xbG2P64KimjnLFx")
+    expect(txs[0].rawTx.outs[0].sats).toBe(700768)
   })
 })


### PR DESCRIPTION
this is the 1st split of the on-chain pay use case refactor

Includes:
- Removes getOnchainReceipt
- Replace getOnChainTransactions
- Renames getIncomingTransactions to match repos standard (list prefix) 