### PR TITLE
Fix all instances of our MongoDb id as our new `walletId` value

### DIFF
--- a/src/core/lightning/wallet.ts
+++ b/src/core/lightning/wallet.ts
@@ -50,7 +50,7 @@ export class LightningUserWallet extends OnChainMixin(UserWallet) {
         if (userPastState.earn.findIndex((item) => item === id) === -1) {
           // FIXME: use pay by username instead
           const lnInvoice = await addInvoice({
-            walletId: this.user.id,
+            walletId: this.user.walletId,
             amount,
             memo: id,
           })
@@ -59,7 +59,7 @@ export class LightningUserWallet extends OnChainMixin(UserWallet) {
           const payResult = await lnInvoicePaymentSend({
             paymentRequest: lnInvoice.paymentRequest,
             memo: null,
-            walletId: lightningFundingWallet.user.id,
+            walletId: lightningFundingWallet.user.walletId,
             userId: lightningFundingWallet.user.id,
             logger: this.logger,
           })

--- a/src/core/on-chain/index.ts
+++ b/src/core/on-chain/index.ts
@@ -79,7 +79,7 @@ export const OnChainMixin = (superclass) =>
       const walletId_ = this.user.id // FIXME: just set this variable for easier code review. long variable would trigger adding a tab and much bigger diff
       return redlock({ path: walletId_, logger: onchainLogger }, async (lock) => {
         const balanceSats = await Wallets.getBalanceForWallet({
-          walletId: this.user.id,
+          walletId: this.user.walletId,
           logger: onchainLogger,
           lock,
         })
@@ -111,7 +111,7 @@ export const OnChainMixin = (superclass) =>
                 amount: toSats(amountToSendPayeeUser),
                 twoFAToken: twoFAToken ? (twoFAToken as TwoFAToken) : null,
                 twoFASecret: twoFA.secret,
-                walletId: this.user.id,
+                walletId: this.user.walletId,
               })
             : true
           if (twoFACheck instanceof TwoFANewCodeNeededError)
@@ -125,7 +125,7 @@ export const OnChainMixin = (superclass) =>
 
           const intraledgerLimitCheck = await checkIntraledgerLimits({
             amount: toSats(amountToSendPayeeUser),
-            walletId: this.user.id,
+            walletId: this.user.walletId,
           })
           if (intraledgerLimitCheck instanceof Error)
             throw new TransactionRestrictedError(intraledgerLimitCheck.message, {
@@ -160,7 +160,7 @@ export const OnChainMixin = (superclass) =>
             { logger: onchainLoggerOnUs, lock },
             async () =>
               LedgerService().addOnChainIntraledgerTxSend({
-                walletId: this.user.id,
+                walletId: this.user.walletId,
                 description: "",
                 sats: toSats(sats),
                 fee: onChainFee,
@@ -210,7 +210,7 @@ export const OnChainMixin = (superclass) =>
 
         const withdrawalLimitCheck = await checkWithdrawalLimits({
           amount: toSats(checksAmount),
-          walletId: this.user.id,
+          walletId: this.user.walletId,
         })
         if (withdrawalLimitCheck instanceof Error)
           throw new TransactionRestrictedError(withdrawalLimitCheck.message, {
@@ -222,7 +222,7 @@ export const OnChainMixin = (superclass) =>
               amount: toSats(checksAmount),
               twoFAToken: twoFAToken ? (twoFAToken as TwoFAToken) : null,
               twoFASecret: twoFA.secret,
-              walletId: this.user.id,
+              walletId: this.user.walletId,
             })
           : true
         if (twoFACheck instanceof TwoFANewCodeNeededError)

--- a/src/core/on-chain/index.ts
+++ b/src/core/on-chain/index.ts
@@ -76,7 +76,7 @@ export const OnChainMixin = (superclass) =>
         /// TODO: unable to check balanceSats vs this.dustThreshold at this point...
       }
 
-      const walletId_ = this.user.id // FIXME: just set this variable for easier code review. long variable would trigger adding a tab and much bigger diff
+      const walletId_ = this.user.walletId // FIXME: just set this variable for easier code review. long variable would trigger adding a tab and much bigger diff
       return redlock({ path: walletId_, logger: onchainLogger }, async (lock) => {
         const balanceSats = await Wallets.getBalanceForWallet({
           walletId: this.user.walletId,
@@ -92,7 +92,7 @@ export const OnChainMixin = (superclass) =>
           throw new InsufficientBalanceError(undefined, { logger: onchainLogger })
         }
 
-        const payeeUser = await User.getUserByAddress({ address })
+        const payeeUser: UserType = await User.getUserByAddress({ address })
 
         const user = await UsersRepository().findById(this.user.id)
         if (user instanceof Error) throw user
@@ -151,9 +151,9 @@ export const OnChainMixin = (superclass) =>
           const usd = sats * price
           const usdFee = onChainFee * price
 
-          const payerWallet = await WalletsRepository().findById(this.user.id)
+          const payerWallet = await WalletsRepository().findById(this.user.walletId)
           if (payerWallet instanceof Error) throw payerWallet
-          const recipientWallet = await WalletsRepository().findById(payeeUser.id)
+          const recipientWallet = await WalletsRepository().findById(payeeUser.walletId)
           if (recipientWallet instanceof Error) throw recipientWallet
 
           const journal = await LockService().extendLock(
@@ -168,9 +168,9 @@ export const OnChainMixin = (superclass) =>
                 usdFee,
                 payeeAddresses: [address as OnChainAddress],
                 sendAll,
-                recipientWalletId: payeeUser.id,
+                recipientWalletId: payeeUser.walletId,
                 payerUsername: this.user.username,
-                recipientUsername: payeeUser.username,
+                recipientUsername: (payeeUser.username as Username) || null,
                 memoPayer: memo || null,
               }),
           )

--- a/src/core/user-wallet.ts
+++ b/src/core/user-wallet.ts
@@ -37,12 +37,12 @@ export abstract class UserWallet {
   async getBalances(lock?): Promise<Balances> {
     // was the await omit on purpose?
     await Wallets.updatePendingInvoices({
-      walletId: this.user.id as WalletId,
+      walletId: this.user.walletId as WalletId,
       lock,
       logger: this.logger,
     })
     const result = await Wallets.updatePendingPayments({
-      walletId: this.user.id as WalletId,
+      walletId: this.user.walletId as WalletId,
       lock,
       logger: this.logger,
     })
@@ -264,7 +264,7 @@ export abstract class UserWallet {
 
   sendBalance = async (): Promise<void> => {
     const balanceSats = await Wallets.getBalanceForWallet({
-      walletId: this.user.id as WalletId,
+      walletId: this.user.walletId as WalletId,
       logger: this.logger,
     })
     if (balanceSats instanceof Error) throw balanceSats

--- a/src/graphql/types/object/btc-wallet.ts
+++ b/src/graphql/types/object/btc-wallet.ts
@@ -25,7 +25,7 @@ const BTCWallet = new GT.Object({
       type: GT.NonNull(SignedAmount),
       resolve: async (_, __, { wallet, logger }) => {
         const balanceSats = await Wallets.getBalanceForWallet({
-          walletId: wallet.user.id as WalletId,
+          walletId: wallet.user.walletId as WalletId,
           logger,
         })
         if (balanceSats instanceof Error) throw balanceSats

--- a/src/servers/exporter.ts
+++ b/src/servers/exporter.ts
@@ -112,7 +112,7 @@ const main = async () => {
       try {
         const wallet = await getWalletFromRole({ role, logger })
         const balanceSats = await Wallets.getBalanceForWallet({
-          walletId: wallet.user.id as WalletId,
+          walletId: wallet.user.walletId as WalletId,
           logger,
         })
         if (balanceSats instanceof Error) throw balanceSats

--- a/src/servers/graphql-old-server.ts
+++ b/src/servers/graphql-old-server.ts
@@ -193,7 +193,7 @@ const resolvers = {
       return response
     },
     getLastOnChainAddress: async (_, __, { wallet }) => {
-      const address = await Wallets.getLastOnChainAddress(wallet.user.id)
+      const address = await Wallets.getLastOnChainAddress(wallet.user.walletId)
       if (address instanceof Error) throw address
 
       return {
@@ -383,7 +383,7 @@ const resolvers = {
     earnCompleted: async (_, { ids }, { wallet }) => wallet.addEarn(ids),
     onchain: (_, __, { wallet }) => ({
       getNewAddress: async () => {
-        const address = await Wallets.createOnChainAddress(wallet.user.id)
+        const address = await Wallets.createOnChainAddress(wallet.user.walletId)
         if (address instanceof Error) throw mapError(address)
         return address
       },

--- a/src/servers/graphql-old-server.ts
+++ b/src/servers/graphql-old-server.ts
@@ -114,7 +114,7 @@ const resolvers = {
         currency: "BTC",
         balance: async () => {
           const balanceSats = await Wallets.getBalanceForWallet({
-            walletId: wallet.user.id as WalletId,
+            walletId: wallet.user.walletId as WalletId,
             logger,
           })
           if (balanceSats instanceof Error) throw balanceSats
@@ -123,7 +123,7 @@ const resolvers = {
         },
         transactions: async () => {
           const { result: txs, error } = await Wallets.getTransactionsForWalletId({
-            walletId: wallet.user.id,
+            walletId: wallet.user.walletId,
           })
           if (error instanceof Error || txs === null) {
             throw error
@@ -288,12 +288,12 @@ const resolvers = {
         const lnInvoice =
           value && value > 0
             ? await Wallets.addInvoice({
-                walletId: wallet.user.id,
+                walletId: wallet.user.walletId,
                 amount: value,
                 memo,
               })
             : await Wallets.addInvoiceNoAmount({
-                walletId: wallet.user.id,
+                walletId: wallet.user.walletId,
                 memo,
               })
         if (lnInvoice instanceof Error) throw mapError(lnInvoice)
@@ -324,7 +324,7 @@ const resolvers = {
               const status = await Wallets.lnInvoicePaymentSend({
                 paymentRequest: invoice,
                 memo,
-                walletId: wallet.user.id as WalletId,
+                walletId: wallet.user.walletId as WalletId,
                 userId: wallet.user.id as UserId,
                 logger,
               })
@@ -335,7 +335,7 @@ const resolvers = {
               paymentRequest: invoice,
               memo,
               amount,
-              walletId: wallet.user.id as WalletId,
+              walletId: wallet.user.walletId as WalletId,
               userId: wallet.user.id as UserId,
               logger,
             })
@@ -348,7 +348,7 @@ const resolvers = {
           recipientUsername: username,
           memo,
           amount,
-          walletId: wallet.user.id,
+          walletId: wallet.user.walletId,
           userId: wallet.user.id,
           logger,
         })
@@ -361,7 +361,7 @@ const resolvers = {
         let feeSatAmount: Satoshis | ApplicationError
         if (amount && amount > 0) {
           feeSatAmount = await getNoAmountLightningFee({
-            walletId: wallet.user.id,
+            walletId: wallet.user.walletId,
             amount,
             paymentRequest: invoice,
             logger,
@@ -372,7 +372,7 @@ const resolvers = {
         }
 
         feeSatAmount = await getLightningFee({
-          walletId: wallet.user.id,
+          walletId: wallet.user.walletId,
           paymentRequest: invoice,
           logger,
         })
@@ -401,7 +401,7 @@ const resolvers = {
       }),
       getFee: async ({ address, amount }) => {
         const fee = await Wallets.getOnChainFeeByWalletId({
-          walletId: wallet.user.id,
+          walletId: wallet.user.walletId,
           amount,
           address,
           targetConfirmations: 1,

--- a/src/servers/trigger.ts
+++ b/src/servers/trigger.ts
@@ -133,7 +133,7 @@ export async function onchainTransactionEventHandler(tx) {
       const price = await getCurrentPrice()
       const usdPerSat = price instanceof Error ? undefined : price
       await NotificationsService(onchainLogger).onChainTransactionReceivedPending({
-        walletId: user.id,
+        walletId: user.walletId,
         amount: toSats(Number(tx.tokens)),
         txHash: tx.id,
         usdPerSat,

--- a/src/services/ledger/schema.ts
+++ b/src/services/ledger/schema.ts
@@ -113,7 +113,10 @@ const transactionSchema = new Schema({
   meta: Schema.Types.Mixed,
   datetime: Date,
   account_path: [String],
-  accounts: String,
+  accounts: {
+    type: String,
+    maxlength: 36, // TODO: remove after switching account to uuid-v4
+  },
   book: String,
   memo: String,
   _journal: {

--- a/src/services/mongodb/index.ts
+++ b/src/services/mongodb/index.ts
@@ -8,18 +8,18 @@ import { loadLedger } from "@services/ledger"
 
 export const ledger = loadLedger({
   bankOwnerWalletResolver: async () => {
-    const { _id } = await User.findOne(
+    const { walletId } = await User.findOne(
       { role: "bankowner" },
       { lastIPs: 0, lastConnection: 0 },
     )
-    return _id
+    return walletId
   },
   dealerWalletResolver: async () => {
-    const { _id } = await User.findOne(
+    const { walletId } = await User.findOne(
       { role: "dealer" },
       { lastIPs: 0, lastConnection: 0 },
     )
-    return _id
+    return walletId
   },
 })
 

--- a/src/services/mongoose/accounts.ts
+++ b/src/services/mongoose/accounts.ts
@@ -34,7 +34,7 @@ export const AccountsRepository = (): IAccountsRepository => {
     walletId: WalletId,
   ): Promise<Account | RepositoryError> => {
     try {
-      const result: UserType = await User.findOne({ _id: walletId }, projection)
+      const result: UserType = await User.findOne({ walletId }, projection)
       if (!result) return new CouldNotFindError()
       return translateToAccount(result)
     } catch (err) {

--- a/src/services/mongoose/accounts.ts
+++ b/src/services/mongoose/accounts.ts
@@ -134,12 +134,12 @@ export const AccountsRepository = (): IAccountsRepository => {
 const translateToAccount = (result: UserType): Account => ({
   id: result.id as AccountId,
   createdAt: new Date(result.created_at),
-  defaultWalletId: result.id as WalletId, // TODO: add defaultWalletId at the persistence layer when Account have multiple wallet
+  defaultWalletId: result.walletId as WalletId, // TODO: add defaultWalletId at the persistence layer when Account have multiple wallet
   username: result.username as Username,
   level: (result.level as AccountLevel) || AccountLevel.One,
   status: (result.status as AccountStatus) || AccountStatus.Active,
   title: result.title as BusinessMapTitle,
   coordinates: result.coordinates as Coordinates,
-  walletIds: [result.id as WalletId],
+  walletIds: [result.walletId as WalletId],
   ownerId: result.id as UserId,
 })

--- a/src/services/mongoose/schema.ts
+++ b/src/services/mongoose/schema.ts
@@ -285,7 +285,7 @@ UserSchema.virtual("ratioBtc").get(function (this: typeof UserSchema) {
 
 // this is the accounting path in medici for this user
 UserSchema.virtual("walletPath").get(function (this: typeof UserSchema) {
-  return walletPath(this.id)
+  return walletPath(this.walletId)
 })
 
 UserSchema.virtual("oldEnoughForWithdrawal").get(function (this: typeof UserSchema) {

--- a/src/services/mongoose/wallet-on-chain-addresses.ts
+++ b/src/services/mongoose/wallet-on-chain-addresses.ts
@@ -1,4 +1,3 @@
-import { Types as MongooseTypes } from "mongoose"
 import { User } from "@services/mongoose/schema"
 import {
   CouldNotFindError,
@@ -38,7 +37,7 @@ export const WalletOnChainAddressesRepository = (): IWalletOnChainAddressesRepos
   ): Promise<OnChainAddressIdentifier | RepositoryError> => {
     try {
       const [result] = await User.aggregate([
-        { $match: { _id: new MongooseTypes.ObjectId(walletId) } },
+        { $match: { walletId } },
         { $project: { lastAddress: { $last: "$onchain" } } },
       ])
 

--- a/src/services/mongoose/wallet-on-chain-addresses.ts
+++ b/src/services/mongoose/wallet-on-chain-addresses.ts
@@ -15,7 +15,7 @@ export const WalletOnChainAddressesRepository = (): IWalletOnChainAddressesRepos
     try {
       const { address, pubkey } = onChainAddress
       const result = await User.updateOne(
-        { _id: walletId },
+        { walletId },
         { $push: { onchain: { address, pubkey } } },
       )
 

--- a/src/services/mongoose/wallets.ts
+++ b/src/services/mongoose/wallets.ts
@@ -74,7 +74,7 @@ export const WalletsRepository = (): IWalletsRepository => {
 }
 
 const resultToWallet = (result: UserType): Wallet => {
-  const walletId = result.id as WalletId
+  const walletId = result.walletId as WalletId
   const depositFeeRatio = result.depositFeeRatio as DepositFeeRatio
   const withdrawFee = result.withdrawFee as WithdrawFee
 

--- a/src/services/mongoose/wallets.ts
+++ b/src/services/mongoose/wallets.ts
@@ -12,7 +12,7 @@ import { caseInsensitiveRegex } from "./users"
 export const WalletsRepository = (): IWalletsRepository => {
   const findById = async (walletId: WalletId): Promise<Wallet | RepositoryError> => {
     try {
-      const result = await User.findOne({ _id: walletId })
+      const result = await User.findOne({ walletId })
       if (!result) {
         return new CouldNotFindWalletFromIdError()
       }

--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -42,7 +42,6 @@ export const NotificationsService = (logger: Logger): INotificationsService => {
 
       // Notify the recipient (via GraphQL subscription if any)
       const walletUpdatedEventName = walletUpdateEvent(user.walletId)
-
       pubsub.publish(walletUpdatedEventName, {
         transaction: {
           txNotificationType: type,
@@ -108,7 +107,7 @@ export const NotificationsService = (logger: Logger): INotificationsService => {
   }: LnInvoicePaidArgs) => {
     try {
       // work around to move forward before re-wrighting the whole notifications module
-      const user = await User.findOne({ _id: recipientWalletId })
+      const user = await User.findOne({ walletId: recipientWalletId })
 
       // Do not await this call for quicker processing
       transactionNotification({
@@ -168,7 +167,7 @@ export const NotificationsService = (logger: Logger): INotificationsService => {
       publish(recipientWalletId, NotificationType.IntraLedgerReceipt)
 
       // work around to move forward before re-wrighting the whole notifications module
-      const payerUser = await User.findOne({ _id: payerWalletId })
+      const payerUser = await User.findOne({ walletId: payerWalletId })
 
       // Do not await this call for quicker processing
       transactionNotification({
@@ -179,7 +178,7 @@ export const NotificationsService = (logger: Logger): INotificationsService => {
         usdPerSat,
       })
 
-      const recipientUser = await User.findOne({ _id: recipientWalletId })
+      const recipientUser = await User.findOne({ walletId: recipientWalletId })
 
       // Do not await this call for quicker processing
       transactionNotification({

--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -28,7 +28,7 @@ export const NotificationsService = (logger: Logger): INotificationsService => {
   }): Promise<void | NotificationsServiceError> => {
     try {
       // work around to move forward before re-wrighting the whole notifications module
-      const user = await User.findOne({ walletId })
+      const user: UserType = await User.findOne({ walletId })
 
       // Do not await this call for quicker processing
       transactionNotification({
@@ -41,7 +41,7 @@ export const NotificationsService = (logger: Logger): INotificationsService => {
       })
 
       // Notify the recipient (via GraphQL subscription if any)
-      const walletUpdatedEventName = walletUpdateEvent(user.id)
+      const walletUpdatedEventName = walletUpdateEvent(user.walletId)
 
       pubsub.publish(walletUpdatedEventName, {
         transaction: {

--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -28,7 +28,7 @@ export const NotificationsService = (logger: Logger): INotificationsService => {
   }): Promise<void | NotificationsServiceError> => {
     try {
       // work around to move forward before re-wrighting the whole notifications module
-      const user = await User.findOne({ _id: walletId })
+      const user = await User.findOne({ walletId })
 
       // Do not await this call for quicker processing
       transactionNotification({

--- a/test/integration/01-setup/01-funds-bitcoind-lnds.spec.ts
+++ b/test/integration/01-setup/01-funds-bitcoind-lnds.spec.ts
@@ -78,7 +78,7 @@ describe("Bitcoind", () => {
     await getAndCreateUserWallet(4)
 
     const funderWallet = await getWalletFromRole({ role: "funder", logger: baseLogger })
-    const address = await Wallets.createOnChainAddress(funderWallet.user.id)
+    const address = await Wallets.createOnChainAddress(funderWallet.user.walletId)
     if (address instanceof Error) throw address
 
     await sendToAddressAndConfirm({ walletClient: bitcoindOutside, address, amount })

--- a/test/integration/02-user-wallet/02-invoice.spec.ts
+++ b/test/integration/02-user-wallet/02-invoice.spec.ts
@@ -27,7 +27,7 @@ beforeAll(async () => {
 describe("UserWallet - addInvoice", () => {
   it("adds a self generated invoice", async () => {
     const lnInvoice = await addInvoice({
-      walletId: userWallet1.user.id as WalletId,
+      walletId: userWallet1.user.walletId as WalletId,
       amount: toSats(1000),
     })
     if (lnInvoice instanceof Error) return lnInvoice
@@ -40,7 +40,7 @@ describe("UserWallet - addInvoice", () => {
 
   it("adds a self generated invoice without amount", async () => {
     const lnInvoice = await addInvoiceNoAmount({
-      walletId: userWallet1.user.id as WalletId,
+      walletId: userWallet1.user.walletId as WalletId,
     })
     if (lnInvoice instanceof Error) return lnInvoice
     const { paymentRequest: request } = lnInvoice
@@ -60,7 +60,7 @@ describe("UserWallet - addInvoice", () => {
     const promises: Promise<LnInvoice | ApplicationError>[] = []
     for (let i = 0; i < limitsNum; i++) {
       const lnInvoicePromise = addInvoice({
-        walletId: userWallet1.user.id as WalletId,
+        walletId: userWallet1.user.walletId as WalletId,
         amount: toSats(1000),
       })
       promises.push(lnInvoicePromise)
@@ -83,7 +83,7 @@ describe("UserWallet - addInvoice", () => {
     const promises: Promise<LnInvoice | ApplicationError>[] = []
     for (let i = 0; i < limitsNum; i++) {
       const lnInvoicePromise = addInvoiceNoAmount({
-        walletId: userWallet1.user.id as WalletId,
+        walletId: userWallet1.user.walletId as WalletId,
       })
       promises.push(lnInvoicePromise)
     }
@@ -156,13 +156,13 @@ describe("UserWallet - addInvoice", () => {
 const testPastSelfInvoiceLimits = async (user) => {
   // Test that first invoice past the limit fails
   const lnInvoice = await addInvoice({
-    walletId: user.id as WalletId,
+    walletId: user.walletId as WalletId,
     amount: toSats(1000),
   })
   expect(lnInvoice).toBeInstanceOf(RateLimiterExceededError)
 
   const lnNoAmountInvoice = await addInvoiceNoAmount({
-    walletId: user.id as WalletId,
+    walletId: user.walletId as WalletId,
   })
   expect(lnNoAmountInvoice).toBeInstanceOf(RateLimiterExceededError)
 
@@ -202,14 +202,14 @@ const testPastRecipientInvoiceLimits = async (user) => {
 
   // Test that recipient invoices still work
   const lnInvoice = await addInvoice({
-    walletId: user.id as WalletId,
+    walletId: user.walletId as WalletId,
     amount: toSats(1000),
   })
   expect(lnInvoice).not.toBeInstanceOf(Error)
   expect(lnInvoice).toHaveProperty("paymentRequest")
 
   const lnNoAmountInvoice = await addInvoiceNoAmount({
-    walletId: user.id as WalletId,
+    walletId: user.walletId as WalletId,
   })
   expect(lnNoAmountInvoice).not.toBeInstanceOf(Error)
   expect(lnNoAmountInvoice).toHaveProperty("paymentRequest")

--- a/test/integration/02-user-wallet/02-receive-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-lightning.spec.ts
@@ -37,7 +37,7 @@ describe("UserWallet - Lightning", () => {
     const memo = "myMemo"
 
     const lnInvoice = await addInvoice({
-      walletId: userWallet1.user.id as WalletId,
+      walletId: userWallet1.user.walletId as WalletId,
       amount: toSats(sats),
       memo,
     })
@@ -81,7 +81,7 @@ describe("UserWallet - Lightning", () => {
 
     // check that memo is not filtered by spam filter
     const { result: txns, error } = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
     })
     if (error instanceof Error || txns === null) {
       throw error
@@ -101,7 +101,7 @@ describe("UserWallet - Lightning", () => {
     const sats = 1000
 
     const lnInvoice = await addInvoiceNoAmount({
-      walletId: userWallet1.user.id as WalletId,
+      walletId: userWallet1.user.walletId as WalletId,
     })
     if (lnInvoice instanceof Error) return lnInvoice
     const { paymentRequest: invoice } = lnInvoice
@@ -143,7 +143,7 @@ describe("UserWallet - Lightning", () => {
 
     // process spam transaction
     const lnInvoice = await addInvoice({
-      walletId: userWallet1.user.id as WalletId,
+      walletId: userWallet1.user.walletId as WalletId,
       amount: toSats(sats),
       memo,
     })
@@ -165,7 +165,7 @@ describe("UserWallet - Lightning", () => {
 
     // check that spam memo is filtered from transaction description
     const { result: txns, error } = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
     })
     if (error instanceof Error || txns === null) {
       throw error

--- a/test/integration/02-user-wallet/02-receive-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-lightning.spec.ts
@@ -23,7 +23,7 @@ beforeAll(async () => {
 })
 
 beforeEach(async () => {
-  initBalance1 = await getBTCBalance(userWallet1.user.id)
+  initBalance1 = await getBTCBalance(userWallet1.user.walletId)
 })
 
 afterEach(async () => {
@@ -93,7 +93,7 @@ describe("UserWallet - Lightning", () => {
     ) as WalletTransaction
     expect(noSpamTxn.deprecated.description).toBe(memo)
 
-    const finalBalance = await getBTCBalance(userWallet1.user.id)
+    const finalBalance = await getBTCBalance(userWallet1.user.walletId)
     expect(finalBalance).toBe(initBalance1 + sats)
   })
 
@@ -129,7 +129,7 @@ describe("UserWallet - Lightning", () => {
     expect(dbTx.memo).toBe("")
     expect(dbTx.pending).toBe(false)
 
-    const finalBalance = await getBTCBalance(userWallet1.user.id)
+    const finalBalance = await getBTCBalance(userWallet1.user.walletId)
     expect(finalBalance).toBe(initBalance1 + sats)
   })
 
@@ -179,7 +179,7 @@ describe("UserWallet - Lightning", () => {
     expect(spamTxn.deprecated.description).toBe(dbTx.type)
 
     // confirm expected final balance
-    const finalBalance = await getBTCBalance(userWallet1.user.id)
+    const finalBalance = await getBTCBalance(userWallet1.user.walletId)
     expect(finalBalance).toBe(initBalance1 + sats)
   })
 })

--- a/test/integration/02-user-wallet/02-receive-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-onchain.spec.ts
@@ -200,7 +200,7 @@ describe("UserWallet - On chain", () => {
     await sleep(1000)
 
     const { result: txs, error } = await Wallets.getTransactionsForWalletId({
-      walletId: walletUser0.user.id,
+      walletId: walletUser0.user.walletId,
     })
     if (error instanceof Error || txs === null) {
       throw error
@@ -269,7 +269,7 @@ async function sendToWallet({ walletDestination }) {
 
   const initialBalance = await getBTCBalance(walletDestination.user.id)
   const { result: initTransactions, error } = await Wallets.getTransactionsForWalletId({
-    walletId: walletDestination.user.id,
+    walletId: walletDestination.user.walletId,
   })
   if (error instanceof Error || initTransactions === null) {
     throw error
@@ -306,7 +306,7 @@ async function sendToWallet({ walletDestination }) {
     )
 
     const { result: transactions, error } = await Wallets.getTransactionsForWalletId({
-      walletId: walletDestination.user.id as WalletId,
+      walletId: walletDestination.user.walletId as WalletId,
     })
     if (error instanceof Error || transactions === null) {
       throw error

--- a/test/integration/02-user-wallet/02-receive-rewards.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-rewards.spec.ts
@@ -28,15 +28,15 @@ afterAll(() => {
 
 describe("UserWallet - addEarn", () => {
   it("adds balance only once", async () => {
-    const resetOk = await resetSelfWalletIdLimits(userWallet1.user.id)
+    const resetOk = await resetSelfWalletIdLimits(userWallet1.user.walletId)
     expect(resetOk).not.toBeInstanceOf(Error)
     if (resetOk instanceof Error) throw resetOk
 
-    const initialBalance = await getBTCBalance(userWallet1.user.id)
+    const initialBalance = await getBTCBalance(userWallet1.user.walletId)
 
     const getAndVerifyRewards = async () => {
       await userWallet1.addEarn(onBoardingEarnIds)
-      const finalBalance = await getBTCBalance(userWallet1.user.id)
+      const finalBalance = await getBTCBalance(userWallet1.user.walletId)
       let rewards = onBoardingEarnAmt
       if (difference(onBoardingEarnIds, userWallet1.user.earn).length === 0) {
         rewards = 0

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -78,7 +78,7 @@ describe("UserWallet - Lightning Pay", () => {
     const memo = "invoiceMemo"
 
     const lnInvoice = await addInvoice({
-      walletId: userWallet2.user.id as WalletId,
+      walletId: userWallet2.user.walletId as WalletId,
       amount: toSats(amountInvoice),
       memo,
     })
@@ -93,7 +93,7 @@ describe("UserWallet - Lightning Pay", () => {
     const paymentResult = await lnInvoicePaymentSend({
       paymentRequest: invoice,
       memo: null,
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
       userId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
@@ -109,7 +109,7 @@ describe("UserWallet - Lightning Pay", () => {
       tx.initiationVia.paymentHash === getHash(invoice)
 
     let txResult = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
     })
     if (txResult.error instanceof Error || txResult.result === null) {
       throw txResult.error
@@ -120,7 +120,7 @@ describe("UserWallet - Lightning Pay", () => {
     // expect(user1Txn.filter(matchTx)[0].recipientUsername).toBe("lily")
 
     txResult = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
     })
     if (txResult.error instanceof Error || txResult.result === null) {
       throw txResult.error
@@ -135,7 +135,7 @@ describe("UserWallet - Lightning Pay", () => {
     const memoPayer = "my memo as a payer"
 
     const lnInvoice = await addInvoice({
-      walletId: userWallet2.user.id as WalletId,
+      walletId: userWallet2.user.walletId as WalletId,
       amount: toSats(amountInvoice),
       memo,
     })
@@ -145,7 +145,7 @@ describe("UserWallet - Lightning Pay", () => {
     const paymentResult = await lnInvoicePaymentSend({
       paymentRequest: request,
       memo: memoPayer,
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
       userId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
@@ -156,7 +156,7 @@ describe("UserWallet - Lightning Pay", () => {
       tx.initiationVia.paymentHash === getHash(request)
 
     let txResult = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet2.user.id,
+      walletId: userWallet2.user.walletId,
     })
     if (txResult.error instanceof Error || txResult.result === null) {
       throw txResult.error
@@ -166,7 +166,7 @@ describe("UserWallet - Lightning Pay", () => {
     expect(user2Txn.filter(matchTx)[0].settlementVia.type).toBe("intraledger")
 
     txResult = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
     })
     if (txResult.error instanceof Error || txResult.result === null) {
       throw txResult.error
@@ -181,7 +181,7 @@ describe("UserWallet - Lightning Pay", () => {
       recipientUsername: userWallet0.user.username,
       memo: "",
       amount: toSats(amountInvoice),
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
       userId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
@@ -190,7 +190,7 @@ describe("UserWallet - Lightning Pay", () => {
 
     const finalBalance0 = await getBTCBalance(userWallet0.user.id)
     const { result: userTransaction0, error } = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet0.user.id,
+      walletId: userWallet0.user.walletId,
     })
     if (error instanceof Error || userTransaction0 === null) {
       throw error
@@ -198,7 +198,7 @@ describe("UserWallet - Lightning Pay", () => {
 
     const finalBalance1 = await getBTCBalance(userWallet1.user.id)
     const txResult = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
     })
     if (txResult.error instanceof Error || txResult.result === null) {
       throw txResult.error
@@ -248,7 +248,7 @@ describe("UserWallet - Lightning Pay", () => {
       recipientUsername: userWallet0.user.username,
       memo: "",
       amount: toSats(amountInvoice),
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
       userId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
@@ -282,7 +282,7 @@ describe("UserWallet - Lightning Pay", () => {
       paymentRequest: request as EncodedPaymentRequest,
       memo: null,
       amount: toSats(amountInvoice),
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
       userId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
@@ -300,7 +300,7 @@ describe("UserWallet - Lightning Pay", () => {
       recipientUsername: userWallet0.user.username,
       memo: memoSpamBelowThreshold,
       amount: toSats(satsBelow),
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
       userId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
@@ -313,7 +313,7 @@ describe("UserWallet - Lightning Pay", () => {
       recipientUsername: userWallet0.user.username,
       memo: memoSpamAboveThreshold,
       amount: toSats(satsAbove),
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
       userId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
@@ -321,7 +321,7 @@ describe("UserWallet - Lightning Pay", () => {
     if (resAboveThreshold instanceof Error) throw resAboveThreshold
 
     let txResult = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet0.user.id,
+      walletId: userWallet0.user.walletId,
     })
     if (txResult.error instanceof Error || txResult.result === null) {
       throw txResult.error
@@ -331,7 +331,7 @@ describe("UserWallet - Lightning Pay", () => {
     const transaction0Below = userTransaction0[1]
 
     txResult = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
     })
     if (txResult.error instanceof Error || txResult.result === null) {
       throw txResult.error
@@ -399,7 +399,7 @@ describe("UserWallet - Lightning Pay", () => {
 
   it("fails if sends to self", async () => {
     const lnInvoice = await addInvoice({
-      walletId: userWallet1.user.id as WalletId,
+      walletId: userWallet1.user.walletId as WalletId,
       amount: toSats(amountInvoice),
       memo: "self payment",
     })
@@ -409,7 +409,7 @@ describe("UserWallet - Lightning Pay", () => {
     const paymentResult = await lnInvoicePaymentSend({
       paymentRequest: invoice,
       memo: null,
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
       userId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
@@ -421,7 +421,7 @@ describe("UserWallet - Lightning Pay", () => {
       recipientUsername: userWallet1.user.username,
       memo: "",
       amount: toSats(amountInvoice),
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
       userId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
@@ -436,7 +436,7 @@ describe("UserWallet - Lightning Pay", () => {
     const paymentResult = await lnInvoicePaymentSend({
       paymentRequest: invoice as EncodedPaymentRequest,
       memo: null,
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
       userId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
@@ -448,7 +448,7 @@ describe("UserWallet - Lightning Pay", () => {
     const paymentResult = await lnInvoicePaymentSend({
       paymentRequest: request as EncodedPaymentRequest,
       memo: null,
-      walletId: userWallet0.user.id,
+      walletId: userWallet0.user.walletId,
       userId: userWallet0.user.id,
       logger: userWallet0.logger,
     })
@@ -461,7 +461,7 @@ describe("UserWallet - Lightning Pay", () => {
     const paymentResult = await lnInvoicePaymentSend({
       paymentRequest: request as EncodedPaymentRequest,
       memo: null,
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
       userId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
@@ -476,7 +476,7 @@ describe("UserWallet - Lightning Pay", () => {
     const paymentResult = await lnInvoicePaymentSend({
       paymentRequest: request as EncodedPaymentRequest,
       memo: null,
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
       userId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
@@ -487,7 +487,7 @@ describe("UserWallet - Lightning Pay", () => {
 
   it("fails to pay when amount exceeds onUs limit", async () => {
     const lnInvoice = await addInvoice({
-      walletId: userWallet0.user.id as WalletId,
+      walletId: userWallet0.user.walletId as WalletId,
       amount: toSats(userLimits.onUsLimit + 1),
     })
     if (lnInvoice instanceof Error) return lnInvoice
@@ -496,7 +496,7 @@ describe("UserWallet - Lightning Pay", () => {
     const paymentResult = await lnInvoicePaymentSend({
       paymentRequest: request as EncodedPaymentRequest,
       memo: null,
-      walletId: userWallet1.user.id,
+      walletId: userWallet1.user.walletId,
       userId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
@@ -520,7 +520,7 @@ describe("UserWallet - Lightning Pay", () => {
       fn: function fn(wallet) {
         return async (input): Promise<PaymentSendStatus | ApplicationError> => {
           const feeFromProbe = await getLightningFee({
-            walletId: wallet.user.id,
+            walletId: wallet.user.walletId,
             paymentRequest: input.invoice,
             logger: wallet.logger,
           })
@@ -528,7 +528,7 @@ describe("UserWallet - Lightning Pay", () => {
           const paymentResult = await lnInvoicePaymentSendWithTwoFA({
             paymentRequest: input.invoice as EncodedPaymentRequest,
             memo: input.memo,
-            walletId: wallet.user.id,
+            walletId: wallet.user.walletId,
             userId: wallet.user.id,
             twoFAToken: input.twoFAToken || null,
             logger: wallet.logger,
@@ -545,7 +545,7 @@ describe("UserWallet - Lightning Pay", () => {
           const paymentResult = await lnInvoicePaymentSendWithTwoFA({
             paymentRequest: input.invoice as EncodedPaymentRequest,
             memo: input.memo,
-            walletId: wallet.user.id,
+            walletId: wallet.user.walletId,
             userId: wallet.user.id,
             twoFAToken: input.twoFAToken || null,
             logger: wallet.logger,
@@ -609,7 +609,7 @@ describe("UserWallet - Lightning Pay", () => {
           const payeeInitialBalance = await getBTCBalance(walletPayee.user.id)
 
           const lnInvoice = await addInvoice({
-            walletId: walletPayee.user.id as WalletId,
+            walletId: walletPayee.user.walletId as WalletId,
             amount: toSats(amountInvoice),
           })
           if (lnInvoice instanceof Error) return lnInvoice
@@ -629,7 +629,7 @@ describe("UserWallet - Lightning Pay", () => {
             tx.initiationVia.paymentHash === hash
 
           let txResult = await Wallets.getTransactionsForWalletId({
-            walletId: walletPayee.user.id,
+            walletId: walletPayee.user.walletId,
           })
           if (txResult.error instanceof Error || txResult.result === null) {
             throw txResult.error
@@ -640,7 +640,7 @@ describe("UserWallet - Lightning Pay", () => {
           await checkIsBalanced()
 
           txResult = await Wallets.getTransactionsForWalletId({
-            walletId: walletPayer.user.id as WalletId,
+            walletId: walletPayer.user.walletId as WalletId,
           })
           if (txResult.error instanceof Error || txResult.result === null) {
             throw txResult.error
@@ -756,7 +756,7 @@ describe("UserWallet - Lightning Pay", () => {
 
         await waitFor(async () => {
           const updatedPayments = await Wallets.updatePendingPayments({
-            walletId: userWallet1.user.id,
+            walletId: userWallet1.user.walletId,
             logger: baseLogger,
           })
           if (updatedPayments instanceof Error) throw updatedPayments
@@ -795,7 +795,7 @@ describe("UserWallet - Lightning Pay", () => {
 
         await waitFor(async () => {
           const updatedPayments = await Wallets.updatePendingPayments({
-            walletId: userWallet1.user.id,
+            walletId: userWallet1.user.walletId,
             logger: baseLogger,
           })
           if (updatedPayments instanceof Error) throw updatedPayments
@@ -871,7 +871,7 @@ describe("UserWallet - Lightning Pay", () => {
     const { lnd } = getActiveLnd()
 
     const lnInvoice = await addInvoice({
-      walletId: userWallet1.user.id as WalletId,
+      walletId: userWallet1.user.walletId as WalletId,
       amount: toSats(amountInvoice),
       memo,
     })

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -61,8 +61,8 @@ beforeAll(async () => {
 })
 
 beforeEach(async () => {
-  initBalance0 = await getBTCBalance(userWallet0.user.id)
-  initBalance1 = await getBTCBalance(userWallet1.user.id)
+  initBalance0 = await getBTCBalance(userWallet0.user.walletId)
+  initBalance1 = await getBTCBalance(userWallet1.user.walletId)
 })
 
 afterEach(async () => {
@@ -188,7 +188,7 @@ describe("UserWallet - Lightning Pay", () => {
     expect(res).not.toBeInstanceOf(Error)
     if (res instanceof Error) throw res
 
-    const finalBalance0 = await getBTCBalance(userWallet0.user.id)
+    const finalBalance0 = await getBTCBalance(userWallet0.user.walletId)
     const { result: userTransaction0, error } = await Wallets.getTransactionsForWalletId({
       walletId: userWallet0.user.walletId,
     })
@@ -196,7 +196,7 @@ describe("UserWallet - Lightning Pay", () => {
       throw error
     }
 
-    const finalBalance1 = await getBTCBalance(userWallet1.user.id)
+    const finalBalance1 = await getBTCBalance(userWallet1.user.walletId)
     const txResult = await Wallets.getTransactionsForWalletId({
       walletId: userWallet1.user.walletId,
     })
@@ -289,7 +289,7 @@ describe("UserWallet - Lightning Pay", () => {
     if (paymentResult instanceof Error) throw paymentResult
     expect(paymentResult).toBe(PaymentSendStatus.Success)
 
-    const finalBalance = await getBTCBalance(userWallet1.user.id)
+    const finalBalance = await getBTCBalance(userWallet1.user.walletId)
     expect(finalBalance).toBe(initBalance1 - amountInvoice)
   })
 
@@ -567,7 +567,7 @@ describe("UserWallet - Lightning Pay", () => {
         if (result instanceof Error) throw result
         expect(result).toBe(PaymentSendStatus.Success)
 
-        const finalBalance = await getBTCBalance(userWallet1.user.id)
+        const finalBalance = await getBTCBalance(userWallet1.user.walletId)
         expect(finalBalance).toBe(initBalance1 - amountInvoice)
       })
 
@@ -578,13 +578,13 @@ describe("UserWallet - Lightning Pay", () => {
         })
         const intermediateResult = await fn(userWallet1)({ invoice: request })
         if (intermediateResult instanceof Error) throw intermediateResult
-        const intermediateBalanceSats = await getBTCBalance(userWallet1.user.id)
+        const intermediateBalanceSats = await getBTCBalance(userWallet1.user.walletId)
 
         const result = await fn(userWallet1)({ invoice: request })
         if (result instanceof Error) throw result
         expect(result).toBe(PaymentSendStatus.AlreadyPaid)
 
-        const finalBalanceSats = await getBTCBalance(userWallet1.user.id)
+        const finalBalanceSats = await getBTCBalance(userWallet1.user.walletId)
         expect(finalBalanceSats).toEqual(intermediateBalanceSats)
       })
 
@@ -597,7 +597,7 @@ describe("UserWallet - Lightning Pay", () => {
         const result = await fn(userWallet1)({ invoice: request })
         if (result instanceof Error) throw result
         expect(result).toBe(PaymentSendStatus.Success)
-        const finalBalance = await getBTCBalance(userWallet1.user.id)
+        const finalBalance = await getBTCBalance(userWallet1.user.walletId)
         expect(finalBalance).toBe(initBalance1 - amountInvoice)
       })
 
@@ -605,8 +605,8 @@ describe("UserWallet - Lightning Pay", () => {
         const memo = "my memo as a payer"
 
         const paymentOtherGaloyUser = async ({ walletPayer, walletPayee }) => {
-          const payerInitialBalance = await getBTCBalance(walletPayer.user.id)
-          const payeeInitialBalance = await getBTCBalance(walletPayee.user.id)
+          const payerInitialBalance = await getBTCBalance(walletPayer.user.walletId)
+          const payeeInitialBalance = await getBTCBalance(walletPayee.user.walletId)
 
           const lnInvoice = await addInvoice({
             walletId: walletPayee.user.walletId as WalletId,
@@ -617,8 +617,8 @@ describe("UserWallet - Lightning Pay", () => {
           const result = await fn(walletPayer)({ invoice: request, memo })
           if (result instanceof Error) throw result
 
-          const payerFinalBalance = await getBTCBalance(walletPayer.user.id)
-          const payeeFinalBalance = await getBTCBalance(walletPayee.user.id)
+          const payerFinalBalance = await getBTCBalance(walletPayer.user.walletId)
+          const payeeFinalBalance = await getBTCBalance(walletPayee.user.walletId)
 
           expect(payerFinalBalance).toBe(payerInitialBalance - amountInvoice)
           expect(payeeFinalBalance).toBe(payeeInitialBalance + amountInvoice)
@@ -699,7 +699,7 @@ describe("UserWallet - Lightning Pay", () => {
           is_including_private_channels: true,
         })
 
-        const initialBalance = await getBTCBalance(userWallet1.user.id)
+        const initialBalance = await getBTCBalance(userWallet1.user.walletId)
 
         const result = await fn(userWallet1)({
           invoice: request,
@@ -712,7 +712,7 @@ describe("UserWallet - Lightning Pay", () => {
         await waitUntilChannelBalanceSyncAll()
 
         expect(result).toBe(PaymentSendStatus.Success)
-        const finalBalance = await getBTCBalance(userWallet1.user.id)
+        const finalBalance = await getBTCBalance(userWallet1.user.walletId)
 
         // const { id } = await decodePaymentRequest({ lnd: lndOutside2, request })
         // const { results: [{ fee }] } = await getAccountTransactions(userWallet1.walletPath, { hash: id })
@@ -737,7 +737,7 @@ describe("UserWallet - Lightning Pay", () => {
         if (result instanceof Error) throw result
 
         expect(result).toBe(PaymentSendStatus.Pending)
-        const balanceBeforeSettlement = await getBTCBalance(userWallet1.user.id)
+        const balanceBeforeSettlement = await getBTCBalance(userWallet1.user.walletId)
         expect(balanceBeforeSettlement).toBe(
           initBalance1 - amountInvoice * (1 + initialFee),
         )
@@ -761,7 +761,9 @@ describe("UserWallet - Lightning Pay", () => {
           })
           if (updatedPayments instanceof Error) throw updatedPayments
 
-          const count = await LedgerService().getPendingPaymentsCount(userWallet1.user.id)
+          const count = await LedgerService().getPendingPaymentsCount(
+            userWallet1.user.walletId,
+          )
           if (count instanceof Error) throw count
 
           const { is_confirmed } = await getInvoice({ lnd: lndOutside1, id })
@@ -770,7 +772,7 @@ describe("UserWallet - Lightning Pay", () => {
 
         await waitUntilChannelBalanceSyncAll()
 
-        const finalBalance = await getBTCBalance(userWallet1.user.id)
+        const finalBalance = await getBTCBalance(userWallet1.user.walletId)
         expect(finalBalance).toBe(initBalance1 - amountInvoice)
       }, 60000)
 
@@ -788,7 +790,7 @@ describe("UserWallet - Lightning Pay", () => {
         expect(result).toBe(PaymentSendStatus.Pending)
         baseLogger.info("payment has timeout. status is pending.")
 
-        const intermediateBalance = await getBTCBalance(userWallet1.user.id)
+        const intermediateBalance = await getBTCBalance(userWallet1.user.walletId)
         expect(intermediateBalance).toBe(initBalance1 - amountInvoice * (1 + initialFee))
 
         await cancelHodlInvoice({ id, lnd: lndOutside1 })
@@ -800,7 +802,9 @@ describe("UserWallet - Lightning Pay", () => {
           })
           if (updatedPayments instanceof Error) throw updatedPayments
 
-          const count = await LedgerService().getPendingPaymentsCount(userWallet1.user.id)
+          const count = await LedgerService().getPendingPaymentsCount(
+            userWallet1.user.walletId,
+          )
           if (count instanceof Error) throw count
 
           return count === 0
@@ -813,7 +817,7 @@ describe("UserWallet - Lightning Pay", () => {
         // arrives before wallet balances updates in lnd
         await waitUntilChannelBalanceSyncAll()
 
-        const finalBalance = await getBTCBalance(userWallet1.user.id)
+        const finalBalance = await getBTCBalance(userWallet1.user.walletId)
         expect(finalBalance).toBe(initBalance1)
       }, 60000)
     })
@@ -821,7 +825,7 @@ describe("UserWallet - Lightning Pay", () => {
     describe("2FA", () => {
       it(`fails to pay above 2fa limit without 2fa token`, async () => {
         enable2FA({ wallet: userWallet0 })
-        const remainingLimit = await getRemainingTwoFALimit(userWallet0.user.id)
+        const remainingLimit = await getRemainingTwoFALimit(userWallet0.user.walletId)
         expect(remainingLimit).not.toBeInstanceOf(Error)
         if (remainingLimit instanceof Error) return remainingLimit
 
@@ -832,7 +836,7 @@ describe("UserWallet - Lightning Pay", () => {
         const result = await fn(userWallet0)({ invoice: request })
         expect(result).toBeInstanceOf(TwoFAError)
 
-        const finalBalance = await getBTCBalance(userWallet0.user.id)
+        const finalBalance = await getBTCBalance(userWallet0.user.walletId)
         expect(finalBalance).toBe(initBalance0)
       })
 
@@ -913,7 +917,7 @@ describe("UserWallet - Lightning Pay", () => {
 
     // await sleep(1000)
 
-    // await getBTCBalance(userWallet1.user.id)
+    // await getBTCBalance(userWallet1.user.walletId)
 
     // FIXME: test is failing.
     // lnd doens't always delete invoice just after they have expired

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -58,7 +58,7 @@ beforeAll(async () => {
 })
 
 beforeEach(async () => {
-  initialBalanceUser0 = await getBTCBalance(userWallet0.user.id)
+  initialBalanceUser0 = await getBTCBalance(userWallet0.user.walletId)
 })
 
 afterEach(async () => {
@@ -97,8 +97,7 @@ describe("UserWallet - onChainPay", () => {
     const {
       results: [pendingTxn],
     } = await ledger.getAccountTransactions(userWallet0.walletPath, { pending: true })
-
-    const interimBalance = await getBTCBalance(userWallet0.user.id)
+    const interimBalance = await getBTCBalance(userWallet0.user.walletId)
     expect(interimBalance).toBe(initialBalanceUser0 - amount - pendingTxn.fee)
     await checkIsBalanced()
 
@@ -161,7 +160,7 @@ describe("UserWallet - onChainPay", () => {
     expect(txn?.settlementAmount).toBe(-amount - fee)
     expect(txn?.deprecated.type).toBe("onchain_payment")
 
-    const finalBalance = await getBTCBalance(userWallet0.user.id)
+    const finalBalance = await getBTCBalance(userWallet0.user.walletId)
     expect(finalBalance).toBe(initialBalanceUser0 - amount - fee)
     sub.removeAllListeners()
   })
@@ -172,7 +171,7 @@ describe("UserWallet - onChainPay", () => {
     const sub = subscribeToTransactions({ lnd: lndonchain })
     sub.on("chain_transaction", onchainTransactionEventHandler)
 
-    const initialBalanceUser11 = await getBTCBalance(userWallet11.user.id)
+    const initialBalanceUser11 = await getBTCBalance(userWallet11.user.walletId)
 
     const results = await Promise.all([
       once(sub, "chain_transaction"),
@@ -192,7 +191,7 @@ describe("UserWallet - onChainPay", () => {
       results: [pendingTxn],
     } = await ledger.getAccountTransactions(userWallet11.accountPath, { pending: true })
 
-    const interimBalance = await getBTCBalance(userWallet11.user.id)
+    const interimBalance = await getBTCBalance(userWallet11.user.walletId)
     expect(interimBalance).toBe(0)
     await checkIsBalanced()
 
@@ -255,7 +254,7 @@ describe("UserWallet - onChainPay", () => {
     expect(txn?.settlementAmount).toBe(-initialBalanceUser11)
     expect(txn?.deprecated.type).toBe("onchain_payment")
 
-    const finalBalance = await getBTCBalance(userWallet11.user.id)
+    const finalBalance = await getBTCBalance(userWallet11.user.walletId)
     expect(finalBalance).toBe(0)
     sub.removeAllListeners()
   })
@@ -285,15 +284,15 @@ describe("UserWallet - onChainPay", () => {
   })
 
   it("sends an on us transaction", async () => {
-    const address = await Wallets.createOnChainAddress(userWallet3.user.id)
+    const address = await Wallets.createOnChainAddress(userWallet3.user.walletId)
     if (address instanceof Error) throw address
 
-    const initialBalanceUser3 = await getBTCBalance(userWallet3.user.id)
+    const initialBalanceUser3 = await getBTCBalance(userWallet3.user.walletId)
 
     const paid = await userWallet0.onChainPay({ address, amount, targetConfirmations })
 
-    const finalBalanceUser0 = await getBTCBalance(userWallet0.user.id)
-    const finalBalanceUser3 = await getBTCBalance(userWallet3.user.id)
+    const finalBalanceUser0 = await getBTCBalance(userWallet0.user.walletId)
+    const finalBalanceUser3 = await getBTCBalance(userWallet3.user.walletId)
 
     expect(paid).toBe(true)
     expect(finalBalanceUser0).toBe(initialBalanceUser0 - amount)
@@ -313,7 +312,7 @@ describe("UserWallet - onChainPay", () => {
   it("sends an on us transaction with memo", async () => {
     const memo = "this is my onchain memo"
 
-    const address = await Wallets.createOnChainAddress(userWallet3.user.id)
+    const address = await Wallets.createOnChainAddress(userWallet3.user.walletId)
     if (address instanceof Error) throw address
 
     const paid = await userWallet0.onChainPay({
@@ -353,12 +352,12 @@ describe("UserWallet - onChainPay", () => {
   })
 
   it("sends all with an on us transaction", async () => {
-    const initialBalanceUser12 = await getBTCBalance(userWallet12.user.id)
+    const initialBalanceUser12 = await getBTCBalance(userWallet12.user.walletId)
 
-    const address = await Wallets.createOnChainAddress(userWallet3.user.id)
+    const address = await Wallets.createOnChainAddress(userWallet3.user.walletId)
     if (address instanceof Error) throw address
 
-    const initialBalanceUser3 = await getBTCBalance(userWallet3.user.id)
+    const initialBalanceUser3 = await getBTCBalance(userWallet3.user.walletId)
 
     const paid = await userWallet12.onChainPay({
       address,
@@ -367,8 +366,8 @@ describe("UserWallet - onChainPay", () => {
       targetConfirmations,
     })
 
-    const finalBalanceUser12 = await getBTCBalance(userWallet12.user.id)
-    const finalBalanceUser3 = await getBTCBalance(userWallet3.user.id)
+    const finalBalanceUser12 = await getBTCBalance(userWallet12.user.walletId)
+    const finalBalanceUser3 = await getBTCBalance(userWallet3.user.walletId)
 
     expect(paid).toBe(true)
     expect(finalBalanceUser12).toBe(0)
@@ -386,7 +385,7 @@ describe("UserWallet - onChainPay", () => {
   })
 
   it("fails if try to send a transaction to self", async () => {
-    const address = await Wallets.createOnChainAddress(userWallet0.user.id)
+    const address = await Wallets.createOnChainAddress(userWallet0.user.walletId)
     if (address instanceof Error) throw address
 
     await expect(
@@ -395,7 +394,7 @@ describe("UserWallet - onChainPay", () => {
   })
 
   it("fails if an on us payment has insufficient balance", async () => {
-    const address = await Wallets.createOnChainAddress(userWallet3.user.id)
+    const address = await Wallets.createOnChainAddress(userWallet3.user.walletId)
     if (address instanceof Error) throw address
     await expect(
       userWallet0.onChainPay({
@@ -411,7 +410,7 @@ describe("UserWallet - onChainPay", () => {
       lnd: lndOutside1,
       format: "p2wpkh",
     })
-    const initialBalanceUser3 = await getBTCBalance(userWallet3.user.id)
+    const initialBalanceUser3 = await getBTCBalance(userWallet3.user.walletId)
 
     //should fail because user does not have balance to pay for on-chain fee
     await expect(
@@ -424,7 +423,7 @@ describe("UserWallet - onChainPay", () => {
   })
 
   it("fails if send all with a nonzero amount", async () => {
-    const address = await Wallets.createOnChainAddress(userWallet3.user.id)
+    const address = await Wallets.createOnChainAddress(userWallet3.user.walletId)
     if (address instanceof Error) throw address
 
     await expect(
@@ -482,7 +481,7 @@ describe("UserWallet - onChainPay", () => {
   describe("2FA", () => {
     it("fails to pay above 2fa limit without 2fa token", async () => {
       enable2FA({ wallet: userWallet0 })
-      const remainingLimit = await getRemainingTwoFALimit(userWallet0.user.id)
+      const remainingLimit = await getRemainingTwoFALimit(userWallet0.user.walletId)
       expect(remainingLimit).not.toBeInstanceOf(Error)
       if (remainingLimit instanceof Error) return remainingLimit
 
@@ -498,7 +497,7 @@ describe("UserWallet - onChainPay", () => {
     it("sends a successful large payment with a 2fa code", async () => {
       enable2FA({ wallet: userWallet0 })
 
-      const initialBalance = await getBTCBalance(userWallet0.user.id)
+      const initialBalance = await getBTCBalance(userWallet0.user.walletId)
       const { address } = await createChainAddress({ format: "p2wpkh", lnd: lndOutside1 })
       const twoFAToken = generateTokenHelper({
         secret: userWallet0.user.twoFA.secret,
@@ -529,7 +528,7 @@ describe("UserWallet - onChainPay", () => {
 
       // settlementAmount is negative
       const expectedBalance = initialBalance + txs[0].settlementAmount
-      const finalBalance = await getBTCBalance(userWallet0.user.id)
+      const finalBalance = await getBTCBalance(userWallet0.user.walletId)
       expect(expectedBalance).toBe(finalBalance)
     })
   })

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -105,7 +105,7 @@ describe("UserWallet - onChainPay", () => {
     await sleep(1000)
 
     let txResult = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet0.user.id,
+      walletId: userWallet0.user.walletId,
     })
     if (txResult.error instanceof Error || txResult.result === null) {
       throw txResult.error
@@ -146,7 +146,7 @@ describe("UserWallet - onChainPay", () => {
     expect(feeUsd).toBeGreaterThan(0)
 
     txResult = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet0.user.id,
+      walletId: userWallet0.user.walletId,
     })
     if (txResult.error instanceof Error || txResult.result === null) {
       throw txResult.error
@@ -199,7 +199,7 @@ describe("UserWallet - onChainPay", () => {
     await sleep(1000)
 
     let txResult = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet11.user.id,
+      walletId: userWallet11.user.walletId,
     })
     if (txResult.error instanceof Error || txResult.result === null) {
       throw txResult
@@ -240,7 +240,7 @@ describe("UserWallet - onChainPay", () => {
     expect(feeUsd).toBeGreaterThan(0)
 
     txResult = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet11.user.id,
+      walletId: userWallet11.user.walletId,
     })
     if (txResult.error instanceof Error || txResult.result === null) {
       throw txResult.error
@@ -271,7 +271,7 @@ describe("UserWallet - onChainPay", () => {
     })
     expect(paymentResult).toBe(true)
     const { result: txs, error } = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet0.user.id,
+      walletId: userWallet0.user.walletId,
     })
     if (error instanceof Error || txs === null) {
       throw error
@@ -331,7 +331,7 @@ describe("UserWallet - onChainPay", () => {
       tx.initiationVia.address === address
 
     const { result: txs, error } = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet0.user.id,
+      walletId: userWallet0.user.walletId,
     })
     if (error instanceof Error || txs === null) {
       throw error
@@ -342,7 +342,7 @@ describe("UserWallet - onChainPay", () => {
 
     // receiver should not know memo from sender
     const { result: txsUser3, error: error2 } = await Wallets.getTransactionsForWalletId({
-      walletId: userWallet3.user.id as WalletId,
+      walletId: userWallet3.user.walletId as WalletId,
     })
     if (error2 instanceof Error || txsUser3 === null) {
       throw error2
@@ -520,7 +520,7 @@ describe("UserWallet - onChainPay", () => {
       }
 
       const { result: txs, error } = await Wallets.getTransactionsForWalletId({
-        walletId: userWallet0.user.id,
+        walletId: userWallet0.user.walletId,
       })
 
       if (error instanceof Error || txs === null) {

--- a/test/integration/02-user-wallet/02-tx-onchain-fees.spec.ts
+++ b/test/integration/02-user-wallet/02-tx-onchain-fees.spec.ts
@@ -11,7 +11,7 @@ let userWallet0: Wallet, userWallet1: Wallet
 
 const getWallet = async (testWallet: number): Promise<Wallet> => {
   const userWallet = await getAndCreateUserWallet(testWallet)
-  const wallet = await Wallets.getWallet(userWallet.user.id)
+  const wallet = await Wallets.getWallet(userWallet.user.walletId)
   if (wallet instanceof Error) throw wallet
   return wallet
 }

--- a/test/integration/servers/trigger.spec.ts
+++ b/test/integration/servers/trigger.spec.ts
@@ -47,7 +47,7 @@ afterAll(async () => {
 })
 
 const getWalletState = async (wallet) => {
-  const balance = await getBTCBalance(wallet.user.id)
+  const balance = await getBTCBalance(wallet.user.walletId)
   const { result: transactions, error } = await Wallets.getTransactionsForWalletId({
     walletId: wallet.user.walletId as WalletId,
   })
@@ -76,7 +76,7 @@ describe("onchainBlockEventhandler", () => {
     const initWallet0State = await getWalletState(wallet0)
     const initWallet3State = await getWalletState(wallet3)
 
-    const address = await Wallets.createOnChainAddress(wallet0.user.id)
+    const address = await Wallets.createOnChainAddress(wallet0.user.walletId)
     if (address instanceof Error) throw address
 
     const initialBlock = await bitcoindClient.getBlockCount()
@@ -94,7 +94,7 @@ describe("onchainBlockEventhandler", () => {
     const output0 = {}
     output0[address] = amount
 
-    const address2 = await Wallets.createOnChainAddress(wallet3.user.id)
+    const address2 = await Wallets.createOnChainAddress(wallet3.user.walletId)
     if (address2 instanceof Error) throw address2
 
     const output1 = {}

--- a/test/integration/servers/trigger.spec.ts
+++ b/test/integration/servers/trigger.spec.ts
@@ -49,7 +49,7 @@ afterAll(async () => {
 const getWalletState = async (wallet) => {
   const balance = await getBTCBalance(wallet.user.id)
   const { result: transactions, error } = await Wallets.getTransactionsForWalletId({
-    walletId: wallet.user.id as WalletId,
+    walletId: wallet.user.walletId as WalletId,
   })
   if (error instanceof Error || transactions === null) {
     throw error
@@ -144,7 +144,7 @@ describe("onchainBlockEventhandler", () => {
     const sats = 500
     const wallet = await getAndCreateUserWallet(12)
     const lnInvoice = await addInvoice({
-      walletId: wallet.user.id as WalletId,
+      walletId: wallet.user.walletId as WalletId,
       amount: toSats(sats),
     })
     expect(lnInvoice).not.toBeInstanceOf(Error)

--- a/test/integration/services/ledger/transaction.spec.ts
+++ b/test/integration/services/ledger/transaction.spec.ts
@@ -69,7 +69,7 @@ describe("receipt via Ledger Service", () => {
     const usdFee = fee * price
 
     const result = await LedgerService().addLnTxReceive({
-      walletId: walletBTC.id,
+      walletId: walletBTC.walletId,
       paymentHash: "paymentHash" as PaymentHash,
       description: "transaction test",
       sats,
@@ -161,7 +161,7 @@ describe("payment with lnd via Ledger Service", () => {
     const usdFee = fee * price
 
     const result = await LedgerService().addLnTxSend({
-      walletId: walletBTC.id,
+      walletId: walletBTC.walletId,
       paymentHash: "paymentHash" as PaymentHash,
       description: "transaction test",
       sats,
@@ -263,13 +263,13 @@ describe("on us payment via Ledger Service", () => {
     const usdFee = fee * price
 
     const result = await LedgerService().addUsernameIntraledgerTxSend({
-      walletId: payer.id,
+      walletId: payer.walletId,
       description: "desc",
       sats,
       fee: lnFee,
       usd,
       usdFee,
-      recipientWalletId: payee.id,
+      recipientWalletId: payee.walletId,
       payerUsername: "payerUsername" as Username,
       recipientUsername: "recipientUsername" as Username,
       memoPayer: null,

--- a/test/integration/services/mongoose/wallet-invoices.spec.ts
+++ b/test/integration/services/mongoose/wallet-invoices.spec.ts
@@ -74,7 +74,7 @@ describe("WalletInvoices", () => {
     })
 
     const repo = WalletInvoicesRepository()
-    const invoices = repo.findPendingByWalletId(wallet.user.id)
+    const invoices = repo.findPendingByWalletId(wallet.user.walletId)
     expect(invoices).not.toBeInstanceOf(Error)
 
     const pendingInvoices = invoices as AsyncGenerator<WalletInvoice>

--- a/test/integration/services/mongoose/wallet-invoices.spec.ts
+++ b/test/integration/services/mongoose/wallet-invoices.spec.ts
@@ -69,7 +69,7 @@ describe("WalletInvoices", () => {
     }
 
     const invoicesCount = await InvoiceUser.countDocuments({
-      uid: wallet.user.id,
+      uid: wallet.user.walletId,
       paid: false,
     })
 

--- a/test/integration/services/mongoose/wallet-invoices.spec.ts
+++ b/test/integration/services/mongoose/wallet-invoices.spec.ts
@@ -63,7 +63,7 @@ describe("WalletInvoices", () => {
     const wallet = await getAndCreateUserWallet(1)
     for (let i = 0; i < 2; i++) {
       await addInvoice({
-        walletId: wallet.user.id as WalletId,
+        walletId: wallet.user.walletId as WalletId,
         amount: toSats(1000),
       })
     }

--- a/test/unit/ledger/ledger.spec.ts
+++ b/test/unit/ledger/ledger.spec.ts
@@ -4,13 +4,13 @@ const { walletPath, liabilitiesMainAccount, resolveWalletId } = ledger
 
 describe("ledger.ts", () => {
   describe("resolveWalletId", () => {
-    const accountId = "123542"
+    const walletId = "123542"
     it("returns account id from string path", () => {
-      expect(resolveWalletId(walletPath(accountId))).toEqual(accountId)
+      expect(resolveWalletId(walletPath(walletId))).toEqual(walletId)
     })
 
     it("returns account id from array path", () => {
-      expect(resolveWalletId([liabilitiesMainAccount, accountId])).toEqual(accountId)
+      expect(resolveWalletId([liabilitiesMainAccount, walletId])).toEqual(walletId)
     })
 
     it("returns null if invalid path", () => {


### PR DESCRIPTION
## Description

⚠️  **_This fixes errors currently deployed to staging_**

I started by fixing a `"CastError: Cast to ObjectId failed for value \"ae2f7b11-1ee6-41fa-9264-3867dda26831\" at path \"_id\" for model \"User\""` when passing the `walletId` we persisted into requests which then broke our tests and snowballed into changing all the places I could find where were passing the mongoDb `id` in places where we should be passing our `uuid4`-formatted `walletId`.