### PR TITLE
refactor: add payToAddress and getBalance to on-chain service

### DIFF
--- a/src/app/wallets/get-on-chain-fee.ts
+++ b/src/app/wallets/get-on-chain-fee.ts
@@ -44,11 +44,11 @@ export const getOnChainFee = async ({
   const onChainService = OnChainService(TxDecoder(BTC_NETWORK))
   if (onChainService instanceof Error) return onChainService
 
-  const onChainFee = await onChainService.getOnChainFeeEstimate(
+  const onChainFee = await onChainService.getOnChainFeeEstimate({
     amount,
     address,
     targetConfirmations,
-  )
+  })
   if (onChainFee instanceof Error) return onChainFee
 
   return withdrawalFeeCalculator.onChainWithdrawalFee({

--- a/src/core/on-chain/index.ts
+++ b/src/core/on-chain/index.ts
@@ -7,12 +7,12 @@ import {
   checkWithdrawalLimits,
 } from "@app/wallets/check-limit-helpers"
 import { BTC_NETWORK, ONCHAIN_SCAN_DEPTH_OUTGOING } from "@config/app"
-import { toSats } from "@domain/bitcoin"
-import { TxDecoder } from "@domain/bitcoin/onchain"
+import { checkedToTargetConfs, toSats, toTargetConfs } from "@domain/bitcoin"
+import { checkedToOnChainAddress, TxDecoder } from "@domain/bitcoin/onchain"
 import { TwoFANewCodeNeededError } from "@domain/twoFA"
+import { WithdrawalFeeCalculator } from "@domain/wallets"
 import { LedgerService } from "@services/ledger"
 import { OnChainService } from "@services/lnd/onchain-service"
-import { getActiveOnchainLnd } from "@services/lnd/utils"
 import { LockService } from "@services/lock"
 import { ledger } from "@services/mongodb"
 import { User } from "@services/mongoose/schema"
@@ -261,7 +261,7 @@ export const OnChainMixin = (superclass) =>
         const targetConfs = getTargetConfirmations()
 
         const estimatedFee = await Wallets.getOnChainFeeByWalletId({
-          walletId: this.user.id,
+          walletId: this.user.walletId,
           amount: checksAmount,
           address: checkedAddress,
           targetConfirmations: targetConfs,

--- a/src/core/on-chain/index.ts
+++ b/src/core/on-chain/index.ts
@@ -17,7 +17,6 @@ import { LockService } from "@services/lock"
 import { ledger } from "@services/mongodb"
 import { User } from "@services/mongoose/schema"
 import { NotificationsService } from "@services/notifications"
-import { getChainBalance, getChainFeeEstimate, sendToChainAddress } from "lightning"
 
 import {
   DustAmountError,
@@ -249,7 +248,10 @@ export const OnChainMixin = (superclass) =>
 
         const sendTo = [{ address, tokens: checksAmount }]
 
-        const checkedAddress = checkedToOnChainAddress(address)
+        const checkedAddress = checkedToOnChainAddress({
+          network: BTC_NETWORK,
+          value: address,
+        })
         if (checkedAddress instanceof Error) throw checkedAddress
 
         const getTargetConfirmations = (): TargetConfirmations => {

--- a/src/core/on-chain/index.ts
+++ b/src/core/on-chain/index.ts
@@ -227,8 +227,6 @@ export const OnChainMixin = (superclass) =>
         if (twoFACheck instanceof Error)
           throw new TwoFAError(undefined, { logger: onchainLogger })
 
-        const { lnd } = getActiveOnchainLnd()
-
         const getOnChainBalance = async (): Promise<Satoshis> => {
           const onChainService = OnChainService(TxDecoder(BTC_NETWORK))
           if (onChainService instanceof Error) {
@@ -247,13 +245,20 @@ export const OnChainMixin = (superclass) =>
 
         const onChainBalance = await getOnChainBalance()
 
-        let id, amountToSend
+        let amountToSend
 
         const sendTo = [{ address, tokens: checksAmount }]
-        const targetConfs = targetConfirmations > 0 ? targetConfirmations : 1
 
         const checkedAddress = checkedToOnChainAddress(address)
         if (checkedAddress instanceof Error) throw checkedAddress
+
+        const getTargetConfirmations = (): TargetConfirmations => {
+          const confs = checkedToTargetConfs(targetConfirmations)
+          if (confs instanceof Error) return toTargetConfs(1)
+          return confs
+        }
+
+        const targetConfs = getTargetConfirmations()
 
         const estimatedFee = await Wallets.getOnChainFeeByWalletId({
           walletId: this.user.id,
@@ -286,13 +291,13 @@ export const OnChainMixin = (superclass) =>
           }
 
           // case where the user doesn't have enough money
-          if (balanceSats < amountToSend + estimatedFee + this.user.withdrawFee) {
+          if (balanceSats < amountToSend + estimatedFee) {
             throw new InsufficientBalanceError(undefined, { logger: onchainLogger })
           }
         }
         // when sendAll the amount to sendToChainAddress is the whole balance minus the fees
         else {
-          amountToSend = balanceSats - estimatedFee - this.user.withdrawFee
+          amountToSend = balanceSats - estimatedFee
 
           // case where there is not enough money available within lnd on-chain wallet
           if (onChainBalance < amountToSend) {
@@ -316,17 +321,21 @@ export const OnChainMixin = (superclass) =>
 
         const lockArgs = { logger: onchainLogger, lock }
         const result = await LockService().extendLock(lockArgs, async () => {
-          try {
-            ;({ id } = await sendToChainAddress({
-              address,
-              lnd,
-              tokens: amountToSend,
-              utxo_confirmations: 0,
-              target_confirmations: targetConfs,
-            }))
-          } catch (err) {
+          const payToAddress = () => {
+            const onChainService = OnChainService(TxDecoder(BTC_NETWORK))
+            if (onChainService instanceof Error) return onChainService
+
+            return onChainService.payToAddress({
+              address: checkedAddress,
+              amount: amountToSend,
+              targetConfirmations: targetConfs,
+            })
+          }
+
+          const txHash = await payToAddress()
+          if (txHash instanceof Error) {
             onchainLogger.error(
-              { err, address, tokens: amountToSend, success: false },
+              { err: txHash, address, tokens: amountToSend, success: false },
               "Impossible to sendToChainAddress",
             )
             return false
@@ -350,20 +359,23 @@ export const OnChainMixin = (superclass) =>
               return toSats(0)
             }
 
-            return onChainTxFee
+            return WithdrawalFeeCalculator().onChainWithdrawalFee({
+              onChainFee: onChainTxFee,
+              walletFee: toSats(this.user.withdrawFee),
+            })
           }
 
-          const fee = (await getOnChainFee(id)) + this.user.withdrawFee
+          const fee = await getOnChainFee(txHash)
 
           {
-            let sats = amount + fee
+            let sats = amountToSend + fee
             if (sendAll) {
               // when sendAll the amount debited from the account is the whole balance
               sats = balanceSats
             }
 
             const metadata = {
-              hash: id,
+              hash: txHash,
               payee_addresses: [address],
               ...UserWallet.getCurrencyEquivalent({ sats, fee }),
               sendAll,

--- a/src/core/on-chain/index.ts
+++ b/src/core/on-chain/index.ts
@@ -229,7 +229,23 @@ export const OnChainMixin = (superclass) =>
 
         const { lnd } = getActiveOnchainLnd()
 
-        const { chain_balance: onChainBalance } = await getChainBalance({ lnd })
+        const getOnChainBalance = async (): Promise<Satoshis> => {
+          const onChainService = OnChainService(TxDecoder(BTC_NETWORK))
+          if (onChainService instanceof Error) {
+            onchainLogger.fatal({ err: onChainService })
+            return toSats(0)
+          }
+
+          const onChainBalance = await onChainService.getBalance()
+          if (onChainBalance instanceof Error) {
+            onchainLogger.fatal({ err: onChainBalance })
+            return toSats(0)
+          }
+
+          return onChainBalance
+        }
+
+        const onChainBalance = await getOnChainBalance()
 
         let id, amountToSend
 

--- a/src/domain/bitcoin/onchain/index.ts
+++ b/src/domain/bitcoin/onchain/index.ts
@@ -1,8 +1,23 @@
-import { InvalidScanDepthAmount } from "@domain/errors"
+import { InvalidOnChainAddress, InvalidScanDepthAmount } from "@domain/errors"
 
 export * from "./errors"
 export * from "./tx-filter"
 export * from "./tx-decoder"
+
+export const checkedToOnChainAddress = (
+  value: string,
+): OnChainAddress | ValidationError => {
+  // Regex patterns: https://regexland.com/regex-bitcoin-addresses/
+  const regexes = [
+    /^[13]{1}[a-km-zA-HJ-NP-Z1-9]{26,34}$/, // mainnet non-segwit
+    /^bc1[a-z0-9]{39,59}$/i, // mainnet segwit
+    /^[mn2]{1}[a-km-zA-HJ-NP-Z1-9]{26,34}$/, // testnet non-segwit
+    /^tb1[a-z0-9]{39,59}$/i, // testnet segwit
+  ]
+
+  if (regexes.some((r) => value.match(r))) return value as OnChainAddress
+  return new InvalidOnChainAddress()
+}
 
 export const checkedToScanDepth = (value: number): ScanDepth | ValidationError => {
   // 1 month as max scan depth

--- a/src/domain/bitcoin/onchain/index.ts
+++ b/src/domain/bitcoin/onchain/index.ts
@@ -26,7 +26,7 @@ export const checkedToScanDepth = (value: number): ScanDepth | ValidationError =
   return new InvalidScanDepthAmount()
 }
 
-export const BaseOnChainTransaction = ({
+export const IncomingOnChainTransaction = ({
   confirmations,
   rawTx,
   fee,
@@ -36,7 +36,7 @@ export const BaseOnChainTransaction = ({
   rawTx: OnChainTransaction
   fee: Satoshis
   createdAt: Date
-}): BaseOnChainTransaction => ({
+}): IncomingOnChainTransaction => ({
   confirmations,
   rawTx,
   fee,
@@ -48,24 +48,6 @@ export const BaseOnChainTransaction = ({
     }, []),
 })
 
-export const IncomingOnChainTransaction = ({
-  confirmations,
-  rawTx,
-  fee,
-  createdAt,
-}: {
-  confirmations: number
-  rawTx: OnChainTransaction
-  fee: Satoshis
-  createdAt: Date
-}): IncomingOnChainTransaction =>
-  BaseOnChainTransaction({
-    confirmations,
-    rawTx,
-    fee,
-    createdAt,
-  })
-
 export const OutgoingOnChainTransaction = ({
   confirmations,
   rawTx,
@@ -76,10 +58,14 @@ export const OutgoingOnChainTransaction = ({
   rawTx: OnChainTransaction
   fee: Satoshis
   createdAt: Date
-}): OutgoingOnChainTransaction =>
-  BaseOnChainTransaction({
-    confirmations,
-    rawTx,
-    fee,
-    createdAt,
-  })
+}): OutgoingOnChainTransaction => ({
+  confirmations,
+  rawTx,
+  fee,
+  createdAt,
+  uniqueAddresses: () =>
+    rawTx.outs.reduce<OnChainAddress[]>((a: OnChainAddress[], o: TxOut) => {
+      if (o.address && !a.includes(o.address)) a.push(o.address)
+      return a
+    }, []),
+})

--- a/src/domain/bitcoin/onchain/index.ts
+++ b/src/domain/bitcoin/onchain/index.ts
@@ -10,9 +10,10 @@ export const checkedToOnChainAddress = (
   // Regex patterns: https://regexland.com/regex-bitcoin-addresses/
   const regexes = [
     /^[13]{1}[a-km-zA-HJ-NP-Z1-9]{26,34}$/, // mainnet non-segwit
-    /^bc1[a-z0-9]{39,59}$/i, // mainnet segwit
     /^[mn2]{1}[a-km-zA-HJ-NP-Z1-9]{26,34}$/, // testnet non-segwit
+    /^bc1[a-z0-9]{39,59}$/i, // mainnet segwit
     /^tb1[a-z0-9]{39,59}$/i, // testnet segwit
+    /^bcrt1[a-z0-9]{39,59}$/i, // regtest segwit
   ]
 
   if (regexes.some((r) => value.match(r))) return value as OnChainAddress

--- a/src/domain/bitcoin/onchain/index.ts
+++ b/src/domain/bitcoin/onchain/index.ts
@@ -4,19 +4,21 @@ export * from "./errors"
 export * from "./tx-filter"
 export * from "./tx-decoder"
 
-export const checkedToOnChainAddress = (
-  value: string,
-): OnChainAddress | ValidationError => {
+export const checkedToOnChainAddress = ({
+  network,
+  value,
+}: {
+  network: BtcNetwork
+  value: string
+}): OnChainAddress | ValidationError => {
   // Regex patterns: https://regexland.com/regex-bitcoin-addresses/
-  const regexes = [
-    /^[13]{1}[a-km-zA-HJ-NP-Z1-9]{26,34}$/, // mainnet non-segwit
-    /^[mn2]{1}[a-km-zA-HJ-NP-Z1-9]{26,34}$/, // testnet non-segwit
-    /^bc1[a-z0-9]{39,59}$/i, // mainnet segwit
-    /^tb1[a-z0-9]{39,59}$/i, // testnet segwit
-    /^bcrt1[a-z0-9]{39,59}$/i, // regtest segwit
-  ]
+  const regexes = {
+    mainnet: [/^[13]{1}[a-km-zA-HJ-NP-Z1-9]{26,34}$/, /^bc1[a-z0-9]{39,59}$/i],
+    testnet: [/^[mn2]{1}[a-km-zA-HJ-NP-Z1-9]{26,34}$/, /^tb1[a-z0-9]{39,59}$/i],
+    regtest: [/^bcrt1[a-z0-9]{39,59}$/i],
+  }
 
-  if (regexes.some((r) => value.match(r))) return value as OnChainAddress
+  if (regexes[network].some((r) => value.match(r))) return value as OnChainAddress
   return new InvalidOnChainAddress()
 }
 

--- a/src/domain/bitcoin/onchain/index.types.d.ts
+++ b/src/domain/bitcoin/onchain/index.types.d.ts
@@ -17,7 +17,7 @@ type OnChainTransaction = {
   outs: TxOut[]
 }
 
-type BaseOnChainTransaction = {
+type IncomingOnChainTransaction = {
   confirmations: number
   rawTx: OnChainTransaction
   fee: Satoshis
@@ -25,8 +25,13 @@ type BaseOnChainTransaction = {
   uniqueAddresses: () => OnChainAddress[]
 }
 
-type IncomingOnChainTransaction = BaseOnChainTransaction
-type OutgoingOnChainTransaction = BaseOnChainTransaction
+type OutgoingOnChainTransaction = {
+  confirmations: number
+  rawTx: OnChainTransaction
+  fee: Satoshis
+  createdAt: Date
+  uniqueAddresses: () => OnChainAddress[]
+}
 
 type TxDecoder = {
   decode(txHex: string): OnChainTransaction

--- a/src/domain/bitcoin/onchain/index.types.d.ts
+++ b/src/domain/bitcoin/onchain/index.types.d.ts
@@ -48,6 +48,8 @@ type LookupOnChainFeeArgs = {
 }
 
 interface IOnChainService {
+  getBalance(): Promise<Satoshis | OnChainServiceError>
+
   listIncomingTransactions(
     scanDepth: ScanDepth,
   ): Promise<IncomingOnChainTransaction[] | OnChainServiceError>

--- a/src/domain/bitcoin/onchain/index.types.d.ts
+++ b/src/domain/bitcoin/onchain/index.types.d.ts
@@ -47,6 +47,18 @@ type LookupOnChainFeeArgs = {
   scanDepth: ScanDepth
 }
 
+type GetOnChainFeeEstimateArgs = {
+  amount: Satoshis
+  address: OnChainAddress
+  targetConfirmations: TargetConfirmations
+}
+
+type PayToAddressArgs = {
+  amount: Satoshis
+  address: OnChainAddress
+  targetConfirmations: TargetConfirmations
+}
+
 interface IOnChainService {
   getBalance(): Promise<Satoshis | OnChainServiceError>
 
@@ -61,9 +73,15 @@ interface IOnChainService {
 
   createOnChainAddress(): Promise<OnChainAddressIdentifier | OnChainServiceError>
 
-  getOnChainFeeEstimate(
-    amount: Satoshis,
-    address: OnChainAddress,
-    targetConfirmations: TargetConfirmations,
-  ): Promise<Satoshis | OnChainServiceError>
+  getOnChainFeeEstimate({
+    amount,
+    address,
+    targetConfirmations,
+  }: GetOnChainFeeEstimateArgs): Promise<Satoshis | OnChainServiceError>
+
+  payToAddress({
+    amount,
+    address,
+    targetConfirmations,
+  }: PayToAddressArgs): Promise<OnChainTxHash | OnChainServiceError>
 }

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -35,6 +35,7 @@ export class RewardNonValidTypeError extends DomainError {}
 
 export class ValidationError extends DomainError {}
 export class InvalidSatoshiAmount extends ValidationError {}
+export class InvalidOnChainAddress extends ValidationError {}
 export class InvalidScanDepthAmount extends ValidationError {}
 export class SatoshiAmountRequiredError extends ValidationError {}
 export class InvalidUsername extends ValidationError {}

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -240,6 +240,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "RewardNonValidTypeError":
     case "RewardAlreadyPresentError":
     case "InvalidAccountStatusError":
+    case "InvalidOnChainAddress":
     case "InvalidScanDepthAmount":
     case "InsufficientBalanceForRoutingError":
       message = `Unknown error occurred (code: ${error.name})`

--- a/src/graphql/types/scalar/on-chain-address.ts
+++ b/src/graphql/types/scalar/on-chain-address.ts
@@ -1,3 +1,4 @@
+import { checkedToOnChainAddress } from "@domain/bitcoin/onchain"
 import { GT } from "@graphql/index"
 import { UserInputError } from "apollo-server-errors"
 
@@ -16,17 +17,10 @@ const OnChainAddress = new GT.Scalar({
 })
 
 function validOnChainAddressValue(value) {
-  // Regex patterns: https://regexland.com/regex-bitcoin-addresses/
-  const regexes = [
-    /^[13]{1}[a-km-zA-HJ-NP-Z1-9]{26,34}$/, // mainnet non-segwit
-    /^bc1[a-z0-9]{39,59}$/i, // mainnet segwit
-    /^[mn2]{1}[a-km-zA-HJ-NP-Z1-9]{26,34}$/, // testnet non-segwit
-    /^tb1[a-z0-9]{39,59}$/i, // testnet segwit
-  ]
-
-  return regexes.some((r) => value.match(r))
-    ? value
-    : new UserInputError("Invalid value for OnChainAddress")
+  const address = checkedToOnChainAddress(value)
+  if (address instanceof Error)
+    return new UserInputError("Invalid value for OnChainAddress")
+  return address
 }
 
 export default OnChainAddress

--- a/src/graphql/types/scalar/on-chain-address.ts
+++ b/src/graphql/types/scalar/on-chain-address.ts
@@ -1,3 +1,4 @@
+import { BTC_NETWORK } from "@config/app"
 import { checkedToOnChainAddress } from "@domain/bitcoin/onchain"
 import { GT } from "@graphql/index"
 import { UserInputError } from "apollo-server-errors"
@@ -17,7 +18,7 @@ const OnChainAddress = new GT.Scalar({
 })
 
 function validOnChainAddressValue(value) {
-  const address = checkedToOnChainAddress(value)
+  const address = checkedToOnChainAddress({ network: BTC_NETWORK, value })
   if (address instanceof Error)
     return new UserInputError("Invalid value for OnChainAddress")
   return address

--- a/src/services/lnd/onchain-service.ts
+++ b/src/services/lnd/onchain-service.ts
@@ -12,6 +12,8 @@ import {
   createChainAddress,
   getChainFeeEstimate,
   getWalletInfo,
+  getChainBalance,
+  sendToChainAddress,
 } from "lightning"
 
 import { wrapAsyncToRunInSpan } from "@services/tracing"

--- a/src/services/lnd/onchain-service.ts
+++ b/src/services/lnd/onchain-service.ts
@@ -35,6 +35,15 @@ export const OnChainService = (
     return new OnChainServiceUnavailableError(err)
   }
 
+  const getBalance = async (): Promise<Satoshis | OnChainServiceError> => {
+    try {
+      const { chain_balance } = await getChainBalance({ lnd })
+      return toSats(chain_balance)
+    } catch (err) {
+      return new UnknownOnChainServiceError(err)
+    }
+  }
+
   const listTransactions = async (
     scanDepth: ScanDepth,
   ): Promise<GetChainTransactionsResult | OnChainServiceError> => {
@@ -125,6 +134,7 @@ export const OnChainService = (
   }
 
   return {
+    getBalance,
     listIncomingTransactions: wrapAsyncToRunInSpan({
       namespace: `service.lnd`,
       fn: listIncomingTransactions,

--- a/test/unit/domain/bitcoin/onchain/checked-to-on-chain-address.spec.ts
+++ b/test/unit/domain/bitcoin/onchain/checked-to-on-chain-address.spec.ts
@@ -1,0 +1,51 @@
+import { BtcNetwork } from "@domain/bitcoin"
+import { checkedToOnChainAddress } from "@domain/bitcoin/onchain"
+import { InvalidOnChainAddress } from "@domain/errors"
+
+const addresses = [
+  { network: "mainnet", address: "17sELMebjQNf1k1CRucF67QAtegNsTjXUn" },
+  { network: "mainnet", address: "3QcAYUrGoKv8tqg24VRB8TDUejmumLG8rL" },
+  { network: "mainnet", address: "bc1q40aetdah8wcrsxvzl5qcft4svx696xsw0tnchd" },
+  {
+    network: "mainnet",
+    address: "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcxswfvpysxf3qccfmv3",
+  },
+  { network: "testnet", address: "mipcBbFg9gLiKh81Kj8taadgoZiY1ZJRfn" },
+  { network: "testnet", address: "tb1qw508d6qejxtdg4y5r3aadgory0c5xw7kxpjzsx" },
+  {
+    network: "testnet",
+    address: "tb1p84x2taadgovgnlpnxt9f39gm7r68gwtvllxqe5w2n5ru00s9aquslzggwq",
+  },
+  { network: "regtest", address: "bcrt1q6z64a43mjgkcq0ul2zaqusq3spghrlau9slefp" },
+  {
+    network: "regtest",
+    address: "bcrt1q5n2k3frgpxces3aqusqfpqk4kksv0cz96pldxdwxrrw0d5ud5haqusx7zt",
+  },
+]
+
+describe("checkedToOnChainAddress", () => {
+  test.each(addresses)("$address is valid for $network", ({ network, address }) => {
+    const result = checkedToOnChainAddress({
+      network: network as BtcNetwork,
+      value: address,
+    })
+    expect(result).not.toBeInstanceOf(InvalidOnChainAddress)
+    expect(result).toBe(address)
+  })
+
+  test.each(addresses)(
+    "$address is invalid for other networks",
+    ({ network, address }) => {
+      let networksToCheck: Array<BtcNetwork> = [BtcNetwork.testnet, BtcNetwork.regtest]
+      if (network === "testnet")
+        networksToCheck = [BtcNetwork.mainnet, BtcNetwork.regtest]
+      if (network === "regtest")
+        networksToCheck = [BtcNetwork.mainnet, BtcNetwork.testnet]
+
+      for (const wrongNetwork of networksToCheck) {
+        const result = checkedToOnChainAddress({ network: wrongNetwork, value: address })
+        expect(result).toBeInstanceOf(InvalidOnChainAddress)
+      }
+    },
+  )
+})


### PR DESCRIPTION
this is the 2nd split of the on-chain pay use case refactor

- Move on-chain address validator to domain
- Add payToAddress and getBalance to onchain service
- Update error parsing in on-chain service
- Update getOnChainFeeEstimate with 1 param policy 