### PR TITLE
fix: remove index sync by default in setupMongoConnection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ reset-integration: reset-deps integration
 
 integration-in-ci:
 	. ./.envrc && \
-		LOGLEVEL=error $(BIN_DIR)/jest --config ./test/jest-integration.config.js --bail --runInBand --ci --reporters=default --reporters=jest-junit
+		NODE_ENV=test LOGLEVEL=error $(BIN_DIR)/jest --config ./test/jest-integration.config.js --bail --runInBand --ci --reporters=default --reporters=jest-junit
 
 unit-in-ci:
 	. ./.envrc && \

--- a/src/servers/graphql-main-server.ts
+++ b/src/servers/graphql-main-server.ts
@@ -64,7 +64,7 @@ export async function startApolloServerForCoreSchema() {
 }
 
 if (require.main === module) {
-  setupMongoConnection()
+  setupMongoConnection(true)
     .then(async () => {
       await startApolloServerForCoreSchema()
       activateLndHealthCheck()

--- a/src/services/mongodb/index.ts
+++ b/src/services/mongodb/index.ts
@@ -33,7 +33,7 @@ const db = process.env.MONGODB_DATABASE ?? "galoy"
 
 const path = `mongodb://${user}:${password}@${address}/${db}`
 
-export const setupMongoConnection = async () => {
+export const setupMongoConnection = async (syncIndexes = false) => {
   try {
     await mongoose.connect(path, {
       useNewUrlParser: true,
@@ -48,9 +48,11 @@ export const setupMongoConnection = async () => {
 
   try {
     mongoose.set("runValidators", true)
-    await User.syncIndexes()
-    await Transaction.syncIndexes()
-    await InvoiceUser.syncIndexes()
+    if (syncIndexes) {
+      await User.syncIndexes()
+      await Transaction.syncIndexes()
+      await InvoiceUser.syncIndexes()
+    }
   } catch (err) {
     baseLogger.fatal({ err, user, address, db }, `error setting the indexes`)
     throw err


### PR DESCRIPTION
- Allow re-indexing only in main server 
- Remove index sync by default in setupMongoConnection (it was done in admin, old server, exporter, cron, trigger, and daily balance notification) 
- Fix writeSDLFile open handle