### PR TITLE
ci: Update staging worker tag

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -97,10 +97,10 @@ jobs:
   - in_parallel:
     - { get: repo, trigger: true }
     - { get: pipeline-tasks }
-    - { get: bundled-deps, tags: ["staging"], trigger: true}
+    - { get: bundled-deps, tags: ["galoy-staging"], trigger: true}
   - task: test-integration
     timeout: 12m
-    tags: ["staging"]
+    tags: ["galoy-staging"]
     config:
       platform: linux
       image_resource: #@ task_image_config()


### PR DESCRIPTION
Changes the integration testing on Concourse worker with tag: `staging` -> `galoy-staging`