### PR TITLE
docs(lightning): add a rough description of the lib's error type

### DIFF
--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -485,7 +485,7 @@ const lookupPaymentByPubkeyAndHash = async ({
 // where '<Error Code Details Object>' is an Error object with
 // the usual 'message', 'stack' etc. properties and additional
 // properties: 'code', 'details', 'metadata'.
-const parseLndErrorDetails = (err) =>
+export const parseLndErrorDetails = (err) =>
   err[2]?.err?.details || err[2]?.failures?.[0]?.[2]?.err?.details || err[1]
 
 const KnownLndErrorDetails = {

--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -462,6 +462,29 @@ const lookupPaymentByPubkeyAndHash = async ({
   }
 }
 
+// A rough description of the error type we get back from the
+// 'lightning' library can be described as:
+//
+// [
+//   0: <Error Classification Code Number>
+//   1: <Error Type String>
+//   2: {
+//     err?: <Error Code Details Object>
+//     failures?: [
+//       [
+//         0: <Error Code Number>
+//         1: <Error Code Message String>
+//         2: {
+//           err?: <Error Code Details Object>
+//         }
+//       ]
+//     ]
+//   }
+// ]
+//
+// where '<Error Code Details Object>' is an Error object with
+// the usual 'message', 'stack' etc. properties and additional
+// properties: 'code', 'details', 'metadata'.
 const parseLndErrorDetails = (err) =>
   err[2]?.err?.details || err[2]?.failures?.[0]?.[2]?.err?.details || err[1]
 

--- a/test/integration/services/lnd/parse-errors.spec.ts
+++ b/test/integration/services/lnd/parse-errors.spec.ts
@@ -1,0 +1,127 @@
+import { decodeInvoice } from "@domain/bitcoin/lightning"
+import { parseLndErrorDetails } from "@services/lnd"
+import { getActiveLnd } from "@services/lnd/utils"
+
+import { createInvoice, payViaPaymentDetails, payViaRoutes } from "lightning"
+import { lndOutside1 } from "test/helpers"
+
+describe("'lightning' library error handling", () => {
+  const { lnd } = getActiveLnd()
+
+  // Test construction taken from:
+  // https://github.com/alexbosworth/lightning/blob/edcaf671e6a0bd2d8f8aa39b51ef816b2a633560/test/lnd_methods/offchain/test_pay_via_routes.js#L28
+  it("parses error message when no additional details are found", async () => {
+    const payArgs = { id: "id", lnd, routes: [] }
+    try {
+      await payViaRoutes(payArgs)
+    } catch (err) {
+      expect(err).toHaveLength(2)
+      expect(err[0]).toEqual(400)
+
+      const parsedErr = parseLndErrorDetails(err)
+      expect(parsedErr).toBe("ExpectedStandardHexPaymentHashId")
+    }
+  })
+
+  it("parses error message from err object", async () => {
+    const { request } = await createInvoice({
+      lnd: lndOutside1,
+      tokens: 1000,
+    })
+    const decodedInvoice = decodeInvoice(request as EncodedPaymentRequest)
+    expect(decodedInvoice).not.toBeInstanceOf(Error)
+    if (decodedInvoice instanceof Error) throw decodedInvoice
+
+    const paymentDetailsArgs = {
+      lnd,
+      id: decodedInvoice.paymentHash,
+      destination: decodedInvoice.destination,
+      mtokens: decodedInvoice.milliSatsAmount.toString(),
+      payment: decodedInvoice.paymentSecret as string,
+      cltv_delta: decodedInvoice.cltvDelta || undefined,
+      features: decodedInvoice.features
+        ? decodedInvoice.features.map((f) => ({
+            bit: f.bit,
+            is_required: f.isRequired,
+            type: f.type,
+          }))
+        : undefined,
+      routes: [],
+    }
+
+    try {
+      await payViaPaymentDetails(paymentDetailsArgs)
+      await payViaPaymentDetails(paymentDetailsArgs)
+    } catch (err) {
+      expect(err).toHaveLength(3)
+      expect(err[0]).toEqual(503)
+      expect(err[1]).toBe("UnexpectedPaymentError")
+      expect(err[2]).toHaveProperty("err")
+      expect(err[2]).not.toHaveProperty("failures")
+
+      const nestedErrObj = err[2].err
+      expect(nestedErrObj).toBeInstanceOf(Error)
+      expect(nestedErrObj).toHaveProperty("code")
+      expect(nestedErrObj).toHaveProperty("metadata")
+      expect(nestedErrObj).toHaveProperty("details")
+
+      const expectedDetails = "invoice is already paid"
+      expect(nestedErrObj.details).toBe(expectedDetails)
+
+      const parsedErr = parseLndErrorDetails(err)
+      expect(parsedErr).toBe(expectedDetails)
+    }
+  })
+
+  it("parses error message from failures object", async () => {
+    const payArgs = {
+      lnd,
+      routes: [
+        {
+          fee: 1,
+          fee_mtokens: "1000",
+          hops: [
+            {
+              channel: "1x1x1",
+              channel_capacity: 1,
+              fee: 1,
+              fee_mtokens: "1000",
+              forward: 1,
+              forward_mtokens: "1000",
+              public_key: Buffer.alloc(33).toString("hex"),
+              timeout: 100,
+            },
+          ],
+          mtokens: "1000",
+          timeout: 100,
+          tokens: 1,
+        },
+      ],
+    }
+    try {
+      await payViaRoutes(payArgs)
+    } catch (err) {
+      console.log(err[2].failures[0][2].err)
+      expect(err).toHaveLength(3)
+      expect(err[0]).toEqual(503)
+      expect(err[1]).toBe("UnexpectedErrorWhenPayingViaRoute")
+
+      const nestedFailureErr = err[2].failures[0]
+      expect(nestedFailureErr).toHaveLength(3)
+      expect(nestedFailureErr[0]).toEqual(err[0])
+      expect(nestedFailureErr[1]).toBe(err[1])
+
+      const nestedErrObj = nestedFailureErr[2].err
+      expect(nestedErrObj).toBeInstanceOf(Error)
+      expect(nestedErrObj).toHaveProperty("code")
+      expect(nestedErrObj).toHaveProperty("metadata")
+      expect(nestedErrObj).toHaveProperty("details")
+
+      const expectedDetails = "invalid magic in compressed pubkey string: 0"
+      expect(nestedErrObj.details).toBe(expectedDetails)
+
+      const parsedErr = parseLndErrorDetails(err)
+      expect(parsedErr).toBe(expectedDetails)
+    }
+  })
+})


### PR DESCRIPTION
### Description

An attempt at describing the object that gets thrown from the `lightning` library we use, based on the request in [this comment](https://github.com/GaloyMoney/galoy/pull/786#discussion_r762862086).

It wasn't possible (afaik) to define as a usual Typescript type since the object was an array with specific values expected at specific indices. I instead included a rough description as a multi-line comment above the method we've implemented to parse these errors.