### PR TITLE
docs: add placeholder query to playground

### DIFF
--- a/src/graphql/playground.ts
+++ b/src/graphql/playground.ts
@@ -17,4 +17,3 @@ export const playgroundTabs = {
     variables: JSON.stringify({ range: "ONE_DAY" }),
   },
 }
-

--- a/src/graphql/playground.ts
+++ b/src/graphql/playground.ts
@@ -1,0 +1,17 @@
+const defaultQuery = `query btcPriceList($range: PriceGraphRange!) {
+    btcPriceList(range: $range) {
+        timestamp
+        price {
+        base
+        offset
+        currencyUnit
+        formattedAmount
+      }
+    }
+}`
+
+const defaultQueryName = "btcPriceList (Sample Query)"
+
+const defaultQueryVars = '{"range": "ONE_DAY"}'
+
+export { defaultQuery, defaultQueryName, defaultQueryVars }

--- a/src/graphql/playground.ts
+++ b/src/graphql/playground.ts
@@ -1,17 +1,20 @@
-const defaultQuery = `query btcPriceList($range: PriceGraphRange!) {
-    btcPriceList(range: $range) {
-        timestamp
-        price {
-        base
-        offset
-        currencyUnit
-        formattedAmount
-      }
+export const BTC_PRICE_QUERY = `query btcPriceList($range: PriceGraphRange!) {
+  btcPriceList(range: $range) {
+      timestamp
+      price {
+      base
+      offset
+      currencyUnit
+      formattedAmount
     }
+  }
 }`
 
-const defaultQueryName = "btcPriceList (Sample Query)"
+export const playgroundTabs = {
+  default: {
+    query: BTC_PRICE_QUERY,
+    name: "btcPriceList (Sample Query)",
+    variables: JSON.stringify({ range: "ONE_DAY" }),
+  },
+}
 
-const defaultQueryVars = '{"range": "ONE_DAY"}'
-
-export { defaultQuery, defaultQueryName, defaultQueryVars }

--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -31,6 +31,7 @@ import {
   ENDUSER_ALIAS,
 } from "@services/tracing"
 import { AccountsRepository } from "@services/mongoose"
+import { defaultQuery, defaultQueryName, defaultQueryVars } from "../graphql/playground"
 
 const graphqlLogger = baseLogger.child({
   module: "graphql",
@@ -152,9 +153,9 @@ export const startApolloServer = async ({
           tabs: [
             {
               endpoint: "https://api.staging.galoy.io/graphql",
-              query:
-                "query btcPriceList($range: PriceGraphRange!) {\n    btcPriceList(range: $range) {\n    	timestamp\n      price {\n        base\n        offset\n        currencyUnit\n        formattedAmount\n      }\n    }\n}",
-              variables: '{"range": "ONE_DAY"}',
+              query: defaultQuery,
+              name: defaultQueryName,
+              variables: defaultQueryVars,
             },
           ],
         }

--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -147,7 +147,17 @@ export const startApolloServer = async ({
   const apolloServer = new ApolloServer({
     schema,
     playground: apolloConfig.playground
-      ? { settings: { "schema.polling.enable": false } }
+      ? {
+          settings: { "schema.polling.enable": false },
+          tabs: [
+            {
+              endpoint: "https://api.staging.galoy.io/graphql",
+              query:
+                "query btcPriceList($range: PriceGraphRange!) {\n    btcPriceList(range: $range) {\n    	timestamp\n      price {\n        base\n        offset\n        currencyUnit\n        formattedAmount\n      }\n    }\n}",
+              variables: '{"range": "ONE_DAY"}',
+            },
+          ],
+        }
       : false,
     introspection: apolloConfig.playground,
     plugins: apolloPulgins,

--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -31,7 +31,7 @@ import {
   ENDUSER_ALIAS,
 } from "@services/tracing"
 import { AccountsRepository } from "@services/mongoose"
-import { defaultQuery, defaultQueryName, defaultQueryVars } from "../graphql/playground"
+import { playgroundTabs } from "../graphql/playground"
 
 const graphqlLogger = baseLogger.child({
   module: "graphql",

--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -153,9 +153,7 @@ export const startApolloServer = async ({
           tabs: [
             {
               endpoint: "https://api.staging.galoy.io/graphql",
-              query: defaultQuery,
-              name: defaultQueryName,
-              variables: defaultQueryVars,
+              ...playgroundTabs.default,
             },
           ],
         }


### PR DESCRIPTION
To address #757.

Tested locally and worked fine.

Placeholder query is currently `btcPriceList` since it doesn't require authentication. This query also uses a variable, which may be useful for people to see. But let me know if you would prefer a different query.