### PR TITLE
chore: add cron run to github integration job

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -15,5 +15,3 @@ jobs:
     - run: yarn install
     - name: Run integration tests
       run: docker compose up -d && make integration-in-ci
-    - name: Run cron
-      run: make cron-in-ci

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -15,3 +15,5 @@ jobs:
     - run: yarn install
     - name: Run integration tests
       run: docker compose up -d && make integration-in-ci
+    - name: Run cron
+      run: make cron-in-ci

--- a/Makefile
+++ b/Makefile
@@ -52,12 +52,11 @@ integration:
 
 reset-integration: reset-deps integration
 
-cron-in-ci:
-	. ./.envrc && yarn build && LOGLEVEL=error node lib/servers/cron.js
-
 integration-in-ci:
 	. ./.envrc && \
-		NODE_ENV=test LOGLEVEL=error $(BIN_DIR)/jest --config ./test/jest-integration.config.js --bail --runInBand --ci --reporters=default --reporters=jest-junit
+		NODE_ENV=test LOGLEVEL=error $(BIN_DIR)/jest --config ./test/jest-integration.config.js --bail --runInBand --ci --reporters=default --reporters=jest-junit && \
+		yarn build && \
+		LOGLEVEL=error node lib/servers/cron.js
 
 unit-in-ci:
 	. ./.envrc && \

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,9 @@ integration:
 
 reset-integration: reset-deps integration
 
+cron-in-ci:
+	. ./.envrc && yarn build && LOGLEVEL=error node lib/servers/cron.js
+
 integration-in-ci:
 	. ./.envrc && \
 		NODE_ENV=test LOGLEVEL=error $(BIN_DIR)/jest --config ./test/jest-integration.config.js --bail --runInBand --ci --reporters=default --reporters=jest-junit


### PR DESCRIPTION
- Add an additional task to integration test to run cron and try to detect configuration issues
- Is necessary to run cron after integration test because DbMetadata needs to be initialized
- This is not a final solution because config can be updated in staging or prod (CI tasks need to be updated) but will help developers to avoid issues with cron job

Example
![image](https://user-images.githubusercontent.com/2079600/145509117-ab3d441d-7152-4eaa-b504-bd2698272925.png)

