### PR TITLE
fix: accommodate capitalized authorization header property

### DIFF
--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -291,8 +291,10 @@ export const startApolloServer = async ({
               const { request } = connectionContext
 
               let token: string | jwt.JwtPayload | null = null
-              if (connectionParams.authorization) {
-                const rawToken = connectionParams.authorization.slice(7)
+              const authz =
+                connectionParams.authorization || connectionParams.Authorization
+              if (authz) {
+                const rawToken = authz.slice(7)
                 token = jwt.decode(rawToken)
               }
 


### PR DESCRIPTION
## Description

I'm not sure if this change could affect anything else, but I just lost a lot of time debugging a `"Not authenticated"` error to realize that it was because my header was `{"Authorization": "Bearer <token>"}` and not `{"authorization": "Bearer <token>"}`.