### PR TITLE
feat: add telemetry wrappers

### DIFF
--- a/src/app/lightning/index.ts
+++ b/src/app/lightning/index.ts
@@ -1,3 +1,18 @@
-export * from "./payment-status-checker"
-export * from "./lookup-invoice-by-hash"
-export * from "./lookup-payment-by-hash"
+import { wrapAsyncToRunInSpan, wrapToRunInSpan } from "@services/tracing"
+import * as LookupInvoiceByHash from "./lookup-invoice-by-hash"
+import * as LookupPaymentByHash from "./lookup-payment-by-hash"
+import { PaymentStatusChecker as PaymentStatusCheckerFn } from "./payment-status-checker"
+
+// creates an object with all the functions of imported modules
+const dynamicWrapper = { ...LookupInvoiceByHash, ...LookupPaymentByHash }
+
+for (const fn in dynamicWrapper) {
+  // wrap with async span, we need to be careful with functions that don't return a promise like PaymentStatusChecker
+  dynamicWrapper[fn] = wrapAsyncToRunInSpan({ fn: dynamicWrapper[fn] })
+}
+
+// Still we need to do a static export
+export const { PaymentStatusChecker, lookupInvoiceByHash, lookupPaymentByHash } = {
+  PaymentStatusChecker: wrapToRunInSpan({ fn: PaymentStatusCheckerFn }),
+  ...dynamicWrapper,
+}

--- a/src/app/users/get-user.ts
+++ b/src/app/users/get-user.ts
@@ -22,29 +22,24 @@ export const getUserForLogin = async ({
   userId: string
   ip?: string
   logger: Logger
-}): Promise<User | ApplicationError> =>
-  asyncRunInSpan(
-    "app.getUserForLogin",
-    { [SemanticAttributes.CODE_FUNCTION]: "getUserForLogin" },
-    async () => {
-      const user = await users.findById(userId as UserId)
+}): Promise<User | ApplicationError> => {
+  const user = await users.findById(userId as UserId)
 
-      if (user instanceof Error) {
-        return user
-      }
-      addAttributesToCurrentSpan({
-        [ENDUSER_ALIAS]: user.username,
-      })
-      // this routing run asynchrously, to update metadata on the background
-      updateUserIPsInfo({ userId, ip, logger } as {
-        userId: UserId
-        ip: IpAddress
-        logger: Logger
-      })
+  if (user instanceof Error) {
+    return user
+  }
+  addAttributesToCurrentSpan({
+    [ENDUSER_ALIAS]: user.username,
+  })
+  // this routing run asynchrously, to update metadata on the background
+  updateUserIPsInfo({ userId, ip, logger } as {
+    userId: UserId
+    ip: IpAddress
+    logger: Logger
+  })
 
-      return user
-    },
-  )
+  return user
+}
 
 const updateUserIPsInfo = async ({
   userId,

--- a/src/app/users/index.ts
+++ b/src/app/users/index.ts
@@ -1,5 +1,13 @@
-export * from "./get-user"
+import { wrapAsyncToRunInSpan } from "@services/tracing"
+import { getUserForLogin as getUserForLoginFn } from "./get-user"
+
 export * from "./username-available"
 export * from "./update-contact-alias"
 export * from "./get-contact-by-username"
 export * from "./add-new-contact"
+
+const telemetryWrappers = {
+  getUserForLogin: wrapAsyncToRunInSpan({ fn: getUserForLoginFn }),
+}
+
+export const { getUserForLogin } = telemetryWrappers

--- a/src/app/users/index.ts
+++ b/src/app/users/index.ts
@@ -1,5 +1,8 @@
 import { wrapAsyncToRunInSpan } from "@services/tracing"
-import { getUserForLogin as getUserForLoginFn } from "./get-user"
+import {
+  getUserForLogin as getUserForLoginFn,
+  getUsernameFromWalletPublicId as getUsernameFromWalletPublicIdFn,
+} from "./get-user"
 
 export * from "./username-available"
 export * from "./update-contact-alias"
@@ -8,6 +11,9 @@ export * from "./add-new-contact"
 
 const telemetryWrappers = {
   getUserForLogin: wrapAsyncToRunInSpan({ fn: getUserForLoginFn }),
+  getUsernameFromWalletPublicId: wrapAsyncToRunInSpan({
+    fn: getUsernameFromWalletPublicIdFn,
+  }),
 }
 
-export const { getUserForLogin } = telemetryWrappers
+export const { getUserForLogin, getUsernameFromWalletPublicId } = telemetryWrappers

--- a/src/services/tracing.ts
+++ b/src/services/tracing.ts
@@ -187,6 +187,13 @@ export const wrapToRunInSpan = <A extends Array<any>, R>({
     const name = fnName || fn.name
     const spanName = `${namespace}.${name}`
     const attributes = { [SemanticAttributes.CODE_FUNCTION]: name, ...spanAttributes }
+    if (args && args.length > 0) {
+      let params = { "0": args[0] }
+      if (typeof args[0] === "object") params = args[0]
+      for (const key in params) {
+        attributes[`${SemanticAttributes.CODE_FUNCTION}.params.${key}`] = params[key]
+      }
+    }
     const ret = tracer.startActiveSpan(spanName, { attributes }, (span) => {
       const ret = fn(...args)
       if (ret instanceof Error) {
@@ -217,6 +224,13 @@ export const wrapAsyncToRunInSpan = <A extends Array<any>, R>({
     const name = fnName || fn.name
     const spanName = `${namespace}.${name}`
     const attributes = { [SemanticAttributes.CODE_FUNCTION]: name, ...spanAttributes }
+    if (args && args.length > 0) {
+      let params = { "0": args[0] }
+      if (typeof args[0] === "object") params = args[0]
+      for (const key in params) {
+        attributes[`${SemanticAttributes.CODE_FUNCTION}.params.${key}`] = params[key]
+      }
+    }
     const ret = tracer.startActiveSpan(spanName, { attributes }, async (span) => {
       const ret = await fn(...args)
       if (ret instanceof Error) {


### PR DESCRIPTION
Findings:

- Is not possible to do dynamic exports (so we cant do automatic wrapping without modify TS pipeline)  
- The alternative to add span at function level is to wrap at module level (index files)
- This implementation does not break Typescript types and/or IDE integration

The code in this PR is only to validate if we prefer it against the current implementation.
- Add wrappers in lightning `sub-module` ( 'dynamic' way). Please keep in mind that we can use this code at `app/index.ts` to support all sub-modules.
- Update current `getUserForLogin` span (manual way)
- In wrapAsyncToRunInSpan we can use args to add common attributes to the span (walletId, userId, ...)