### PR TITLE
fix: trigger health check

### DIFF
--- a/src/servers/exporter.ts
+++ b/src/servers/exporter.ts
@@ -154,7 +154,7 @@ const main = async () => {
     "/healthz",
     healthzHandler({
       checkDbConnectionStatus: true,
-      checkRedisStatus: true, // TODO: set to false when invoices/payments updates are removed from get balance
+      checkRedisStatus: false,
       checkLndsStatus: true,
     }),
   )

--- a/src/servers/exporter.ts
+++ b/src/servers/exporter.ts
@@ -14,6 +14,8 @@ import { User } from "@services/mongoose/schema"
 import express from "express"
 import client, { register } from "prom-client"
 
+import healthzHandler from "./healthz-handler"
+
 const logger = baseLogger.child({ module: "exporter" })
 
 const server = express()
@@ -148,9 +150,14 @@ const main = async () => {
     res.end(await register.metrics())
   })
 
-  server.get("/healthz", async (req, res) => {
-    res.send("OK")
-  })
+  server.get(
+    "/healthz",
+    healthzHandler({
+      checkDbConnectionStatus: true,
+      checkRedisStatus: true, // TODO: set to false when invoices/payments updates are removed from get balance
+      checkLndsStatus: true,
+    }),
+  )
 
   const port = process.env.PORT || 3000
   logger.info(`Server listening to ${port}, metrics exposed on /metrics endpoint`)

--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -6,7 +6,6 @@ import { WalletFactory } from "@core/wallet-factory"
 import Geetest from "@services/geetest"
 import { baseLogger } from "@services/logger"
 import { User } from "@services/mongoose/schema"
