### PR TITLE
feat: ledger to use walletId instead of userId

### DIFF
--- a/src/app/accounts/index.ts
+++ b/src/app/accounts/index.ts
@@ -1,14 +1,9 @@
 import { hashApiKey } from "@domain/accounts"
-import { ValidationError } from "@domain/errors"
-import {
-  AccountApiKeysRepository,
-  AccountsRepository,
-  WalletsRepository,
-} from "@services/mongoose"
+import { AccountApiKeysRepository, AccountsRepository } from "@services/mongoose"
 
 export * from "./add-api-key-for-account"
-export * from "./get-api-keys-for-account"
 export * from "./disable-api-key-for-account"
+export * from "./get-api-keys-for-account"
 
 export const getAccount = async (accountId: AccountId) => {
   const accounts = AccountsRepository()
@@ -32,14 +27,14 @@ export const getAccountByApiKey = async (
 
 export const hasPermissions = async (
   userId: UserId,
-  walletPublicId: WalletPublicId,
+  walletId: WalletId,
 ): Promise<boolean | ApplicationError> => {
   const accounts = AccountsRepository()
 
   const userAccounts = await accounts.listByUserId(userId)
   if (userAccounts instanceof Error) return userAccounts
 
-  const walletAccount = await accounts.findByWalletPublicId(walletPublicId)
+  const walletAccount = await accounts.findByWalletId(walletId)
   if (walletAccount instanceof Error) return walletAccount
 
   return userAccounts.some((a) => a.id === walletAccount.id)
@@ -48,30 +43,4 @@ export const hasPermissions = async (
 export const getBusinessMapMarkers = async () => {
   const accounts = AccountsRepository()
   return accounts.listBusinessesForMap()
-}
-
-export const toWalletIds = async ({
-  account,
-  walletPublicIds,
-}: {
-  account: Account
-  walletPublicIds: WalletPublicId[]
-}): Promise<WalletId[] | ApplicationError> => {
-  const wallets = WalletsRepository()
-
-  const walletIds: WalletId[] = []
-
-  for (const walletPublicId of walletPublicIds) {
-    const wallet = await wallets.findByPublicId(walletPublicId)
-    if (wallet instanceof Error) {
-      return wallet
-    }
-
-    if (!account.walletIds.includes(wallet.id)) {
-      return new ValidationError()
-    }
-    walletIds.push(wallet.id)
-  }
-
-  return walletIds
 }

--- a/src/app/accounts/index.ts
+++ b/src/app/accounts/index.ts
@@ -5,8 +5,9 @@ export * from "./add-api-key-for-account"
 export * from "./disable-api-key-for-account"
 export * from "./get-api-keys-for-account"
 
+const accounts = AccountsRepository()
+
 export const getAccount = async (accountId: AccountId) => {
-  const accounts = AccountsRepository()
   return accounts.findById(accountId)
 }
 
@@ -21,16 +22,13 @@ export const getAccountByApiKey = async (
   const accountApiKey = await accountApiKeysRepository.findByHashedKey(hashedKey)
   if (accountApiKey instanceof Error) return accountApiKey
 
-  const accountRepo = AccountsRepository()
-  return accountRepo.findById(accountApiKey.accountId)
+  return accounts.findById(accountApiKey.accountId)
 }
 
 export const hasPermissions = async (
   userId: UserId,
   walletId: WalletId,
 ): Promise<boolean | ApplicationError> => {
-  const accounts = AccountsRepository()
-
   const userAccounts = await accounts.listByUserId(userId)
   if (userAccounts instanceof Error) return userAccounts
 
@@ -41,6 +39,13 @@ export const hasPermissions = async (
 }
 
 export const getBusinessMapMarkers = async () => {
-  const accounts = AccountsRepository()
   return accounts.listBusinessesForMap()
+}
+
+export const getUsernameFromWalletId = async (
+  walletId: WalletId,
+): Promise<Username | ApplicationError> => {
+  const account = await accounts.findByWalletId(walletId)
+  if (account instanceof Error) return account
+  return account.username
 }

--- a/src/app/users/get-user.ts
+++ b/src/app/users/get-user.ts
@@ -115,12 +115,10 @@ const updateUserIPsInfo = async ({
     },
   )
 
-export const getUsernameFromWalletPublicId = async (
-  walletPublicId: WalletPublicId,
+export const getUsernameFromWalletId = async (
+  walletId: WalletId,
 ): Promise<Username | ApplicationError> => {
-  const user = await users.findByWalletPublicId(walletPublicId)
-
+  const user = await users.findByWalletId(walletId)
   if (user instanceof Error) return user
-
   return user.username
 }

--- a/src/app/users/get-user.ts
+++ b/src/app/users/get-user.ts
@@ -114,11 +114,3 @@ const updateUserIPsInfo = async ({
       }
     },
   )
-
-export const getUsernameFromWalletId = async (
-  walletId: WalletId,
-): Promise<Username | ApplicationError> => {
-  const user = await users.findByWalletId(walletId)
-  if (user instanceof Error) return user
-  return user.username
-}

--- a/src/app/wallets/add-invoice-for-wallet.ts
+++ b/src/app/wallets/add-invoice-for-wallet.ts
@@ -77,15 +77,15 @@ export const addInvoiceForRecipient = async ({
   memo = "",
   descriptionHash,
 }: AddInvoiceForRecipientArgs): Promise<LnInvoice | ApplicationError> => {
-  const walletIdChecked = checkedToWalletId(recipientWalletId)
-  if (walletIdChecked instanceof Error) return walletIdChecked
+  const recipientWalletIdChecked = checkedToWalletId(recipientWalletId)
+  if (recipientWalletIdChecked instanceof Error) return recipientWalletIdChecked
 
-  const limitOk = await checkRecipientWalletIdRateLimits(walletIdChecked)
+  const limitOk = await checkRecipientWalletIdRateLimits(recipientWalletIdChecked)
   if (limitOk instanceof Error) return limitOk
   const sats = checkedToSats(amount)
   if (sats instanceof Error) return sats
 
-  const walletInvoiceFactory = WalletInvoiceFactory(walletIdChecked)
+  const walletInvoiceFactory = WalletInvoiceFactory(recipientWalletIdChecked)
   return registerAndPersistInvoice({
     sats,
     memo,

--- a/src/app/wallets/add-invoice-for-wallet.ts
+++ b/src/app/wallets/add-invoice-for-wallet.ts
@@ -145,26 +145,25 @@ export const registerAndPersistInvoice = async ({
   return invoice
 }
 
-const invoiceCreateAttemptLimits = getInvoiceCreateAttemptLimits()
-const limiterInvoiceCreateAttemptLimits = RedisRateLimitService({
-  keyPrefix: RateLimitPrefix.invoiceCreate,
-  limitOptions: invoiceCreateAttemptLimits,
-})
-
 export const checkSelfWalletIdRateLimits = async (
   walletId: WalletId,
 ): Promise<true | RateLimiterExceededError> => {
+  const invoiceCreateAttemptLimits = getInvoiceCreateAttemptLimits()
+  const limiterInvoiceCreateAttemptLimits = RedisRateLimitService({
+    keyPrefix: RateLimitPrefix.invoiceCreate,
+    limitOptions: invoiceCreateAttemptLimits,
+  })
   return limiterInvoiceCreateAttemptLimits.consume(walletId)
 }
-
-const invoiceCreateForRecipientAttemptLimits = getInvoiceCreateForRecipientAttemptLimits()
-const limiterInvoiceCreateForRecipient = RedisRateLimitService({
-  keyPrefix: RateLimitPrefix.invoiceCreateForRecipient,
-  limitOptions: invoiceCreateForRecipientAttemptLimits,
-})
 
 export const checkRecipientWalletIdRateLimits = async (
   walletId: WalletId,
 ): Promise<true | RateLimiterExceededError> => {
+  const invoiceCreateForRecipientAttemptLimits =
+    getInvoiceCreateForRecipientAttemptLimits()
+  const limiterInvoiceCreateForRecipient = RedisRateLimitService({
+    keyPrefix: RateLimitPrefix.invoiceCreateForRecipient,
+    limitOptions: invoiceCreateForRecipientAttemptLimits,
+  })
   return limiterInvoiceCreateForRecipient.consume(walletId)
 }

--- a/src/app/wallets/add-invoice-for-wallet.ts
+++ b/src/app/wallets/add-invoice-for-wallet.ts
@@ -7,19 +7,18 @@ import { invoiceExpirationForCurrency } from "@domain/bitcoin/lightning"
 import { RateLimitPrefix } from "@domain/rate-limit"
 import { RateLimiterExceededError } from "@domain/rate-limit/errors"
 import { WalletInvoiceFactory } from "@domain/wallet-invoices/wallet-invoice-factory"
-import { checkedToWalletPublicId } from "@domain/wallets"
+import { checkedToWalletId } from "@domain/wallets"
 import { LndService } from "@services/lnd"
 import { WalletInvoicesRepository, WalletsRepository } from "@services/mongoose"
 import { RedisRateLimitService } from "@services/rate-limit"
-import { walletIdFromPublicId } from "."
 
-export const addInvoiceByWalletPublicId = async ({
-  walletPublicId,
+export const addInvoiceByWalletId = async ({
+  walletId,
   amount,
   memo = "",
-}: AddInvoiceByWalletPublicIdArgs): Promise<LnInvoice | ApplicationError> => {
+}: addInvoiceByWalletIdArgs): Promise<LnInvoice | ApplicationError> => {
   const wallets = WalletsRepository()
-  const wallet = await wallets.findByPublicId(walletPublicId)
+  const wallet = await wallets.findById(walletId)
   if (wallet instanceof Error) return wallet
 
   return addInvoice({
@@ -34,7 +33,7 @@ export const addInvoice = async ({
   amount,
   memo = "",
 }: AddInvoiceArgs): Promise<LnInvoice | ApplicationError> => {
-  const limitOk = await checkSelfWalletIdLimits(walletId)
+  const limitOk = await checkSelfWalletIdRateLimits(walletId)
   if (limitOk instanceof Error) return limitOk
   const sats = checkedToSats(amount)
   if (sats instanceof Error) return sats
@@ -47,16 +46,12 @@ export const addInvoice = async ({
   })
 }
 
-export const addInvoiceNoAmountByWalletPublicId = async ({
-  walletPublicId,
+export const addInvoiceNoAmountByWalletId = async ({
+  walletId,
   memo = "",
-}: AddInvoiceNoAmountByWalletPublicIdArgs): Promise<LnInvoice | ApplicationError> => {
-  const wallets = WalletsRepository()
-  const wallet = await wallets.findByPublicId(walletPublicId)
-  if (wallet instanceof Error) return wallet
-
+}: AddInvoiceNoAmountByWalletIdArgs): Promise<LnInvoice | ApplicationError> => {
   return addInvoiceNoAmount({
-    walletId: wallet.id,
+    walletId,
     memo,
   })
 }
@@ -65,7 +60,7 @@ export const addInvoiceNoAmount = async ({
   walletId,
   memo = "",
 }: AddInvoiceNoAmountArgs): Promise<LnInvoice | ApplicationError> => {
-  const limitOk = await checkSelfWalletIdLimits(walletId)
+  const limitOk = await checkSelfWalletIdRateLimits(walletId)
   if (limitOk instanceof Error) return limitOk
 
   const walletInvoiceFactory = WalletInvoiceFactory(walletId)
@@ -77,22 +72,20 @@ export const addInvoiceNoAmount = async ({
 }
 
 export const addInvoiceForRecipient = async ({
-  recipientWalletPublicId,
+  recipientWalletId,
   amount,
   memo = "",
   descriptionHash,
 }: AddInvoiceForRecipientArgs): Promise<LnInvoice | ApplicationError> => {
-  const walletPublicId = checkedToWalletPublicId(recipientWalletPublicId)
-  if (walletPublicId instanceof Error) return walletPublicId
-  const walletId = await walletIdFromPublicId(walletPublicId)
-  if (walletId instanceof Error) return walletId
+  const walletIdChecked = checkedToWalletId(recipientWalletId)
+  if (walletIdChecked instanceof Error) return walletIdChecked
 
-  const limitOk = await checkRecipientWalletIdLimits(walletId)
+  const limitOk = await checkRecipientWalletIdRateLimits(walletIdChecked)
   if (limitOk instanceof Error) return limitOk
   const sats = checkedToSats(amount)
   if (sats instanceof Error) return sats
 
-  const walletInvoiceFactory = WalletInvoiceFactory(walletId)
+  const walletInvoiceFactory = WalletInvoiceFactory(walletIdChecked)
   return registerAndPersistInvoice({
     sats,
     memo,
@@ -102,18 +95,16 @@ export const addInvoiceForRecipient = async ({
 }
 
 export const addInvoiceNoAmountForRecipient = async ({
-  recipientWalletPublicId,
+  recipientWalletId,
   memo = "",
 }: AddInvoiceNoAmountForRecipientArgs): Promise<LnInvoice | ApplicationError> => {
-  const walletPublicId = checkedToWalletPublicId(recipientWalletPublicId)
-  if (walletPublicId instanceof Error) return walletPublicId
-  const walletId = await walletIdFromPublicId(walletPublicId)
-  if (walletId instanceof Error) return walletId
+  const recipientWalletIdChecked = checkedToWalletId(recipientWalletId)
+  if (recipientWalletIdChecked instanceof Error) return recipientWalletIdChecked
 
-  const limitOk = await checkRecipientWalletIdLimits(walletId)
+  const limitOk = await checkRecipientWalletIdRateLimits(recipientWalletIdChecked)
   if (limitOk instanceof Error) return limitOk
 
-  const walletInvoiceFactory = WalletInvoiceFactory(walletId)
+  const walletInvoiceFactory = WalletInvoiceFactory(recipientWalletIdChecked)
   return registerAndPersistInvoice({
     sats: toSats(0),
     memo,
@@ -154,24 +145,26 @@ export const registerAndPersistInvoice = async ({
   return invoice
 }
 
-export const checkSelfWalletIdLimits = async (
+const invoiceCreateAttemptLimits = getInvoiceCreateAttemptLimits()
+const limiterInvoiceCreateAttemptLimits = RedisRateLimitService({
+  keyPrefix: RateLimitPrefix.invoiceCreate,
+  limitOptions: invoiceCreateAttemptLimits,
+})
+
+export const checkSelfWalletIdRateLimits = async (
   walletId: WalletId,
 ): Promise<true | RateLimiterExceededError> => {
-  const invoiceCreateAttemptLimits = getInvoiceCreateAttemptLimits()
-  const limiter = RedisRateLimitService({
-    keyPrefix: RateLimitPrefix.invoiceCreate,
-    limitOptions: invoiceCreateAttemptLimits,
-  })
-  return limiter.consume(walletId)
+  return limiterInvoiceCreateAttemptLimits.consume(walletId)
 }
 
-export const checkRecipientWalletIdLimits = async (
+const invoiceCreateForRecipientAttemptLimits = getInvoiceCreateForRecipientAttemptLimits()
+const limiterInvoiceCreateForRecipient = RedisRateLimitService({
+  keyPrefix: RateLimitPrefix.invoiceCreateForRecipient,
+  limitOptions: invoiceCreateForRecipientAttemptLimits,
+})
+
+export const checkRecipientWalletIdRateLimits = async (
   walletId: WalletId,
 ): Promise<true | RateLimiterExceededError> => {
-  const invoiceCreateForRecipientAttempt = getInvoiceCreateForRecipientAttemptLimits()
-  const limiter = RedisRateLimitService({
-    keyPrefix: RateLimitPrefix.invoiceCreateForRecipient,
-    limitOptions: invoiceCreateForRecipientAttempt,
-  })
-  return limiter.consume(walletId)
+  return limiterInvoiceCreateForRecipient.consume(walletId)
 }

--- a/src/app/wallets/check-limit-helpers.ts
+++ b/src/app/wallets/check-limit-helpers.ts
@@ -1,6 +1,5 @@
 import { getTwoFALimits, getUserLimits, MS_PER_DAY } from "@config/app"
 import { LimitsChecker } from "@domain/accounts"
-import { toLiabilitiesWalletId } from "@domain/ledger"
 import { TwoFA, TwoFANewCodeNeededError } from "@domain/twoFA"
 import { LedgerService } from "@services/ledger"
 import { AccountsRepository } from "@services/mongoose"
@@ -16,11 +15,10 @@ export const checkIntraledgerLimits = async ({
   if (limitsChecker instanceof Error) return limitsChecker
 
   const ledgerService = LedgerService()
-  const liabilitiesWalletId = toLiabilitiesWalletId(walletId)
   const timestamp1Day = new Date(Date.now() - MS_PER_DAY)
 
   const walletVolume = await ledgerService.intraledgerTxVolumeSince({
-    liabilitiesWalletId,
+    walletId,
     timestamp: timestamp1Day,
   })
   if (walletVolume instanceof Error) return walletVolume
@@ -42,11 +40,10 @@ export const checkWithdrawalLimits = async ({
   if (limitsChecker instanceof Error) return limitsChecker
 
   const ledgerService = LedgerService()
-  const liabilitiesWalletId = toLiabilitiesWalletId(walletId)
   const timestamp1Day = new Date(Date.now() - MS_PER_DAY)
 
   const walletVolume = await ledgerService.withdrawalTxVolumeSince({
-    liabilitiesWalletId,
+    walletId,
     timestamp: timestamp1Day,
   })
   if (walletVolume instanceof Error) return walletVolume
@@ -68,11 +65,10 @@ export const checkTwoFALimits = async ({
   if (limitsChecker instanceof Error) return limitsChecker
 
   const ledgerService = LedgerService()
-  const liabilitiesWalletId = toLiabilitiesWalletId(walletId)
   const timestamp1Day = new Date(Date.now() - MS_PER_DAY)
 
   const walletVolume = await ledgerService.twoFATxVolumeSince({
-    liabilitiesWalletId,
+    walletId,
     timestamp: timestamp1Day,
   })
   if (walletVolume instanceof Error) return walletVolume

--- a/src/app/wallets/check-limit-helpers.ts
+++ b/src/app/wallets/check-limit-helpers.ts
@@ -1,6 +1,6 @@
 import { getTwoFALimits, getUserLimits, MS_PER_DAY } from "@config/app"
 import { LimitsChecker } from "@domain/accounts"
-import { toLiabilitiesAccountId } from "@domain/ledger"
+import { toLiabilitiesWalletId } from "@domain/ledger"
 import { TwoFA, TwoFANewCodeNeededError } from "@domain/twoFA"
 import { LedgerService } from "@services/ledger"
 import { AccountsRepository } from "@services/mongoose"
@@ -16,11 +16,11 @@ export const checkIntraledgerLimits = async ({
   if (limitsChecker instanceof Error) return limitsChecker
 
   const ledgerService = LedgerService()
-  const liabilitiesAccountId = toLiabilitiesAccountId(walletId)
+  const liabilitiesWalletId = toLiabilitiesWalletId(walletId)
   const timestamp1Day = new Date(Date.now() - MS_PER_DAY)
 
   const walletVolume = await ledgerService.intraledgerTxVolumeSince({
-    liabilitiesAccountId,
+    liabilitiesWalletId,
     timestamp: timestamp1Day,
   })
   if (walletVolume instanceof Error) return walletVolume
@@ -42,11 +42,11 @@ export const checkWithdrawalLimits = async ({
   if (limitsChecker instanceof Error) return limitsChecker
 
   const ledgerService = LedgerService()
-  const liabilitiesAccountId = toLiabilitiesAccountId(walletId)
+  const liabilitiesWalletId = toLiabilitiesWalletId(walletId)
   const timestamp1Day = new Date(Date.now() - MS_PER_DAY)
 
   const walletVolume = await ledgerService.withdrawalTxVolumeSince({
-    liabilitiesAccountId,
+    liabilitiesWalletId,
     timestamp: timestamp1Day,
   })
   if (walletVolume instanceof Error) return walletVolume
@@ -68,11 +68,11 @@ export const checkTwoFALimits = async ({
   if (limitsChecker instanceof Error) return limitsChecker
 
   const ledgerService = LedgerService()
-  const liabilitiesAccountId = toLiabilitiesAccountId(walletId)
+  const liabilitiesWalletId = toLiabilitiesWalletId(walletId)
   const timestamp1Day = new Date(Date.now() - MS_PER_DAY)
 
   const walletVolume = await ledgerService.twoFATxVolumeSince({
-    liabilitiesAccountId,
+    liabilitiesWalletId,
     timestamp: timestamp1Day,
   })
   if (walletVolume instanceof Error) return walletVolume

--- a/src/app/wallets/create-on-chain-address.ts
+++ b/src/app/wallets/create-on-chain-address.ts
@@ -31,15 +31,14 @@ export const createOnChainAddress = async (
   return savedOnChainAddress.address
 }
 
-const onChainAddressCreateAttempt = getOnChainAddressCreateAttemptLimits()
-const limiterOnChainAddressCreateAttempt = RedisRateLimitService({
-  keyPrefix: RateLimitPrefix.onChainAddressCreate,
-  limitOptions: onChainAddressCreateAttempt,
-})
-
 const checkOnChainAddressWalletIdLimits = async (
   walletId: WalletId,
 ): Promise<true | RateLimiterExceededError> => {
+  const onChainAddressCreateAttempt = getOnChainAddressCreateAttemptLimits()
+  const limiterOnChainAddressCreateAttempt = RedisRateLimitService({
+    keyPrefix: RateLimitPrefix.onChainAddressCreate,
+    limitOptions: onChainAddressCreateAttempt,
+  })
   const limitOk = await limiterOnChainAddressCreateAttempt.consume(walletId)
   if (limitOk instanceof RateLimiterExceededError)
     return new OnChainAddressCreateRateLimiterExceededError()

--- a/src/app/wallets/create-on-chain-address.ts
+++ b/src/app/wallets/create-on-chain-address.ts
@@ -1,13 +1,13 @@
-import { OnChainService } from "@services/lnd/onchain-service"
-import { TxDecoder } from "@domain/bitcoin/onchain"
 import { BTC_NETWORK, getOnChainAddressCreateAttemptLimits } from "@config/app"
-import { WalletOnChainAddressesRepository, WalletsRepository } from "@services/mongoose"
-import { RedisRateLimitService } from "@services/rate-limit"
+import { TxDecoder } from "@domain/bitcoin/onchain"
 import { RateLimitPrefix } from "@domain/rate-limit"
 import {
   OnChainAddressCreateRateLimiterExceededError,
   RateLimiterExceededError,
 } from "@domain/rate-limit/errors"
+import { OnChainService } from "@services/lnd/onchain-service"
+import { WalletOnChainAddressesRepository } from "@services/mongoose"
+import { RedisRateLimitService } from "@services/rate-limit"
 
 export const createOnChainAddress = async (
   walletId: WalletId,
@@ -31,24 +31,16 @@ export const createOnChainAddress = async (
   return savedOnChainAddress.address
 }
 
-export const createOnChainAddressByWalletPublicId = async (
-  walletPublicId: WalletPublicId,
-): Promise<OnChainAddress | ApplicationError> => {
-  const wallets = WalletsRepository()
-  const wallet = await wallets.findByPublicId(walletPublicId)
-  if (wallet instanceof Error) return wallet
-  return createOnChainAddress(wallet.id)
-}
+const onChainAddressCreateAttempt = getOnChainAddressCreateAttemptLimits()
+const limiterOnChainAddressCreateAttempt = RedisRateLimitService({
+  keyPrefix: RateLimitPrefix.onChainAddressCreate,
+  limitOptions: onChainAddressCreateAttempt,
+})
 
 const checkOnChainAddressWalletIdLimits = async (
   walletId: WalletId,
 ): Promise<true | RateLimiterExceededError> => {
-  const onChainAddressCreateAttempt = getOnChainAddressCreateAttemptLimits()
-  const limiter = RedisRateLimitService({
-    keyPrefix: RateLimitPrefix.onChainAddressCreate,
-    limitOptions: onChainAddressCreateAttempt,
-  })
-  const limitOk = await limiter.consume(walletId)
+  const limitOk = await limiterOnChainAddressCreateAttempt.consume(walletId)
   if (limitOk instanceof RateLimiterExceededError)
     return new OnChainAddressCreateRateLimiterExceededError()
   return limitOk

--- a/src/app/wallets/get-account-transactions-for-contact.ts
+++ b/src/app/wallets/get-account-transactions-for-contact.ts
@@ -1,5 +1,5 @@
 import { LedgerService } from "@services/ledger"
-import { toLiabilitiesWalletId, LedgerError } from "@domain/ledger"
+import { LedgerError } from "@domain/ledger"
 import { WalletTransactionHistory } from "@domain/wallets"
 
 export const getAccountTransactionsForContact = async ({
@@ -13,9 +13,8 @@ export const getAccountTransactionsForContact = async ({
   let transactions: WalletTransaction[] = []
 
   for (const walletId of account.walletIds) {
-    const liabilitiesWalletId = toLiabilitiesWalletId(walletId)
     const ledgerTransactions = await ledger.getLiabilityTransactionsForContactUsername(
-      liabilitiesWalletId,
+      walletId,
       contactUsername,
     )
     if (ledgerTransactions instanceof LedgerError) return ledgerTransactions

--- a/src/app/wallets/get-account-transactions-for-contact.ts
+++ b/src/app/wallets/get-account-transactions-for-contact.ts
@@ -1,5 +1,5 @@
 import { LedgerService } from "@services/ledger"
-import { toLiabilitiesAccountId, LedgerError } from "@domain/ledger"
+import { toLiabilitiesWalletId, LedgerError } from "@domain/ledger"
 import { WalletTransactionHistory } from "@domain/wallets"
 
 export const getAccountTransactionsForContact = async ({
@@ -13,9 +13,9 @@ export const getAccountTransactionsForContact = async ({
   let transactions: WalletTransaction[] = []
 
   for (const walletId of account.walletIds) {
-    const liabilitiesAccountId = toLiabilitiesAccountId(walletId)
+    const liabilitiesWalletId = toLiabilitiesWalletId(walletId)
     const ledgerTransactions = await ledger.getLiabilityTransactionsForContactUsername(
-      liabilitiesAccountId,
+      liabilitiesWalletId,
       contactUsername,
     )
     if (ledgerTransactions instanceof LedgerError) return ledgerTransactions

--- a/src/app/wallets/get-balance-for-wallet.ts
+++ b/src/app/wallets/get-balance-for-wallet.ts
@@ -1,4 +1,4 @@
-import { toLiabilitiesAccountId } from "@domain/ledger"
+import { toLiabilitiesWalletId } from "@domain/ledger"
 import { LedgerService } from "@services/ledger"
 import * as Wallets from "@app/wallets"
 
@@ -13,12 +13,12 @@ export const getBalanceForWallet = async ({
 }): Promise<Satoshis | ApplicationError> => {
   const [, updatePaymentsResult] = await Promise.all([
     Wallets.updatePendingInvoices({
-      walletId: walletId,
+      walletId,
       lock,
       logger,
     }),
     Wallets.updatePendingPayments({
-      walletId: walletId,
+      walletId,
       lock,
       logger,
     }),
@@ -31,9 +31,9 @@ export const getBalanceForWallet = async ({
 export const getBalanceForWalletId = async (
   walletId: WalletId,
 ): Promise<Satoshis | ApplicationError> => {
-  const liabilitiesAccountId = toLiabilitiesAccountId(walletId)
+  const liabilitiesWalletId = toLiabilitiesWalletId(walletId)
 
-  const balance = await LedgerService().getAccountBalance(liabilitiesAccountId)
+  const balance = await LedgerService().getAccountBalance(liabilitiesWalletId)
   if (balance instanceof Error) return balance
 
   return balance

--- a/src/app/wallets/get-balance-for-wallet.ts
+++ b/src/app/wallets/get-balance-for-wallet.ts
@@ -1,4 +1,3 @@
-import { toLiabilitiesWalletId } from "@domain/ledger"
 import { LedgerService } from "@services/ledger"
 import * as Wallets from "@app/wallets"
 
@@ -31,9 +30,7 @@ export const getBalanceForWallet = async ({
 export const getBalanceForWalletId = async (
   walletId: WalletId,
 ): Promise<Satoshis | ApplicationError> => {
-  const liabilitiesWalletId = toLiabilitiesWalletId(walletId)
-
-  const balance = await LedgerService().getAccountBalance(liabilitiesWalletId)
+  const balance = await LedgerService().getAccountBalance(walletId)
   if (balance instanceof Error) return balance
 
   return balance

--- a/src/app/wallets/get-csv-for-wallets.ts
+++ b/src/app/wallets/get-csv-for-wallets.ts
@@ -1,12 +1,12 @@
 import { CSVAccountExport } from "@core/csv-account-export"
-import { accountPath } from "@services/ledger/accounts"
+import { walletPath } from "@services/ledger/accounts"
 
 export const getCSVForWallets = async (
   walletIds: WalletId[],
 ): Promise<string | ApplicationError> => {
   const csv = new CSVAccountExport()
   for (const walletId of walletIds) {
-    await csv.addAccount({ account: accountPath(walletId) })
+    await csv.addAccount({ account: walletPath(walletId) })
   }
   return csv.getBase64()
 }

--- a/src/app/wallets/get-last-on-chain-address.ts
+++ b/src/app/wallets/get-last-on-chain-address.ts
@@ -1,5 +1,5 @@
 import { CouldNotFindError } from "@domain/errors"
-import { WalletsRepository, WalletOnChainAddressesRepository } from "@services/mongoose"
+import { WalletOnChainAddressesRepository } from "@services/mongoose"
 import { createOnChainAddress } from "./create-on-chain-address"
 
 export const getLastOnChainAddress = async (
@@ -14,13 +14,4 @@ export const getLastOnChainAddress = async (
   if (lastOnChainAddress instanceof Error) return lastOnChainAddress
 
   return lastOnChainAddress.address
-}
-
-export const getLastOnChainAddressByWalletPublicId = async (
-  walletPublicId: WalletPublicId,
-): Promise<OnChainAddress | ApplicationError> => {
-  const wallets = WalletsRepository()
-  const wallet = await wallets.findByPublicId(walletPublicId)
-  if (wallet instanceof Error) return wallet
-  return getLastOnChainAddress(wallet.id)
 }

--- a/src/app/wallets/get-on-chain-fee.ts
+++ b/src/app/wallets/get-on-chain-fee.ts
@@ -79,27 +79,3 @@ export const getOnChainFeeByWalletId = async ({
     targetConfirmations: targetConfs,
   })
 }
-
-export const getOnChainFeeByWalletPublicId = async ({
-  walletPublicId,
-  amount,
-  address,
-  targetConfirmations,
-}: GetOnChainFeeByWalletPublicIdArgs): Promise<Satoshis | ApplicationError> => {
-  const sats = checkedToSats(amount)
-  if (sats instanceof Error) return sats
-
-  const targetConfs = checkedToTargetConfs(targetConfirmations)
-  if (targetConfs instanceof Error) return targetConfs
-
-  const wallets = WalletsRepository()
-  const wallet = await wallets.findByPublicId(walletPublicId)
-  if (wallet instanceof Error) return wallet
-
-  return getOnChainFee({
-    wallet,
-    amount: sats,
-    address,
-    targetConfirmations: targetConfs,
-  })
-}

--- a/src/app/wallets/get-transactions-for-wallet.ts
+++ b/src/app/wallets/get-transactions-for-wallet.ts
@@ -1,13 +1,13 @@
-import { RepositoryError } from "@domain/errors"
-import { OnChainError, TxFilter, TxDecoder } from "@domain/bitcoin/onchain"
-import { WalletsRepository } from "@services/mongoose"
-import { LedgerService } from "@services/ledger"
-import { OnChainService } from "@services/lnd/onchain-service"
-import { toLiabilitiesAccountId, LedgerError } from "@domain/ledger"
-import { ONCHAIN_SCAN_DEPTH, ONCHAIN_MIN_CONFIRMATIONS, BTC_NETWORK } from "@config/app"
-import { WalletTransactionHistory } from "@domain/wallets"
 import { PartialResult } from "@app/partial-result"
 import { getCurrentPrice } from "@app/prices"
+import { BTC_NETWORK, ONCHAIN_MIN_CONFIRMATIONS, ONCHAIN_SCAN_DEPTH } from "@config/app"
+import { OnChainError, TxDecoder, TxFilter } from "@domain/bitcoin/onchain"
+import { RepositoryError } from "@domain/errors"
+import { LedgerError, toLiabilitiesWalletId } from "@domain/ledger"
+import { WalletTransactionHistory } from "@domain/wallets"
+import { LedgerService } from "@services/ledger"
+import { OnChainService } from "@services/lnd/onchain-service"
+import { WalletsRepository } from "@services/mongoose"
 
 export const getTransactionsForWalletId = async ({
   walletId,
@@ -24,8 +24,8 @@ export const getTransactionsForWallet = async (
   wallet: Wallet,
 ): Promise<PartialResult<WalletTransaction[]>> => {
   const ledger = LedgerService()
-  const liabilitiesAccountId = toLiabilitiesAccountId(wallet.id)
-  const ledgerTransactions = await ledger.getLiabilityTransactions(liabilitiesAccountId)
+  const liabilitiesWalletId = toLiabilitiesWalletId(wallet.id)
+  const ledgerTransactions = await ledger.getLiabilityTransactions(liabilitiesWalletId)
   if (ledgerTransactions instanceof LedgerError)
     return PartialResult.err(ledgerTransactions)
 

--- a/src/app/wallets/get-transactions-for-wallet.ts
+++ b/src/app/wallets/get-transactions-for-wallet.ts
@@ -3,7 +3,7 @@ import { getCurrentPrice } from "@app/prices"
 import { BTC_NETWORK, ONCHAIN_MIN_CONFIRMATIONS, ONCHAIN_SCAN_DEPTH } from "@config/app"
 import { OnChainError, TxDecoder, TxFilter } from "@domain/bitcoin/onchain"
 import { RepositoryError } from "@domain/errors"
-import { LedgerError, toLiabilitiesWalletId } from "@domain/ledger"
+import { LedgerError } from "@domain/ledger"
 import { WalletTransactionHistory } from "@domain/wallets"
 import { LedgerService } from "@services/ledger"
 import { OnChainService } from "@services/lnd/onchain-service"
@@ -24,8 +24,7 @@ export const getTransactionsForWallet = async (
   wallet: Wallet,
 ): Promise<PartialResult<WalletTransaction[]>> => {
   const ledger = LedgerService()
-  const liabilitiesWalletId = toLiabilitiesWalletId(wallet.id)
-  const ledgerTransactions = await ledger.getLiabilityTransactions(liabilitiesWalletId)
+  const ledgerTransactions = await ledger.getLiabilityTransactions(wallet.id)
   if (ledgerTransactions instanceof LedgerError)
     return PartialResult.err(ledgerTransactions)
 

--- a/src/app/wallets/index.ts
+++ b/src/app/wallets/index.ts
@@ -22,20 +22,3 @@ export const getWallet = async (walletId: WalletId) => {
   const wallets = WalletsRepository()
   return wallets.findById(walletId)
 }
-
-export const getWalletByPublicId = async (
-  walletPublicId: WalletPublicId,
-): Promise<Wallet | ApplicationError> => {
-  const wallets = WalletsRepository()
-  return wallets.findByPublicId(walletPublicId)
-}
-
-export const walletIdFromPublicId = async (
-  walletPublicId: WalletPublicId,
-): Promise<WalletId | RepositoryError> => {
-  const walletsRepo = WalletsRepository()
-  const wallet = await walletsRepo.findByPublicId(walletPublicId)
-  if (wallet instanceof Error) return wallet
-
-  return wallet.id
-}

--- a/src/app/wallets/index.types.d.ts
+++ b/src/app/wallets/index.types.d.ts
@@ -1,5 +1,5 @@
-type AddInvoiceByWalletPublicIdArgs = {
-  walletPublicId: WalletPublicId
+type addInvoiceByWalletIdArgs = {
+  walletId: WalletId
   amount: number
   memo?: string
 }
@@ -10,8 +10,8 @@ type AddInvoiceArgs = {
   memo?: string
 }
 
-type AddInvoiceNoAmountByWalletPublicIdArgs = {
-  walletPublicId: WalletPublicId
+type AddInvoiceNoAmountByWalletIdArgs = {
+  walletId: WalletId
   memo?: string
 }
 
@@ -21,14 +21,14 @@ type AddInvoiceNoAmountArgs = {
 }
 
 type AddInvoiceForRecipientArgs = {
-  recipientWalletPublicId: WalletPublicId
+  recipientWalletId: WalletId
   amount: number
   memo?: string
   descriptionHash?: string
 }
 
 type AddInvoiceNoAmountForRecipientArgs = {
-  recipientWalletPublicId: WalletPublicId
+  recipientWalletId: WalletId
   memo?: string
 }
 
@@ -46,13 +46,6 @@ type GetOnChainFeeByWalletIdArgs = {
   targetConfirmations: number
 }
 
-type GetOnChainFeeByWalletPublicIdArgs = {
-  walletPublicId: WalletPublicId
-  amount: number
-  address: OnChainAddress
-  targetConfirmations: number
-}
-
 type PaymentSendArgs = {
   memo: string | null
   walletId: WalletId
@@ -60,16 +53,16 @@ type PaymentSendArgs = {
   logger: Logger
 }
 
-type PayLnInvoiceByWalletPublicIdArgs = {
-  walletPublicId: WalletPublicId
+type PayLnInvoiceByWalletIdArgs = {
+  walletId: WalletId
   paymentRequest: EncodedPaymentRequest
   memo: string | null
   userId: UserId
   logger: Logger
 }
 
-type PayLnNoAmountInvoiceByWalletPublicIdArgs = {
-  walletPublicId: WalletPublicId
+type payLnNoAmountInvoiceByWalletIdArgs = {
+  walletId: WalletId
   paymentRequest: EncodedPaymentRequest
   amount: Satoshis
   memo: string | null

--- a/src/app/wallets/intraledger-send-payment.ts
+++ b/src/app/wallets/intraledger-send-payment.ts
@@ -165,6 +165,7 @@ const executePaymentViaIntraledger = async ({
   if (recipientUser instanceof Error) return recipientUser
   if (recipientUser.id === userId) return new SelfPaymentError()
   // FIXME: selfPayment should be at the walletId level, no longer at the UserId
+  // but this is not a bloquer until we have multiple wallets per account
 
   const recipientAccount = await AccountsRepository().findById(
     recipientUser.defaultAccountId,
@@ -206,7 +207,7 @@ const executePaymentViaIntraledger = async ({
         fee: lnFee,
         usd,
         usdFee,
-        recipientLiabilitiesAccountId: toLiabilitiesWalletId(recipientWalletId),
+        recipientLiabilitiesWalletId: toLiabilitiesWalletId(recipientWalletId),
         payerUsername: username,
         recipientUsername,
         memoPayer,

--- a/src/app/wallets/intraledger-send-payment.ts
+++ b/src/app/wallets/intraledger-send-payment.ts
@@ -13,7 +13,6 @@ import {
   SatoshiAmountRequiredError,
   SelfPaymentError,
 } from "@domain/errors"
-import { toLiabilitiesWalletId } from "@domain/ledger"
 import { LedgerService } from "@services/ledger"
 import { LockService } from "@services/lock"
 import {
@@ -198,16 +197,15 @@ const executePaymentViaIntraledger = async ({
       )
     }
 
-    const liabilitiesWalletId = toLiabilitiesWalletId(walletId)
     const journal = await LockService().extendLock({ logger, lock }, async () =>
       LedgerService().addUsernameIntraledgerTxSend({
-        liabilitiesWalletId,
+        walletId,
         description: "",
         sats,
         fee: lnFee,
         usd,
         usdFee,
-        recipientLiabilitiesWalletId: toLiabilitiesWalletId(recipientWalletId),
+        recipientWalletId,
         payerUsername: username,
         recipientUsername,
         memoPayer,

--- a/src/app/wallets/ln-send-payment.ts
+++ b/src/app/wallets/ln-send-payment.ts
@@ -9,7 +9,7 @@ import { getBalanceForWallet } from "@app/wallets"
 
 import { PaymentInitiationMethod, SettlementMethod } from "@domain/wallets"
 import { toMilliSatsFromNumber, toSats } from "@domain/bitcoin"
-import { toLiabilitiesAccountId } from "@domain/ledger"
+import { toLiabilitiesWalletId } from "@domain/ledger"
 import { WalletInvoiceValidator } from "@domain/wallet-invoices"
 
 import {
@@ -94,19 +94,15 @@ export const lnInvoicePaymentSendWithTwoFA = async ({
     },
   )
 
-export const payLnInvoiceByWalletPublicId = async ({
-  walletPublicId,
+export const payLnInvoiceByWalletId = async ({
+  walletId,
   paymentRequest,
   memo,
   userId,
   logger,
-}: PayLnInvoiceByWalletPublicIdArgs): Promise<PaymentSendStatus | ApplicationError> => {
-  const wallets = WalletsRepository()
-  const wallet = await wallets.findByPublicId(walletPublicId)
-  if (wallet instanceof Error) return wallet
-
+}: PayLnInvoiceByWalletIdArgs): Promise<PaymentSendStatus | ApplicationError> => {
   return lnInvoicePaymentSend({
-    walletId: wallet.id,
+    walletId,
     paymentRequest,
     memo,
     userId,
@@ -210,22 +206,16 @@ export const lnNoAmountInvoicePaymentSendWithTwoFA = async ({
     },
   )
 
-export const payLnNoAmountInvoiceByWalletPublicId = async ({
-  walletPublicId,
+export const payLnNoAmountInvoiceByWalletId = async ({
+  walletId,
   paymentRequest,
   amount,
   memo,
   userId,
   logger,
-}: PayLnNoAmountInvoiceByWalletPublicIdArgs): Promise<
-  PaymentSendStatus | ApplicationError
-> => {
-  const wallets = WalletsRepository()
-  const wallet = await wallets.findByPublicId(walletPublicId)
-  if (wallet instanceof Error) return wallet
-
+}: payLnNoAmountInvoiceByWalletIdArgs): Promise<PaymentSendStatus | ApplicationError> => {
   return lnNoAmountInvoicePaymentSend({
-    walletId: wallet.id,
+    walletId,
     paymentRequest,
     amount,
     memo,
@@ -392,17 +382,17 @@ const executePaymentViaIntraledger = async ({
       )
     }
 
-    const liabilitiesAccountId = toLiabilitiesAccountId(payerWalletId)
+    const liabilitiesWalletId = toLiabilitiesWalletId(payerWalletId)
     const journal = await LockService().extendLock({ logger, lock }, async () =>
       LedgerService().addLnIntraledgerTxSend({
-        liabilitiesAccountId,
+        liabilitiesWalletId,
         paymentHash,
         description,
         sats,
         fee: lnFee,
         usd,
         usdFee,
-        recipientLiabilitiesAccountId: toLiabilitiesAccountId(recipientWalletId),
+        recipientLiabilitiesAccountId: toLiabilitiesWalletId(recipientWalletId),
         pubkey: lndService.defaultPubkey(),
         payerUsername,
         recipientUsername: null,
@@ -492,10 +482,10 @@ const executePaymentViaLn = async ({
     }
 
     const ledgerService = LedgerService()
-    const liabilitiesAccountId = toLiabilitiesAccountId(walletId)
+    const liabilitiesWalletId = toLiabilitiesWalletId(walletId)
     const journal = await LockService().extendLock({ logger, lock }, async () =>
       ledgerService.addLnTxSend({
-        liabilitiesAccountId,
+        liabilitiesWalletId,
         paymentHash,
         description: decodedInvoice.description,
         sats,
@@ -536,7 +526,7 @@ const executePaymentViaLn = async ({
 
     if (!rawRoute) {
       const reimbursed = await reimburseFee({
-        liabilitiesAccountId,
+        liabilitiesWalletId,
         journalId,
         paymentHash,
         maxFee,

--- a/src/app/wallets/ln-send-payment.ts
+++ b/src/app/wallets/ln-send-payment.ts
@@ -392,7 +392,7 @@ const executePaymentViaIntraledger = async ({
         fee: lnFee,
         usd,
         usdFee,
-        recipientLiabilitiesAccountId: toLiabilitiesWalletId(recipientWalletId),
+        recipientLiabilitiesWalletId: toLiabilitiesWalletId(recipientWalletId),
         pubkey: lndService.defaultPubkey(),
         payerUsername,
         recipientUsername: null,

--- a/src/app/wallets/ln-send-payment.ts
+++ b/src/app/wallets/ln-send-payment.ts
@@ -9,7 +9,6 @@ import { getBalanceForWallet } from "@app/wallets"
 
 import { PaymentInitiationMethod, SettlementMethod } from "@domain/wallets"
 import { toMilliSatsFromNumber, toSats } from "@domain/bitcoin"
-import { toLiabilitiesWalletId } from "@domain/ledger"
 import { WalletInvoiceValidator } from "@domain/wallet-invoices"
 
 import {
@@ -382,17 +381,16 @@ const executePaymentViaIntraledger = async ({
       )
     }
 
-    const liabilitiesWalletId = toLiabilitiesWalletId(payerWalletId)
     const journal = await LockService().extendLock({ logger, lock }, async () =>
       LedgerService().addLnIntraledgerTxSend({
-        liabilitiesWalletId,
+        walletId: payerWalletId,
         paymentHash,
         description,
         sats,
         fee: lnFee,
         usd,
         usdFee,
-        recipientLiabilitiesWalletId: toLiabilitiesWalletId(recipientWalletId),
+        recipientWalletId,
         pubkey: lndService.defaultPubkey(),
         payerUsername,
         recipientUsername: null,
@@ -482,10 +480,9 @@ const executePaymentViaLn = async ({
     }
 
     const ledgerService = LedgerService()
-    const liabilitiesWalletId = toLiabilitiesWalletId(walletId)
     const journal = await LockService().extendLock({ logger, lock }, async () =>
       ledgerService.addLnTxSend({
-        liabilitiesWalletId,
+        walletId,
         paymentHash,
         description: decodedInvoice.description,
         sats,
@@ -526,7 +523,7 @@ const executePaymentViaLn = async ({
 
     if (!rawRoute) {
       const reimbursed = await reimburseFee({
-        liabilitiesWalletId,
+        walletId,
         journalId,
         paymentHash,
         maxFee,

--- a/src/app/wallets/reimburse-fee.ts
+++ b/src/app/wallets/reimburse-fee.ts
@@ -3,14 +3,14 @@ import { FeeReimbursement } from "@domain/ledger/fee-reimbursement"
 import { LedgerService } from "@services/ledger"
 
 export const reimburseFee = async ({
-  liabilitiesWalletId,
+  walletId,
   journalId,
   paymentHash,
   maxFee,
   actualFee,
   logger,
 }: {
-  liabilitiesWalletId: LiabilitiesWalletId
+  walletId: WalletId
   journalId: LedgerJournalId
   paymentHash: PaymentHash
   maxFee: Satoshis
@@ -48,7 +48,7 @@ export const reimburseFee = async ({
 
   const ledgerService = LedgerService()
   const result = await ledgerService.addLnFeeReimbursementReceive({
-    liabilitiesWalletId,
+    walletId,
     paymentHash,
     sats: feeDifference,
     usd,

--- a/src/app/wallets/reimburse-fee.ts
+++ b/src/app/wallets/reimburse-fee.ts
@@ -3,14 +3,14 @@ import { FeeReimbursement } from "@domain/ledger/fee-reimbursement"
 import { LedgerService } from "@services/ledger"
 
 export const reimburseFee = async ({
-  liabilitiesAccountId,
+  liabilitiesWalletId,
   journalId,
   paymentHash,
   maxFee,
   actualFee,
   logger,
 }: {
-  liabilitiesAccountId: LiabilitiesAccountId
+  liabilitiesWalletId: LiabilitiesWalletId
   journalId: LedgerJournalId
   paymentHash: PaymentHash
   maxFee: Satoshis
@@ -48,7 +48,7 @@ export const reimburseFee = async ({
 
   const ledgerService = LedgerService()
   const result = await ledgerService.addLnFeeReimbursementReceive({
-    liabilitiesAccountId,
+    liabilitiesWalletId,
     paymentHash,
     sats: feeDifference,
     usd,

--- a/src/app/wallets/update-on-chain-receipt.ts
+++ b/src/app/wallets/update-on-chain-receipt.ts
@@ -3,7 +3,7 @@ import { OnChainService } from "@services/lnd/onchain-service"
 import { NotificationsService } from "@services/notifications"
 import { LedgerService } from "@services/ledger"
 import { OnChainError, TxDecoder } from "@domain/bitcoin/onchain"
-import { toLiabilitiesAccountId } from "@domain/ledger"
+import { toLiabilitiesWalletId } from "@domain/ledger"
 import { DepositFeeCalculator } from "@domain/wallets"
 import { LockService } from "@services/lock"
 import { ONCHAIN_SCAN_DEPTH, ONCHAIN_MIN_CONFIRMATIONS, BTC_NETWORK } from "@config/app"
@@ -79,12 +79,12 @@ const processTxForWallet = async (
   const usdPerSat = await getCurrentPrice()
   if (usdPerSat instanceof Error) return usdPerSat
 
-  const liabilitiesAccountId = toLiabilitiesAccountId(wallet.id)
+  const liabilitiesWalletId = toLiabilitiesWalletId(wallet.id)
 
   const lockService = LockService()
   return lockService.lockOnChainTxHash({ txHash: tx.rawTx.txHash, logger }, async () => {
     const recorded = await ledger.isOnChainTxRecorded(
-      liabilitiesAccountId,
+      liabilitiesWalletId,
       tx.rawTx.txHash,
     )
     if (recorded instanceof Error) {
@@ -103,7 +103,7 @@ const processTxForWallet = async (
           const usdFee = fee * usdPerSat
 
           const result = await ledger.addOnChainTxReceive({
-            liabilitiesAccountId,
+            liabilitiesWalletId,
             txHash: tx.rawTx.txHash,
             sats,
             fee,

--- a/src/app/wallets/update-on-chain-receipt.ts
+++ b/src/app/wallets/update-on-chain-receipt.ts
@@ -3,7 +3,6 @@ import { OnChainService } from "@services/lnd/onchain-service"
 import { NotificationsService } from "@services/notifications"
 import { LedgerService } from "@services/ledger"
 import { OnChainError, TxDecoder } from "@domain/bitcoin/onchain"
-import { toLiabilitiesWalletId } from "@domain/ledger"
 import { DepositFeeCalculator } from "@domain/wallets"
 import { LockService } from "@services/lock"
 import { ONCHAIN_SCAN_DEPTH, ONCHAIN_MIN_CONFIRMATIONS, BTC_NETWORK } from "@config/app"
@@ -79,14 +78,12 @@ const processTxForWallet = async (
   const usdPerSat = await getCurrentPrice()
   if (usdPerSat instanceof Error) return usdPerSat
 
-  const liabilitiesWalletId = toLiabilitiesWalletId(wallet.id)
-
   const lockService = LockService()
   return lockService.lockOnChainTxHash({ txHash: tx.rawTx.txHash, logger }, async () => {
-    const recorded = await ledger.isOnChainTxRecorded(
-      liabilitiesWalletId,
-      tx.rawTx.txHash,
-    )
+    const recorded = await ledger.isOnChainTxRecorded({
+      walletId: wallet.id,
+      txHash: tx.rawTx.txHash,
+    })
     if (recorded instanceof Error) {
       logger.error({ error: recorded }, "Could not query ledger")
       return recorded
@@ -103,7 +100,7 @@ const processTxForWallet = async (
           const usdFee = fee * usdPerSat
 
           const result = await ledger.addOnChainTxReceive({
-            liabilitiesWalletId,
+            walletId: wallet.id,
             txHash: tx.rawTx.txHash,
             sats,
             fee,

--- a/src/app/wallets/update-pending-invoices.ts
+++ b/src/app/wallets/update-pending-invoices.ts
@@ -1,7 +1,6 @@
 import { getCurrentPrice } from "@app/prices"
 import { InvoiceNotFoundError } from "@domain/bitcoin/lightning"
 import { CouldNotFindError } from "@domain/errors"
-import { toLiabilitiesWalletId } from "@domain/ledger"
 import { DepositFeeCalculator } from "@domain/wallets"
 import { LedgerService } from "@services/ledger"
 import { LndService } from "@services/lnd"
@@ -123,10 +122,9 @@ const updatePendingInvoice = async ({
       const usd = received * usdPerSat
       const usdFee = fee * usdPerSat
 
-      const liabilitiesWalletId = toLiabilitiesWalletId(walletId)
       const ledgerService = LedgerService()
       const result = await ledgerService.addLnTxReceive({
-        liabilitiesWalletId,
+        walletId,
         paymentHash,
         description,
         sats: received,

--- a/src/app/wallets/update-pending-invoices.ts
+++ b/src/app/wallets/update-pending-invoices.ts
@@ -1,14 +1,12 @@
 import { getCurrentPrice } from "@app/prices"
-
 import { InvoiceNotFoundError } from "@domain/bitcoin/lightning"
-import { toLiabilitiesAccountId } from "@domain/ledger"
 import { CouldNotFindError } from "@domain/errors"
+import { toLiabilitiesWalletId } from "@domain/ledger"
 import { DepositFeeCalculator } from "@domain/wallets"
-
-import { LndService } from "@services/lnd"
 import { LedgerService } from "@services/ledger"
-import { WalletInvoicesRepository } from "@services/mongoose"
+import { LndService } from "@services/lnd"
 import { LockService } from "@services/lock"
+import { WalletInvoicesRepository } from "@services/mongoose"
 import { NotificationsService } from "@services/notifications"
 
 export const updatePendingInvoices = async ({
@@ -81,7 +79,7 @@ const updatePendingInvoice = async ({
   if (lnInvoiceLookup.isSettled) {
     const pendingInvoiceLogger = logger.child({
       hash: paymentHash,
-      wallet: walletId,
+      walletId,
       topic: "payment",
       protocol: "lightning",
       transactionType: "receipt",
@@ -125,10 +123,10 @@ const updatePendingInvoice = async ({
       const usd = received * usdPerSat
       const usdFee = fee * usdPerSat
 
-      const liabilitiesAccountId = toLiabilitiesAccountId(walletId)
+      const liabilitiesWalletId = toLiabilitiesWalletId(walletId)
       const ledgerService = LedgerService()
       const result = await ledgerService.addLnTxReceive({
-        liabilitiesAccountId,
+        liabilitiesWalletId,
         paymentHash,
         description,
         sats: received,
@@ -141,7 +139,7 @@ const updatePendingInvoice = async ({
       const notificationsService = NotificationsService(logger)
       notificationsService.lnInvoicePaid({
         paymentHash,
-        recipientWalletId: updatedWalletInvoice.walletId,
+        recipientWalletId: walletId,
         amount: received,
         usdPerSat,
       })

--- a/src/core/balance-sheet.ts
+++ b/src/core/balance-sheet.ts
@@ -27,7 +27,7 @@ const updatePendingLightningInvoices = async () => {
   await runInParallel({
     iterator: walletIdsWithPendingInvoices,
     logger,
-    processor: async (walletId, index) => {
+    processor: async (walletId: WalletId, index) => {
       logger.trace(
         "updating pending invoices for wallet %s in worker %d",
         walletId,
@@ -58,7 +58,7 @@ const updatePendingLightningPayments = async () => {
         index,
       )
       const result = await Wallets.updatePendingPayments({
-        walletId: ledger.resolveAccountId(account) as WalletId,
+        walletId: ledger.resolveWalletId(account) as WalletId,
         logger,
       })
       if (result instanceof Error) throw result

--- a/src/core/lightning/wallet.ts
+++ b/src/core/lightning/wallet.ts
@@ -50,7 +50,7 @@ export class LightningUserWallet extends OnChainMixin(UserWallet) {
         if (userPastState.earn.findIndex((item) => item === id) === -1) {
           // FIXME: use pay by username instead
           const lnInvoice = await addInvoice({
-            walletId: this.user.id,
+            walletId: this.user.walletId,
             amount,
             memo: id,
           })
@@ -59,7 +59,7 @@ export class LightningUserWallet extends OnChainMixin(UserWallet) {
           const payResult = await lnInvoicePaymentSend({
             paymentRequest: lnInvoice.paymentRequest,
             memo: null,
-            walletId: lightningFundingWallet.user.id,
+            walletId: lightningFundingWallet.user.walletId,
             userId: lightningFundingWallet.user.id,
             logger: this.logger,
           })

--- a/src/core/lightning/wallet.ts
+++ b/src/core/lightning/wallet.ts
@@ -35,7 +35,7 @@ export class LightningUserWallet extends OnChainMixin(UserWallet) {
       logger: this.logger,
     })
 
-    return redlock({ path: this.user._id, logger: this.logger }, async () => {
+    return redlock({ path: this.user.walletId, logger: this.logger }, async () => {
       const result: Record<string, unknown>[] = []
 
       for (const id of ids) {

--- a/src/core/on-chain/index.ts
+++ b/src/core/on-chain/index.ts
@@ -169,7 +169,7 @@ export const OnChainMixin = (superclass) =>
                 usdFee,
                 payeeAddresses: [address as OnChainAddress],
                 sendAll,
-                recipientLiabilitiesAccountId: toLiabilitiesWalletId(payeeUser.walletId),
+                recipientLiabilitiesWalletId: toLiabilitiesWalletId(payeeUser.walletId),
                 payerUsername: this.user.username,
                 recipientUsername: payeeUser.username,
                 memoPayer: memo || null,

--- a/src/core/on-chain/index.ts
+++ b/src/core/on-chain/index.ts
@@ -8,7 +8,6 @@ import {
 import { BTC_NETWORK, ONCHAIN_SCAN_DEPTH_OUTGOING } from "@config/app"
 import { toSats } from "@domain/bitcoin"
 import { TxDecoder } from "@domain/bitcoin/onchain"
-import { toLiabilitiesWalletId } from "@domain/ledger"
 import { TwoFANewCodeNeededError } from "@domain/twoFA"
 import { LedgerService } from "@services/ledger"
 import { OnChainService } from "@services/lnd/onchain-service"
@@ -161,7 +160,7 @@ export const OnChainMixin = (superclass) =>
             { logger: onchainLoggerOnUs, lock },
             async () =>
               LedgerService().addOnChainIntraledgerTxSend({
-                liabilitiesWalletId: toLiabilitiesWalletId(this.user.walletId),
+                walletId: this.user.walletId,
                 description: "",
                 sats: toSats(sats),
                 fee: onChainFee,
@@ -169,7 +168,7 @@ export const OnChainMixin = (superclass) =>
                 usdFee,
                 payeeAddresses: [address as OnChainAddress],
                 sendAll,
-                recipientLiabilitiesWalletId: toLiabilitiesWalletId(payeeUser.walletId),
+                recipientWalletId: payeeUser.walletId,
                 payerUsername: this.user.username,
                 recipientUsername: payeeUser.username,
                 memoPayer: memo || null,

--- a/src/core/user-wallet.ts
+++ b/src/core/user-wallet.ts
@@ -264,7 +264,7 @@ export abstract class UserWallet {
 
   sendBalance = async (): Promise<void> => {
     const balanceSats = await Wallets.getBalanceForWallet({
-      walletId: this.user.id as WalletId,
+      walletId: this.user.walletId,
       logger: this.logger,
     })
     if (balanceSats instanceof Error) throw balanceSats

--- a/src/core/user-wallet.ts
+++ b/src/core/user-wallet.ts
@@ -35,13 +35,14 @@ export abstract class UserWallet {
   }
 
   async getBalances(lock?): Promise<Balances> {
-    Wallets.updatePendingInvoices({
-      walletId: this.user.id as WalletId,
+    // was the await omit on purpose?
+    await Wallets.updatePendingInvoices({
+      walletId: this.user.walletId as WalletId,
       lock,
       logger: this.logger,
     })
     const result = await Wallets.updatePendingPayments({
-      walletId: this.user.id as WalletId,
+      walletId: this.user.walletId as WalletId,
       lock,
       logger: this.logger,
     })

--- a/src/core/user-wallet.ts
+++ b/src/core/user-wallet.ts
@@ -58,7 +58,7 @@ export abstract class UserWallet {
 
     // TODO: run this code in parrallel
     for (const { id } of this.user.currencies) {
-      const balance = await ledger.getAccountBalance(this.user.accountPath, {
+      const balance = await ledger.getAccountBalance(this.user.walletPath, {
         currency: id,
       })
 
@@ -101,7 +101,7 @@ export abstract class UserWallet {
 
   async getStringCsv() {
     const csv = new CSVAccountExport()
-    await csv.addAccount({ account: this.user.accountPath })
+    await csv.addAccount({ account: this.user.walletPath })
     return csv.getBase64()
   }
 

--- a/src/core/wallets.ts
+++ b/src/core/wallets.ts
@@ -1,4 +1,4 @@
-import { checkRecipientWalletIdLimits, registerAndPersistInvoice } from "@app/wallets"
+import { checkRecipientWalletIdRateLimits, registerAndPersistInvoice } from "@app/wallets"
 
 import { checkedToSats, toSats } from "@domain/bitcoin"
 import { checkedToUsername } from "@domain/users"
@@ -28,7 +28,7 @@ export const addInvoiceForUsername = async ({
   const walletId = await walletIdFromUsername(checkedUsername)
   if (walletId instanceof Error) return walletId
 
-  const limitOk = await checkRecipientWalletIdLimits(walletId)
+  const limitOk = await checkRecipientWalletIdRateLimits(walletId)
   if (limitOk instanceof Error) return limitOk
   const sats = checkedToSats(amount)
   if (sats instanceof Error) return sats
@@ -51,7 +51,7 @@ export const addInvoiceNoAmountForUsername = async ({
   const walletId = await walletIdFromUsername(checkedUsername)
   if (walletId instanceof Error) return walletId
 
-  const limitOk = await checkRecipientWalletIdLimits(walletId)
+  const limitOk = await checkRecipientWalletIdRateLimits(walletId)
   if (limitOk instanceof Error) return limitOk
 
   const walletInvoiceFactory = WalletInvoiceFactory(walletId)

--- a/src/debug/export-accounts-to-csv.ts
+++ b/src/debug/export-accounts-to-csv.ts
@@ -39,7 +39,7 @@ const exportAllUserLedger = async () => {
   const csv = new CSVAccountExport()
 
   for await (const user of User.find({})) {
-    await csv.addAccount({ account: ledger.accountPath(user._id) })
+    await csv.addAccount({ account: ledger.walletPath(user.walletId) })
   }
 
   await csv.saveToDisk()
@@ -101,14 +101,14 @@ const exportUsers = async () => {
     }
 
     for (const currency of ["USD", "BTC"]) {
-      record[`balance${currency}`] = await ledger.getAccountBalance(user.accountPath, {
+      record[`balance${currency}`] = await ledger.getAccountBalance(user.walletPath, {
         currency,
       })
     }
 
     try {
       const { totalDebit, totalCredit, countTxs } = _.find(aggregateTxs, {
-        _id: user.accountPath,
+        _id: user.walletPath,
       })
       record["totalDebit"] = totalDebit
       record["totalCredit"] = totalCredit

--- a/src/domain/accounts/index.types.d.ts
+++ b/src/domain/accounts/index.types.d.ts
@@ -13,7 +13,7 @@ type Account = {
   readonly id: AccountId
   readonly createdAt: Date
   readonly username: Username
-  readonly defaultWalletId: WalletPublicId
+  readonly defaultWalletId: WalletId
   readonly ownerId: UserId
   level: AccountLevel
   status: AccountStatus
@@ -73,7 +73,6 @@ interface IAccountsRepository {
   findById(accountId: AccountId): Promise<Account | RepositoryError>
   listByUserId(userId: UserId): Promise<Account[] | RepositoryError>
   findByWalletId(walletId: WalletId): Promise<Account | RepositoryError>
-  findByWalletPublicId(walletPublicId: WalletPublicId): Promise<Account | RepositoryError>
   findByUsername(username: Username): Promise<Account | RepositoryError>
   listBusinessesForMap(): Promise<BusinessMapMarker[] | RepositoryError>
   update(account: Account): Promise<Account | RepositoryError>

--- a/src/domain/bitcoin/lightning/index.types.d.ts
+++ b/src/domain/bitcoin/lightning/index.types.d.ts
@@ -90,6 +90,7 @@ type RegisterInvoiceArgs = {
 type RegisteredInvoice = {
   invoice: LnInvoice
   pubkey: Pubkey
+  descriptionHash: string // TODO: proper type
 }
 
 type LnFeeCalculator = {

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -39,7 +39,7 @@ export class InvalidCoordinatesError extends ValidationError {}
 export class InvalidBusinessTitleLengthError extends ValidationError {}
 export class InvalidAccountStatusError extends ValidationError {}
 export class InvalidPhoneNumber extends ValidationError {}
-export class InvalidPublicWalletId extends ValidationError {}
+export class InvalidWalletId extends ValidationError {}
 export class InvalidLedgerTransactionId extends ValidationError {}
 export class AlreadyPaidError extends ValidationError {}
 export class SelfPaymentError extends ValidationError {}

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -24,7 +24,6 @@ export class CouldNotFindPhoneCodeError extends CouldNotFindError {}
 export class CouldNotFindWalletFromIdError extends CouldNotFindError {}
 export class CouldNotFindWalletFromUsernameError extends CouldNotFindError {}
 export class CouldNotFindWalletFromOnChainAddressError extends CouldNotFindError {}
-export class CouldNotFindWalletFromPublicIdError extends CouldNotFindError {}
 export class CouldNotFindWalletFromOnChainAddressesError extends CouldNotFindError {}
 
 export class CouldNotFindAccountFromUsernameError extends CouldNotFindError {}

--- a/src/domain/ledger/index.ts
+++ b/src/domain/ledger/index.ts
@@ -4,8 +4,8 @@ export * from "./errors"
 
 export const liabilitiesMainAccount = "Liabilities"
 
-export const toLiabilitiesAccountId = (walletId: WalletId): LiabilitiesAccountId =>
-  `${liabilitiesMainAccount}:${walletId}` as LiabilitiesAccountId
+export const toLiabilitiesWalletId = (walletId: WalletId): LiabilitiesWalletId =>
+  `${liabilitiesMainAccount}:${walletId}` as LiabilitiesWalletId
 
 export const LedgerTransactionType = {
   Invoice: "invoice",
@@ -31,8 +31,8 @@ export const ExtendedLedgerTransactionType = {
   LnIntraLedger: "ln_on_us",
 } as const
 
-export const toWalletId = (accountId: LiabilitiesAccountId): WalletId | null => {
-  const path = accountId.split(":")
+export const toWalletId = (walletIdPath: LiabilitiesWalletId): WalletId | null => {
+  const path = walletIdPath.split(":")
 
   if (
     Array.isArray(path) &&

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -44,6 +44,7 @@ type LedgerTransaction = {
   readonly feeUsd: number
 
   // for IntraLedger
+  readonly recipientWalletId?: WalletId
   readonly username?: Username
   readonly memoFromPayer?: string
 

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -91,7 +91,7 @@ type IntraledgerTxArgs = {
   liabilitiesWalletId: LiabilitiesWalletId
   description: string
   sats: Satoshis
-  recipientLiabilitiesAccountId: LiabilitiesWalletId | null
+  recipientLiabilitiesWalletId: LiabilitiesWalletId | null
   payerUsername: Username | null
   recipientUsername: Username | null
   memoPayer: string | null

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -28,7 +28,7 @@ type LedgerJournal = {
 // Differentiate fields depending on what 'type' we have (see domain/wallets/index.types.d.ts)
 type LedgerTransaction = {
   readonly id: LedgerTransactionId
-  readonly walletId: WalletId | null // FIXME XXX should not be null!?
+  readonly walletId: WalletId | null // FIXME create a subclass so that this field is always set for liabilities wallets
   readonly type: LedgerTransactionType
   readonly debit: Satoshis
   readonly credit: Satoshis

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -1,8 +1,8 @@
 type LedgerError = import("./errors").LedgerError
 type LedgerServiceError = import("./errors").LedgerServiceError
 
-declare const liabilitiesAccountId: unique symbol
-type LiabilitiesAccountId = string & { [liabilitiesAccountId]: never }
+declare const liabilitiesWalletId: unique symbol
+type LiabilitiesWalletId = string & { [liabilitiesWalletId]: never }
 
 declare const ledgerTransactionIdSymbol: unique symbol
 type LedgerTransactionId = string & { [ledgerTransactionIdSymbol]: never }
@@ -28,7 +28,7 @@ type LedgerJournal = {
 // Differentiate fields depending on what 'type' we have (see domain/wallets/index.types.d.ts)
 type LedgerTransaction = {
   readonly id: LedgerTransactionId
-  readonly walletId: WalletId | null
+  readonly walletId: WalletId | null // FIXME XXX should not be null!?
   readonly type: LedgerTransactionType
   readonly debit: Satoshis
   readonly credit: Satoshis
@@ -44,7 +44,6 @@ type LedgerTransaction = {
   readonly feeUsd: number
 
   // for IntraLedger
-  readonly walletPublicId?: WalletPublicId
   readonly username?: Username
   readonly memoFromPayer?: string
 
@@ -59,7 +58,7 @@ type LedgerTransaction = {
 }
 
 type ReceiveOnChainTxArgs = {
-  liabilitiesAccountId: LiabilitiesAccountId
+  liabilitiesWalletId: LiabilitiesWalletId
   txHash: OnChainTxHash
   sats: Satoshis
   fee: Satoshis
@@ -69,7 +68,7 @@ type ReceiveOnChainTxArgs = {
 }
 
 type TxArgs = {
-  liabilitiesAccountId: LiabilitiesAccountId
+  liabilitiesWalletId: LiabilitiesWalletId
   description: string
   sats: Satoshis
   fee: Satoshis
@@ -89,10 +88,10 @@ type AddLnTxSendArgs = LnTxArgs & {
 }
 
 type IntraledgerTxArgs = {
-  liabilitiesAccountId: LiabilitiesAccountId
+  liabilitiesWalletId: LiabilitiesWalletId
   description: string
   sats: Satoshis
-  recipientLiabilitiesAccountId: LiabilitiesAccountId | null
+  recipientLiabilitiesAccountId: LiabilitiesWalletId | null
   payerUsername: Username | null
   recipientUsername: Username | null
   memoPayer: string | null
@@ -119,7 +118,7 @@ type AddUsernameIntraledgerTxSendArgs = AddIntraLedgerTxSendArgs & {
 }
 
 type AddLnFeeReeimbursementReceiveArgs = {
-  liabilitiesAccountId: LiabilitiesAccountId
+  liabilitiesWalletId: LiabilitiesWalletId
   paymentHash: PaymentHash
   sats: Satoshis
   usd: number
@@ -145,52 +144,52 @@ interface ILedgerService {
   ): Promise<LedgerTransaction[] | LedgerServiceError>
 
   getLiabilityTransactions(
-    liabilitiesAccountId: LiabilitiesAccountId,
+    liabilitiesWalletId: LiabilitiesWalletId,
   ): Promise<LedgerTransaction[] | LedgerServiceError>
 
   getLiabilityTransactionsForContactUsername(
-    liabilitiesAccountId: LiabilitiesAccountId,
+    liabilitiesWalletId: LiabilitiesWalletId,
     contactUsername: Username,
   ): Promise<LedgerTransaction[] | LedgerServiceError>
 
   listPendingPayments(
-    liabilitiesAccountId: LiabilitiesAccountId,
+    liabilitiesWalletId: LiabilitiesWalletId,
   ): Promise<LedgerTransaction[] | LedgerServiceError>
 
   getPendingPaymentsCount(
-    liabilitiesAccountId: LiabilitiesAccountId,
+    liabilitiesWalletId: LiabilitiesWalletId,
   ): Promise<number | LedgerServiceError>
 
   getAccountBalance(
-    liabilitiesAccountId: LiabilitiesAccountId,
+    liabilitiesWalletId: LiabilitiesWalletId,
   ): Promise<Satoshis | LedgerServiceError>
 
   twoFATxVolumeSince({
-    liabilitiesAccountId,
+    liabilitiesWalletId,
     timestamp,
   }: {
-    liabilitiesAccountId: LiabilitiesAccountId
+    liabilitiesWalletId: LiabilitiesWalletId
     timestamp: Date
   }): Promise<TxVolume | LedgerServiceError>
 
   withdrawalTxVolumeSince({
-    liabilitiesAccountId,
+    liabilitiesWalletId,
     timestamp,
   }: {
-    liabilitiesAccountId: LiabilitiesAccountId
+    liabilitiesWalletId: LiabilitiesWalletId
     timestamp: Date
   }): Promise<TxVolume | LedgerServiceError>
 
   intraledgerTxVolumeSince({
-    liabilitiesAccountId,
+    liabilitiesWalletId,
     timestamp,
   }: {
-    liabilitiesAccountId: LiabilitiesAccountId
+    liabilitiesWalletId: LiabilitiesWalletId
     timestamp: Date
   }): Promise<TxVolume | LedgerServiceError>
 
   isOnChainTxRecorded(
-    liabilitiesAccountId: LiabilitiesAccountId,
+    liabilitiesWalletId: LiabilitiesWalletId,
     txHash: OnChainTxHash,
   ): Promise<boolean | LedgerServiceError>
 

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -59,7 +59,7 @@ type LedgerTransaction = {
 }
 
 type ReceiveOnChainTxArgs = {
-  liabilitiesWalletId: LiabilitiesWalletId
+  walletId: WalletId
   txHash: OnChainTxHash
   sats: Satoshis
   fee: Satoshis
@@ -69,7 +69,7 @@ type ReceiveOnChainTxArgs = {
 }
 
 type TxArgs = {
-  liabilitiesWalletId: LiabilitiesWalletId
+  walletId: WalletId
   description: string
   sats: Satoshis
   fee: Satoshis
@@ -89,10 +89,10 @@ type AddLnTxSendArgs = LnTxArgs & {
 }
 
 type IntraledgerTxArgs = {
-  liabilitiesWalletId: LiabilitiesWalletId
+  walletId: WalletId
   description: string
   sats: Satoshis
-  recipientLiabilitiesWalletId: LiabilitiesWalletId | null
+  recipientWalletId: WalletId
   payerUsername: Username | null
   recipientUsername: Username | null
   memoPayer: string | null
@@ -119,7 +119,7 @@ type AddUsernameIntraledgerTxSendArgs = AddIntraLedgerTxSendArgs & {
 }
 
 type AddLnFeeReeimbursementReceiveArgs = {
-  liabilitiesWalletId: LiabilitiesWalletId
+  walletId: WalletId
   paymentHash: PaymentHash
   sats: Satoshis
   usd: number
@@ -145,54 +145,53 @@ interface ILedgerService {
   ): Promise<LedgerTransaction[] | LedgerServiceError>
 
   getLiabilityTransactions(
-    liabilitiesWalletId: LiabilitiesWalletId,
+    WalletId: WalletId,
   ): Promise<LedgerTransaction[] | LedgerServiceError>
 
   getLiabilityTransactionsForContactUsername(
-    liabilitiesWalletId: LiabilitiesWalletId,
+    WalletId: WalletId,
     contactUsername: Username,
   ): Promise<LedgerTransaction[] | LedgerServiceError>
 
   listPendingPayments(
-    liabilitiesWalletId: LiabilitiesWalletId,
+    WalletId: WalletId,
   ): Promise<LedgerTransaction[] | LedgerServiceError>
 
-  getPendingPaymentsCount(
-    liabilitiesWalletId: LiabilitiesWalletId,
-  ): Promise<number | LedgerServiceError>
+  getPendingPaymentsCount(WalletId: WalletId): Promise<number | LedgerServiceError>
 
-  getAccountBalance(
-    liabilitiesWalletId: LiabilitiesWalletId,
-  ): Promise<Satoshis | LedgerServiceError>
+  getAccountBalance(WalletId: WalletId): Promise<Satoshis | LedgerServiceError>
 
   twoFATxVolumeSince({
-    liabilitiesWalletId,
+    walletId,
     timestamp,
   }: {
-    liabilitiesWalletId: LiabilitiesWalletId
+    walletId: WalletId
     timestamp: Date
   }): Promise<TxVolume | LedgerServiceError>
 
   withdrawalTxVolumeSince({
-    liabilitiesWalletId,
+    walletId,
     timestamp,
   }: {
-    liabilitiesWalletId: LiabilitiesWalletId
+    walletId: WalletId
     timestamp: Date
   }): Promise<TxVolume | LedgerServiceError>
 
   intraledgerTxVolumeSince({
-    liabilitiesWalletId,
+    walletId,
     timestamp,
   }: {
-    liabilitiesWalletId: LiabilitiesWalletId
+    walletId: WalletId
     timestamp: Date
   }): Promise<TxVolume | LedgerServiceError>
 
-  isOnChainTxRecorded(
-    liabilitiesWalletId: LiabilitiesWalletId,
-    txHash: OnChainTxHash,
-  ): Promise<boolean | LedgerServiceError>
+  isOnChainTxRecorded({
+    walletId,
+    txHash,
+  }: {
+    walletId: WalletId
+    txHash: OnChainTxHash
+  }): Promise<boolean | LedgerServiceError>
 
   isLnTxRecorded(paymentHash: PaymentHash): Promise<boolean | LedgerServiceError>
 

--- a/src/domain/primitives/index.types.d.ts
+++ b/src/domain/primitives/index.types.d.ts
@@ -13,9 +13,6 @@ type Pubkey = string & { [pubkeySymbol]: never }
 declare const walletIdSymbol: unique symbol
 type WalletId = string & { [walletIdSymbol]: never }
 
-declare const walletPublicIdSymbol: unique symbol
-type WalletPublicId = string & { [walletPublicIdSymbol]: never }
-
 declare const accountIdSymbol: unique symbol
 type AccountId = string & { [accountIdSymbol]: never }
 

--- a/src/domain/users/index.types.d.ts
+++ b/src/domain/users/index.types.d.ts
@@ -84,6 +84,6 @@ interface IUsersRepository {
   findByUsername(username: Username): Promise<User | RepositoryError>
   findByPhone(phone: PhoneNumber): Promise<User | RepositoryError>
   persistNew({ phone, phoneMetadata }: NewUserInfo): Promise<User | RepositoryError>
-  findByWalletPublicId(walletPublicId: WalletPublicId): Promise<User | RepositoryError>
+  findByWalletId(walletId: WalletId): Promise<User | RepositoryError>
   update(user: User): Promise<User | RepositoryError>
 }

--- a/src/domain/users/index.types.d.ts
+++ b/src/domain/users/index.types.d.ts
@@ -84,6 +84,5 @@ interface IUsersRepository {
   findByUsername(username: Username): Promise<User | RepositoryError>
   findByPhone(phone: PhoneNumber): Promise<User | RepositoryError>
   persistNew({ phone, phoneMetadata }: NewUserInfo): Promise<User | RepositoryError>
-  findByWalletId(walletId: WalletId): Promise<User | RepositoryError>
   update(user: User): Promise<User | RepositoryError>
 }

--- a/src/domain/wallets/index.ts
+++ b/src/domain/wallets/index.ts
@@ -1,4 +1,4 @@
-import { InvalidPublicWalletId } from "@domain/errors"
+import { InvalidWalletId } from "@domain/errors"
 
 export { WalletTransactionHistory } from "./tx-history"
 export * from "./tx-methods"
@@ -6,14 +6,12 @@ export * from "./tx-status"
 export * from "./deposit-fee-calculator"
 export * from "./withdrawal-fee-calculator"
 
-export const WalletPublicIdRegex =
+export const WalletIdRegex =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
-export const checkedToWalletPublicId = (
-  walletPublicId: string,
-): WalletPublicId | ValidationError => {
-  if (!walletPublicId.match(WalletPublicIdRegex)) {
-    return new InvalidPublicWalletId(walletPublicId)
+export const checkedToWalletId = (walletId: string): WalletId | ValidationError => {
+  if (!walletId.match(WalletIdRegex)) {
+    return new InvalidWalletId(walletId)
   }
-  return walletPublicId as WalletPublicId
+  return walletId as WalletId
 }

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -12,7 +12,7 @@ type Deprecated = {
 
 type InitiationViaIntraledger = {
   readonly type: PaymentInitiationMethod["IntraLedger"]
-  readonly counterPartyWalletPublicId: WalletPublicId
+  readonly counterPartyWalletId: WalletId
   readonly counterPartyUsername: Username
 }
 
@@ -35,7 +35,7 @@ type InitiationViaOnChainLegacy = {
 
 type SettlementViaIntraledger = {
   readonly type: SettlementMethod["IntraLedger"]
-  readonly counterPartyWalletPublicId: WalletPublicId
+  readonly counterPartyWalletId: WalletId
   readonly counterPartyUsername: Username | null
 }
 
@@ -132,7 +132,6 @@ type WithdrawFee = number & { [withdrawFeeSymbol]: never }
 
 type Wallet = {
   readonly id: WalletId
-  readonly publicId: WalletPublicId
   readonly depositFeeRatio: DepositFeeRatio
   readonly withdrawFee: WithdrawFee
   readonly onChainAddressIdentifiers: OnChainAddressIdentifier[]
@@ -143,7 +142,6 @@ interface IWalletsRepository {
   findById(walletId: WalletId): Promise<Wallet | RepositoryError>
   findByAddress(address: OnChainAddress): Promise<Wallet | RepositoryError>
   findByUsername(username: Username): Promise<Wallet | RepositoryError>
-  findByPublicId(publicId: WalletPublicId): Promise<Wallet | RepositoryError>
   listByAddresses(addresses: string[]): Promise<Wallet[] | RepositoryError>
 }
 

--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -51,6 +51,7 @@ export const fromLedger = (
     ({
       id,
       walletId,
+      recipientWalletId,
       memoFromPayer,
       lnMemo,
       type,
@@ -116,12 +117,12 @@ export const fromLedger = (
             ...baseTransaction,
             initiationVia: {
               type: PaymentInitiationMethod.IntraLedger,
-              counterPartyWalletId: walletId as WalletId,
+              counterPartyWalletId: recipientWalletId as WalletId,
               counterPartyUsername: username as Username,
             },
             settlementVia: {
               type: SettlementMethod.IntraLedger,
-              counterPartyWalletId: walletId as WalletId,
+              counterPartyWalletId: recipientWalletId as WalletId,
               counterPartyUsername: username as Username,
             },
           }
@@ -136,7 +137,7 @@ export const fromLedger = (
             },
             settlementVia: {
               type: SettlementMethod.IntraLedger,
-              counterPartyWalletId: walletId as WalletId,
+              counterPartyWalletId: recipientWalletId as WalletId,
               counterPartyUsername: username || null,
             },
           }
@@ -167,7 +168,7 @@ export const fromLedger = (
             },
             settlementVia: {
               type: SettlementMethod.IntraLedger,
-              counterPartyWalletId: walletId as WalletId,
+              counterPartyWalletId: recipientWalletId as WalletId,
               counterPartyUsername: username || null,
             },
           }
@@ -194,12 +195,12 @@ export const fromLedger = (
         ...baseTransaction,
         initiationVia: {
           type: PaymentInitiationMethod.IntraLedger,
-          counterPartyWalletId: walletId as WalletId,
+          counterPartyWalletId: recipientWalletId as WalletId,
           counterPartyUsername: username as Username,
         },
         settlementVia: {
           type: SettlementMethod.IntraLedger,
-          counterPartyWalletId: walletId as WalletId,
+          counterPartyWalletId: recipientWalletId as WalletId,
           counterPartyUsername: username || null,
         },
       }

--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -62,7 +62,6 @@ export const fromLedger = (
       paymentHash,
       txHash,
       pubkey,
-      walletPublicId,
       username,
       address,
       pendingConfirmation,
@@ -117,12 +116,12 @@ export const fromLedger = (
             ...baseTransaction,
             initiationVia: {
               type: PaymentInitiationMethod.IntraLedger,
-              counterPartyWalletPublicId: walletPublicId as WalletPublicId,
+              counterPartyWalletId: walletId as WalletId,
               counterPartyUsername: username as Username,
             },
             settlementVia: {
               type: SettlementMethod.IntraLedger,
-              counterPartyWalletPublicId: walletPublicId as WalletPublicId,
+              counterPartyWalletId: walletId as WalletId,
               counterPartyUsername: username as Username,
             },
           }
@@ -137,7 +136,7 @@ export const fromLedger = (
             },
             settlementVia: {
               type: SettlementMethod.IntraLedger,
-              counterPartyWalletPublicId: walletPublicId as WalletPublicId,
+              counterPartyWalletId: walletId as WalletId,
               counterPartyUsername: username || null,
             },
           }
@@ -168,7 +167,7 @@ export const fromLedger = (
             },
             settlementVia: {
               type: SettlementMethod.IntraLedger,
-              counterPartyWalletPublicId: walletPublicId as WalletPublicId,
+              counterPartyWalletId: walletId as WalletId,
               counterPartyUsername: username || null,
             },
           }
@@ -195,12 +194,12 @@ export const fromLedger = (
         ...baseTransaction,
         initiationVia: {
           type: PaymentInitiationMethod.IntraLedger,
-          counterPartyWalletPublicId: walletPublicId as WalletPublicId,
+          counterPartyWalletId: walletId as WalletId,
           counterPartyUsername: username as Username,
         },
         settlementVia: {
           type: SettlementMethod.IntraLedger,
-          counterPartyWalletPublicId: walletPublicId as WalletPublicId,
+          counterPartyWalletId: walletId as WalletId,
           counterPartyUsername: username || null,
         },
       }

--- a/src/graphql/admin/root/mutation/account-update-level.ts
+++ b/src/graphql/admin/root/mutation/account-update-level.ts
@@ -7,7 +7,7 @@ import { GT } from "@graphql/index"
 const AccountUpdateLevelInput = new GT.Input({
   name: "AccountUpdateLevelInput",
   fields: () => ({
-    // FIXME: should no longer be uid
+    // FIXME: should be account id
     uid: {
       type: GT.NonNullID,
     },
@@ -23,7 +23,7 @@ const AccountUpdateLevelMutation = GT.Field({
     input: { type: GT.NonNull(AccountUpdateLevelInput) },
   },
   resolve: async (_, args) => {
-    // FIXME: should no longer be uid
+    // FIXME: should be account id
     const { uid, level } = args.input
 
     for (const input of [uid, level]) {

--- a/src/graphql/admin/root/mutation/account-update-level.ts
+++ b/src/graphql/admin/root/mutation/account-update-level.ts
@@ -7,6 +7,7 @@ import { GT } from "@graphql/index"
 const AccountUpdateLevelInput = new GT.Input({
   name: "AccountUpdateLevelInput",
   fields: () => ({
+    // FIXME: should no longer be uid
     uid: {
       type: GT.NonNullID,
     },
@@ -22,6 +23,7 @@ const AccountUpdateLevelMutation = GT.Field({
     input: { type: GT.NonNull(AccountUpdateLevelInput) },
   },
   resolve: async (_, args) => {
+    // FIXME: should no longer be uid
     const { uid, level } = args.input
 
     for (const input of [uid, level]) {

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -184,7 +184,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "ValidationError":
     case "InvalidUsername":
     case "InvalidPhoneNumber":
-    case "InvalidPublicWalletId":
+    case "InvalidWalletId":
     case "LessThanDustThresholdError":
     case "InvalidTargetConfirmations":
     case "NoContactForUsernameError":

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -193,7 +193,6 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "CouldNotFindWalletFromIdError":
     case "CouldNotFindWalletFromUsernameError":
     case "CouldNotFindWalletFromOnChainAddressError":
-    case "CouldNotFindWalletFromPublicIdError":
     case "CouldNotFindWalletFromOnChainAddressesError":
     case "LockError":
     case "LockServiceError":

--- a/src/graphql/root/mutation/intraledger-payment-send.ts
+++ b/src/graphql/root/mutation/intraledger-payment-send.ts
@@ -1,6 +1,5 @@
-import { getWalletByPublicId, intraledgerPaymentSend } from "@app/wallets"
-import { getUsernameFromWalletPublicId } from "@app/users"
-import { checkedToWalletPublicId } from "@domain/wallets"
+import { getWallet, intraledgerPaymentSend } from "@app/wallets"
+import { checkedToWalletId } from "@domain/wallets"
 import { GT } from "@graphql/index"
 
 import PaymentSendPayload from "@graphql/types/payload/payment-send"
@@ -8,6 +7,7 @@ import Memo from "@graphql/types/scalar/memo"
 import SatAmount from "@graphql/types/scalar/sat-amount"
 import WalletId from "@graphql/types/scalar/wallet-id"
 import { mapError } from "@graphql/error-map"
+import { getUsernameFromWalletId } from "@app/users"
 
 const IntraLedgerPaymentSendInput = new GT.Input({
   name: "IntraLedgerPaymentSendInput",
@@ -32,19 +32,19 @@ const IntraLedgerPaymentSendMutation = GT.Field({
       }
     }
 
-    const wallet = await getWalletByPublicId(walletId)
+    const wallet = await getWallet(walletId)
     if (wallet instanceof Error) {
       const appErr = mapError(wallet)
       return { errors: [{ message: appErr.message }] }
     }
 
-    const recipientWalletPublicId = checkedToWalletPublicId(recipientWalletId)
-    if (recipientWalletPublicId instanceof Error) {
-      const appErr = mapError(recipientWalletPublicId)
+    const recipientWalletIdChecked = checkedToWalletId(recipientWalletId)
+    if (recipientWalletIdChecked instanceof Error) {
+      const appErr = mapError(recipientWalletIdChecked)
       return { errors: [{ message: appErr.message }] }
     }
 
-    const recipientUsername = await getUsernameFromWalletPublicId(recipientWalletPublicId)
+    const recipientUsername = await getUsernameFromWalletId(recipientWalletIdChecked)
     if (recipientUsername instanceof Error) {
       const appErr = mapError(recipientUsername)
       return { errors: [{ message: appErr.message }] }
@@ -54,7 +54,7 @@ const IntraLedgerPaymentSendMutation = GT.Field({
       recipientUsername,
       memo,
       amount,
-      walletId: wallet.id,
+      walletId,
       userId: user.id,
       logger,
     })

--- a/src/graphql/root/mutation/intraledger-payment-send.ts
+++ b/src/graphql/root/mutation/intraledger-payment-send.ts
@@ -7,7 +7,7 @@ import Memo from "@graphql/types/scalar/memo"
 import SatAmount from "@graphql/types/scalar/sat-amount"
 import WalletId from "@graphql/types/scalar/wallet-id"
 import { mapError } from "@graphql/error-map"
-import { getUsernameFromWalletId } from "@app/users"
+import { getUsernameFromWalletId } from "@app/accounts"
 
 const IntraLedgerPaymentSendInput = new GT.Input({
   name: "IntraLedgerPaymentSendInput",

--- a/src/graphql/root/mutation/ln-invoice-create-on-behalf-of-recipient.ts
+++ b/src/graphql/root/mutation/ln-invoice-create-on-behalf-of-recipient.ts
@@ -32,7 +32,7 @@ const LnInvoiceCreateOnBehalfOfRecipientMutation = GT.Field({
     }
 
     const result = await addInvoiceForRecipient({
-      recipientWalletPublicId: recipientWalletId,
+      recipientWalletId,
       amount,
       memo,
       descriptionHash,

--- a/src/graphql/root/mutation/ln-invoice-create.ts
+++ b/src/graphql/root/mutation/ln-invoice-create.ts
@@ -4,7 +4,7 @@ import Memo from "@graphql/types/scalar/memo"
 import WalletId from "@graphql/types/scalar/wallet-id"
 import SatAmount from "@graphql/types/scalar/sat-amount"
 import LnInvoicePayload from "@graphql/types/payload/ln-invoice"
-import { addInvoiceByWalletPublicId } from "@app/wallets/add-invoice-for-wallet"
+import { addInvoiceByWalletId } from "@app/wallets/add-invoice-for-wallet"
 
 const LnInvoiceCreateInput = new GT.Input({
   name: "LnInvoiceCreateInput",
@@ -29,8 +29,8 @@ const LnInvoiceCreateMutation = GT.Field({
       }
     }
 
-    const lnInvoice = await addInvoiceByWalletPublicId({
-      walletPublicId: walletId,
+    const lnInvoice = await addInvoiceByWalletId({
+      walletId,
       amount,
       memo,
     })

--- a/src/graphql/root/mutation/ln-invoice-fee-probe.ts
+++ b/src/graphql/root/mutation/ln-invoice-fee-probe.ts
@@ -28,7 +28,7 @@ const LnInvoiceFeeProbeMutation = GT.Field({
     }
 
     const feeSatAmount = await getLightningFee({
-      walletPublicId: walletId,
+      walletId,
       paymentRequest,
       logger,
     })

--- a/src/graphql/root/mutation/ln-invoice-payment-send.ts
+++ b/src/graphql/root/mutation/ln-invoice-payment-send.ts
@@ -2,7 +2,7 @@ import { GT } from "@graphql/index"
 import Memo from "@graphql/types/scalar/memo"
 import { mapError } from "@graphql/error-map"
 import WalletId from "@graphql/types/scalar/wallet-id"
-import { payLnInvoiceByWalletPublicId } from "@app/wallets"
+import { payLnInvoiceByWalletId } from "@app/wallets"
 import PaymentSendPayload from "@graphql/types/payload/payment-send"
 import LnPaymentRequest from "@graphql/types/scalar/ln-payment-request"
 import {
@@ -41,8 +41,8 @@ const LnInvoicePaymentSendMutation = GT.Field({
           }
         }
 
-        const status = await payLnInvoiceByWalletPublicId({
-          walletPublicId: walletId,
+        const status = await payLnInvoiceByWalletId({
+          walletId,
           paymentRequest,
           memo,
           userId: domainUser.id,

--- a/src/graphql/root/mutation/ln-noamount-invoice-create-on-behalf-of-recipient.ts
+++ b/src/graphql/root/mutation/ln-noamount-invoice-create-on-behalf-of-recipient.ts
@@ -29,7 +29,7 @@ const LnNoAmountInvoiceCreateOnBehalfOfRecipientMutation = GT.Field({
     }
 
     const result = await addInvoiceNoAmountForRecipient({
-      recipientWalletPublicId: recipientWalletId,
+      recipientWalletId: recipientWalletId,
       memo,
     })
 

--- a/src/graphql/root/mutation/ln-noamount-invoice-create-on-behalf-of-recipient.ts
+++ b/src/graphql/root/mutation/ln-noamount-invoice-create-on-behalf-of-recipient.ts
@@ -29,7 +29,7 @@ const LnNoAmountInvoiceCreateOnBehalfOfRecipientMutation = GT.Field({
     }
 
     const result = await addInvoiceNoAmountForRecipient({
-      recipientWalletId: recipientWalletId,
+      recipientWalletId,
       memo,
     })
 

--- a/src/graphql/root/mutation/ln-noamount-invoice-create.ts
+++ b/src/graphql/root/mutation/ln-noamount-invoice-create.ts
@@ -3,7 +3,7 @@ import { mapError } from "@graphql/error-map"
 import Memo from "@graphql/types/scalar/memo"
 import WalletId from "@graphql/types/scalar/wallet-id"
 import LnNoAmountInvoicePayload from "@graphql/types/payload/ln-noamount-invoice"
-import { addInvoiceNoAmountByWalletPublicId } from "@app/wallets/add-invoice-for-wallet"
+import { addInvoiceNoAmountByWalletId } from "@app/wallets/add-invoice-for-wallet"
 
 const LnNoAmountInvoiceCreateInput = new GT.Input({
   name: "LnNoAmountInvoiceCreateInput",
@@ -27,8 +27,8 @@ const LnNoAmountInvoiceCreateMutation = GT.Field({
       }
     }
 
-    const lnInvoice = await addInvoiceNoAmountByWalletPublicId({
-      walletPublicId: walletId,
+    const lnInvoice = await addInvoiceNoAmountByWalletId({
+      walletId,
       memo,
     })
 

--- a/src/graphql/root/mutation/ln-noamount-invoice-fee-probe.ts
+++ b/src/graphql/root/mutation/ln-noamount-invoice-fee-probe.ts
@@ -30,7 +30,7 @@ const LnNoAmountInvoiceFeeProbeMutation = GT.Field({
     }
 
     const feeSatAmount = await getNoAmountLightningFee({
-      walletPublicId: walletId,
+      walletId,
       amount,
       paymentRequest,
       logger,

--- a/src/graphql/root/mutation/ln-noamount-invoice-payment-send.ts
+++ b/src/graphql/root/mutation/ln-noamount-invoice-payment-send.ts
@@ -3,7 +3,7 @@ import { mapError } from "@graphql/error-map"
 import Memo from "@graphql/types/scalar/memo"
 import WalletId from "@graphql/types/scalar/wallet-id"
 import SatAmount from "@graphql/types/scalar/sat-amount"
-import { payLnNoAmountInvoiceByWalletPublicId } from "@app/wallets"
+import { payLnNoAmountInvoiceByWalletId } from "@app/wallets"
 import PaymentSendPayload from "@graphql/types/payload/payment-send"
 import LnIPaymentRequest from "@graphql/types/scalar/ln-payment-request"
 
@@ -30,8 +30,8 @@ const LnNoAmountInvoicePaymentSendMutation = GT.Field({
       }
     }
 
-    const status = await payLnNoAmountInvoiceByWalletPublicId({
-      walletPublicId: walletId,
+    const status = await payLnNoAmountInvoiceByWalletId({
+      walletId,
       paymentRequest,
       memo,
       amount,

--- a/src/graphql/root/mutation/on-chain-address-create.ts
+++ b/src/graphql/root/mutation/on-chain-address-create.ts
@@ -22,7 +22,7 @@ const OnChainAddressCreateMutation = GT.Field({
       return { errors: [{ message: walletId.message }] }
     }
 
-    const address = await Wallets.createOnChainAddressByWalletPublicId(walletId)
+    const address = await Wallets.createOnChainAddress(walletId)
     if (address instanceof Error) {
       const appErr = mapError(address)
       return { errors: [{ message: appErr.message }] }

--- a/src/graphql/root/mutation/on-chain-address-current.ts
+++ b/src/graphql/root/mutation/on-chain-address-current.ts
@@ -22,7 +22,7 @@ const OnChainAddressCurrentMutation = GT.Field({
       return { errors: [{ message: walletId.message }] }
     }
 
-    const address = await Wallets.getLastOnChainAddressByWalletPublicId(walletId)
+    const address = await Wallets.getLastOnChainAddress(walletId)
     if (address instanceof Error) {
       const appErr = mapError(address)
       return { errors: [{ message: appErr.message }] }

--- a/src/graphql/root/query/account-default-wallet-id.ts
+++ b/src/graphql/root/query/account-default-wallet-id.ts
@@ -21,8 +21,8 @@ const AccountDefaultWalletIdQuery = GT.Field({
     const account = await AccountsRepository().findByUsername(username)
     if (account instanceof Error) return mapError(account)
 
-    const walletPublicId = account.defaultWalletId
-    return walletPublicId
+    const walletId = account.defaultWalletId
+    return walletId
   },
 })
 

--- a/src/graphql/root/query/on-chain-tx-fee-query.ts
+++ b/src/graphql/root/query/on-chain-tx-fee-query.ts
@@ -22,8 +22,8 @@ const OnChainTxFeeQuery = GT.Field({
       if (input instanceof Error) throw input
     }
 
-    const fee = await Wallets.getOnChainFeeByWalletPublicId({
-      walletPublicId: walletId,
+    const fee = await Wallets.getOnChainFeeByWalletId({
+      walletId,
       amount,
       address,
       targetConfirmations,

--- a/src/graphql/types/object/btc-wallet.ts
+++ b/src/graphql/types/object/btc-wallet.ts
@@ -15,7 +15,7 @@ const BTCWallet = new GT.Object({
   fields: () => ({
     id: {
       type: GT.NonNullID,
-      resolve: (source) => source.publicId,
+      resolve: (source) => source.walletId,
     },
     walletCurrency: {
       type: GT.NonNull(WalletCurrency),

--- a/src/graphql/types/object/btc-wallet.ts
+++ b/src/graphql/types/object/btc-wallet.ts
@@ -15,7 +15,6 @@ const BTCWallet = new GT.Object({
   fields: () => ({
     id: {
       type: GT.NonNullID,
-      resolve: (source) => source.walletId,
     },
     walletCurrency: {
       type: GT.NonNull(WalletCurrency),

--- a/src/graphql/types/object/business-account.ts
+++ b/src/graphql/types/object/business-account.ts
@@ -7,7 +7,6 @@ import Transaction from "./transaction"
 import WalletId from "../scalar/wallet-id"
 
 import * as Wallets from "@app/wallets"
-import * as Accounts from "@app/accounts"
 
 const BusinessAccount = new GT.Object({
   name: "BusinessAccount",
@@ -30,17 +29,8 @@ const BusinessAccount = new GT.Object({
           type: GT.NonNullList(WalletId),
         },
       },
-      resolve: async (source, args) => {
-        const walletIds = await Accounts.toWalletIds({
-          account: source,
-          walletPublicIds: args.walletIds,
-        })
-
-        if (walletIds instanceof Error) {
-          throw walletIds
-        }
-
-        return Wallets.getCSVForWallets(walletIds)
+      resolve: async (source: Account) => {
+        return Wallets.getCSVForWallets(source.walletIds)
       },
     },
   }),

--- a/src/graphql/types/object/consumer-account.ts
+++ b/src/graphql/types/object/consumer-account.ts
@@ -1,13 +1,9 @@
-import getUuidByString from "uuid-by-string"
-
+import * as Wallets from "@app/wallets"
 import { GT } from "@graphql/index"
-
+import getUuidByString from "uuid-by-string"
 import IAccount from "../abstract/account"
 import Wallet from "../abstract/wallet"
 import WalletId from "../scalar/wallet-id"
-
-import * as Wallets from "@app/wallets"
-import * as Accounts from "@app/accounts"
 
 const ConsumerAccount = new GT.Object({
   name: "ConsumerAccount",
@@ -47,17 +43,8 @@ const ConsumerAccount = new GT.Object({
           type: GT.NonNullList(WalletId),
         },
       },
-      resolve: async (source, args) => {
-        const walletIds = await Accounts.toWalletIds({
-          account: source,
-          walletPublicIds: args.walletIds,
-        })
-
-        if (walletIds instanceof Error) {
-          throw walletIds
-        }
-
-        return Wallets.getCSVForWallets(walletIds)
+      resolve: async (source) => {
+        return Wallets.getCSVForWallets(source.walletIds)
       },
     },
   }),

--- a/src/graphql/types/object/fiat-wallet.ts
+++ b/src/graphql/types/object/fiat-wallet.ts
@@ -14,7 +14,6 @@ const FiatWallet = new GT.Object({
   fields: () => ({
     id: {
       type: GT.NonNullID,
-      resolve: (source) => source.walletId,
     },
     walletCurrency: {
       type: GT.NonNull(WalletCurrency),

--- a/src/graphql/types/object/fiat-wallet.ts
+++ b/src/graphql/types/object/fiat-wallet.ts
@@ -14,7 +14,7 @@ const FiatWallet = new GT.Object({
   fields: () => ({
     id: {
       type: GT.NonNullID,
-      resolve: (source) => source.publicId,
+      resolve: (source) => source.walletId,
     },
     walletCurrency: {
       type: GT.NonNull(WalletCurrency),

--- a/src/graphql/types/object/graphql-user.ts
+++ b/src/graphql/types/object/graphql-user.ts
@@ -84,7 +84,7 @@ const GraphQLUser = new GT.Object({
 
     defaultAccount: {
       type: GT.NonNull(Account),
-      resolve: async (source, args, { domainUser }) => {
+      resolve: async (source, args, { domainUser }: { domainUser: User }) => {
         // TODO: could also be return domainAccount
         const account = await Accounts.getAccount(domainUser.defaultAccountId)
         if (account instanceof Error) {

--- a/src/graphql/types/scalar/wallet-id.ts
+++ b/src/graphql/types/scalar/wallet-id.ts
@@ -1,4 +1,4 @@
-import { checkedToWalletPublicId } from "@domain/wallets"
+import { checkedToWalletId } from "@domain/wallets"
 import { GT } from "@graphql/index"
 import { UserInputError } from "apollo-server-errors"
 
@@ -17,7 +17,7 @@ const WalletId = new GT.Scalar({
 })
 
 function validWalletIdValue(value) {
-  const checkedWalletId = checkedToWalletPublicId(value)
+  const checkedWalletId = checkedToWalletId(value)
   if (checkedWalletId instanceof Error) {
     return new UserInputError("Invalid value for WalletId")
   }

--- a/src/migrations/20211209211641-use-single-wallet-id.ts
+++ b/src/migrations/20211209211641-use-single-wallet-id.ts
@@ -1,0 +1,87 @@
+module.exports = {
+  async up(db) {
+    {
+      const result = await db
+        .collection("medici_transactions")
+        .updateMany({ account_path: "Liabilities" }, [
+          {
+            $set: {
+              account_path_org2: "$account_path",
+              accounts_org2: "$accounts",
+            },
+          },
+        ])
+
+      console.log({ result }, "backup the field in case a roll out is needed")
+    }
+
+    {
+      const result = await db.collection("users").updateMany({}, [
+        {
+          $set: {
+            walletId: "$walletPublicId",
+          },
+        },
+      ])
+
+      console.log(
+        { result },
+        "creating walletId for user (duplication of walletPublicId)",
+      )
+    }
+
+    // TODO: remove any pending invoices
+    // maybe reduce invoice time to 1h and then 1 min ahead of migration?
+
+    const users = await db.collection("users").find({})
+    users
+
+    {
+      const result = await db
+        .collection("medici_transactions")
+        .updateMany(
+          { account_path: "Liabilities" },
+          { $pull: { account_path: "Customer" } },
+        )
+
+      console.log({ result }, "set up the account_path array")
+    }
+
+    {
+      const result = await db
+        .collection("medici_transactions")
+        .updateMany({ account_path: "Liabilities" }, [
+          { $set: { tmp_accounts_uid: { $substrCP: ["$accounts_org", 21, 100] } } },
+        ])
+
+      console.log({ result }, "create tmp_accounts_uid field")
+    }
+
+    {
+      const result = await db
+        .collection("medici_transactions")
+        .updateMany({ account_path: "Liabilities" }, [
+          {
+            $set: {
+              accounts: { $concat: ["Liabilities", ":", "$tmp_accounts_uid"] },
+            },
+          },
+        ])
+
+      console.log({ result }, "set the new accounts field")
+    }
+  },
+
+  async down(db) {
+    await db
+      .collection("medici_transactions")
+      .updateMany({ account_path: "Liabilities" }, [
+        {
+          $set: {
+            account_path: "$account_path_org",
+            accounts: "$accounts_org",
+          },
+        },
+      ])
+  },
+}

--- a/src/migrations/migrate-mongo-config.js
+++ b/src/migrations/migrate-mongo-config.js
@@ -1,5 +1,5 @@
 const user = process.env.MONGODB_USER ?? "testGaloy"
-const password = process.env.MONGODB_PASSWORD
+const password = process.env.MONGODB_PASSWORD ?? "password"
 const address = process.env.MONGODB_ADDRESS ?? "localhost"
 const db = process.env.MONGODB_DATABASE ?? "galoy"
 

--- a/src/servers/exporter.ts
+++ b/src/servers/exporter.ts
@@ -112,7 +112,7 @@ const main = async () => {
       try {
         const wallet = await getWalletFromRole({ role, logger })
         const balanceSats = await Wallets.getBalanceForWallet({
-          walletId: wallet.user.id as WalletId,
+          walletId: wallet.user.walletId as WalletId,
           logger,
         })
         if (balanceSats instanceof Error) throw balanceSats

--- a/src/servers/graphql-old-server.ts
+++ b/src/servers/graphql-old-server.ts
@@ -114,7 +114,7 @@ const resolvers = {
         currency: "BTC",
         balance: async () => {
           const balanceSats = await Wallets.getBalanceForWallet({
-            walletId: wallet.user.id as WalletId,
+            walletId: wallet.user.walletId as WalletId,
             logger,
           })
           if (balanceSats instanceof Error) throw balanceSats
@@ -123,7 +123,7 @@ const resolvers = {
         },
         transactions: async () => {
           const { result: txs, error } = await Wallets.getTransactionsForWalletId({
-            walletId: wallet.user.id,
+            walletId: wallet.user.walletId,
           })
           if (error instanceof Error || txs === null) {
             throw error
@@ -135,29 +135,6 @@ const resolvers = {
       },
     ],
 
-    // new way to return the balance
-    // balances are distinc between USD and BTC
-    // but transaction are common, because they could have rely both on USD/BTC
-    wallet2: async (_, __, { wallet }) => {
-      const balances = await wallet.getBalances()
-
-      return {
-        transactions: async () => {
-          const { result: txs, error } = await Wallets.getTransactionsForWalletId({
-            walletId: wallet.user.id,
-          })
-          if (error instanceof Error || txs === null) {
-            throw error
-          }
-
-          return translateWalletTx(txs)
-        },
-        balances: wallet.user.currencies.map((item) => ({
-          id: item.id,
-          balance: balances[item.id],
-        })),
-      }
-    },
     // deprecated
     nodeStats: async () => {
       const { lnd } = getActiveLnd()
@@ -311,12 +288,12 @@ const resolvers = {
         const lnInvoice =
           value && value > 0
             ? await Wallets.addInvoice({
-                walletId: wallet.user.id,
+                walletId: wallet.user.walletId,
                 amount: value,
                 memo,
               })
             : await Wallets.addInvoiceNoAmount({
-                walletId: wallet.user.id,
+                walletId: wallet.user.walletId,
                 memo,
               })
         if (lnInvoice instanceof Error) throw mapError(lnInvoice)
@@ -347,7 +324,7 @@ const resolvers = {
               const status = await Wallets.lnInvoicePaymentSend({
                 paymentRequest: invoice,
                 memo,
-                walletId: wallet.user.id as WalletId,
+                walletId: wallet.user.walletId as WalletId,
                 userId: wallet.user.id as UserId,
                 logger,
               })
@@ -358,7 +335,7 @@ const resolvers = {
               paymentRequest: invoice,
               memo,
               amount,
-              walletId: wallet.user.id as WalletId,
+              walletId: wallet.user.walletId as WalletId,
               userId: wallet.user.id as UserId,
               logger,
             })
@@ -371,7 +348,7 @@ const resolvers = {
           recipientUsername: username,
           memo,
           amount,
-          walletId: wallet.user.id,
+          walletId: wallet.user.walletId,
           userId: wallet.user.id,
           logger,
         })
@@ -406,7 +383,7 @@ const resolvers = {
     earnCompleted: async (_, { ids }, { wallet }) => wallet.addEarn(ids),
     onchain: (_, __, { wallet }) => ({
       getNewAddress: async () => {
-        const address = await Wallets.createOnChainAddress(wallet.user.id)
+        const address = await Wallets.createOnChainAddress(wallet.user.walletId)
         if (address instanceof Error) throw mapError(address)
         return address
       },
@@ -424,7 +401,7 @@ const resolvers = {
       }),
       getFee: async ({ address, amount }) => {
         const fee = await Wallets.getOnChainFeeByWalletId({
-          walletId: wallet.user.id,
+          walletId: wallet.user.walletId,
           amount,
           address,
           targetConfirmations: 1,

--- a/src/servers/graphql-old-server.ts
+++ b/src/servers/graphql-old-server.ts
@@ -216,7 +216,7 @@ const resolvers = {
       return response
     },
     getLastOnChainAddress: async (_, __, { wallet }) => {
-      const address = await Wallets.getLastOnChainAddress(wallet.user.id)
+      const address = await Wallets.getLastOnChainAddress(wallet.user.walletId)
       if (address instanceof Error) throw address
 
       return {
@@ -384,7 +384,7 @@ const resolvers = {
         let feeSatAmount: Satoshis | ApplicationError
         if (amount && amount > 0) {
           feeSatAmount = await getNoAmountLightningFee({
-            walletPublicId: wallet.user.walletPublicId,
+            walletId: wallet.user.walletId,
             amount,
             paymentRequest: invoice,
             logger,
@@ -395,7 +395,7 @@ const resolvers = {
         }
 
         feeSatAmount = await getLightningFee({
-          walletPublicId: wallet.user.walletPublicId,
+          walletId: wallet.user.walletId,
           paymentRequest: invoice,
           logger,
         })

--- a/src/servers/trigger.ts
+++ b/src/servers/trigger.ts
@@ -86,7 +86,7 @@ export async function onchainTransactionEventHandler(tx) {
     )
 
     const accountPath = await ledger.getAccountByTransactionHash(tx.id)
-    const userId = ledger.resolveAccountId(accountPath)
+    const userId = ledger.resolveWalletId(accountPath)
 
     if (!userId) {
       return

--- a/src/servers/trigger.ts
+++ b/src/servers/trigger.ts
@@ -50,6 +50,7 @@ export const uploadBackup = async ({ backup, pubkey }) => {
 }
 
 export async function onchainTransactionEventHandler(tx) {
+  // TODO: test+removed after upgrade to lnd v14 as this may has been fixed
   // workaround for https://github.com/lightningnetwork/lnd/issues/2267
   const hash = crypto.createHash("sha256").update(JSON.stringify(tx)).digest("base64")
   if (txsReceived.has(hash)) {
@@ -85,18 +86,17 @@ export async function onchainTransactionEventHandler(tx) {
       "payment completed",
     )
 
-    const accountPath = await ledger.getAccountByTransactionHash(tx.id)
-    const userId = ledger.resolveWalletId(accountPath)
+    const walletPath = await ledger.getAccountByTransactionHash(tx.id)
+    const walletId = ledger.resolveWalletId(walletPath)
 
-    if (!userId) {
+    if (!walletId) {
       return
     }
 
-    const user = await User.findOne({ _id: userId }, { lastIPs: 0, lastConnection: 0 })
     const price = await getCurrentPrice()
     const usdPerSat = price instanceof Error ? undefined : price
     await NotificationsService(onchainLogger).onChainTransactionPayment({
-      walletId: user.id,
+      walletId,
       amount: toSats(Number(tx.tokens) - tx.fee),
       txHash: tx.id,
       usdPerSat,

--- a/src/servers/trigger.ts
+++ b/src/servers/trigger.ts
@@ -133,7 +133,7 @@ export async function onchainTransactionEventHandler(tx) {
       const price = await getCurrentPrice()
       const usdPerSat = price instanceof Error ? undefined : price
       await NotificationsService(onchainLogger).onChainTransactionReceivedPending({
-        walletId: user.id,
+        walletId: user.walletId,
         amount: toSats(Number(tx.tokens)),
         txHash: tx.id,
         usdPerSat,

--- a/src/services/ledger/accounts.ts
+++ b/src/services/ledger/accounts.ts
@@ -10,17 +10,17 @@ export const escrowAccountingPath = `${assetsMainAccount}:Reserve:Escrow` // TOD
 // liabilities
 export const liabilitiesMainAccount = "Liabilities"
 export const accountPath = (uid) => `${liabilitiesMainAccount}:${uid}`
-export const resolveAccountId = (accountPath: string | string[]) => {
+export const resolveWalletId = (walletPath: string | string[]) => {
   let id: string | null = null
 
-  if (!accountPath) {
+  if (!walletPath) {
     return id
   }
 
-  let path = accountPath
+  let path = walletPath
 
-  if (typeof accountPath === "string") {
-    path = accountPath.split(":")
+  if (typeof walletPath === "string") {
+    path = walletPath.split(":")
   }
 
   if (
@@ -38,15 +38,15 @@ export const resolveAccountId = (accountPath: string | string[]) => {
 let cacheDealerPath: string
 let cachebankOwnerPath: string
 
-const throwError = (account) => Promise.reject(`Invalid ${account}AccountPath`)
+const throwError = (wallet) => Promise.reject(`Invalid ${wallet}WalletPath`)
 let bankOwnerResolver = (): Promise<string> => throwError("bankOwner")
 let dealerResolver = (): Promise<string> => throwError("dealer")
 
-export function setBankOwnerAccountResolver(resolver: () => Promise<string>) {
+export function setbankOwnerWalletResolver(resolver: () => Promise<string>) {
   bankOwnerResolver = resolver
 }
 
-export function setDealerAccountResolver(resolver: () => Promise<string>) {
+export function setdealerWalletResolver(resolver: () => Promise<string>) {
   dealerResolver = resolver
 }
 

--- a/src/services/ledger/accounts.ts
+++ b/src/services/ledger/accounts.ts
@@ -9,12 +9,12 @@ export const escrowAccountingPath = `${assetsMainAccount}:Reserve:Escrow` // TOD
 
 // liabilities
 export const liabilitiesMainAccount = "Liabilities"
-export const accountPath = (uid) => `${liabilitiesMainAccount}:${uid}`
-export const resolveWalletId = (walletPath: string | string[]) => {
+export const walletPath = (walletId) => `${liabilitiesMainAccount}:${walletId}`
+export const resolveWalletId = (walletPath: string | string[]): WalletId | null => {
   let id: string | null = null
 
   if (!walletPath) {
-    return id
+    return null
   }
 
   let path = walletPath
@@ -32,7 +32,8 @@ export const resolveWalletId = (walletPath: string | string[]) => {
     id = path[1]
   }
 
-  return id
+  // TODO: add check for WalletId syntax validity
+  return id as WalletId
 }
 
 let cacheDealerPath: string
@@ -56,7 +57,7 @@ export const dealerAccountPath = async () => {
   }
 
   const dealerId = await dealerResolver()
-  cacheDealerPath = accountPath(dealerId)
+  cacheDealerPath = walletPath(dealerId)
   return cacheDealerPath
 }
 
@@ -66,6 +67,6 @@ export const bankOwnerAccountPath = async () => {
   }
 
   const bankOwnerId = await bankOwnerResolver()
-  cachebankOwnerPath = accountPath(bankOwnerId)
+  cachebankOwnerPath = walletPath(bankOwnerId)
   return cachebankOwnerPath
 }

--- a/src/services/ledger/accounts.ts
+++ b/src/services/ledger/accounts.ts
@@ -11,7 +11,7 @@ export const escrowAccountingPath = `${assetsMainAccount}:Reserve:Escrow` // TOD
 export const liabilitiesMainAccount = "Liabilities"
 export const walletPath = (walletId) => `${liabilitiesMainAccount}:${walletId}`
 export const resolveWalletId = (walletPath: string | string[]): WalletId | null => {
-  let id: string | null = null
+  let id: WalletId | null = null
 
   if (!walletPath) {
     return null
@@ -29,11 +29,10 @@ export const resolveWalletId = (walletPath: string | string[]): WalletId | null 
     path[0] === liabilitiesMainAccount &&
     path[1]
   ) {
-    id = path[1]
+    id = path[1] as WalletId
   }
 
-  // TODO: add check for WalletId syntax validity
-  return id as WalletId
+  return id
 }
 
 let cacheDealerPath: string

--- a/src/services/ledger/index.ts
+++ b/src/services/ledger/index.ts
@@ -408,7 +408,7 @@ export const LedgerService = (): ILedgerService => {
     usd,
     usdFee,
     pubkey,
-    recipientLiabilitiesAccountId,
+    recipientLiabilitiesWalletId,
     payerUsername,
     recipientUsername,
     memoPayer,
@@ -431,7 +431,7 @@ export const LedgerService = (): ILedgerService => {
       liabilitiesWalletId,
       description,
       sats,
-      recipientLiabilitiesAccountId,
+      recipientLiabilitiesWalletId,
       payerUsername,
       recipientUsername,
       memoPayer,
@@ -449,7 +449,7 @@ export const LedgerService = (): ILedgerService => {
     usdFee,
     payeeAddresses,
     sendAll,
-    recipientLiabilitiesAccountId,
+    recipientLiabilitiesWalletId,
     payerUsername,
     recipientUsername,
     memoPayer,
@@ -472,7 +472,7 @@ export const LedgerService = (): ILedgerService => {
       liabilitiesWalletId,
       description,
       sats,
-      recipientLiabilitiesAccountId,
+      recipientLiabilitiesWalletId,
       payerUsername,
       recipientUsername,
       memoPayer,
@@ -488,7 +488,7 @@ export const LedgerService = (): ILedgerService => {
     fee,
     usd,
     usdFee,
-    recipientLiabilitiesAccountId,
+    recipientLiabilitiesWalletId,
     payerUsername,
     recipientUsername,
     memoPayer,
@@ -509,7 +509,7 @@ export const LedgerService = (): ILedgerService => {
       liabilitiesWalletId,
       description,
       sats,
-      recipientLiabilitiesAccountId,
+      recipientLiabilitiesWalletId,
       payerUsername,
       recipientUsername,
       memoPayer,
@@ -522,7 +522,7 @@ export const LedgerService = (): ILedgerService => {
     liabilitiesWalletId,
     description,
     sats,
-    recipientLiabilitiesAccountId,
+    recipientLiabilitiesWalletId,
     payerUsername,
     recipientUsername,
     memoPayer,
@@ -540,7 +540,7 @@ export const LedgerService = (): ILedgerService => {
       const entry = MainBook.entry(description)
 
       entry
-        .credit(recipientLiabilitiesAccountId, sats, creditMetadata)
+        .credit(recipientLiabilitiesWalletId, sats, creditMetadata)
         .debit(liabilitiesWalletId, sats, debitMetadata)
 
       const savedEntry = await entry.commit()

--- a/src/services/ledger/schema.ts
+++ b/src/services/ledger/schema.ts
@@ -159,6 +159,8 @@ transactionSchema.index({
   "book": 1,
   "approved": 1,
 })
+// TODO: look at if this one is still needed. maybe we only have 2 levels now?
+// following this refactoring: https://github.com/GaloyMoney/galoy/pull/377
 transactionSchema.index({
   "account_path.0": 1,
   "account_path.1": 1,

--- a/src/services/ledger/schema.ts
+++ b/src/services/ledger/schema.ts
@@ -113,7 +113,16 @@ const transactionSchema = new Schema({
   meta: Schema.Types.Mixed,
   datetime: Date,
   account_path: [String],
-  accounts: String,
+  accounts: {
+    type: String,
+    validate: {
+      validator: function (v) {
+        // liabilities account should be uuid-v4
+        if (v.startsWith("Liabilities")) return v.length === 12 + 36
+        else return true
+      },
+    },
+  },
   book: String,
   memo: String,
   _journal: {

--- a/src/services/mongodb/index.ts
+++ b/src/services/mongodb/index.ts
@@ -7,19 +7,19 @@ import { User, Transaction, InvoiceUser } from "../mongoose/schema"
 import { loadLedger } from "@services/ledger"
 
 export const ledger = loadLedger({
-  bankOwnerAccountResolver: async () => {
-    const { _id } = await User.findOne(
+  bankOwnerWalletResolver: async () => {
+    const { walletId } = await User.findOne(
       { role: "bankowner" },
       { lastIPs: 0, lastConnection: 0 },
     )
-    return _id
+    return walletId
   },
-  dealerAccountResolver: async () => {
-    const { _id } = await User.findOne(
+  dealerWalletResolver: async () => {
+    const { walletId } = await User.findOne(
       { role: "dealer" },
       { lastIPs: 0, lastConnection: 0 },
     )
-    return _id
+    return walletId
   },
 })
 

--- a/src/services/mongoose/accounts.ts
+++ b/src/services/mongoose/accounts.ts
@@ -12,7 +12,7 @@ const projection = {
   level: 1,
   status: 1,
   coordinates: 1,
-  walletPublicId: 1,
+  walletId: 1,
   username: 1,
   title: 1,
   created_at: 1,
@@ -34,8 +34,8 @@ export const AccountsRepository = (): IAccountsRepository => {
     walletId: WalletId,
   ): Promise<Account | RepositoryError> => {
     try {
-      const result: UserType = await User.findOne({ _id: walletId }, projection)
-      if (!result) return new CouldNotFindError()
+      const result: UserType = await User.findOne({ walletId }, projection)
+      if (!result) return new CouldNotFindError("Invalid wallet")
       return translateToAccount(result)
     } catch (err) {
       return new UnknownRepositoryError(err)
@@ -64,23 +64,6 @@ export const AccountsRepository = (): IAccountsRepository => {
     const account = await findById(accountId)
     if (account instanceof Error) return account
     return [account]
-  }
-
-  const findByWalletPublicId = async (
-    walletPublicId: WalletPublicId,
-  ): Promise<Account | RepositoryError> => {
-    try {
-      const result: UserType = await User.findOne(
-        {
-          walletPublicId,
-        },
-        projection,
-      )
-      if (!result) return new CouldNotFindError("Invalid wallet")
-      return translateToAccount(result)
-    } catch (err) {
-      return new UnknownRepositoryError(err)
-    }
   }
 
   // FIXME: could be in a different file? does not return an Account
@@ -143,7 +126,6 @@ export const AccountsRepository = (): IAccountsRepository => {
     listByUserId,
     findByWalletId,
     findByUsername,
-    findByWalletPublicId,
     listBusinessesForMap,
     update,
   }
@@ -152,12 +134,12 @@ export const AccountsRepository = (): IAccountsRepository => {
 const translateToAccount = (result: UserType): Account => ({
   id: result.id as AccountId,
   createdAt: new Date(result.created_at),
-  defaultWalletId: result.walletPublicId as WalletPublicId, // TODO: add defaultWalletId at the persistence layer when Account have multiple wallet
+  defaultWalletId: result.walletId as WalletId, // TODO: add defaultWalletId at the persistence layer when Account have multiple wallet
   username: result.username as Username,
   level: (result.level as AccountLevel) || AccountLevel.One,
   status: (result.status as AccountStatus) || AccountStatus.Active,
   title: result.title as BusinessMapTitle,
   coordinates: result.coordinates as Coordinates,
-  walletIds: [result.id as WalletId],
+  walletIds: [result.walletId as WalletId],
   ownerId: result.id as UserId,
 })

--- a/src/services/mongoose/schema.ts
+++ b/src/services/mongoose/schema.ts
@@ -9,7 +9,7 @@ import {
   USER_ACTIVENESS_MONTHLY_VOLUME_THRESHOLD,
 } from "@config/app"
 import { UsernameRegex } from "@domain/users"
-import { accountPath } from "@services/ledger/accounts"
+import { walletPath } from "@services/ledger/accounts"
 import { Transaction } from "@services/ledger/schema"
 import crypto from "crypto"
 import * as _ from "lodash"
@@ -284,8 +284,8 @@ UserSchema.virtual("ratioBtc").get(function (this: typeof UserSchema) {
 })
 
 // this is the accounting path in medici for this user
-UserSchema.virtual("accountPath").get(function (this: typeof UserSchema) {
-  return accountPath(this._id)
+UserSchema.virtual("walletPath").get(function (this: typeof UserSchema) {
+  return walletPath(this.walletId)
 })
 
 UserSchema.virtual("oldEnoughForWithdrawal").get(function (this: typeof UserSchema) {
@@ -313,7 +313,7 @@ UserSchema.methods.remainingTwoFALimit = async function () {
   const { outgoingSats } = await User.getVolume({
     after: getTimestampYesterday(),
     txnType,
-    accounts: this.accountPath,
+    accounts: this.walletPath,
   })
 
   return threshold - outgoingSats
@@ -328,7 +328,7 @@ UserSchema.methods.remainingWithdrawalLimit = async function () {
   const { outgoingSats } = await User.getVolume({
     after: getTimestampYesterday(),
     txnType: [{ type: "on_us" }, { type: "onchain_on_us" }],
-    accounts: this.accountPath,
+    accounts: this.walletPath,
   })
 
   return withdrawalLimit - outgoingSats
@@ -341,7 +341,7 @@ UserSchema.methods.remainingOnUsLimit = async function () {
   const { outgoingSats } = await User.getVolume({
     after: getTimestampYesterday(),
     txnType: [{ type: "on_us" }, { type: "onchain_on_us" }],
-    accounts: this.accountPath,
+    accounts: this.walletPath,
   })
 
   return onUsLimit - outgoingSats
@@ -401,7 +401,7 @@ UserSchema.virtual("userIsActive").get(async function (this: typeof UserSchema) 
   const volume = await User.getVolume({
     after: timestamp30DaysAgo,
     txnType: [{ type: { $exists: true } }],
-    accounts: this.accountPath,
+    accounts: this.walletPath,
   })
 
   return (

--- a/src/services/mongoose/schema.ts
+++ b/src/services/mongoose/schema.ts
@@ -31,7 +31,7 @@ export const DbMetadata = mongoose.model("DbMetadata", dbMetadataSchema)
 
 const invoiceUserSchema = new Schema({
   _id: String, // hash of invoice
-  uid: String,
+  walletId: String,
 
   // usd equivalent. sats is attached in the invoice directly.
   // optional, as BTC wallet doesn't have to set a sat amount when creating the invoice
@@ -58,7 +58,7 @@ const invoiceUserSchema = new Schema({
   },
 })
 
-invoiceUserSchema.index({ uid: 1, paid: 1 })
+invoiceUserSchema.index({ walletId: 1, paid: 1 })
 
 export const InvoiceUser = mongoose.model("InvoiceUser", invoiceUserSchema)
 
@@ -263,7 +263,7 @@ const UserSchema = new Schema<UserType>({
     },
   },
 
-  walletPublicId: {
+  walletId: {
     type: String,
     index: true,
     unique: true,

--- a/src/services/mongoose/schema.types.d.ts
+++ b/src/services/mongoose/schema.types.d.ts
@@ -78,7 +78,7 @@ interface UserType {
   // virtual:
   ratioUsd: number
   ratioBtc: number
-  accountPath: string
+  walletPath: string
   oldEnoughForWithdrawal: boolean
 
   // methods

--- a/src/services/mongoose/schema.types.d.ts
+++ b/src/services/mongoose/schema.types.d.ts
@@ -69,7 +69,7 @@ interface UserType {
   currencies: CurrencyObjectForUser[]
   onchain?: OnChainObjectForUser[]
   twoFA: TwoFAForUser
-  walletPublicId: WalletPublicId
+  walletId: WalletId
 
   // business:
   title?: string

--- a/src/services/mongoose/users.ts
+++ b/src/services/mongoose/users.ts
@@ -76,16 +76,12 @@ export const UsersRepository = (): IUsersRepository => {
     }
   }
 
-  const findByWalletPublicId = async (
-    walletPublicId: WalletPublicId,
-  ): Promise<User | RepositoryError> => {
+  // TODO: remove. user should have no direct link with wallet.
+  const findByWalletId = async (walletId: WalletId): Promise<User | RepositoryError> => {
     try {
-      const result = await User.findOne(
-        { walletPublicId },
-        { lastIPs: 0, lastConnection: 0 },
-      )
+      const result = await User.findOne({ walletId }, { lastIPs: 0, lastConnection: 0 })
       if (!result) {
-        return new CouldNotFindUserFromWalletIdError(walletPublicId)
+        return new CouldNotFindUserFromWalletIdError(walletId)
       }
 
       return userFromRaw(result)
@@ -135,7 +131,7 @@ export const UsersRepository = (): IUsersRepository => {
     findByUsername,
     findByPhone,
     persistNew,
-    findByWalletPublicId,
+    findByWalletId,
     update,
   }
 }

--- a/src/services/mongoose/users.ts
+++ b/src/services/mongoose/users.ts
@@ -4,7 +4,6 @@ import {
   CouldNotFindUserFromIdError,
   CouldNotFindUserFromPhoneError,
   CouldNotFindUserFromUsernameError,
-  CouldNotFindUserFromWalletIdError,
   RepositoryError,
   UnknownRepositoryError,
 } from "@domain/errors"
@@ -76,20 +75,6 @@ export const UsersRepository = (): IUsersRepository => {
     }
   }
 
-  // TODO: remove. user should have no direct link with wallet.
-  const findByWalletId = async (walletId: WalletId): Promise<User | RepositoryError> => {
-    try {
-      const result = await User.findOne({ walletId }, { lastIPs: 0, lastConnection: 0 })
-      if (!result) {
-        return new CouldNotFindUserFromWalletIdError(walletId)
-      }
-
-      return userFromRaw(result)
-    } catch (err) {
-      return new UnknownRepositoryError(err)
-    }
-  }
-
   const update = async ({
     id,
     phone,
@@ -131,7 +116,6 @@ export const UsersRepository = (): IUsersRepository => {
     findByUsername,
     findByPhone,
     persistNew,
-    findByWalletId,
     update,
   }
 }

--- a/src/services/mongoose/wallets.ts
+++ b/src/services/mongoose/wallets.ts
@@ -1,11 +1,10 @@
 import {
-  UnknownRepositoryError,
-  RepositoryError,
   CouldNotFindWalletFromIdError,
-  CouldNotFindWalletFromUsernameError,
   CouldNotFindWalletFromOnChainAddressError,
-  CouldNotFindWalletFromPublicIdError,
   CouldNotFindWalletFromOnChainAddressesError,
+  CouldNotFindWalletFromUsernameError,
+  RepositoryError,
+  UnknownRepositoryError,
 } from "@domain/errors"
 import { User } from "@services/mongoose/schema"
 import { caseInsensitiveRegex } from "./users"
@@ -13,7 +12,7 @@ import { caseInsensitiveRegex } from "./users"
 export const WalletsRepository = (): IWalletsRepository => {
   const findById = async (walletId: WalletId): Promise<Wallet | RepositoryError> => {
     try {
-      const result = await User.findOne({ _id: walletId })
+      const result = await User.findOne({ walletId })
       if (!result) {
         return new CouldNotFindWalletFromIdError()
       }
@@ -52,21 +51,6 @@ export const WalletsRepository = (): IWalletsRepository => {
     }
   }
 
-  const findByPublicId = async (
-    walletPublicId: WalletPublicId,
-  ): Promise<Wallet | RepositoryError> => {
-    try {
-      const result = await User.findOne({ walletPublicId })
-      if (!result) {
-        return new CouldNotFindWalletFromPublicIdError()
-      }
-
-      return resultToWallet(result)
-    } catch (err) {
-      return new UnknownRepositoryError(err)
-    }
-  }
-
   const listByAddresses = async (
     addresses: string[],
   ): Promise<Wallet[] | RepositoryError> => {
@@ -85,14 +69,12 @@ export const WalletsRepository = (): IWalletsRepository => {
     findById,
     findByAddress,
     findByUsername,
-    findByPublicId,
     listByAddresses,
   }
 }
 
 const resultToWallet = (result: UserType): Wallet => {
-  const walletId = result.id as WalletId
-  const publicId = result.walletPublicId
+  const walletId = result.walletId as WalletId
   const depositFeeRatio = result.depositFeeRatio as DepositFeeRatio
   const withdrawFee = result.withdrawFee as WithdrawFee
 
@@ -110,7 +92,6 @@ const resultToWallet = (result: UserType): Wallet => {
     id: walletId,
     depositFeeRatio,
     withdrawFee,
-    publicId,
     onChainAddressIdentifiers,
     onChainAddresses,
   }

--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -4,12 +4,9 @@ import {
   USER_PRICE_UPDATE_EVENT,
   walletUpdateEvent,
 } from "@config/app"
-
 import { NotificationsServiceError, NotificationType } from "@domain/notifications"
-
 import { User } from "@services/mongoose/schema"
 import pubsub from "@services/pubsub"
-
 import { transactionNotification } from "./payment"
 
 export const NotificationsService = (logger: Logger): INotificationsService => {
@@ -28,7 +25,7 @@ export const NotificationsService = (logger: Logger): INotificationsService => {
   }): Promise<void | NotificationsServiceError> => {
     try {
       // work around to move forward before re-wrighting the whole notifications module
-      const user = await User.findOne({ _id: walletId })
+      const user = await User.findOne({ walletId })
 
       // Do not await this call for quicker processing
       transactionNotification({
@@ -41,7 +38,7 @@ export const NotificationsService = (logger: Logger): INotificationsService => {
       })
 
       // Notify the recipient (via GraphQL subscription if any)
-      const walletUpdatedEventName = walletUpdateEvent(user.id)
+      const walletUpdatedEventName = walletUpdateEvent(walletId)
 
       pubsub.publish(walletUpdatedEventName, {
         transaction: {
@@ -108,7 +105,7 @@ export const NotificationsService = (logger: Logger): INotificationsService => {
   }: LnInvoicePaidArgs) => {
     try {
       // work around to move forward before re-wrighting the whole notifications module
-      const user = await User.findOne({ _id: recipientWalletId })
+      const user = await User.findOne({ walletId: recipientWalletId })
 
       // Do not await this call for quicker processing
       transactionNotification({
@@ -168,7 +165,7 @@ export const NotificationsService = (logger: Logger): INotificationsService => {
       publish(recipientWalletId, NotificationType.IntraLedgerReceipt)
 
       // work around to move forward before re-wrighting the whole notifications module
-      const payerUser = await User.findOne({ _id: payerWalletId })
+      const payerUser = await User.findOne({ walletId: payerWalletId })
 
       // Do not await this call for quicker processing
       transactionNotification({
@@ -179,7 +176,7 @@ export const NotificationsService = (logger: Logger): INotificationsService => {
         usdPerSat,
       })
 
-      const recipientUser = await User.findOne({ _id: recipientWalletId })
+      const recipientUser = await User.findOne({ walletId: recipientWalletId })
 
       // Do not await this call for quicker processing
       transactionNotification({

--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -105,7 +105,7 @@ export const NotificationsService = (logger: Logger): INotificationsService => {
   }: LnInvoicePaidArgs) => {
     try {
       // work around to move forward before re-wrighting the whole notifications module
-      const user = await User.findOne({ walletId: recipientWalletId })
+      const user: UserType = await User.findOne({ walletId: recipientWalletId })
 
       // Do not await this call for quicker processing
       transactionNotification({

--- a/src/services/rate-limit/index.ts
+++ b/src/services/rate-limit/index.ts
@@ -1,10 +1,9 @@
-import { RateLimiterRedis } from "rate-limiter-flexible"
-import { redis } from "@services/redis"
-
 import {
   RateLimiterExceededError,
   UnknownRateLimitServiceError,
 } from "@domain/rate-limit/errors"
+import { redis } from "@services/redis"
+import { RateLimiterRedis } from "rate-limiter-flexible"
 
 export const RedisRateLimitService = ({
   keyPrefix,

--- a/test/helpers/rate-limit.ts
+++ b/test/helpers/rate-limit.ts
@@ -6,38 +6,36 @@ import {
 import { RateLimitPrefix } from "@domain/rate-limit"
 import { RedisRateLimitService } from "@services/rate-limit"
 
-const invoiceCreateAttemptLimits = getInvoiceCreateAttemptLimits()
-const limiterInvoiceCreateAttemptLimits = RedisRateLimitService({
-  keyPrefix: RateLimitPrefix.invoiceCreate,
-  limitOptions: invoiceCreateAttemptLimits,
-})
-
 export const resetSelfWalletIdLimits = async (
   walletId: WalletId,
 ): Promise<true | RateLimitServiceError> => {
+  const invoiceCreateAttemptLimits = getInvoiceCreateAttemptLimits()
+  const limiterInvoiceCreateAttemptLimits = RedisRateLimitService({
+    keyPrefix: RateLimitPrefix.invoiceCreate,
+    limitOptions: invoiceCreateAttemptLimits,
+  })
   return limiterInvoiceCreateAttemptLimits.reset(walletId)
 }
-
-const invoiceCreateForRecipientAttemptLimits = getInvoiceCreateForRecipientAttemptLimits()
-const limiterInvoiceCreateForRecipientAttemptLimits = RedisRateLimitService({
-  keyPrefix: RateLimitPrefix.invoiceCreateForRecipient,
-  limitOptions: invoiceCreateForRecipientAttemptLimits,
-})
 
 export const resetRecipientWalletIdLimits = async (
   walletId: WalletId,
 ): Promise<true | RateLimitServiceError> => {
+  const invoiceCreateForRecipientAttemptLimits =
+    getInvoiceCreateForRecipientAttemptLimits()
+  const limiterInvoiceCreateForRecipientAttemptLimits = RedisRateLimitService({
+    keyPrefix: RateLimitPrefix.invoiceCreateForRecipient,
+    limitOptions: invoiceCreateForRecipientAttemptLimits,
+  })
   return limiterInvoiceCreateForRecipientAttemptLimits.reset(walletId)
 }
-
-const onChainAddressCreateAttempt = getOnChainAddressCreateAttemptLimits()
-const limiterOnChainAddressCreateAttempt = RedisRateLimitService({
-  keyPrefix: RateLimitPrefix.onChainAddressCreate,
-  limitOptions: onChainAddressCreateAttempt,
-})
 
 export const resetOnChainAddressWalletIdLimits = async (
   walletId: WalletId,
 ): Promise<true | RateLimitServiceError> => {
+  const onChainAddressCreateAttempt = getOnChainAddressCreateAttemptLimits()
+  const limiterOnChainAddressCreateAttempt = RedisRateLimitService({
+    keyPrefix: RateLimitPrefix.onChainAddressCreate,
+    limitOptions: onChainAddressCreateAttempt,
+  })
   return limiterOnChainAddressCreateAttempt.reset(walletId)
 }

--- a/test/helpers/rate-limit.ts
+++ b/test/helpers/rate-limit.ts
@@ -6,36 +6,38 @@ import {
 import { RateLimitPrefix } from "@domain/rate-limit"
 import { RedisRateLimitService } from "@services/rate-limit"
 
+const invoiceCreateAttemptLimits = getInvoiceCreateAttemptLimits()
+const limiterInvoiceCreateAttemptLimits = RedisRateLimitService({
+  keyPrefix: RateLimitPrefix.invoiceCreate,
+  limitOptions: invoiceCreateAttemptLimits,
+})
+
 export const resetSelfWalletIdLimits = async (
   walletId: WalletId,
 ): Promise<true | RateLimitServiceError> => {
-  const invoiceCreateAttemptLimits = getInvoiceCreateAttemptLimits()
-  const limiter = RedisRateLimitService({
-    keyPrefix: RateLimitPrefix.invoiceCreate,
-    limitOptions: invoiceCreateAttemptLimits,
-  })
-  return limiter.reset(walletId)
+  return limiterInvoiceCreateAttemptLimits.reset(walletId)
 }
+
+const invoiceCreateForRecipientAttemptLimits = getInvoiceCreateForRecipientAttemptLimits()
+const limiterInvoiceCreateForRecipientAttemptLimits = RedisRateLimitService({
+  keyPrefix: RateLimitPrefix.invoiceCreateForRecipient,
+  limitOptions: invoiceCreateForRecipientAttemptLimits,
+})
 
 export const resetRecipientWalletIdLimits = async (
   walletId: WalletId,
 ): Promise<true | RateLimitServiceError> => {
-  const invoiceCreateForRecipientAttemptLimits =
-    getInvoiceCreateForRecipientAttemptLimits()
-  const limiter = RedisRateLimitService({
-    keyPrefix: RateLimitPrefix.invoiceCreateForRecipient,
-    limitOptions: invoiceCreateForRecipientAttemptLimits,
-  })
-  return limiter.reset(walletId)
+  return limiterInvoiceCreateForRecipientAttemptLimits.reset(walletId)
 }
+
+const onChainAddressCreateAttempt = getOnChainAddressCreateAttemptLimits()
+const limiterOnChainAddressCreateAttempt = RedisRateLimitService({
+  keyPrefix: RateLimitPrefix.onChainAddressCreate,
+  limitOptions: onChainAddressCreateAttempt,
+})
 
 export const resetOnChainAddressWalletIdLimits = async (
   walletId: WalletId,
 ): Promise<true | RateLimitServiceError> => {
-  const onChainAddressCreateAttempt = getOnChainAddressCreateAttemptLimits()
-  const limiter = RedisRateLimitService({
-    keyPrefix: RateLimitPrefix.onChainAddressCreate,
-    limitOptions: onChainAddressCreateAttempt,
-  })
-  return limiter.reset(walletId)
+  return limiterOnChainAddressCreateAttempt.reset(walletId)
 }

--- a/test/helpers/wallet.ts
+++ b/test/helpers/wallet.ts
@@ -1,7 +1,6 @@
 import * as Wallets from "@app/wallets"
 import { getTwoFALimits, getUserLimits, MS_PER_DAY } from "@config/app"
 import { toSats } from "@domain/bitcoin"
-import { toLiabilitiesWalletId } from "@domain/ledger"
 import { LedgerService } from "@services/ledger"
 import { baseLogger } from "@services/logger"
 
@@ -23,7 +22,7 @@ export const getRemainingIntraledgerLimit = async ({
 }): Promise<Satoshis | ApplicationError> => {
   const timestamp1Day = new Date(Date.now() - MS_PER_DAY)
   const walletVolume = await LedgerService().intraledgerTxVolumeSince({
-    liabilitiesWalletId: toLiabilitiesWalletId(walletId),
+    walletId,
     timestamp: timestamp1Day,
   })
   if (walletVolume instanceof Error) return walletVolume
@@ -42,7 +41,7 @@ export const getRemainingWithdrawalLimit = async ({
 }): Promise<Satoshis | ApplicationError> => {
   const timestamp1Day = new Date(Date.now() - MS_PER_DAY)
   const walletVolume = await LedgerService().withdrawalTxVolumeSince({
-    liabilitiesWalletId: toLiabilitiesWalletId(walletId),
+    walletId,
     timestamp: timestamp1Day,
   })
   if (walletVolume instanceof Error) return walletVolume
@@ -57,7 +56,7 @@ export const getRemainingTwoFALimit = async (
 ): Promise<Satoshis | ApplicationError> => {
   const timestamp1Day = new Date(Date.now() - MS_PER_DAY)
   const walletVolume = await LedgerService().withdrawalTxVolumeSince({
-    liabilitiesWalletId: toLiabilitiesWalletId(walletId),
+    walletId,
     timestamp: timestamp1Day,
   })
   if (walletVolume instanceof Error) return walletVolume

--- a/test/helpers/wallet.ts
+++ b/test/helpers/wallet.ts
@@ -1,7 +1,7 @@
 import * as Wallets from "@app/wallets"
 import { getTwoFALimits, getUserLimits, MS_PER_DAY } from "@config/app"
 import { toSats } from "@domain/bitcoin"
-import { toLiabilitiesAccountId } from "@domain/ledger"
+import { toLiabilitiesWalletId } from "@domain/ledger"
 import { LedgerService } from "@services/ledger"
 import { baseLogger } from "@services/logger"
 
@@ -23,7 +23,7 @@ export const getRemainingIntraledgerLimit = async ({
 }): Promise<Satoshis | ApplicationError> => {
   const timestamp1Day = new Date(Date.now() - MS_PER_DAY)
   const walletVolume = await LedgerService().intraledgerTxVolumeSince({
-    liabilitiesAccountId: toLiabilitiesAccountId(walletId),
+    liabilitiesWalletId: toLiabilitiesWalletId(walletId),
     timestamp: timestamp1Day,
   })
   if (walletVolume instanceof Error) return walletVolume
@@ -42,7 +42,7 @@ export const getRemainingWithdrawalLimit = async ({
 }): Promise<Satoshis | ApplicationError> => {
   const timestamp1Day = new Date(Date.now() - MS_PER_DAY)
   const walletVolume = await LedgerService().withdrawalTxVolumeSince({
-    liabilitiesAccountId: toLiabilitiesAccountId(walletId),
+    liabilitiesWalletId: toLiabilitiesWalletId(walletId),
     timestamp: timestamp1Day,
   })
   if (walletVolume instanceof Error) return walletVolume
@@ -57,7 +57,7 @@ export const getRemainingTwoFALimit = async (
 ): Promise<Satoshis | ApplicationError> => {
   const timestamp1Day = new Date(Date.now() - MS_PER_DAY)
   const walletVolume = await LedgerService().withdrawalTxVolumeSince({
-    liabilitiesAccountId: toLiabilitiesAccountId(walletId),
+    liabilitiesWalletId: toLiabilitiesWalletId(walletId),
     timestamp: timestamp1Day,
   })
   if (walletVolume instanceof Error) return walletVolume

--- a/test/integration/01-setup/01-funds-bitcoind-lnds.spec.ts
+++ b/test/integration/01-setup/01-funds-bitcoind-lnds.spec.ts
@@ -78,7 +78,7 @@ describe("Bitcoind", () => {
     await getAndCreateUserWallet(4)
 
     const funderWallet = await getWalletFromRole({ role: "funder", logger: baseLogger })
-    const address = await Wallets.createOnChainAddress(funderWallet.user.id)
+    const address = await Wallets.createOnChainAddress(funderWallet.user.walletId)
     if (address instanceof Error) throw address
 
     await sendToAddressAndConfirm({ walletClient: bitcoindOutside, address, amount })

--- a/test/integration/02-user-wallet/02-invoice.spec.ts
+++ b/test/integration/02-user-wallet/02-invoice.spec.ts
@@ -95,17 +95,16 @@ describe("UserWallet - addInvoice", () => {
     return testPastSelfInvoiceLimits(userWallet1.user)
   })
 
-  // FIXME: remove the skip
-  it.skip("adds a public invoice", async () => {
-    // const lnInvoice = await addInvoiceNoAmountForRecipient({
-    //   recipientWalletId: "user1",
-    // })
-    // if (lnInvoice instanceof Error) return lnInvoice
-    // const { paymentRequest: request } = lnInvoice
-    // expect(request.startsWith("lnbcrt1")).toBeTruthy()
-    // const { uid, selfGenerated } = await InvoiceUser.findById(getHash(request))
-    // expect(String(uid)).toBe(String(userWallet1.user._id))
-    // expect(selfGenerated).toBe(false)
+  it("adds a public invoice", async () => {
+    const lnInvoice = await addInvoiceNoAmountForRecipient({
+      recipientWalletId: userWallet1.user.walletId,
+    })
+    if (lnInvoice instanceof Error) throw lnInvoice
+    const { paymentRequest: request } = lnInvoice
+    expect(request.startsWith("lnbcrt1")).toBeTruthy()
+    const { walletId, selfGenerated } = await InvoiceUser.findById(getHash(request))
+    expect(String(walletId)).toBe(String(userWallet1.user.walletId))
+    expect(selfGenerated).toBe(false)
   })
 
   it("fails to add public invoice past rate limit", async () => {

--- a/test/integration/02-user-wallet/02-receive-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-lightning.spec.ts
@@ -23,7 +23,7 @@ beforeAll(async () => {
 })
 
 beforeEach(async () => {
-  initBalance1 = await getBTCBalance(userWallet1.user.id)
+  initBalance1 = await getBTCBalance(userWallet1.user.walletId)
 })
 
 afterEach(async () => {
@@ -37,7 +37,7 @@ describe("UserWallet - Lightning", () => {
     const memo = "myMemo"
 
     const lnInvoice = await addInvoice({
-      walletId: userWallet1.user.id as WalletId,
+      walletId: userWallet1.user.walletId as WalletId,
       amount: toSats(sats),
       memo,
     })
@@ -81,7 +81,7 @@ describe("UserWallet - Lightning", () => {
 
     // check that memo is not filtered by spam filter
     const { result: txns, error } = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
     })
     if (error instanceof Error || txns === null) {
       throw error
@@ -93,7 +93,7 @@ describe("UserWallet - Lightning", () => {
     ) as WalletTransaction
     expect(noSpamTxn.deprecated.description).toBe(memo)
 
-    const finalBalance = await getBTCBalance(userWallet1.user.id)
+    const finalBalance = await getBTCBalance(userWallet1.user.walletId)
     expect(finalBalance).toBe(initBalance1 + sats)
   })
 
@@ -101,7 +101,7 @@ describe("UserWallet - Lightning", () => {
     const sats = 1000
 
     const lnInvoice = await addInvoiceNoAmount({
-      walletId: userWallet1.user.id as WalletId,
+      walletId: userWallet1.user.walletId as WalletId,
     })
     if (lnInvoice instanceof Error) return lnInvoice
     const { paymentRequest: invoice } = lnInvoice
@@ -129,7 +129,7 @@ describe("UserWallet - Lightning", () => {
     expect(dbTx.memo).toBe("")
     expect(dbTx.pending).toBe(false)
 
-    const finalBalance = await getBTCBalance(userWallet1.user.id)
+    const finalBalance = await getBTCBalance(userWallet1.user.walletId)
     expect(finalBalance).toBe(initBalance1 + sats)
   })
 
@@ -143,7 +143,7 @@ describe("UserWallet - Lightning", () => {
 
     // process spam transaction
     const lnInvoice = await addInvoice({
-      walletId: userWallet1.user.id as WalletId,
+      walletId: userWallet1.user.walletId as WalletId,
       amount: toSats(sats),
       memo,
     })
@@ -165,7 +165,7 @@ describe("UserWallet - Lightning", () => {
 
     // check that spam memo is filtered from transaction description
     const { result: txns, error } = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
     })
     if (error instanceof Error || txns === null) {
       throw error
@@ -179,7 +179,7 @@ describe("UserWallet - Lightning", () => {
     expect(spamTxn.deprecated.description).toBe(dbTx.type)
 
     // confirm expected final balance
-    const finalBalance = await getBTCBalance(userWallet1.user.id)
+    const finalBalance = await getBTCBalance(userWallet1.user.walletId)
     expect(finalBalance).toBe(initBalance1 + sats)
   })
 })

--- a/test/integration/02-user-wallet/02-receive-rewards.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-rewards.spec.ts
@@ -1,8 +1,8 @@
-import { find, difference } from "lodash"
 import { MS_PER_DAY, onboardingEarn } from "@config/app"
+import { difference, find } from "lodash"
 import { checkIsBalanced, getAndCreateUserWallet } from "test/helpers"
-import { getBTCBalance } from "test/helpers/wallet"
 import { resetSelfWalletIdLimits } from "test/helpers/rate-limit"
+import { getBTCBalance } from "test/helpers/wallet"
 
 let userWallet1
 
@@ -28,15 +28,15 @@ afterAll(() => {
 
 describe("UserWallet - addEarn", () => {
   it("adds balance only once", async () => {
-    const resetOk = await resetSelfWalletIdLimits(userWallet1.user.id)
+    const resetOk = await resetSelfWalletIdLimits(userWallet1.user.walletId)
     expect(resetOk).not.toBeInstanceOf(Error)
     if (resetOk instanceof Error) throw resetOk
 
-    const initialBalance = await getBTCBalance(userWallet1.user.id)
+    const initialBalance = await getBTCBalance(userWallet1.user.walletId)
 
     const getAndVerifyRewards = async () => {
       await userWallet1.addEarn(onBoardingEarnIds)
-      const finalBalance = await getBTCBalance(userWallet1.user.id)
+      const finalBalance = await getBTCBalance(userWallet1.user.walletId)
       let rewards = onBoardingEarnAmt
       if (difference(onBoardingEarnIds, userWallet1.user.earn).length === 0) {
         rewards = 0

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -23,7 +23,7 @@ import {
 import * as Wallets from "@app/wallets"
 import { addInvoice } from "@app/wallets/add-invoice-for-wallet"
 import { toSats, FEECAP } from "@domain/bitcoin"
-import { toLiabilitiesAccountId } from "@domain/ledger"
+import { toLiabilitiesWalletId } from "@domain/ledger"
 import {
   SelfPaymentError as DomainSelfPaymentError,
   InsufficientBalanceError as DomainInsufficientBalanceError,
@@ -62,8 +62,8 @@ beforeAll(async () => {
 })
 
 beforeEach(async () => {
-  initBalance0 = await getBTCBalance(userWallet0.user.id)
-  initBalance1 = await getBTCBalance(userWallet1.user.id)
+  initBalance0 = await getBTCBalance(userWallet0.user.walletId)
+  initBalance1 = await getBTCBalance(userWallet1.user.walletId)
 })
 
 afterEach(async () => {
@@ -79,7 +79,7 @@ describe("UserWallet - Lightning Pay", () => {
     const memo = "invoiceMemo"
 
     const lnInvoice = await addInvoice({
-      walletId: userWallet2.user.id as WalletId,
+      walletId: userWallet2.user.walletId as WalletId,
       amount: toSats(amountInvoice),
       memo,
     })
@@ -94,7 +94,7 @@ describe("UserWallet - Lightning Pay", () => {
     const paymentResult = await lnInvoicePaymentSend({
       paymentRequest: invoice,
       memo: null,
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
       userId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
@@ -110,7 +110,7 @@ describe("UserWallet - Lightning Pay", () => {
       tx.initiationVia.paymentHash === getHash(invoice)
 
     let txResult = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
     })
     if (txResult.error instanceof Error || txResult.result === null) {
       throw txResult.error
@@ -121,7 +121,7 @@ describe("UserWallet - Lightning Pay", () => {
     // expect(user1Txn.filter(matchTx)[0].recipientUsername).toBe("lily")
 
     txResult = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
     })
     if (txResult.error instanceof Error || txResult.result === null) {
       throw txResult.error
@@ -136,7 +136,7 @@ describe("UserWallet - Lightning Pay", () => {
     const memoPayer = "my memo as a payer"
 
     const lnInvoice = await addInvoice({
-      walletId: userWallet2.user.id as WalletId,
+      walletId: userWallet2.user.walletId as WalletId,
       amount: toSats(amountInvoice),
       memo,
     })
@@ -146,7 +146,7 @@ describe("UserWallet - Lightning Pay", () => {
     const paymentResult = await lnInvoicePaymentSend({
       paymentRequest: request,
       memo: memoPayer,
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
       userId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
@@ -157,7 +157,7 @@ describe("UserWallet - Lightning Pay", () => {
       tx.initiationVia.paymentHash === getHash(request)
 
     let txResult = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet2.user.id,
+      walletId: userWallet2.user.walletId,
     })
     if (txResult.error instanceof Error || txResult.result === null) {
       throw txResult.error
@@ -167,7 +167,7 @@ describe("UserWallet - Lightning Pay", () => {
     expect(user2Txn.filter(matchTx)[0].settlementVia.type).toBe("intraledger")
 
     txResult = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
     })
     if (txResult.error instanceof Error || txResult.result === null) {
       throw txResult.error
@@ -182,24 +182,25 @@ describe("UserWallet - Lightning Pay", () => {
       recipientUsername: userWallet0.user.username,
       memo: "",
       amount: toSats(amountInvoice),
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
       userId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
+
     expect(res).not.toBeInstanceOf(Error)
     if (res instanceof Error) throw res
 
-    const finalBalance0 = await getBTCBalance(userWallet0.user.id)
+    const finalBalance0 = await getBTCBalance(userWallet0.user.walletId)
     const { result: userTransaction0, error } = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet0.user.id,
+      walletId: userWallet0.user.walletId,
     })
     if (error instanceof Error || userTransaction0 === null) {
       throw error
     }
 
-    const finalBalance1 = await getBTCBalance(userWallet1.user.id)
+    const finalBalance1 = await getBTCBalance(userWallet1.user.walletId)
     const txResult = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
     })
     if (txResult.error instanceof Error || txResult.result === null) {
       throw txResult.error
@@ -249,7 +250,7 @@ describe("UserWallet - Lightning Pay", () => {
       recipientUsername: userWallet0.user.username,
       memo: "",
       amount: toSats(amountInvoice),
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
       userId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
@@ -283,14 +284,14 @@ describe("UserWallet - Lightning Pay", () => {
       paymentRequest: request as EncodedPaymentRequest,
       memo: null,
       amount: toSats(amountInvoice),
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
       userId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
     if (paymentResult instanceof Error) throw paymentResult
     expect(paymentResult).toBe(PaymentSendStatus.Success)
 
-    const finalBalance = await getBTCBalance(userWallet1.user.id)
+    const finalBalance = await getBTCBalance(userWallet1.user.walletId)
     expect(finalBalance).toBe(initBalance1 - amountInvoice)
   })
 
@@ -301,7 +302,7 @@ describe("UserWallet - Lightning Pay", () => {
       recipientUsername: userWallet0.user.username,
       memo: memoSpamBelowThreshold,
       amount: toSats(satsBelow),
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
       userId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
@@ -314,7 +315,7 @@ describe("UserWallet - Lightning Pay", () => {
       recipientUsername: userWallet0.user.username,
       memo: memoSpamAboveThreshold,
       amount: toSats(satsAbove),
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
       userId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
@@ -322,7 +323,7 @@ describe("UserWallet - Lightning Pay", () => {
     if (resAboveThreshold instanceof Error) throw resAboveThreshold
 
     let txResult = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet0.user.id,
+      walletId: userWallet0.user.walletId,
     })
     if (txResult.error instanceof Error || txResult.result === null) {
       throw txResult.error
@@ -332,7 +333,7 @@ describe("UserWallet - Lightning Pay", () => {
     const transaction0Below = userTransaction0[1]
 
     txResult = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
     })
     if (txResult.error instanceof Error || txResult.result === null) {
       throw txResult.error
@@ -400,7 +401,7 @@ describe("UserWallet - Lightning Pay", () => {
 
   it("fails if sends to self", async () => {
     const lnInvoice = await addInvoice({
-      walletId: userWallet1.user.id as WalletId,
+      walletId: userWallet1.user.walletId as WalletId,
       amount: toSats(amountInvoice),
       memo: "self payment",
     })
@@ -410,7 +411,7 @@ describe("UserWallet - Lightning Pay", () => {
     const paymentResult = await lnInvoicePaymentSend({
       paymentRequest: invoice,
       memo: null,
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
       userId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
@@ -422,7 +423,7 @@ describe("UserWallet - Lightning Pay", () => {
       recipientUsername: userWallet1.user.username,
       memo: "",
       amount: toSats(amountInvoice),
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
       userId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
@@ -437,7 +438,7 @@ describe("UserWallet - Lightning Pay", () => {
     const paymentResult = await lnInvoicePaymentSend({
       paymentRequest: invoice as EncodedPaymentRequest,
       memo: null,
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
       userId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
@@ -449,7 +450,7 @@ describe("UserWallet - Lightning Pay", () => {
     const paymentResult = await lnInvoicePaymentSend({
       paymentRequest: request as EncodedPaymentRequest,
       memo: null,
-      walletId: userWallet0.user.id,
+      walletId: userWallet0.user.walletId,
       userId: userWallet0.user.id,
       logger: userWallet0.logger,
     })
@@ -462,7 +463,7 @@ describe("UserWallet - Lightning Pay", () => {
     const paymentResult = await lnInvoicePaymentSend({
       paymentRequest: request as EncodedPaymentRequest,
       memo: null,
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
       userId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
@@ -477,7 +478,7 @@ describe("UserWallet - Lightning Pay", () => {
     const paymentResult = await lnInvoicePaymentSend({
       paymentRequest: request as EncodedPaymentRequest,
       memo: null,
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
       userId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
@@ -488,7 +489,7 @@ describe("UserWallet - Lightning Pay", () => {
 
   it("fails to pay when amount exceeds onUs limit", async () => {
     const lnInvoice = await addInvoice({
-      walletId: userWallet0.user.id as WalletId,
+      walletId: userWallet0.user.walletId as WalletId,
       amount: toSats(userLimits.onUsLimit + 1),
     })
     if (lnInvoice instanceof Error) return lnInvoice
@@ -497,7 +498,7 @@ describe("UserWallet - Lightning Pay", () => {
     const paymentResult = await lnInvoicePaymentSend({
       paymentRequest: request as EncodedPaymentRequest,
       memo: null,
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
       userId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
@@ -521,7 +522,7 @@ describe("UserWallet - Lightning Pay", () => {
       fn: function fn(wallet) {
         return async (input): Promise<PaymentSendStatus | ApplicationError> => {
           const feeFromProbe = await getLightningFee({
-            walletPublicId: wallet.user.walletPublicId,
+            walletId: wallet.user.walletId,
             paymentRequest: input.invoice,
             logger: wallet.logger,
           })
@@ -529,7 +530,7 @@ describe("UserWallet - Lightning Pay", () => {
           const paymentResult = await lnInvoicePaymentSendWithTwoFA({
             paymentRequest: input.invoice as EncodedPaymentRequest,
             memo: input.memo,
-            walletId: wallet.user.id,
+            walletId: wallet.user.walletId,
             userId: wallet.user.id,
             twoFAToken: input.twoFAToken || null,
             logger: wallet.logger,
@@ -546,7 +547,7 @@ describe("UserWallet - Lightning Pay", () => {
           const paymentResult = await lnInvoicePaymentSendWithTwoFA({
             paymentRequest: input.invoice as EncodedPaymentRequest,
             memo: input.memo,
-            walletId: wallet.user.id,
+            walletId: wallet.user.walletId,
             userId: wallet.user.id,
             twoFAToken: input.twoFAToken || null,
             logger: wallet.logger,
@@ -568,7 +569,7 @@ describe("UserWallet - Lightning Pay", () => {
         if (result instanceof Error) throw result
         expect(result).toBe(PaymentSendStatus.Success)
 
-        const finalBalance = await getBTCBalance(userWallet1.user.id)
+        const finalBalance = await getBTCBalance(userWallet1.user.walletId)
         expect(finalBalance).toBe(initBalance1 - amountInvoice)
       })
 
@@ -579,13 +580,13 @@ describe("UserWallet - Lightning Pay", () => {
         })
         const intermediateResult = await fn(userWallet1)({ invoice: request })
         if (intermediateResult instanceof Error) throw intermediateResult
-        const intermediateBalanceSats = await getBTCBalance(userWallet1.user.id)
+        const intermediateBalanceSats = await getBTCBalance(userWallet1.user.walletId)
 
         const result = await fn(userWallet1)({ invoice: request })
         if (result instanceof Error) throw result
         expect(result).toBe(PaymentSendStatus.AlreadyPaid)
 
-        const finalBalanceSats = await getBTCBalance(userWallet1.user.id)
+        const finalBalanceSats = await getBTCBalance(userWallet1.user.walletId)
         expect(finalBalanceSats).toEqual(intermediateBalanceSats)
       })
 
@@ -598,7 +599,7 @@ describe("UserWallet - Lightning Pay", () => {
         const result = await fn(userWallet1)({ invoice: request })
         if (result instanceof Error) throw result
         expect(result).toBe(PaymentSendStatus.Success)
-        const finalBalance = await getBTCBalance(userWallet1.user.id)
+        const finalBalance = await getBTCBalance(userWallet1.user.walletId)
         expect(finalBalance).toBe(initBalance1 - amountInvoice)
       })
 
@@ -606,11 +607,11 @@ describe("UserWallet - Lightning Pay", () => {
         const memo = "my memo as a payer"
 
         const paymentOtherGaloyUser = async ({ walletPayer, walletPayee }) => {
-          const payerInitialBalance = await getBTCBalance(walletPayer.user.id)
-          const payeeInitialBalance = await getBTCBalance(walletPayee.user.id)
+          const payerInitialBalance = await getBTCBalance(walletPayer.user.walletId)
+          const payeeInitialBalance = await getBTCBalance(walletPayee.user.walletId)
 
           const lnInvoice = await addInvoice({
-            walletId: walletPayee.user.id as WalletId,
+            walletId: walletPayee.user.walletId as WalletId,
             amount: toSats(amountInvoice),
           })
           if (lnInvoice instanceof Error) return lnInvoice
@@ -618,8 +619,8 @@ describe("UserWallet - Lightning Pay", () => {
           const result = await fn(walletPayer)({ invoice: request, memo })
           if (result instanceof Error) throw result
 
-          const payerFinalBalance = await getBTCBalance(walletPayer.user.id)
-          const payeeFinalBalance = await getBTCBalance(walletPayee.user.id)
+          const payerFinalBalance = await getBTCBalance(walletPayer.user.walletId)
+          const payeeFinalBalance = await getBTCBalance(walletPayee.user.walletId)
 
           expect(payerFinalBalance).toBe(payerInitialBalance - amountInvoice)
           expect(payeeFinalBalance).toBe(payeeInitialBalance + amountInvoice)
@@ -630,7 +631,7 @@ describe("UserWallet - Lightning Pay", () => {
             tx.initiationVia.paymentHash === hash
 
           let txResult = await Wallets.getTransactionsForWalletId({
-            walletId: walletPayee.user.id,
+            walletId: walletPayee.user.walletId,
           })
           if (txResult.error instanceof Error || txResult.result === null) {
             throw txResult.error
@@ -641,7 +642,7 @@ describe("UserWallet - Lightning Pay", () => {
           await checkIsBalanced()
 
           txResult = await Wallets.getTransactionsForWalletId({
-            walletId: walletPayer.user.id as WalletId,
+            walletId: walletPayer.user.walletId as WalletId,
           })
           if (txResult.error instanceof Error || txResult.result === null) {
             throw txResult.error
@@ -700,7 +701,7 @@ describe("UserWallet - Lightning Pay", () => {
           is_including_private_channels: true,
         })
 
-        const initialBalance = await getBTCBalance(userWallet1.user.id)
+        const initialBalance = await getBTCBalance(userWallet1.user.walletId)
 
         const result = await fn(userWallet1)({
           invoice: request,
@@ -713,7 +714,7 @@ describe("UserWallet - Lightning Pay", () => {
         await waitUntilChannelBalanceSyncAll()
 
         expect(result).toBe(PaymentSendStatus.Success)
-        const finalBalance = await getBTCBalance(userWallet1.user.id)
+        const finalBalance = await getBTCBalance(userWallet1.user.walletId)
 
         // const { id } = await decodePaymentRequest({ lnd: lndOutside2, request })
         // const { results: [{ fee }] } = await getAccountTransactions(userWallet1.accountPath, { hash: id })
@@ -738,7 +739,7 @@ describe("UserWallet - Lightning Pay", () => {
         if (result instanceof Error) throw result
 
         expect(result).toBe(PaymentSendStatus.Pending)
-        const balanceBeforeSettlement = await getBTCBalance(userWallet1.user.id)
+        const balanceBeforeSettlement = await getBTCBalance(userWallet1.user.walletId)
         expect(balanceBeforeSettlement).toBe(
           initBalance1 - amountInvoice * (1 + initialFee),
         )
@@ -757,15 +758,13 @@ describe("UserWallet - Lightning Pay", () => {
 
         await waitFor(async () => {
           const updatedPayments = await Wallets.updatePendingPayments({
-            walletId: userWallet1.user.id,
+            walletId: userWallet1.user.walletId,
             logger: baseLogger,
           })
           if (updatedPayments instanceof Error) throw updatedPayments
 
-          const liabilitiesAccountId = toLiabilitiesAccountId(userWallet1.user.id)
-          const count = await LedgerService().getPendingPaymentsCount(
-            liabilitiesAccountId,
-          )
+          const liabilitiesWalletId = toLiabilitiesWalletId(userWallet1.user.walletId)
+          const count = await LedgerService().getPendingPaymentsCount(liabilitiesWalletId)
           if (count instanceof Error) throw count
 
           const { is_confirmed } = await getInvoice({ lnd: lndOutside1, id })
@@ -774,7 +773,7 @@ describe("UserWallet - Lightning Pay", () => {
 
         await waitUntilChannelBalanceSyncAll()
 
-        const finalBalance = await getBTCBalance(userWallet1.user.id)
+        const finalBalance = await getBTCBalance(userWallet1.user.walletId)
         expect(finalBalance).toBe(initBalance1 - amountInvoice)
       }, 60000)
 
@@ -792,22 +791,20 @@ describe("UserWallet - Lightning Pay", () => {
         expect(result).toBe(PaymentSendStatus.Pending)
         baseLogger.info("payment has timeout. status is pending.")
 
-        const intermediateBalance = await getBTCBalance(userWallet1.user.id)
+        const intermediateBalance = await getBTCBalance(userWallet1.user.walletId)
         expect(intermediateBalance).toBe(initBalance1 - amountInvoice * (1 + initialFee))
 
         await cancelHodlInvoice({ id, lnd: lndOutside1 })
 
         await waitFor(async () => {
           const updatedPayments = await Wallets.updatePendingPayments({
-            walletId: userWallet1.user.id,
+            walletId: userWallet1.user.walletId,
             logger: baseLogger,
           })
           if (updatedPayments instanceof Error) throw updatedPayments
 
-          const liabilitiesAccountId = toLiabilitiesAccountId(userWallet1.user.id)
-          const count = await LedgerService().getPendingPaymentsCount(
-            liabilitiesAccountId,
-          )
+          const liabilitiesWalletId = toLiabilitiesWalletId(userWallet1.user.walletId)
+          const count = await LedgerService().getPendingPaymentsCount(liabilitiesWalletId)
           if (count instanceof Error) throw count
 
           return count === 0
@@ -820,7 +817,7 @@ describe("UserWallet - Lightning Pay", () => {
         // arrives before wallet balances updates in lnd
         await waitUntilChannelBalanceSyncAll()
 
-        const finalBalance = await getBTCBalance(userWallet1.user.id)
+        const finalBalance = await getBTCBalance(userWallet1.user.walletId)
         expect(finalBalance).toBe(initBalance1)
       }, 60000)
     })
@@ -828,7 +825,7 @@ describe("UserWallet - Lightning Pay", () => {
     describe("2FA", () => {
       it(`fails to pay above 2fa limit without 2fa token`, async () => {
         enable2FA({ wallet: userWallet0 })
-        const remainingLimit = await getRemainingTwoFALimit(userWallet0.user.id)
+        const remainingLimit = await getRemainingTwoFALimit(userWallet0.user.walletId)
         expect(remainingLimit).not.toBeInstanceOf(Error)
         if (remainingLimit instanceof Error) return remainingLimit
 
@@ -839,7 +836,7 @@ describe("UserWallet - Lightning Pay", () => {
         const result = await fn(userWallet0)({ invoice: request })
         expect(result).toBeInstanceOf(TwoFAError)
 
-        const finalBalance = await getBTCBalance(userWallet0.user.id)
+        const finalBalance = await getBTCBalance(userWallet0.user.walletId)
         expect(finalBalance).toBe(initBalance0)
       })
 
@@ -878,7 +875,7 @@ describe("UserWallet - Lightning Pay", () => {
     const { lnd } = getActiveLnd()
 
     const lnInvoice = await addInvoice({
-      walletId: userWallet1.user.id as WalletId,
+      walletId: userWallet1.user.walletId as WalletId,
       amount: toSats(amountInvoice),
       memo,
     })
@@ -920,7 +917,7 @@ describe("UserWallet - Lightning Pay", () => {
 
     // await sleep(1000)
 
-    // await getBTCBalance(userWallet1.user.id)
+    // await getBTCBalance(userWallet1.user.walletId)
 
     // FIXME: test is failing.
     // lnd doens't always delete invoice just after they have expired

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -717,7 +717,7 @@ describe("UserWallet - Lightning Pay", () => {
         const finalBalance = await getBTCBalance(userWallet1.user.walletId)
 
         // const { id } = await decodePaymentRequest({ lnd: lndOutside2, request })
-        // const { results: [{ fee }] } = await getAccountTransactions(userWallet1.accountPath, { hash: id })
+        // const { results: [{ fee }] } = await getAccountTransactions(userWallet1.walletPath, { hash: id })
         // ^^^^ this fetch the wrong transaction
 
         // TODO: have a way to do this more programatically?

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -23,7 +23,6 @@ import {
 import * as Wallets from "@app/wallets"
 import { addInvoice } from "@app/wallets/add-invoice-for-wallet"
 import { toSats, FEECAP } from "@domain/bitcoin"
-import { toLiabilitiesWalletId } from "@domain/ledger"
 import {
   SelfPaymentError as DomainSelfPaymentError,
   InsufficientBalanceError as DomainInsufficientBalanceError,
@@ -763,8 +762,9 @@ describe("UserWallet - Lightning Pay", () => {
           })
           if (updatedPayments instanceof Error) throw updatedPayments
 
-          const liabilitiesWalletId = toLiabilitiesWalletId(userWallet1.user.walletId)
-          const count = await LedgerService().getPendingPaymentsCount(liabilitiesWalletId)
+          const count = await LedgerService().getPendingPaymentsCount(
+            userWallet1.user.walletId,
+          )
           if (count instanceof Error) throw count
 
           const { is_confirmed } = await getInvoice({ lnd: lndOutside1, id })
@@ -803,8 +803,9 @@ describe("UserWallet - Lightning Pay", () => {
           })
           if (updatedPayments instanceof Error) throw updatedPayments
 
-          const liabilitiesWalletId = toLiabilitiesWalletId(userWallet1.user.walletId)
-          const count = await LedgerService().getPendingPaymentsCount(liabilitiesWalletId)
+          const count = await LedgerService().getPendingPaymentsCount(
+            userWallet1.user.walletId,
+          )
           if (count instanceof Error) throw count
 
           return count === 0

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -59,7 +59,6 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   initialBalanceUser0 = await getBTCBalance(userWallet0.user.walletId)
-  baseLogger.warn({ initialBalanceUser0 })
 })
 
 afterEach(async () => {
@@ -75,7 +74,7 @@ const amount = 10040 // sats
 const targetConfirmations = toTargetConfs(1)
 
 describe("UserWallet - onChainPay", () => {
-  it.only("sends a successful payment", async () => {
+  it("sends a successful payment", async () => {
     const { address } = await createChainAddress({ format: "p2wpkh", lnd: lndOutside1 })
 
     const sub = subscribeToTransactions({ lnd: lndonchain })
@@ -97,13 +96,9 @@ describe("UserWallet - onChainPay", () => {
     // FIXME: does this syntax always take the first match item in the array? (which is waht we want, items are return as newest first)
     const {
       results: [pendingTxn],
-    } = await ledger.getAccountTransactions(userWallet0.accountPath, { pending: true })
+    } = await ledger.getAccountTransactions(userWallet0.walletPath, { pending: true })
 
     const interimBalance = await getBTCBalance(userWallet0.user.walletId)
-    baseLogger.warn(
-      { interimBalance, initialBalanceUser0, amount, fee: pendingTxn.fee },
-      "interimBalance",
-    )
     expect(interimBalance).toBe(initialBalanceUser0 - amount - pendingTxn.fee)
     await checkIsBalanced()
 
@@ -141,7 +136,7 @@ describe("UserWallet - onChainPay", () => {
 
     const {
       results: [{ pending, fee, feeUsd }],
-    } = await ledger.getAccountTransactions(userWallet0.accountPath, {
+    } = await ledger.getAccountTransactions(userWallet0.walletPath, {
       hash: pendingTxn.hash,
     })
     const feeRates = getFeeRates()
@@ -195,7 +190,7 @@ describe("UserWallet - onChainPay", () => {
     // FIXME: does this syntax always take the first match item in the array? (which is waht we want, items are return as newest first)
     const {
       results: [pendingTxn],
-    } = await ledger.getAccountTransactions(userWallet11.accountPath, { pending: true })
+    } = await ledger.getAccountTransactions(userWallet11.walletPath, { pending: true })
 
     const interimBalance = await getBTCBalance(userWallet11.user.walletId)
     expect(interimBalance).toBe(0)
@@ -235,7 +230,7 @@ describe("UserWallet - onChainPay", () => {
 
     const {
       results: [{ pending, fee, feeUsd }],
-    } = await ledger.getAccountTransactions(userWallet11.accountPath, {
+    } = await ledger.getAccountTransactions(userWallet11.walletPath, {
       hash: pendingTxn.hash,
     })
     const feeRates = getFeeRates()
@@ -306,7 +301,7 @@ describe("UserWallet - onChainPay", () => {
 
     const {
       results: [{ pending, fee, feeUsd }],
-    } = await ledger.getAccountTransactions(userWallet0.accountPath, {
+    } = await ledger.getAccountTransactions(userWallet0.walletPath, {
       type: "onchain_on_us",
     })
 
@@ -381,7 +376,7 @@ describe("UserWallet - onChainPay", () => {
 
     const {
       results: [{ pending, fee, feeUsd }],
-    } = await ledger.getAccountTransactions(userWallet12.accountPath, {
+    } = await ledger.getAccountTransactions(userWallet12.walletPath, {
       type: "onchain_on_us",
     })
 
@@ -455,7 +450,7 @@ describe("UserWallet - onChainPay", () => {
     const [result] = await Transaction.aggregate([
       {
         $match: {
-          accounts: userWallet0.accountPath,
+          accounts: userWallet0.walletPath,
           type: { $ne: "on_us" },
           timestamp: { $gte: timestampYesterday },
         },

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -58,7 +58,8 @@ beforeAll(async () => {
 })
 
 beforeEach(async () => {
-  initialBalanceUser0 = await getBTCBalance(userWallet0.user.id)
+  initialBalanceUser0 = await getBTCBalance(userWallet0.user.walletId)
+  baseLogger.warn({ initialBalanceUser0 })
 })
 
 afterEach(async () => {
@@ -74,7 +75,7 @@ const amount = 10040 // sats
 const targetConfirmations = toTargetConfs(1)
 
 describe("UserWallet - onChainPay", () => {
-  it("sends a successful payment", async () => {
+  it.only("sends a successful payment", async () => {
     const { address } = await createChainAddress({ format: "p2wpkh", lnd: lndOutside1 })
 
     const sub = subscribeToTransactions({ lnd: lndonchain })
@@ -98,14 +99,18 @@ describe("UserWallet - onChainPay", () => {
       results: [pendingTxn],
     } = await ledger.getAccountTransactions(userWallet0.accountPath, { pending: true })
 
-    const interimBalance = await getBTCBalance(userWallet0.user.id)
+    const interimBalance = await getBTCBalance(userWallet0.user.walletId)
+    baseLogger.warn(
+      { interimBalance, initialBalanceUser0, amount, fee: pendingTxn.fee },
+      "interimBalance",
+    )
     expect(interimBalance).toBe(initialBalanceUser0 - amount - pendingTxn.fee)
     await checkIsBalanced()
 
     await sleep(1000)
 
     let txResult = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet0.user.id,
+      walletId: userWallet0.user.walletId,
     })
     if (txResult.error instanceof Error || txResult.result === null) {
       throw txResult.error
@@ -146,7 +151,7 @@ describe("UserWallet - onChainPay", () => {
     expect(feeUsd).toBeGreaterThan(0)
 
     txResult = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet0.user.id,
+      walletId: userWallet0.user.walletId,
     })
     if (txResult.error instanceof Error || txResult.result === null) {
       throw txResult.error
@@ -161,7 +166,7 @@ describe("UserWallet - onChainPay", () => {
     expect(txn?.settlementAmount).toBe(-amount - fee)
     expect(txn?.deprecated.type).toBe("onchain_payment")
 
-    const finalBalance = await getBTCBalance(userWallet0.user.id)
+    const finalBalance = await getBTCBalance(userWallet0.user.walletId)
     expect(finalBalance).toBe(initialBalanceUser0 - amount - fee)
     sub.removeAllListeners()
   })
@@ -172,7 +177,7 @@ describe("UserWallet - onChainPay", () => {
     const sub = subscribeToTransactions({ lnd: lndonchain })
     sub.on("chain_transaction", onchainTransactionEventHandler)
 
-    const initialBalanceUser11 = await getBTCBalance(userWallet11.user.id)
+    const initialBalanceUser11 = await getBTCBalance(userWallet11.user.walletId)
 
     const results = await Promise.all([
       once(sub, "chain_transaction"),
@@ -192,14 +197,14 @@ describe("UserWallet - onChainPay", () => {
       results: [pendingTxn],
     } = await ledger.getAccountTransactions(userWallet11.accountPath, { pending: true })
 
-    const interimBalance = await getBTCBalance(userWallet11.user.id)
+    const interimBalance = await getBTCBalance(userWallet11.user.walletId)
     expect(interimBalance).toBe(0)
     await checkIsBalanced()
 
     await sleep(1000)
 
     let txResult = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet11.user.id,
+      walletId: userWallet11.user.walletId,
     })
     if (txResult.error instanceof Error || txResult.result === null) {
       throw txResult
@@ -240,7 +245,7 @@ describe("UserWallet - onChainPay", () => {
     expect(feeUsd).toBeGreaterThan(0)
 
     txResult = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet11.user.id,
+      walletId: userWallet11.user.walletId,
     })
     if (txResult.error instanceof Error || txResult.result === null) {
       throw txResult.error
@@ -255,7 +260,7 @@ describe("UserWallet - onChainPay", () => {
     expect(txn?.settlementAmount).toBe(-initialBalanceUser11)
     expect(txn?.deprecated.type).toBe("onchain_payment")
 
-    const finalBalance = await getBTCBalance(userWallet11.user.id)
+    const finalBalance = await getBTCBalance(userWallet11.user.walletId)
     expect(finalBalance).toBe(0)
     sub.removeAllListeners()
   })
@@ -271,7 +276,7 @@ describe("UserWallet - onChainPay", () => {
     })
     expect(paymentResult).toBe(true)
     const { result: txs, error } = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet0.user.id,
+      walletId: userWallet0.user.walletId,
     })
     if (error instanceof Error || txs === null) {
       throw error
@@ -285,15 +290,15 @@ describe("UserWallet - onChainPay", () => {
   })
 
   it("sends an on us transaction", async () => {
-    const address = await Wallets.createOnChainAddress(userWallet3.user.id)
+    const address = await Wallets.createOnChainAddress(userWallet3.user.walletId)
     if (address instanceof Error) throw address
 
-    const initialBalanceUser3 = await getBTCBalance(userWallet3.user.id)
+    const initialBalanceUser3 = await getBTCBalance(userWallet3.user.walletId)
 
     const paid = await userWallet0.onChainPay({ address, amount, targetConfirmations })
 
-    const finalBalanceUser0 = await getBTCBalance(userWallet0.user.id)
-    const finalBalanceUser3 = await getBTCBalance(userWallet3.user.id)
+    const finalBalanceUser0 = await getBTCBalance(userWallet0.user.walletId)
+    const finalBalanceUser3 = await getBTCBalance(userWallet3.user.walletId)
 
     expect(paid).toBe(true)
     expect(finalBalanceUser0).toBe(initialBalanceUser0 - amount)
@@ -313,7 +318,7 @@ describe("UserWallet - onChainPay", () => {
   it("sends an on us transaction with memo", async () => {
     const memo = "this is my onchain memo"
 
-    const address = await Wallets.createOnChainAddress(userWallet3.user.id)
+    const address = await Wallets.createOnChainAddress(userWallet3.user.walletId)
     if (address instanceof Error) throw address
 
     const paid = await userWallet0.onChainPay({
@@ -331,7 +336,7 @@ describe("UserWallet - onChainPay", () => {
       tx.initiationVia.address === address
 
     const { result: txs, error } = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet0.user.id,
+      walletId: userWallet0.user.walletId,
     })
     if (error instanceof Error || txs === null) {
       throw error
@@ -342,7 +347,7 @@ describe("UserWallet - onChainPay", () => {
 
     // receiver should not know memo from sender
     const { result: txsUser3, error: error2 } = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet3.user.id as WalletId,
+      walletId: userWallet3.user.walletId as WalletId,
     })
     if (error2 instanceof Error || txsUser3 === null) {
       throw error2
@@ -353,12 +358,12 @@ describe("UserWallet - onChainPay", () => {
   })
 
   it("sends all with an on us transaction", async () => {
-    const initialBalanceUser12 = await getBTCBalance(userWallet12.user.id)
+    const initialBalanceUser12 = await getBTCBalance(userWallet12.user.walletId)
 
-    const address = await Wallets.createOnChainAddress(userWallet3.user.id)
+    const address = await Wallets.createOnChainAddress(userWallet3.user.walletId)
     if (address instanceof Error) throw address
 
-    const initialBalanceUser3 = await getBTCBalance(userWallet3.user.id)
+    const initialBalanceUser3 = await getBTCBalance(userWallet3.user.walletId)
 
     const paid = await userWallet12.onChainPay({
       address,
@@ -367,8 +372,8 @@ describe("UserWallet - onChainPay", () => {
       targetConfirmations,
     })
 
-    const finalBalanceUser12 = await getBTCBalance(userWallet12.user.id)
-    const finalBalanceUser3 = await getBTCBalance(userWallet3.user.id)
+    const finalBalanceUser12 = await getBTCBalance(userWallet12.user.walletId)
+    const finalBalanceUser3 = await getBTCBalance(userWallet3.user.walletId)
 
     expect(paid).toBe(true)
     expect(finalBalanceUser12).toBe(0)
@@ -386,7 +391,7 @@ describe("UserWallet - onChainPay", () => {
   })
 
   it("fails if try to send a transaction to self", async () => {
-    const address = await Wallets.createOnChainAddress(userWallet0.user.id)
+    const address = await Wallets.createOnChainAddress(userWallet0.user.walletId)
     if (address instanceof Error) throw address
 
     await expect(
@@ -395,7 +400,7 @@ describe("UserWallet - onChainPay", () => {
   })
 
   it("fails if an on us payment has insufficient balance", async () => {
-    const address = await Wallets.createOnChainAddress(userWallet3.user.id)
+    const address = await Wallets.createOnChainAddress(userWallet3.user.walletId)
     if (address instanceof Error) throw address
     await expect(
       userWallet0.onChainPay({
@@ -411,7 +416,7 @@ describe("UserWallet - onChainPay", () => {
       lnd: lndOutside1,
       format: "p2wpkh",
     })
-    const initialBalanceUser3 = await getBTCBalance(userWallet3.user.id)
+    const initialBalanceUser3 = await getBTCBalance(userWallet3.user.walletId)
 
     //should fail because user does not have balance to pay for on-chain fee
     await expect(
@@ -424,7 +429,7 @@ describe("UserWallet - onChainPay", () => {
   })
 
   it("fails if send all with a nonzero amount", async () => {
-    const address = await Wallets.createOnChainAddress(userWallet3.user.id)
+    const address = await Wallets.createOnChainAddress(userWallet3.user.walletId)
     if (address instanceof Error) throw address
 
     await expect(
@@ -482,7 +487,7 @@ describe("UserWallet - onChainPay", () => {
   describe("2FA", () => {
     it("fails to pay above 2fa limit without 2fa token", async () => {
       enable2FA({ wallet: userWallet0 })
-      const remainingLimit = await getRemainingTwoFALimit(userWallet0.user.id)
+      const remainingLimit = await getRemainingTwoFALimit(userWallet0.user.walletId)
       expect(remainingLimit).not.toBeInstanceOf(Error)
       if (remainingLimit instanceof Error) return remainingLimit
 
@@ -498,7 +503,7 @@ describe("UserWallet - onChainPay", () => {
     it("sends a successful large payment with a 2fa code", async () => {
       enable2FA({ wallet: userWallet0 })
 
-      const initialBalance = await getBTCBalance(userWallet0.user.id)
+      const initialBalance = await getBTCBalance(userWallet0.user.walletId)
       const { address } = await createChainAddress({ format: "p2wpkh", lnd: lndOutside1 })
       const twoFAToken = generateTokenHelper({
         secret: userWallet0.user.twoFA.secret,
@@ -520,7 +525,7 @@ describe("UserWallet - onChainPay", () => {
       }
 
       const { result: txs, error } = await Wallets.getTransactionsForWalletId({
-        walletId: userWallet0.user.id,
+        walletId: userWallet0.user.walletId,
       })
 
       if (error instanceof Error || txs === null) {
@@ -529,7 +534,7 @@ describe("UserWallet - onChainPay", () => {
 
       // settlementAmount is negative
       const expectedBalance = initialBalance + txs[0].settlementAmount
-      const finalBalance = await getBTCBalance(userWallet0.user.id)
+      const finalBalance = await getBTCBalance(userWallet0.user.walletId)
       expect(expectedBalance).toBe(finalBalance)
     })
   })

--- a/test/integration/02-user-wallet/02-tx-onchain-fees.spec.ts
+++ b/test/integration/02-user-wallet/02-tx-onchain-fees.spec.ts
@@ -11,7 +11,7 @@ let userWallet0: Wallet, userWallet1: Wallet
 
 const getWallet = async (testWallet: number): Promise<Wallet> => {
   const userWallet = await getAndCreateUserWallet(testWallet)
-  const wallet = await Wallets.getWallet(userWallet.user.id)
+  const wallet = await Wallets.getWallet(userWallet.user.walletId)
   if (wallet instanceof Error) throw wallet
   return wallet
 }

--- a/test/integration/notifications/notification.spec.ts
+++ b/test/integration/notifications/notification.spec.ts
@@ -29,7 +29,7 @@ describe("notification", () => {
       const numActiveUsers = (await User.getActiveUsers()).length
       expect(sendNotification.mock.calls.length).toBe(numActiveUsers)
       for (const [call] of sendNotification.mock.calls) {
-        const balance = await ledger.getAccountBalance(call.user.accountPath)
+        const balance = await ledger.getAccountBalance(call.user.walletPath)
 
         const expectedUsdBalance = (price * balance).toLocaleString("en", {
           maximumFractionDigits: 2,

--- a/test/integration/servers/trigger.spec.ts
+++ b/test/integration/servers/trigger.spec.ts
@@ -47,9 +47,9 @@ afterAll(async () => {
 })
 
 const getWalletState = async (wallet) => {
-  const balance = await getBTCBalance(wallet.user.id)
+  const balance = await getBTCBalance(wallet.user.walletId)
   const { result: transactions, error } = await Wallets.getTransactionsForWalletId({
-    walletId: wallet.user.id as WalletId,
+    walletId: wallet.user.walletId as WalletId,
   })
   if (error instanceof Error || transactions === null) {
     throw error
@@ -76,7 +76,7 @@ describe("onchainBlockEventhandler", () => {
     const initWallet0State = await getWalletState(wallet0)
     const initWallet3State = await getWalletState(wallet3)
 
-    const address = await Wallets.createOnChainAddress(wallet0.user.id)
+    const address = await Wallets.createOnChainAddress(wallet0.user.walletId)
     if (address instanceof Error) throw address
 
     const initialBlock = await bitcoindClient.getBlockCount()
@@ -94,7 +94,7 @@ describe("onchainBlockEventhandler", () => {
     const output0 = {}
     output0[address] = amount
 
-    const address2 = await Wallets.createOnChainAddress(wallet3.user.id)
+    const address2 = await Wallets.createOnChainAddress(wallet3.user.walletId)
     if (address2 instanceof Error) throw address2
 
     const output1 = {}
@@ -144,7 +144,7 @@ describe("onchainBlockEventhandler", () => {
     const sats = 500
     const wallet = await getAndCreateUserWallet(12)
     const lnInvoice = await addInvoice({
-      walletId: wallet.user.id as WalletId,
+      walletId: wallet.user.walletId as WalletId,
       amount: toSats(sats),
     })
     expect(lnInvoice).not.toBeInstanceOf(Error)
@@ -166,7 +166,9 @@ describe("onchainBlockEventhandler", () => {
     expect(sendNotification.mock.calls[0][0].title).toBe(
       getTitle[NotificationType.LnInvoicePaid]({ usd, amount: sats }),
     )
-    expect(sendNotification.mock.calls[0][0].user._id).toStrictEqual(wallet.user._id)
+    expect(sendNotification.mock.calls[0][0].user.walletId).toStrictEqual(
+      wallet.user.walletId,
+    )
     expect(sendNotification.mock.calls[0][0].data.type).toBe(
       NotificationType.LnInvoicePaid,
     )

--- a/test/integration/services/ledger/transaction.spec.ts
+++ b/test/integration/services/ledger/transaction.spec.ts
@@ -69,7 +69,7 @@ describe("receipt via Ledger Service", () => {
     const usdFee = fee * price
 
     const result = await LedgerService().addLnTxReceive({
-      liabilitiesWalletId: walletBTC.accountPath,
+      liabilitiesWalletId: walletBTC.walletPath,
       paymentHash: "paymentHash" as PaymentHash,
       description: "transaction test",
       sats,
@@ -80,7 +80,7 @@ describe("receipt via Ledger Service", () => {
     expect(result).not.toBeInstanceOf(Error)
 
     await expectBalance({
-      account: walletBTC.accountPath,
+      account: walletBTC.walletPath,
       currency: "BTC",
       balance: 1000,
     })
@@ -99,7 +99,7 @@ describe("receipt", () => {
     })
 
     await expectBalance({
-      account: walletBTC.accountPath,
+      account: walletBTC.walletPath,
       currency: "BTC",
       balance: 1000,
     })
@@ -115,11 +115,11 @@ describe("receipt", () => {
       lastPrice: UserWallet.lastPrice,
     })
 
-    await expectBalance({ account: walletUSD.accountPath, currency: "BTC", balance: 0 })
+    await expectBalance({ account: walletUSD.walletPath, currency: "BTC", balance: 0 })
     await expectBalance({ account: dealerPath, currency: "BTC", balance: 1000 })
     await expectBalance({ account: lndAccountingPath, currency: "BTC", balance: -1000 })
 
-    await expectBalance({ account: walletUSD.accountPath, currency: "USD", balance: 0.1 })
+    await expectBalance({ account: walletUSD.walletPath, currency: "USD", balance: 0.1 })
     await expectBalance({ account: dealerPath, currency: "USD", balance: -0.1 })
   })
 
@@ -133,7 +133,7 @@ describe("receipt", () => {
     })
 
     await expectBalance({
-      account: wallet5050.accountPath,
+      account: wallet5050.walletPath,
       currency: "BTC",
       balance: 500,
     })
@@ -141,7 +141,7 @@ describe("receipt", () => {
     await expectBalance({ account: lndAccountingPath, currency: "BTC", balance: -1000 })
 
     await expectBalance({
-      account: wallet5050.accountPath,
+      account: wallet5050.walletPath,
       currency: "USD",
       balance: 0.05,
     })
@@ -161,7 +161,7 @@ describe("payment with lnd via Ledger Service", () => {
     const usdFee = fee * price
 
     const result = await LedgerService().addLnTxSend({
-      liabilitiesWalletId: walletBTC.accountPath,
+      liabilitiesWalletId: walletBTC.walletPath,
       paymentHash: "paymentHash" as PaymentHash,
       description: "transaction test",
       sats,
@@ -174,7 +174,7 @@ describe("payment with lnd via Ledger Service", () => {
     expect(result).not.toBeInstanceOf(Error)
 
     await expectBalance({
-      account: walletBTC.accountPath,
+      account: walletBTC.walletPath,
       currency: "BTC",
       balance: -1000,
     })
@@ -193,7 +193,7 @@ describe("payment with lnd", () => {
     })
 
     await expectBalance({
-      account: walletBTC.accountPath,
+      account: walletBTC.walletPath,
       currency: "BTC",
       balance: -1000,
     })
@@ -214,7 +214,7 @@ describe("payment with lnd", () => {
 
     await expectBalance({ account: dealerPath, currency: "USD", balance: 0.1 })
     await expectBalance({
-      account: walletUSD.accountPath,
+      account: walletUSD.walletPath,
       currency: "USD",
       balance: -0.1,
     })
@@ -231,7 +231,7 @@ describe("payment with lnd", () => {
 
     await expectBalance({ account: dealerPath, currency: "BTC", balance: -500 })
     await expectBalance({
-      account: wallet5050.accountPath,
+      account: wallet5050.walletPath,
       currency: "BTC",
       balance: -500,
     })
@@ -240,7 +240,7 @@ describe("payment with lnd", () => {
 
     await expectBalance({ account: dealerPath, currency: "USD", balance: 0.05 })
     await expectBalance({
-      account: wallet5050.accountPath,
+      account: wallet5050.walletPath,
       currency: "USD",
       balance: -0.05,
     })
@@ -263,13 +263,13 @@ describe("on us payment via Ledger Service", () => {
     const usdFee = fee * price
 
     const result = await LedgerService().addUsernameIntraledgerTxSend({
-      liabilitiesWalletId: payer.accountPath,
+      liabilitiesWalletId: payer.walletPath,
       description: "desc",
       sats,
       fee: lnFee,
       usd,
       usdFee,
-      recipientLiabilitiesAccountId: payee.accountPath,
+      recipientLiabilitiesAccountId: payee.walletPath,
       payerUsername: "payerUsername" as Username,
       recipientUsername: "recipientUsername" as Username,
       memoPayer: null,
@@ -281,8 +281,8 @@ describe("on us payment via Ledger Service", () => {
       if (tx instanceof Error) throw tx
       expect(tx.type).toBe(LedgerTransactionType.IntraLedger)
     }
-    await expectBalance({ account: payer.accountPath, currency: "BTC", balance: -1000 })
-    await expectBalance({ account: payee.accountPath, currency: "BTC", balance: 1000 })
+    await expectBalance({ account: payer.walletPath, currency: "BTC", balance: -1000 })
+    await expectBalance({ account: payee.walletPath, currency: "BTC", balance: 1000 })
   })
 })
 
@@ -300,10 +300,10 @@ describe("on us payment", () => {
       lastPrice: UserWallet.lastPrice,
     })
 
-    await expectBalance({ account: payer.accountPath, currency: "BTC", balance: -1000 })
-    await expectBalance({ account: payee.accountPath, currency: "BTC", balance: 1000 })
-    await expectBalance({ account: payer.accountPath, currency: "USD", balance: 0 })
-    await expectBalance({ account: payee.accountPath, currency: "USD", balance: 0 })
+    await expectBalance({ account: payer.walletPath, currency: "BTC", balance: -1000 })
+    await expectBalance({ account: payee.walletPath, currency: "BTC", balance: 1000 })
+    await expectBalance({ account: payer.walletPath, currency: "USD", balance: 0 })
+    await expectBalance({ account: payee.walletPath, currency: "USD", balance: 0 })
   })
 
   it("onUsUSDOnly", async () => {
@@ -319,10 +319,10 @@ describe("on us payment", () => {
       lastPrice: UserWallet.lastPrice,
     })
 
-    await expectBalance({ account: payer.accountPath, currency: "USD", balance: -0.1 })
-    await expectBalance({ account: payee.accountPath, currency: "USD", balance: 0.1 })
-    await expectBalance({ account: payer.accountPath, currency: "BTC", balance: 0 })
-    await expectBalance({ account: payee.accountPath, currency: "BTC", balance: 0 })
+    await expectBalance({ account: payer.walletPath, currency: "USD", balance: -0.1 })
+    await expectBalance({ account: payee.walletPath, currency: "USD", balance: 0.1 })
+    await expectBalance({ account: payer.walletPath, currency: "BTC", balance: 0 })
+    await expectBalance({ account: payee.walletPath, currency: "BTC", balance: 0 })
   })
 
   it("onUsBtcToUSD", async () => {
@@ -338,13 +338,13 @@ describe("on us payment", () => {
       lastPrice: UserWallet.lastPrice,
     })
 
-    await expectBalance({ account: payer.accountPath, currency: "BTC", balance: -1000 })
+    await expectBalance({ account: payer.walletPath, currency: "BTC", balance: -1000 })
     await expectBalance({ account: dealerPath, currency: "BTC", balance: 1000 })
-    await expectBalance({ account: payee.accountPath, currency: "BTC", balance: 0 })
+    await expectBalance({ account: payee.walletPath, currency: "BTC", balance: 0 })
 
-    await expectBalance({ account: payer.accountPath, currency: "USD", balance: 0 })
+    await expectBalance({ account: payer.walletPath, currency: "USD", balance: 0 })
     await expectBalance({ account: dealerPath, currency: "USD", balance: -0.1 })
-    await expectBalance({ account: payee.accountPath, currency: "USD", balance: 0.1 })
+    await expectBalance({ account: payee.walletPath, currency: "USD", balance: 0.1 })
   })
 
   it("onUsBtcTo5050", async () => {
@@ -360,13 +360,13 @@ describe("on us payment", () => {
       lastPrice: UserWallet.lastPrice,
     })
 
-    await expectBalance({ account: payer.accountPath, currency: "BTC", balance: -1000 })
+    await expectBalance({ account: payer.walletPath, currency: "BTC", balance: -1000 })
     await expectBalance({ account: dealerPath, currency: "BTC", balance: 500 })
-    await expectBalance({ account: payee.accountPath, currency: "BTC", balance: 500 })
-    await expectBalance({ account: payer.accountPath, currency: "USD", balance: 0 })
+    await expectBalance({ account: payee.walletPath, currency: "BTC", balance: 500 })
+    await expectBalance({ account: payer.walletPath, currency: "USD", balance: 0 })
 
     await expectBalance({ account: dealerPath, currency: "USD", balance: -0.05 })
-    await expectBalance({ account: payee.accountPath, currency: "USD", balance: 0.05 })
+    await expectBalance({ account: payee.walletPath, currency: "USD", balance: 0.05 })
   })
 
   it("onUs5050ToBtc", async () => {
@@ -382,14 +382,14 @@ describe("on us payment", () => {
       lastPrice: UserWallet.lastPrice,
     })
 
-    await expectBalance({ account: payer.accountPath, currency: "BTC", balance: -500 })
+    await expectBalance({ account: payer.walletPath, currency: "BTC", balance: -500 })
 
-    await expectBalance({ account: payer.accountPath, currency: "USD", balance: -0.05 })
+    await expectBalance({ account: payer.walletPath, currency: "USD", balance: -0.05 })
     await expectBalance({ account: dealerPath, currency: "USD", balance: 0.05 })
     await expectBalance({ account: dealerPath, currency: "BTC", balance: -500 })
 
-    await expectBalance({ account: payee.accountPath, currency: "BTC", balance: 1000 })
-    await expectBalance({ account: payee.accountPath, currency: "USD", balance: 0 })
+    await expectBalance({ account: payee.walletPath, currency: "BTC", balance: 1000 })
+    await expectBalance({ account: payee.walletPath, currency: "USD", balance: 0 })
   })
 
   it("onUsUsdTo5050", async () => {
@@ -405,14 +405,14 @@ describe("on us payment", () => {
       lastPrice: UserWallet.lastPrice,
     })
 
-    await expectBalance({ account: payer.accountPath, currency: "BTC", balance: 0 })
-    await expectBalance({ account: payer.accountPath, currency: "USD", balance: -0.1 })
+    await expectBalance({ account: payer.walletPath, currency: "BTC", balance: 0 })
+    await expectBalance({ account: payer.walletPath, currency: "USD", balance: -0.1 })
 
     await expectBalance({ account: dealerPath, currency: "USD", balance: 0.05 })
     await expectBalance({ account: dealerPath, currency: "BTC", balance: -500 })
 
-    await expectBalance({ account: payee.accountPath, currency: "BTC", balance: 500 })
-    await expectBalance({ account: payee.accountPath, currency: "USD", balance: 0.05 })
+    await expectBalance({ account: payee.walletPath, currency: "BTC", balance: 500 })
+    await expectBalance({ account: payee.walletPath, currency: "USD", balance: 0.05 })
   })
 
   it("onUs5050ToUsd", async () => {
@@ -428,14 +428,14 @@ describe("on us payment", () => {
       lastPrice: UserWallet.lastPrice,
     })
 
-    await expectBalance({ account: payer.accountPath, currency: "BTC", balance: -500 })
-    await expectBalance({ account: payer.accountPath, currency: "USD", balance: -0.05 })
+    await expectBalance({ account: payer.walletPath, currency: "BTC", balance: -500 })
+    await expectBalance({ account: payer.walletPath, currency: "USD", balance: -0.05 })
 
     await expectBalance({ account: dealerPath, currency: "USD", balance: -0.05 })
     await expectBalance({ account: dealerPath, currency: "BTC", balance: 500 })
 
-    await expectBalance({ account: payee.accountPath, currency: "BTC", balance: 0 })
-    await expectBalance({ account: payee.accountPath, currency: "USD", balance: 0.1 })
+    await expectBalance({ account: payee.walletPath, currency: "BTC", balance: 0 })
+    await expectBalance({ account: payee.walletPath, currency: "USD", balance: 0.1 })
   })
 })
 
@@ -452,7 +452,7 @@ describe("rebalancePortfolio", () => {
     })
 
     await expectBalance({
-      account: wallet.user.accountPath,
+      account: wallet.user.walletPath,
       currency: "BTC",
       balance: 1000,
     })
@@ -465,7 +465,7 @@ describe("rebalancePortfolio", () => {
     })
 
     await expectBalance({
-      account: wallet.user.accountPath,
+      account: wallet.user.walletPath,
       currency: "BTC",
       balance: 1000,
     })
@@ -484,7 +484,7 @@ describe("rebalancePortfolio", () => {
     })
 
     await expectBalance({
-      account: wallet.user.accountPath,
+      account: wallet.user.walletPath,
       currency: "BTC",
       balance: 1000,
     })
@@ -501,12 +501,12 @@ describe("rebalancePortfolio", () => {
     })
 
     await expectBalance({
-      account: wallet.user.accountPath,
+      account: wallet.user.walletPath,
       currency: "BTC",
       balance: 500,
     })
     await expectBalance({
-      account: wallet.user.accountPath,
+      account: wallet.user.walletPath,
       currency: "USD",
       balance: 0.05,
     })
@@ -527,12 +527,12 @@ describe("rebalancePortfolio", () => {
       lastPrice: UserWallet.lastPrice,
     })
 
-    await expectBalance({ account: wallet.user.accountPath, currency: "BTC", balance: 0 })
+    await expectBalance({ account: wallet.user.walletPath, currency: "BTC", balance: 0 })
     await expectBalance({ account: dealerPath, currency: "BTC", balance: 1000 })
     await expectBalance({ account: lndAccountingPath, currency: "BTC", balance: -1000 })
 
     await expectBalance({
-      account: wallet.user.accountPath,
+      account: wallet.user.walletPath,
       currency: "USD",
       balance: 0.1,
     })
@@ -549,12 +549,12 @@ describe("rebalancePortfolio", () => {
     })
 
     await expectBalance({
-      account: wallet.user.accountPath,
+      account: wallet.user.walletPath,
       currency: "BTC",
       balance: 500,
     })
     await expectBalance({
-      account: wallet.user.accountPath,
+      account: wallet.user.walletPath,
       currency: "USD",
       balance: 0.05,
     })

--- a/test/integration/services/ledger/transaction.spec.ts
+++ b/test/integration/services/ledger/transaction.spec.ts
@@ -69,7 +69,7 @@ describe("receipt via Ledger Service", () => {
     const usdFee = fee * price
 
     const result = await LedgerService().addLnTxReceive({
-      liabilitiesAccountId: walletBTC.accountPath,
+      liabilitiesWalletId: walletBTC.accountPath,
       paymentHash: "paymentHash" as PaymentHash,
       description: "transaction test",
       sats,
@@ -161,7 +161,7 @@ describe("payment with lnd via Ledger Service", () => {
     const usdFee = fee * price
 
     const result = await LedgerService().addLnTxSend({
-      liabilitiesAccountId: walletBTC.accountPath,
+      liabilitiesWalletId: walletBTC.accountPath,
       paymentHash: "paymentHash" as PaymentHash,
       description: "transaction test",
       sats,
@@ -263,7 +263,7 @@ describe("on us payment via Ledger Service", () => {
     const usdFee = fee * price
 
     const result = await LedgerService().addUsernameIntraledgerTxSend({
-      liabilitiesAccountId: payer.accountPath,
+      liabilitiesWalletId: payer.accountPath,
       description: "desc",
       sats,
       fee: lnFee,

--- a/test/integration/services/ledger/transaction.spec.ts
+++ b/test/integration/services/ledger/transaction.spec.ts
@@ -69,7 +69,7 @@ describe("receipt via Ledger Service", () => {
     const usdFee = fee * price
 
     const result = await LedgerService().addLnTxReceive({
-      liabilitiesWalletId: walletBTC.walletPath,
+      walletId: walletBTC.walletId,
       paymentHash: "paymentHash" as PaymentHash,
       description: "transaction test",
       sats,
@@ -161,7 +161,7 @@ describe("payment with lnd via Ledger Service", () => {
     const usdFee = fee * price
 
     const result = await LedgerService().addLnTxSend({
-      liabilitiesWalletId: walletBTC.walletPath,
+      walletId: walletBTC.walletId,
       paymentHash: "paymentHash" as PaymentHash,
       description: "transaction test",
       sats,
@@ -263,13 +263,13 @@ describe("on us payment via Ledger Service", () => {
     const usdFee = fee * price
 
     const result = await LedgerService().addUsernameIntraledgerTxSend({
-      liabilitiesWalletId: payer.walletPath,
+      walletId: payer.walletId,
       description: "desc",
       sats,
       fee: lnFee,
       usd,
       usdFee,
-      recipientLiabilitiesWalletId: payee.walletPath,
+      recipientWalletId: payee.walletId,
       payerUsername: "payerUsername" as Username,
       recipientUsername: "recipientUsername" as Username,
       memoPayer: null,

--- a/test/integration/services/ledger/transaction.spec.ts
+++ b/test/integration/services/ledger/transaction.spec.ts
@@ -269,7 +269,7 @@ describe("on us payment via Ledger Service", () => {
       fee: lnFee,
       usd,
       usdFee,
-      recipientLiabilitiesAccountId: payee.walletPath,
+      recipientLiabilitiesWalletId: payee.walletPath,
       payerUsername: "payerUsername" as Username,
       recipientUsername: "recipientUsername" as Username,
       memoPayer: null,

--- a/test/integration/services/mongoose/wallet-invoices.spec.ts
+++ b/test/integration/services/mongoose/wallet-invoices.spec.ts
@@ -63,18 +63,18 @@ describe("WalletInvoices", () => {
     const wallet = await getAndCreateUserWallet(1)
     for (let i = 0; i < 2; i++) {
       await addInvoice({
-        walletId: wallet.user.id as WalletId,
+        walletId: wallet.user.walletId as WalletId,
         amount: toSats(1000),
       })
     }
 
     const invoicesCount = await InvoiceUser.countDocuments({
-      uid: wallet.user.id,
+      walletId: wallet.user.walletId,
       paid: false,
     })
 
     const repo = WalletInvoicesRepository()
-    const invoices = repo.findPendingByWalletId(wallet.user.id)
+    const invoices = repo.findPendingByWalletId(wallet.user.walletId)
     expect(invoices).not.toBeInstanceOf(Error)
 
     const pendingInvoices = invoices as AsyncGenerator<WalletInvoice>

--- a/test/unit/domain/errors.spec.ts
+++ b/test/unit/domain/errors.spec.ts
@@ -4,7 +4,7 @@ import {
   UnknownRepositoryError,
   ValidationError,
   InvalidSatoshiAmount,
-  InvalidPublicWalletId,
+  InvalidWalletId,
 } from "@domain/errors"
 
 describe("errors.ts", () => {
@@ -29,7 +29,7 @@ describe("errors.ts", () => {
     expect(error instanceof ValidationError).toBe(true)
     expect(error instanceof Error).toBe(true)
 
-    error = new InvalidPublicWalletId()
+    error = new InvalidWalletId()
     expect(error instanceof ValidationError).toBe(true)
     expect(error instanceof Error).toBe(true)
   })

--- a/test/unit/domain/wallet-invoices/wallet-invoice-factory.spec.ts
+++ b/test/unit/domain/wallet-invoices/wallet-invoice-factory.spec.ts
@@ -23,6 +23,7 @@ describe("wallet invoice factory methods", () => {
         features: [],
       },
       pubkey: "pubkey" as Pubkey,
+      descriptionHash: "descriptionHash" as string, // FIXME
     }
     const result = walletInvoiceFactory.create({ registeredInvoice })
     const expected = {

--- a/test/unit/domain/wallets/tx-history.spec.ts
+++ b/test/unit/domain/wallets/tx-history.spec.ts
@@ -41,7 +41,6 @@ describe("WalletTransactionHistory.fromLedger", () => {
         type: LedgerTransactionType.IntraLedger,
         paymentHash: "paymentHash" as PaymentHash,
         pubkey: "pubkey" as Pubkey,
-        walletPublicId: "walletPublicId" as WalletPublicId,
         username: "username" as Username,
         debit: toSats(0),
         fee: toSats(0),
@@ -60,7 +59,6 @@ describe("WalletTransactionHistory.fromLedger", () => {
         type: LedgerTransactionType.OnchainIntraLedger,
         address: "address" as OnChainAddress,
         paymentHash: "paymentHash" as PaymentHash,
-        walletPublicId: "walletPublicId" as WalletPublicId,
         txHash: "txHash" as OnChainTxHash,
         debit: toSats(0),
         fee: toSats(0),
@@ -128,7 +126,7 @@ describe("WalletTransactionHistory.fromLedger", () => {
         },
         settlementVia: {
           type: SettlementMethod.IntraLedger,
-          counterPartyWalletPublicId: "walletPublicId" as WalletPublicId,
+          counterPartyWalletId: "walletId" as WalletId,
           counterPartyUsername: "username",
         },
         memo: null,
@@ -154,7 +152,7 @@ describe("WalletTransactionHistory.fromLedger", () => {
         },
         settlementVia: {
           type: SettlementMethod.IntraLedger,
-          counterPartyWalletPublicId: "walletPublicId" as WalletPublicId,
+          counterPartyWalletId: "walletId" as WalletId,
           counterPartyUsername: null,
         },
         memo: null,

--- a/test/unit/domain/wallets/tx-history.spec.ts
+++ b/test/unit/domain/wallets/tx-history.spec.ts
@@ -38,6 +38,7 @@ describe("WalletTransactionHistory.fromLedger", () => {
       {
         id: "id" as LedgerTransactionId,
         walletId: "walletId" as WalletId,
+        recipientWalletId: "walletIdRecipient" as WalletId,
         type: LedgerTransactionType.IntraLedger,
         paymentHash: "paymentHash" as PaymentHash,
         pubkey: "pubkey" as Pubkey,
@@ -56,6 +57,7 @@ describe("WalletTransactionHistory.fromLedger", () => {
       {
         id: "id" as LedgerTransactionId,
         walletId: "walletId" as WalletId,
+        recipientWalletId: "walletIdRecipient" as WalletId,
         type: LedgerTransactionType.OnchainIntraLedger,
         address: "address" as OnChainAddress,
         paymentHash: "paymentHash" as PaymentHash,
@@ -126,7 +128,7 @@ describe("WalletTransactionHistory.fromLedger", () => {
         },
         settlementVia: {
           type: SettlementMethod.IntraLedger,
-          counterPartyWalletId: "walletId" as WalletId,
+          counterPartyWalletId: "walletIdRecipient" as WalletId,
           counterPartyUsername: "username",
         },
         memo: null,
@@ -152,7 +154,7 @@ describe("WalletTransactionHistory.fromLedger", () => {
         },
         settlementVia: {
           type: SettlementMethod.IntraLedger,
-          counterPartyWalletId: "walletId" as WalletId,
+          counterPartyWalletId: "walletIdRecipient" as WalletId,
           counterPartyUsername: null,
         },
         memo: null,

--- a/test/unit/ledger/ledger.spec.ts
+++ b/test/unit/ledger/ledger.spec.ts
@@ -1,31 +1,31 @@
 import { ledger } from "@services/mongodb"
 
-const { accountPath, liabilitiesMainAccount, resolveAccountId } = ledger
+const { accountPath, liabilitiesMainAccount, resolveWalletId } = ledger
 
 describe("ledger.ts", () => {
-  describe("resolveAccountId", () => {
+  describe("resolveWalletId", () => {
     const accountId = "123542"
     it("returns account id from string path", () => {
-      expect(resolveAccountId(accountPath(accountId))).toEqual(accountId)
+      expect(resolveWalletId(accountPath(accountId))).toEqual(accountId)
     })
 
     it("returns account id from array path", () => {
-      expect(resolveAccountId([liabilitiesMainAccount, accountId])).toEqual(accountId)
+      expect(resolveWalletId([liabilitiesMainAccount, accountId])).toEqual(accountId)
     })
 
     it("returns null if invalid path", () => {
       const lowerCasePrefix = liabilitiesMainAccount.toLowerCase()
-      expect(resolveAccountId("")).toBe(null)
-      expect(resolveAccountId("test")).toBe(null)
-      expect(resolveAccountId("test:id")).toBe(null)
-      expect(resolveAccountId(`${liabilitiesMainAccount}:`)).toBe(null)
-      expect(resolveAccountId(`${lowerCasePrefix}:`)).toBe(null)
-      expect(resolveAccountId([])).toBe(null)
-      expect(resolveAccountId(["a"])).toBe(null)
-      expect(resolveAccountId(["a", "b", "c"])).toBe(null)
-      expect(resolveAccountId([lowerCasePrefix, ""])).toBe(null)
-      expect(resolveAccountId([lowerCasePrefix, "id"])).toBe(null)
-      expect(resolveAccountId([lowerCasePrefix, "id", "b"])).toBe(null)
+      expect(resolveWalletId("")).toBe(null)
+      expect(resolveWalletId("test")).toBe(null)
+      expect(resolveWalletId("test:id")).toBe(null)
+      expect(resolveWalletId(`${liabilitiesMainAccount}:`)).toBe(null)
+      expect(resolveWalletId(`${lowerCasePrefix}:`)).toBe(null)
+      expect(resolveWalletId([])).toBe(null)
+      expect(resolveWalletId(["a"])).toBe(null)
+      expect(resolveWalletId(["a", "b", "c"])).toBe(null)
+      expect(resolveWalletId([lowerCasePrefix, ""])).toBe(null)
+      expect(resolveWalletId([lowerCasePrefix, "id"])).toBe(null)
+      expect(resolveWalletId([lowerCasePrefix, "id", "b"])).toBe(null)
     })
   })
 })

--- a/test/unit/ledger/ledger.spec.ts
+++ b/test/unit/ledger/ledger.spec.ts
@@ -1,12 +1,12 @@
 import { ledger } from "@services/mongodb"
 
-const { accountPath, liabilitiesMainAccount, resolveWalletId } = ledger
+const { walletPath, liabilitiesMainAccount, resolveWalletId } = ledger
 
 describe("ledger.ts", () => {
   describe("resolveWalletId", () => {
     const accountId = "123542"
     it("returns account id from string path", () => {
-      expect(resolveWalletId(accountPath(accountId))).toEqual(accountId)
+      expect(resolveWalletId(walletPath(accountId))).toEqual(accountId)
     })
 
     it("returns account id from array path", () => {


### PR DESCRIPTION
- remove the hard dependency between userId and walletId for transaction. this is necessary for having multiple wallets/account
- remove the use of walletPublicId