### PR TITLE
chore: define GraphQLContext and use it for the GraphQL User type

### DIFF
--- a/src/graphql/types/object/graphql-user.ts
+++ b/src/graphql/types/object/graphql-user.ts
@@ -15,7 +15,7 @@ import Username from "../scalar/username"
 import * as Users from "@app/users"
 import { UnknownClientError } from "@core/error"
 
-const GraphQLUser = new GT.Object({
+const GraphQLUser = new GT.Object<User, GraphQLContext>({
   name: "User",
   fields: () => ({
     id: {
@@ -32,7 +32,7 @@ const GraphQLUser = new GT.Object({
       type: Username,
       description: "Optional immutable user friendly identifier.",
       resolve: async (source, args, { domainAccount }) => {
-        return domainAccount.username
+        return domainAccount?.username
       },
     },
 
@@ -62,6 +62,9 @@ const GraphQLUser = new GT.Object({
       },
       resolve: async (source, args, { domainUser }) => {
         const { username } = args
+        if (!domainUser) {
+          throw new UnknownClientError("Something went wrong")
+        }
         if (username instanceof Error) {
           throw username
         }
@@ -83,7 +86,6 @@ const GraphQLUser = new GT.Object({
 
     createdAt: {
       type: GT.NonNull(Timestamp),
-      resolve: (source) => source.createdAt ?? source.created_at, // TODO: Get rid of this resolver
     },
 
     defaultAccount: {

--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -56,7 +56,13 @@ export const isEditor = rule({ cache: "contextual" })((parent, args, ctx) => {
 const geeTestConfig = getGeetestConfig()
 const geetest = Geetest(geeTestConfig)
 
-const sessionContext = ({ token, ips, body, apiKey, apiSecret }) => {
+const sessionContext = ({
+  token,
+  ips,
+  body,
+  apiKey,
+  apiSecret,
+}): Promise<GraphQLContext> => {
   const userId = token?.uid ?? null
   let ip: string | undefined
 

--- a/src/servers/index.files.d.ts
+++ b/src/servers/index.files.d.ts
@@ -1,0 +1,11 @@
+type GraphQLContext = {
+  logger: Logger
+  uid: UserId | null
+  wallet: Wallet | null
+  domainUser: User | null
+  domainAccount: Account | null
+  user: User | null
+  geetest: GeetestType
+  account: Account | null
+  ip: string | undefined
+}

--- a/src/servers/index.files.d.ts
+++ b/src/servers/index.files.d.ts
@@ -7,5 +7,5 @@ type GraphQLContext = {
   user: User | null
   geetest: GeetestType
   account: Account | null
-  ip: string | undefined
+  ip: IpAddress | undefined
 }

--- a/src/servers/index.files.d.ts
+++ b/src/servers/index.files.d.ts
@@ -7,5 +7,5 @@ type GraphQLContext = {
   user: User | null
   geetest: GeetestType
   account: Account | null
-  ip: IpAddress | undefined
+  ip: string | undefined
 }


### PR DESCRIPTION
@nicolasburtey we can define the context for all resolvers this way