### PR TITLE
chore: one user should only connect to one account

### DIFF
--- a/src/app/accounts/index.ts
+++ b/src/app/accounts/index.ts
@@ -33,13 +33,13 @@ export const hasPermissions = async (
   userId: UserId,
   walletId: WalletId,
 ): Promise<boolean | ApplicationError> => {
-  const userAccounts = await accounts.listByUserId(userId)
-  if (userAccounts instanceof Error) return userAccounts
+  const userAccount = await accounts.findByUserId(userId)
+  if (userAccount instanceof Error) return userAccount
 
   const walletAccount = await accounts.findByWalletId(walletId)
   if (walletAccount instanceof Error) return walletAccount
 
-  return userAccounts.some((a) => a.id === walletAccount.id)
+  return userAccount.id === walletAccount.id
 }
 
 export const getBusinessMapMarkers = async () => {

--- a/src/domain/accounts/index.types.d.ts
+++ b/src/domain/accounts/index.types.d.ts
@@ -72,7 +72,7 @@ type LimitsChecker = {
 interface IAccountsRepository {
   listUnlockedAccounts(): Promise<Account[] | RepositoryError>
   findById(accountId: AccountId): Promise<Account | RepositoryError>
-  listByUserId(userId: UserId): Promise<Account[] | RepositoryError>
+  findByUserId(userId: UserId): Promise<Account | RepositoryError>
   findByWalletId(walletId: WalletId): Promise<Account | RepositoryError>
   findByUsername(username: Username): Promise<Account | RepositoryError>
   listBusinessesForMap(): Promise<BusinessMapMarker[] | RepositoryError>

--- a/src/services/mongoose/accounts.ts
+++ b/src/services/mongoose/accounts.ts
@@ -70,11 +70,11 @@ export const AccountsRepository = (): IAccountsRepository => {
     }
   }
 
-  const listByUserId = async (userId: UserId): Promise<Account[] | RepositoryError> => {
+  const findByUserId = async (userId: UserId): Promise<Account | RepositoryError> => {
     const accountId = `${userId}` as AccountId
     const account = await findById(accountId)
     if (account instanceof Error) return account
-    return [account]
+    return account
   }
 
   // FIXME: could be in a different file? does not return an Account
@@ -135,7 +135,7 @@ export const AccountsRepository = (): IAccountsRepository => {
   return {
     listUnlockedAccounts,
     findById,
-    listByUserId,
+    findByUserId,
     findByWalletId,
     findByUsername,
     listBusinessesForMap,


### PR DESCRIPTION
managing user that could have several accounts is a very complex use case, that we should not try to cover for the time being (and probably for some time). most financial product from fintech that I have used in the recent past didn't offer this capability for this same reason