-import { redis } from "@services/redis"
 import {
   addAttributesToCurrentSpan,
   addAttributesToCurrentSpanAndPropagate,
@@ -21,7 +20,7 @@ import { execute, GraphQLError, subscribe } from "graphql"
 import { rule } from "graphql-shield"
 import helmet from "helmet"
 import * as jwt from "jsonwebtoken"
-import mongoose from "mongoose"
+
 import pino from "pino"
 import PinoHttp from "pino-http"
 import { SubscriptionServer } from "subscriptions-transport-ws"
@@ -29,6 +28,7 @@ import { v4 as uuidv4 } from "uuid"
 
 import { playgroundTabs } from "../graphql/playground"
 
+import healthzHandler from "./healthz-handler"
 import expressApiKeyAuth from "./graphql-middlewares/api-key-auth"
 
 const graphqlLogger = baseLogger.child({
@@ -273,11 +273,14 @@ export const startApolloServer = async ({
   app.use(expressApiKeyAuth)
 
   // Health check
-  app.get("/healthz", async function (req, res) {
-    const isMongoAlive = mongoose.connection.readyState === 1 ? true : false
-    const isRedisAlive = (await redis.ping()) === "PONG"
-    res.status(isMongoAlive && isRedisAlive ? 200 : 503).send()
-  })
+  app.get(
+    "/healthz",
+    healthzHandler({
+      checkDbConnectionStatus: true,
+      checkRedisStatus: true,
+      checkLndsStatus: false,
+    }),
+  )
 
   apolloServer.applyMiddleware({ app })
 

--- a/src/servers/healthz-handler.ts
+++ b/src/servers/healthz-handler.ts
@@ -1,0 +1,44 @@
+import express from "express"
+import mongoose from "mongoose"
+import { redis } from "@services/redis"
+import { lndStatusEvent } from "@services/lnd/health"
+
+type HealthzArgs = {
+  checkDbConnectionStatus: boolean
+  checkRedisStatus: boolean
+  checkLndsStatus: boolean
+}
+
+export default function ({
+  checkDbConnectionStatus,
+  checkRedisStatus,
+  checkLndsStatus,
+}: HealthzArgs) {
+  const lndStatus: { [key: string]: boolean } = {}
+  if (checkLndsStatus) {
+    lndStatusEvent.on("started", ({ pubkey, active }) => {
+      lndStatus[pubkey] = active
+    })
+
+    lndStatusEvent.on("stopped", ({ pubkey, active }) => {
+      lndStatus[pubkey] = active
+    })
+  }
+
+  return async (_req: express.Request, res: express.Response) => {
+    const isMongoAlive = !checkDbConnectionStatus || mongoose.connection.readyState === 1
+    const isRedisAlive = !checkRedisStatus || (await isRedisAvailable())
+    const statuses = Object.values(lndStatus)
+    const areLndsAlive =
+      !checkLndsStatus || (statuses.length > 0 && statuses.some((s) => s))
+    res.status(isMongoAlive && isRedisAlive && areLndsAlive ? 200 : 503).send()
+  }
+}
+
+const isRedisAvailable = async (): Promise<boolean> => {
+  try {
+    return (await redis.ping()) === "PONG"
+  } catch {
+    return false
+  }
+}

--- a/src/servers/trigger.ts
+++ b/src/servers/trigger.ts
@@ -265,7 +265,7 @@ const healthCheck = () => {
     const isMongoAlive = mongoose.connection.readyState === 1
     const isRedisAlive = (await redis.ping()) === "PONG"
     const statuses = Object.values(lndStatus)
-    const areLndsAlive = statuses.length > 0 && statuses.every((s) => s)
+    const areLndsAlive = statuses.length > 0 && statuses.some((s) => s)
     res.status(isMongoAlive && isRedisAlive && areLndsAlive ? 200 : 503).send()
   })
   app.listen(port, () => logger.info(`Health check listening on port ${port}!`))

--- a/src/servers/trigger.ts
+++ b/src/servers/trigger.ts
@@ -15,6 +15,7 @@ import { NotificationsService } from "@services/notifications"
 import { updatePriceHistory } from "@services/price/update-price-history"
 import { Dropbox } from "dropbox"
 import express from "express"
+import mongoose from "mongoose"
 import {
   subscribeToBackups,
   subscribeToBlocks,
@@ -232,8 +233,9 @@ const listenerOffchain = ({ lnd, pubkey }) => {
   })
 }
 
+const lndStatus: { [key: string]: boolean } = {}
 const main = () => {
-  lndStatusEvent.on("started", ({ lnd, pubkey, socket, type }) => {
+  lndStatusEvent.on("started", ({ lnd, pubkey, active, socket, type }) => {
     baseLogger.info({ socket }, "lnd started")
 
     if (type.indexOf("onchain") !== -1) {
@@ -243,10 +245,13 @@ const main = () => {
     if (type.indexOf("offchain") !== -1) {
       listenerOffchain({ lnd, pubkey })
     }
+
+    lndStatus[pubkey] = active
   })
 
-  lndStatusEvent.on("stopped", ({ socket }) => {
+  lndStatusEvent.on("stopped", ({ pubkey, active, socket }) => {
     baseLogger.info({ socket }, "lnd stopped")
+    lndStatus[pubkey] = active
   })
 
   activateLndHealthCheck()
@@ -256,7 +261,13 @@ const main = () => {
 const healthCheck = () => {
   const app = express()
   const port = 8888
-  app.get("/healthz", (req, res) => res.sendStatus(200))
+  app.get("/healthz", async (_req, res) => {
+    const isMongoAlive = mongoose.connection.readyState === 1
+    const isRedisAlive = (await redis.ping()) === "PONG"
+    const statuses = Object.values(lndStatus)
+    const areLndsAlive = statuses.length > 0 && statuses.every((s) => s)
+    res.status(isMongoAlive && isRedisAlive && areLndsAlive ? 200 : 503).send()
+  })
   app.listen(port, () => logger.info(`Health check listening on port ${port}!`))
 }
 

--- a/src/services/lnd/health.ts
+++ b/src/services/lnd/health.ts
@@ -26,9 +26,8 @@ export const isUp = async (param): Promise<void> => {
 
   try {
     // will throw if there is an error
-    // TODO: add is_ready validation when lnd is updated above 0.13.4 https://github.com/alexbosworth/ln-service#getwalletstatus
-    const { is_active } = await getWalletStatus({ lnd })
-    active = !!is_active
+    const { is_active, is_ready } = await getWalletStatus({ lnd })
+    active = !!is_active && !!is_ready
   } catch (err) {
     baseLogger.warn({ err }, `can't get wallet info from ${socket}`)
     active = false

--- a/src/services/lnd/health.ts
+++ b/src/services/lnd/health.ts
@@ -26,6 +26,7 @@ export const isUp = async (param): Promise<void> => {
 
   try {
     // will throw if there is an error
+    // TODO: add is_ready validation when lnd is updated above 0.13.4 https://github.com/alexbosworth/ln-service#getwalletstatus
     const { is_active } = await getWalletStatus({ lnd })
     active = !!is_active
   } catch (err) {

--- a/src/services/redis/index.ts
+++ b/src/services/redis/index.ts
@@ -53,6 +53,8 @@ redis.on("error", (err) => baseLogger.error({ err }, "Redis error"))
 
 export const redisSub = new Redis(connectionObj)
 
+redisSub.on("error", (err) => baseLogger.error({ err }, "redisSub error"))
+
 export const redisPubSub = new RedisPubSub({
   publisher: redis,
   subscriber: redisSub,


### PR DESCRIPTION
Add mongo, redis and lnds status validation to trigger healthz endpoint

How to test:

- Run `TEST="01|02" make reset-integration`
- Run `make trigger`
- GET `http://localhost:8888/healthz` (should receive 200 after trigger initialization)
- Run `docker ps` to get container ids 
- Run `docker stop <galoy-backend-lnd2-1 container id>`
- GET `http://localhost:8888/healthz` (should receive 503)
- Run `docker start <galoy-backend-lnd2-1 container id>` 
- GET `http://localhost:8888/healthz` (should receive 200)

ps: you can use the same procedure with redis and mongo