### PR TITLE
github complain that Math.random is not secure for a hash

### DIFF
--- a/test/integration/services/mongoose/wallet-invoices.spec.ts
+++ b/test/integration/services/mongoose/wallet-invoices.spec.ts
@@ -6,7 +6,7 @@ import { getAndCreateUserWallet } from "test/helpers"
 import crypto from "crypto"
 
 const createTestWalletInvoice = () => {
-  const randomPaymentHash = crypto.createHash("sha256") as unknown as PaymentHash
+  const randomPaymentHash = crypto.randomBytes(32).toString("hex") as PaymentHash
   return {
     paymentHash: randomPaymentHash,
     walletId: "walletId" as WalletId,

--- a/test/integration/services/mongoose/wallet-invoices.spec.ts
+++ b/test/integration/services/mongoose/wallet-invoices.spec.ts
@@ -3,9 +3,10 @@ import { toSats } from "@domain/bitcoin"
 import { WalletInvoicesRepository } from "@services/mongoose"
 import { InvoiceUser } from "@services/mongoose/schema"
 import { getAndCreateUserWallet } from "test/helpers"
+import crypto from "crypto"
 
 const createTestWalletInvoice = () => {
-  const randomPaymentHash = Math.random().toString(36) as PaymentHash
+  const randomPaymentHash = crypto.createHash("sha256") as unknown as PaymentHash
   return {
     paymentHash: randomPaymentHash,
     walletId: "walletId" as WalletId,


### PR DESCRIPTION
although this is only used in test, doing this to remove the warning