### PR TITLE
chore: extracting another part from `add_earn` refactoring

### DIFF
--- a/src/app/users/index.ts
+++ b/src/app/users/index.ts
@@ -1,3 +1,5 @@
+import { UsersRepository } from "@services/mongoose"
+
 export * from "./add-new-contact"
 export * from "./get-contact-by-username"
 export * from "./get-user"
@@ -5,3 +7,9 @@ export * from "./login"
 export * from "./request-phone-code"
 export * from "./update-contact-alias"
 export * from "./username-available"
+
+const users = UsersRepository()
+
+export const getUser = async (userId: UserId) => {
+  return users.findById(userId)
+}

--- a/src/app/wallets/index.types.d.ts
+++ b/src/app/wallets/index.types.d.ts
@@ -39,6 +39,7 @@ type GetOnChainFeeArgs = {
   targetConfirmations: TargetConfirmations
 }
 
+// FIXME: only use for v1
 type GetOnChainFeeByWalletIdArgs = {
   walletId: WalletId
   amount: number
@@ -47,31 +48,31 @@ type GetOnChainFeeByWalletIdArgs = {
 }
 
 type PaymentSendArgs = {
+  senderWalletId: WalletId
   memo: string | null
-  walletId: WalletId
-  userId: UserId
   logger: Logger
 }
 
 type PayLnInvoiceByWalletIdArgs = {
-  walletId: WalletId
+  senderWalletId: WalletId
   paymentRequest: EncodedPaymentRequest
   memo: string | null
-  userId: UserId
+  payerUserId: UserId
   logger: Logger
 }
 
 type payLnNoAmountInvoiceByWalletIdArgs = {
-  walletId: WalletId
+  senderWalletId: WalletId
   paymentRequest: EncodedPaymentRequest
   amount: Satoshis
   memo: string | null
-  userId: UserId
+  payerUserId: UserId
   logger: Logger
 }
 
 type LnInvoicePaymentSendArgs = PaymentSendArgs & {
   paymentRequest: EncodedPaymentRequest
+  payerUserId: UserId
 }
 type LnInvoicePaymentSendWithTwoFAArgs = LnInvoicePaymentSendArgs & {
   twoFAToken: TwoFAToken
@@ -80,15 +81,23 @@ type LnInvoicePaymentSendWithTwoFAArgs = LnInvoicePaymentSendArgs & {
 type LnNoAmountInvoicePaymentSendArgs = PaymentSendArgs & {
   paymentRequest: EncodedPaymentRequest
   amount: Satoshis
+  payerUserId: UserId
 }
 type LnNoAmountInvoicePaymentSendWithTwoFAArgs = LnNoAmountInvoicePaymentSendArgs & {
   twoFAToken: TwoFAToken
 }
 
-type IntraLedgerPaymentSendArgs = PaymentSendArgs & {
+type IntraLedgerPaymentSendUsernameArgs = PaymentSendArgs & {
+  payerUserId: UserId
   recipientUsername: Username
   amount: Satoshis
 }
-type IntraLedgerPaymentSendWithTwoFAArgs = IntraLedgerPaymentSendArgs & {
+
+type IntraLedgerPaymentSendWalletIdArgs = PaymentSendArgs & {
+  recipientWalletId: WalletId
+  amount: Satoshis
+}
+
+type IntraLedgerPaymentSendWithTwoFAArgs = IntraLedgerPaymentSendUsernameArgs & {
   twoFAToken: TwoFAToken
 }

--- a/src/core/lightning/wallet.ts
+++ b/src/core/lightning/wallet.ts
@@ -59,8 +59,8 @@ export class LightningUserWallet extends OnChainMixin(UserWallet) {
           const payResult = await Wallets.lnInvoicePaymentSend({
             paymentRequest: lnInvoice.paymentRequest,
             memo: null,
-            walletId: lightningFundingWallet.user.walletId,
-            userId: lightningFundingWallet.user.id,
+            senderWalletId: lightningFundingWallet.user.walletId,
+            payerUserId: lightningFundingWallet.user.id,
             logger: this.logger,
           })
           if (payResult instanceof Error) throw payResult

--- a/src/core/on-chain/index.ts
+++ b/src/core/on-chain/index.ts
@@ -1,5 +1,4 @@
-import { Prices, Wallets } from "@app"
-import { getUser } from "@app/users"
+import { Prices, Wallets, Users } from "@app"
 import {
   checkAndVerifyTwoFA,
   checkIntraledgerLimits,
@@ -93,7 +92,7 @@ export const OnChainMixin = (superclass) =>
 
         const payeeUser = await User.getUserByAddress({ address })
 
-        const user = await getUser(this.user.id)
+        const user = await Users.getUser(this.user.id)
         if (user instanceof Error) throw user
         const { twoFA } = user
 

--- a/src/core/on-chain/index.ts
+++ b/src/core/on-chain/index.ts
@@ -1,4 +1,5 @@
-import { Wallets, Prices } from "@app"
+import { Prices, Wallets } from "@app"
+import { getUser } from "@app/users"
 import {
   checkAndVerifyTwoFA,
   checkIntraledgerLimits,
@@ -13,7 +14,6 @@ import { OnChainService } from "@services/lnd/onchain-service"
 import { getActiveOnchainLnd } from "@services/lnd/utils"
 import { LockService } from "@services/lock"
 import { ledger } from "@services/mongodb"
-import { UsersRepository, WalletsRepository } from "@services/mongoose"
 import { User } from "@services/mongoose/schema"
 import { NotificationsService } from "@services/notifications"
 import assert from "assert"
@@ -93,7 +93,7 @@ export const OnChainMixin = (superclass) =>
 
         const payeeUser = await User.getUserByAddress({ address })
 
-        const user = await UsersRepository().findById(this.user.id)
+        const user = await getUser(this.user.id)
         if (user instanceof Error) throw user
         const { twoFA } = user
 
@@ -150,16 +150,16 @@ export const OnChainMixin = (superclass) =>
           const usd = sats * price
           const usdFee = onChainFee * price
 
-          const payerWallet = await WalletsRepository().findById(this.user.walletId)
-          if (payerWallet instanceof Error) throw payerWallet
-          const recipientWallet = await WalletsRepository().findById(payeeUser.walletId)
+          const senderWallet = await Wallets.getWallet(this.user.walletId)
+          if (senderWallet instanceof Error) throw senderWallet
+          const recipientWallet = await Wallets.getWallet(payeeUser.walletId)
           if (recipientWallet instanceof Error) throw recipientWallet
 
           const journal = await LockService().extendLock(
             { logger: onchainLoggerOnUs, lock },
             async () =>
               LedgerService().addOnChainIntraledgerTxSend({
-                walletId: this.user.walletId,
+                senderWalletId: this.user.walletId,
                 description: "",
                 sats: toSats(sats),
                 fee: onChainFee,
@@ -177,7 +177,7 @@ export const OnChainMixin = (superclass) =>
 
           const notificationsService = NotificationsService(onchainLoggerOnUs)
           notificationsService.intraLedgerPaid({
-            payerWalletId: payerWallet.id,
+            senderWalletId: senderWallet.id,
             recipientWalletId: recipientWallet.id,
             amount: toSats(sats),
             usdPerSat: price,

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -89,7 +89,7 @@ type AddLnTxSendArgs = LnTxArgs & {
 }
 
 type IntraledgerTxArgs = {
-  walletId: WalletId
+  senderWalletId: WalletId
   description: string
   sats: Satoshis
   recipientWalletId: WalletId
@@ -114,9 +114,7 @@ type AddOnChainIntraledgerTxSendArgs = AddIntraLedgerTxSendArgs & {
   sendAll: boolean
 }
 
-type AddUsernameIntraledgerTxSendArgs = AddIntraLedgerTxSendArgs & {
-  recipientUsername: Username
-}
+type addWalletIdIntraledgerTxSendArgs = AddIntraLedgerTxSendArgs
 
 type AddLnFeeReeimbursementReceiveArgs = {
   walletId: WalletId
@@ -206,8 +204,8 @@ interface ILedgerService {
     args: AddOnChainIntraledgerTxSendArgs,
   ): Promise<LedgerJournal | LedgerServiceError>
 
-  addUsernameIntraledgerTxSend(
-    args: AddUsernameIntraledgerTxSendArgs,
+  addWalletIdIntraledgerTxSend(
+    args: AddIntraLedgerTxSendArgs,
   ): Promise<LedgerJournal | LedgerServiceError>
 
   settlePendingLnPayments(paymentHash: PaymentHash): Promise<boolean | LedgerServiceError>

--- a/src/domain/notifications/index.types.d.ts
+++ b/src/domain/notifications/index.types.d.ts
@@ -23,7 +23,7 @@ type LnInvoicePaidArgs = {
 }
 
 type IntraLedgerArgs = {
-  payerWalletId: WalletId
+  senderWalletId: WalletId
   recipientWalletId: WalletId
   amount: Satoshis
   usdPerSat?: UsdPerSat

--- a/src/graphql/admin/types/object/account.ts
+++ b/src/graphql/admin/types/object/account.ts
@@ -1,8 +1,8 @@
+import { getUser } from "@app/users"
 import { GT } from "@graphql/index"
 import Coordinates from "@graphql/types/object/coordinates"
 import Timestamp from "@graphql/types/scalar/timestamp"
 import Username from "@graphql/types/scalar/username"
-import { UsersRepository } from "@services/mongoose"
 import AccountLevel from "../scalar/account-level"
 import AccountStatus from "../scalar/account-status"
 import GraphQLUser from "./user"
@@ -24,7 +24,7 @@ const Account = new GT.Object({
 
       type: GT.NonNull(GraphQLUser),
       resolve: async (source: Account) => {
-        const user = await UsersRepository().findById(source.ownerId)
+        const user = await getUser(source.ownerId)
         if (user instanceof Error) {
           throw user
         }

--- a/src/graphql/admin/types/object/account.ts
+++ b/src/graphql/admin/types/object/account.ts
@@ -1,4 +1,4 @@
-import { getUser } from "@app/users"
+import { Users } from "@app"
 import { GT } from "@graphql/index"
 import Coordinates from "@graphql/types/object/coordinates"
 import Timestamp from "@graphql/types/scalar/timestamp"
@@ -24,7 +24,7 @@ const Account = new GT.Object({
 
       type: GT.NonNull(GraphQLUser),
       resolve: async (source: Account) => {
-        const user = await getUser(source.ownerId)
+        const user = await Users.getUser(source.ownerId)
         if (user instanceof Error) {
           throw user
         }

--- a/src/graphql/admin/types/object/user.ts
+++ b/src/graphql/admin/types/object/user.ts
@@ -1,8 +1,8 @@
+import { getAccount } from "@app/accounts"
 import { GT } from "@graphql/index"
 import Language from "@graphql/types/scalar/language"
 import Phone from "@graphql/types/scalar/phone"
 import Timestamp from "@graphql/types/scalar/timestamp"
-import { AccountsRepository } from "@services/mongoose"
 import Account from "./account"
 
 const User = new GT.Object({
@@ -15,7 +15,7 @@ const User = new GT.Object({
     defaultAccount: {
       type: GT.NonNull(Account),
       resolve: async (source: User) => {
-        const account = await AccountsRepository().findById(source.defaultAccountId)
+        const account = await getAccount(source.defaultAccountId)
         if (account instanceof Error) {
           throw account
         }

--- a/src/graphql/admin/types/object/user.ts
+++ b/src/graphql/admin/types/object/user.ts
@@ -1,4 +1,4 @@
-import { getAccount } from "@app/accounts"
+import { Accounts } from "@app"
 import { GT } from "@graphql/index"
 import Language from "@graphql/types/scalar/language"
 import Phone from "@graphql/types/scalar/phone"
@@ -15,7 +15,7 @@ const User = new GT.Object({
     defaultAccount: {
       type: GT.NonNull(Account),
       resolve: async (source: User) => {
-        const account = await getAccount(source.defaultAccountId)
+        const account = await Accounts.getAccount(source.defaultAccountId)
         if (account instanceof Error) {
           throw account
         }

--- a/src/graphql/root/mutation/intraledger-payment-send.ts
+++ b/src/graphql/root/mutation/intraledger-payment-send.ts
@@ -1,5 +1,5 @@
-import { getUsernameFromWalletId } from "@app/accounts"
-import { getWallet, intraledgerPaymentSendUsername } from "@app/wallets"
+import { Wallets, Accounts } from "@app"
+import { getWallet } from "@app/wallets"
 import { checkedToWalletId } from "@domain/wallets"
 import { mapError } from "@graphql/error-map"
 import { GT } from "@graphql/index"
@@ -49,13 +49,15 @@ const IntraLedgerPaymentSendMutation = GT.Field({
       return { errors: [{ message: appErr.message }] }
     }
 
-    const recipientUsername = await getUsernameFromWalletId(recipientWalletIdChecked)
+    const recipientUsername = await Accounts.getUsernameFromWalletId(
+      recipientWalletIdChecked,
+    )
     if (recipientUsername instanceof Error) {
       const appErr = mapError(recipientUsername)
       return { errors: [{ message: appErr.message }] }
     }
 
-    const status = await intraledgerPaymentSendUsername({
+    const status = await Wallets.intraledgerPaymentSendUsername({
       recipientUsername,
       memo,
       amount,

--- a/src/graphql/root/mutation/intraledger-payment-send.ts
+++ b/src/graphql/root/mutation/intraledger-payment-send.ts
@@ -1,17 +1,17 @@
-import { Accounts, Wallets } from "@app"
+import { getUsernameFromWalletId } from "@app/accounts"
+import { getWallet, intraledgerPaymentSendUsername } from "@app/wallets"
 import { checkedToWalletId } from "@domain/wallets"
+import { mapError } from "@graphql/error-map"
 import { GT } from "@graphql/index"
-
 import PaymentSendPayload from "@graphql/types/payload/payment-send"
 import Memo from "@graphql/types/scalar/memo"
 import SatAmount from "@graphql/types/scalar/sat-amount"
 import WalletId from "@graphql/types/scalar/wallet-id"
-import { mapError } from "@graphql/error-map"
 
 const IntraLedgerPaymentSendInput = new GT.Input({
   name: "IntraLedgerPaymentSendInput",
   fields: () => ({
-    walletId: { type: GT.NonNull(WalletId) },
+    walletId: { type: GT.NonNull(WalletId) }, // TODO: rename senderWalletId
     recipientWalletId: { type: GT.NonNull(WalletId) },
     amount: { type: GT.NonNull(SatAmount) },
     memo: { type: Memo },
@@ -31,7 +31,13 @@ const IntraLedgerPaymentSendMutation = GT.Field({
       }
     }
 
-    const wallet = await Wallets.getWallet(walletId)
+    const wallet = await getWallet(walletId)
+    const senderWalletId = checkedToWalletId(walletId)
+    if (senderWalletId instanceof Error) {
+      const appErr = mapError(senderWalletId)
+      return { errors: [{ message: appErr.message }] }
+    }
+
     if (wallet instanceof Error) {
       const appErr = mapError(wallet)
       return { errors: [{ message: appErr.message }] }
@@ -43,20 +49,18 @@ const IntraLedgerPaymentSendMutation = GT.Field({
       return { errors: [{ message: appErr.message }] }
     }
 
-    const recipientUsername = await Accounts.getUsernameFromWalletId(
-      recipientWalletIdChecked,
-    )
+    const recipientUsername = await getUsernameFromWalletId(recipientWalletIdChecked)
     if (recipientUsername instanceof Error) {
       const appErr = mapError(recipientUsername)
       return { errors: [{ message: appErr.message }] }
     }
 
-    const status = await Wallets.intraledgerPaymentSend({
+    const status = await intraledgerPaymentSendUsername({
       recipientUsername,
       memo,
       amount,
-      walletId,
-      userId: user.id,
+      senderWalletId: walletId,
+      payerUserId: user.id,
       logger,
     })
     if (status instanceof Error) {

--- a/src/graphql/root/mutation/ln-invoice-payment-send.ts
+++ b/src/graphql/root/mutation/ln-invoice-payment-send.ts
@@ -42,10 +42,10 @@ const LnInvoicePaymentSendMutation = GT.Field({
         }
 
         const status = await Wallets.payLnInvoiceByWalletId({
-          walletId,
+          senderWalletId: walletId,
           paymentRequest,
           memo,
-          userId: domainUser.id,
+          payerUserId: domainUser.id,
           logger,
         })
 

--- a/src/graphql/root/mutation/ln-noamount-invoice-payment-send.ts
+++ b/src/graphql/root/mutation/ln-noamount-invoice-payment-send.ts
@@ -31,11 +31,11 @@ const LnNoAmountInvoicePaymentSendMutation = GT.Field({
     }
 
     const status = await Wallets.payLnNoAmountInvoiceByWalletId({
-      walletId,
+      senderWalletId: walletId,
       paymentRequest,
       memo,
       amount,
-      userId: user.id as UserId,
+      payerUserId: user.id as UserId,
       logger,
     })
 

--- a/src/servers/graphql-old-server.ts
+++ b/src/servers/graphql-old-server.ts
@@ -320,8 +320,8 @@ const resolvers = {
               const status = await Wallets.lnInvoicePaymentSend({
                 paymentRequest: invoice,
                 memo,
-                walletId: wallet.user.walletId as WalletId,
-                userId: wallet.user.id as UserId,
+                senderWalletId: wallet.user.walletId as WalletId,
+                payerUserId: wallet.user.id as UserId,
                 logger,
               })
               if (status instanceof Error) throw mapError(status)
@@ -331,8 +331,8 @@ const resolvers = {
               paymentRequest: invoice,
               memo,
               amount,
-              walletId: wallet.user.walletId as WalletId,
-              userId: wallet.user.id as UserId,
+              senderWalletId: wallet.user.walletId as WalletId,
+              payerUserId: wallet.user.id as UserId,
               logger,
             })
             if (status instanceof Error) throw mapError(status)
@@ -340,12 +340,12 @@ const resolvers = {
           },
         ),
       payKeysendUsername: async ({ username, amount, memo }) => {
-        const status = await Wallets.intraledgerPaymentSend({
+        const status = await Wallets.intraledgerPaymentSendUsername({
           recipientUsername: username,
           memo,
           amount,
-          walletId: wallet.user.walletId,
-          userId: wallet.user.id,
+          senderWalletId: wallet.user.walletId,
+          payerUserId: wallet.user.id,
           logger,
         })
 

--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -1,5 +1,4 @@
-import * as Accounts from "@app/accounts"
-import * as Users from "@app/users"
+import { Accounts, Users } from "@app"
 import { getApolloConfig, getGeetestConfig, isProd, JWT_SECRET } from "@config/app"
 import { WalletFactory } from "@core/wallet-factory"
 import Geetest from "@services/geetest"

--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -1,36 +1,33 @@
-import { createServer } from "http"
-import { execute, GraphQLError, subscribe } from "graphql"
+import * as Accounts from "@app/accounts"
+import * as Users from "@app/users"
+import { getApolloConfig, getGeetestConfig, isProd, JWT_SECRET } from "@config/app"
+import { WalletFactory } from "@core/wallet-factory"
+import Geetest from "@services/geetest"
+import { baseLogger } from "@services/logger"
+import { User } from "@services/mongoose/schema"
+import { redis } from "@services/redis"
+import {
+  addAttributesToCurrentSpan,
+  addAttributesToCurrentSpanAndPropagate,
+  ENDUSER_ALIAS,
+  SemanticAttributes,
+} from "@services/tracing"
+import { ApolloServerPluginUsageReporting } from "apollo-server-core"
 import { ApolloError, ApolloServer } from "apollo-server-express"
-import { SubscriptionServer } from "subscriptions-transport-ws"
 import express from "express"
 import expressJwt from "express-jwt"
-import * as jwt from "jsonwebtoken"
+import { execute, GraphQLError, subscribe } from "graphql"
 import { rule } from "graphql-shield"
+import helmet from "helmet"
+import { createServer } from "http"
+import * as jwt from "jsonwebtoken"
 import mongoose from "mongoose"
 import pino from "pino"
 import PinoHttp from "pino-http"
+import { SubscriptionServer } from "subscriptions-transport-ws"
 import { v4 as uuidv4 } from "uuid"
-import helmet from "helmet"
-
-import { getApolloConfig, getGeetestConfig, isProd, JWT_SECRET } from "@config/app"
-import { Accounts, Users } from "@app"
-
-import { baseLogger } from "@services/logger"
-import { redis } from "@services/redis"
-import { User } from "@services/mongoose/schema"
-
-import { WalletFactory } from "@core/wallet-factory"
-import { ApolloServerPluginUsageReporting } from "apollo-server-core"
-import Geetest from "@services/geetest"
-import expressApiKeyAuth from "./graphql-middlewares/api-key-auth"
-import {
-  SemanticAttributes,
-  addAttributesToCurrentSpanAndPropagate,
-  addAttributesToCurrentSpan,
-  ENDUSER_ALIAS,
-} from "@services/tracing"
-import { AccountsRepository } from "@services/mongoose"
 import { playgroundTabs } from "../graphql/playground"
+import expressApiKeyAuth from "./graphql-middlewares/api-key-auth"
 
 const graphqlLogger = baseLogger.child({
   module: "graphql",
@@ -86,7 +83,7 @@ const sessionContext = ({ token, ips, body, apiKey, apiSecret }) => {
           })
         domainUser = loggedInUser
 
-        const loggedInDomainAccount = await AccountsRepository().findById(
+        const loggedInDomainAccount = await Accounts.getAccount(
           domainUser.defaultAccountId,
         )
         if (loggedInDomainAccount instanceof Error) throw Error

--- a/src/services/ledger/index.ts
+++ b/src/services/ledger/index.ts
@@ -439,7 +439,7 @@ export const LedgerService = (): ILedgerService => {
   }
 
   const addLnIntraledgerTxSend = async ({
-    walletId,
+    senderWalletId,
     paymentHash,
     description,
     sats,
@@ -467,7 +467,7 @@ export const LedgerService = (): ILedgerService => {
     }
 
     return addIntraledgerTxSend({
-      walletId,
+      senderWalletId,
       description,
       sats,
       recipientWalletId,
@@ -480,7 +480,7 @@ export const LedgerService = (): ILedgerService => {
   }
 
   const addOnChainIntraledgerTxSend = async ({
-    walletId,
+    senderWalletId,
     description,
     sats,
     fee,
@@ -508,7 +508,7 @@ export const LedgerService = (): ILedgerService => {
     }
 
     return addIntraledgerTxSend({
-      walletId,
+      senderWalletId,
       description,
       sats,
       recipientWalletId,
@@ -520,8 +520,8 @@ export const LedgerService = (): ILedgerService => {
     })
   }
 
-  const addUsernameIntraledgerTxSend = async ({
-    walletId,
+  const addWalletIdIntraledgerTxSend = async ({
+    senderWalletId,
     description,
     sats,
     fee,
@@ -531,8 +531,8 @@ export const LedgerService = (): ILedgerService => {
     payerUsername,
     recipientUsername,
     memoPayer,
-  }: AddUsernameIntraledgerTxSendArgs): Promise<LedgerJournal | LedgerError> => {
-    const metadata: AddUsernameIntraledgerTxSendMetadata = {
+  }: addWalletIdIntraledgerTxSendArgs): Promise<LedgerJournal | LedgerError> => {
+    const metadata: addWalletIdIntraledgerTxSendMetadata = {
       type: LedgerTransactionType.IntraLedger,
       pending: false,
       fee,
@@ -545,7 +545,7 @@ export const LedgerService = (): ILedgerService => {
     }
 
     return addIntraledgerTxSend({
-      walletId,
+      senderWalletId,
       description,
       sats,
       recipientWalletId,
@@ -558,7 +558,7 @@ export const LedgerService = (): ILedgerService => {
   }
 
   const addIntraledgerTxSend = async ({
-    walletId,
+    senderWalletId,
     description,
     sats,
     recipientWalletId,
@@ -568,7 +568,7 @@ export const LedgerService = (): ILedgerService => {
     shareMemoWithPayee,
     metadata,
   }: SendIntraledgerTxArgs): Promise<LedgerJournal | LedgerError> => {
-    const liabilitiesWalletId = toLiabilitiesWalletId(walletId)
+    const senderLiabilitiesWalletId = toLiabilitiesWalletId(senderWalletId)
     const recipientLiabilitiesWalletId = toLiabilitiesWalletId(recipientWalletId)
 
     try {
@@ -583,7 +583,7 @@ export const LedgerService = (): ILedgerService => {
 
       entry
         .credit(recipientLiabilitiesWalletId, sats, creditMetadata)
-        .debit(liabilitiesWalletId, sats, debitMetadata)
+        .debit(senderLiabilitiesWalletId, sats, debitMetadata)
 
       const savedEntry = await entry.commit()
       return translateToLedgerJournal(savedEntry)
@@ -637,7 +637,7 @@ export const LedgerService = (): ILedgerService => {
     addLnTxSend,
     addLnIntraledgerTxSend,
     addOnChainIntraledgerTxSend,
-    addUsernameIntraledgerTxSend,
+    addWalletIdIntraledgerTxSend,
     settlePendingLnPayments,
     voidLedgerTransactionsForJournal,
   }

--- a/src/services/ledger/index.types.d.ts
+++ b/src/services/ledger/index.types.d.ts
@@ -33,7 +33,7 @@ type AddOnChainIntraledgerTxSendMetadata = IntraledgerTxMetadata & {
   sendAll: boolean
 }
 
-type AddUsernameIntraledgerTxSendMetadata = IntraledgerTxMetadata
+type addWalletIdIntraledgerTxSendMetadata = IntraledgerTxMetadata
 
 type SendIntraledgerTxArgs = IntraledgerTxArgs & {
   recipientUsername: Username | null
@@ -41,7 +41,7 @@ type SendIntraledgerTxArgs = IntraledgerTxArgs & {
   metadata:
     | AddLnIntraledgerTxSendMetadata
     | AddOnChainIntraledgerTxSendMetadata
-    | AddUsernameIntraledgerTxSendMetadata
+    | addWalletIdIntraledgerTxSendMetadata
 }
 
 type LoadLedgerParams = {

--- a/src/services/mongoose/schema.ts
+++ b/src/services/mongoose/schema.ts
@@ -115,7 +115,7 @@ const UserSchema = new Schema<UserType>({
     enum: ["user", "editor", "dealer", "bankowner", "funder"],
     required: true,
     default: "user",
-    // TODO : enfore the fact there can be only one dealer
+    // TODO : enfore the fact there can be only one dealer/bankowner/funder
   },
 
   onchain: {

--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -143,7 +143,7 @@ export const NotificationsService = (logger: Logger): INotificationsService => {
   }
 
   const intraLedgerPaid = async ({
-    payerWalletId,
+    senderWalletId,
     recipientWalletId,
     amount,
     usdPerSat,
@@ -162,11 +162,11 @@ export const NotificationsService = (logger: Logger): INotificationsService => {
         })
       }
 
-      publish(payerWalletId, NotificationType.IntraLedgerPayment)
+      publish(senderWalletId, NotificationType.IntraLedgerPayment)
       publish(recipientWalletId, NotificationType.IntraLedgerReceipt)
 
       // work around to move forward before re-wrighting the whole notifications module
-      const payerUser = await User.findOne({ walletId: payerWalletId })
+      const payerUser = await User.findOne({ walletId: senderWalletId })
 
       // Do not await this call for quicker processing
       transactionNotification({

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -1,9 +1,23 @@
-import { createHash, randomBytes } from "crypto"
+import { Wallets } from "@app"
+import { intraledgerPaymentSendUsername } from "@app/wallets"
 import { getUserLimits } from "@config/app"
+import { getHash, sleep } from "@core/utils"
+import { FEECAP_PERCENT, toSats } from "@domain/bitcoin"
+import { LightningServiceError, PaymentSendStatus } from "@domain/bitcoin/lightning"
+import {
+  InsufficientBalanceError as DomainInsufficientBalanceError,
+  LimitsExceededError,
+  SelfPaymentError as DomainSelfPaymentError,
+  ValidationError,
+} from "@domain/errors"
+import { TwoFAError } from "@domain/twoFA"
+import { PaymentInitiationMethod } from "@domain/wallets"
+import { LedgerService } from "@services/ledger"
 import { getActiveLnd, getInvoiceAttempt } from "@services/lnd/utils"
 import { baseLogger } from "@services/logger"
+import { WalletInvoicesRepository } from "@services/mongoose"
 import { InvoiceUser } from "@services/mongoose/schema"
-import { getHash, sleep } from "@core/utils"
+import { createHash, randomBytes } from "crypto"
 import {
   cancelHodlInvoice,
   checkIsBalanced,
@@ -12,28 +26,15 @@ import {
   decodePaymentRequest,
   enable2FA,
   generateTokenHelper,
-  getInvoice,
   getAndCreateUserWallet,
+  getInvoice,
   lndOutside1,
   lndOutside2,
   settleHodlInvoice,
   waitFor,
   waitUntilChannelBalanceSyncAll,
 } from "test/helpers"
-import { Wallets } from "@app"
-import { toSats, FEECAP_PERCENT } from "@domain/bitcoin"
-import {
-  SelfPaymentError as DomainSelfPaymentError,
-  InsufficientBalanceError as DomainInsufficientBalanceError,
-  ValidationError,
-  LimitsExceededError,
-} from "@domain/errors"
-import { TwoFAError } from "@domain/twoFA"
-import { LedgerService } from "@services/ledger"
 import { getBTCBalance, getRemainingTwoFALimit } from "test/helpers/wallet"
-import { WalletInvoicesRepository } from "@services/mongoose"
-import { LightningServiceError, PaymentSendStatus } from "@domain/bitcoin/lightning"
-import { PaymentInitiationMethod } from "@domain/wallets"
 
 const date = Date.now() + 1000 * 60 * 60 * 24 * 8
 // required to avoid oldEnoughForWithdrawal validation
@@ -85,8 +86,8 @@ describe("UserWallet - Lightning Pay", () => {
     const paymentResult = await Wallets.lnInvoicePaymentSend({
       paymentRequest: invoice,
       memo: null,
-      walletId: userWallet1.user.walletId,
-      userId: userWallet1.user.id,
+      senderWalletId: userWallet1.user.walletId,
+      payerUserId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
     if (paymentResult instanceof Error) throw paymentResult
@@ -137,8 +138,8 @@ describe("UserWallet - Lightning Pay", () => {
     const paymentResult = await Wallets.lnInvoicePaymentSend({
       paymentRequest: request,
       memo: memoPayer,
-      walletId: userWallet1.user.walletId,
-      userId: userWallet1.user.id,
+      senderWalletId: userWallet1.user.walletId,
+      payerUserId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
     if (paymentResult instanceof Error) throw paymentResult
@@ -169,12 +170,12 @@ describe("UserWallet - Lightning Pay", () => {
   })
 
   it("sends to another Galoy user a push payment", async () => {
-    const res = await Wallets.intraledgerPaymentSend({
+    const res = await intraledgerPaymentSendUsername({
       recipientUsername: userWallet0.user.username,
       memo: "",
       amount: toSats(amountInvoice),
-      walletId: userWallet1.user.walletId,
-      userId: userWallet1.user.id,
+      senderWalletId: userWallet1.user.walletId,
+      payerUserId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
 
@@ -237,12 +238,12 @@ describe("UserWallet - Lightning Pay", () => {
     )
     const txnCount1 = contact1?.transactionsCount || 0
 
-    const res2 = await Wallets.intraledgerPaymentSend({
+    const res2 = await intraledgerPaymentSendUsername({
       recipientUsername: userWallet0.user.username,
       memo: "",
       amount: toSats(amountInvoice),
-      walletId: userWallet1.user.walletId,
-      userId: userWallet1.user.id,
+      senderWalletId: userWallet1.user.walletId,
+      payerUserId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
     expect(res2).not.toBeInstanceOf(Error)
@@ -275,8 +276,8 @@ describe("UserWallet - Lightning Pay", () => {
       paymentRequest: request as EncodedPaymentRequest,
       memo: null,
       amount: toSats(amountInvoice),
-      walletId: userWallet1.user.walletId,
-      userId: userWallet1.user.id,
+      senderWalletId: userWallet1.user.walletId,
+      payerUserId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
     if (paymentResult instanceof Error) throw paymentResult
@@ -289,12 +290,12 @@ describe("UserWallet - Lightning Pay", () => {
   it("filters spam from send to another Galoy user as push payment", async () => {
     const satsBelow = 100
     const memoSpamBelowThreshold = "Spam BELOW threshold"
-    const resBelowThreshold = await Wallets.intraledgerPaymentSend({
+    const resBelowThreshold = await intraledgerPaymentSendUsername({
       recipientUsername: userWallet0.user.username,
       memo: memoSpamBelowThreshold,
       amount: toSats(satsBelow),
-      walletId: userWallet1.user.walletId,
-      userId: userWallet1.user.id,
+      senderWalletId: userWallet1.user.walletId,
+      payerUserId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
     expect(resBelowThreshold).not.toBeInstanceOf(Error)
@@ -302,12 +303,12 @@ describe("UserWallet - Lightning Pay", () => {
 
     const satsAbove = 1100
     const memoSpamAboveThreshold = "Spam ABOVE threshold"
-    const resAboveThreshold = await Wallets.intraledgerPaymentSend({
+    const resAboveThreshold = await intraledgerPaymentSendUsername({
       recipientUsername: userWallet0.user.username,
       memo: memoSpamAboveThreshold,
       amount: toSats(satsAbove),
-      walletId: userWallet1.user.walletId,
-      userId: userWallet1.user.id,
+      senderWalletId: userWallet1.user.walletId,
+      payerUserId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
     expect(resAboveThreshold).not.toBeInstanceOf(Error)
@@ -402,20 +403,20 @@ describe("UserWallet - Lightning Pay", () => {
     const paymentResult = await Wallets.lnInvoicePaymentSend({
       paymentRequest: invoice,
       memo: null,
-      walletId: userWallet1.user.walletId,
-      userId: userWallet1.user.id,
+      senderWalletId: userWallet1.user.walletId,
+      payerUserId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
     expect(paymentResult).toBeInstanceOf(DomainSelfPaymentError)
   })
 
   it("fails if sends to self an on us push payment", async () => {
-    const paymentResult = await Wallets.intraledgerPaymentSend({
+    const paymentResult = await intraledgerPaymentSendUsername({
       recipientUsername: userWallet1.user.username,
       memo: "",
       amount: toSats(amountInvoice),
-      walletId: userWallet1.user.walletId,
-      userId: userWallet1.user.id,
+      senderWalletId: userWallet1.user.walletId,
+      payerUserId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
     expect(paymentResult).toBeInstanceOf(DomainSelfPaymentError)
@@ -429,8 +430,8 @@ describe("UserWallet - Lightning Pay", () => {
     const paymentResult = await Wallets.lnInvoicePaymentSend({
       paymentRequest: invoice as EncodedPaymentRequest,
       memo: null,
-      walletId: userWallet1.user.walletId,
-      userId: userWallet1.user.id,
+      senderWalletId: userWallet1.user.walletId,
+      payerUserId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
     await expect(paymentResult).toBeInstanceOf(DomainInsufficientBalanceError)
@@ -441,8 +442,8 @@ describe("UserWallet - Lightning Pay", () => {
     const paymentResult = await Wallets.lnInvoicePaymentSend({
       paymentRequest: request as EncodedPaymentRequest,
       memo: null,
-      walletId: userWallet0.user.walletId,
-      userId: userWallet0.user.id,
+      senderWalletId: userWallet0.user.walletId,
+      payerUserId: userWallet0.user.id,
       logger: userWallet0.logger,
     })
     expect(paymentResult).toBeInstanceOf(LightningServiceError)
@@ -454,8 +455,8 @@ describe("UserWallet - Lightning Pay", () => {
     const paymentResult = await Wallets.lnInvoicePaymentSend({
       paymentRequest: request as EncodedPaymentRequest,
       memo: null,
-      walletId: userWallet1.user.walletId,
-      userId: userWallet1.user.id,
+      senderWalletId: userWallet1.user.walletId,
+      payerUserId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
     expect(paymentResult).toBeInstanceOf(ValidationError)
@@ -469,8 +470,8 @@ describe("UserWallet - Lightning Pay", () => {
     const paymentResult = await Wallets.lnInvoicePaymentSend({
       paymentRequest: request as EncodedPaymentRequest,
       memo: null,
-      walletId: userWallet1.user.walletId,
-      userId: userWallet1.user.id,
+      senderWalletId: userWallet1.user.walletId,
+      payerUserId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
     expect(paymentResult).toBeInstanceOf(LimitsExceededError)
@@ -489,8 +490,8 @@ describe("UserWallet - Lightning Pay", () => {
     const paymentResult = await Wallets.lnInvoicePaymentSend({
       paymentRequest: request as EncodedPaymentRequest,
       memo: null,
-      walletId: userWallet1.user.walletId,
-      userId: userWallet1.user.id,
+      senderWalletId: userWallet1.user.walletId,
+      payerUserId: userWallet1.user.id,
       logger: userWallet1.logger,
     })
     expect(paymentResult).toBeInstanceOf(LimitsExceededError)
@@ -521,8 +522,8 @@ describe("UserWallet - Lightning Pay", () => {
           const paymentResult = await Wallets.lnInvoicePaymentSendWithTwoFA({
             paymentRequest: input.invoice as EncodedPaymentRequest,
             memo: input.memo,
-            walletId: wallet.user.walletId,
-            userId: wallet.user.id,
+            senderWalletId: wallet.user.walletId,
+            payerUserId: wallet.user.id,
             twoFAToken: input.twoFAToken || null,
             logger: wallet.logger,
           })
@@ -537,9 +538,9 @@ describe("UserWallet - Lightning Pay", () => {
         return async (input): Promise<PaymentSendStatus | ApplicationError> => {
           const paymentResult = await Wallets.lnInvoicePaymentSendWithTwoFA({
             paymentRequest: input.invoice as EncodedPaymentRequest,
+            payerUserId: wallet.user.id,
             memo: input.memo,
-            walletId: wallet.user.walletId,
-            userId: wallet.user.id,
+            senderWalletId: wallet.user.walletId,
             twoFAToken: input.twoFAToken || null,
             logger: wallet.logger,
           })

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -1,5 +1,4 @@
 import { Wallets } from "@app"
-import { intraledgerPaymentSendUsername } from "@app/wallets"
 import { getUserLimits } from "@config/app"
 import { getHash, sleep } from "@core/utils"
 import { FEECAP_PERCENT, toSats } from "@domain/bitcoin"
@@ -170,7 +169,7 @@ describe("UserWallet - Lightning Pay", () => {
   })
 
   it("sends to another Galoy user a push payment", async () => {
-    const res = await intraledgerPaymentSendUsername({
+    const res = await Wallets.intraledgerPaymentSendUsername({
       recipientUsername: userWallet0.user.username,
       memo: "",
       amount: toSats(amountInvoice),
@@ -238,7 +237,7 @@ describe("UserWallet - Lightning Pay", () => {
     )
     const txnCount1 = contact1?.transactionsCount || 0
 
-    const res2 = await intraledgerPaymentSendUsername({
+    const res2 = await Wallets.intraledgerPaymentSendUsername({
       recipientUsername: userWallet0.user.username,
       memo: "",
       amount: toSats(amountInvoice),
@@ -290,7 +289,7 @@ describe("UserWallet - Lightning Pay", () => {
   it("filters spam from send to another Galoy user as push payment", async () => {
     const satsBelow = 100
     const memoSpamBelowThreshold = "Spam BELOW threshold"
-    const resBelowThreshold = await intraledgerPaymentSendUsername({
+    const resBelowThreshold = await Wallets.intraledgerPaymentSendUsername({
       recipientUsername: userWallet0.user.username,
       memo: memoSpamBelowThreshold,
       amount: toSats(satsBelow),
@@ -303,7 +302,7 @@ describe("UserWallet - Lightning Pay", () => {
 
     const satsAbove = 1100
     const memoSpamAboveThreshold = "Spam ABOVE threshold"
-    const resAboveThreshold = await intraledgerPaymentSendUsername({
+    const resAboveThreshold = await Wallets.intraledgerPaymentSendUsername({
       recipientUsername: userWallet0.user.username,
       memo: memoSpamAboveThreshold,
       amount: toSats(satsAbove),
@@ -411,7 +410,7 @@ describe("UserWallet - Lightning Pay", () => {
   })
 
   it("fails if sends to self an on us push payment", async () => {
-    const paymentResult = await intraledgerPaymentSendUsername({
+    const paymentResult = await Wallets.intraledgerPaymentSendUsername({
       recipientUsername: userWallet1.user.username,
       memo: "",
       amount: toSats(amountInvoice),

--- a/test/integration/services/ledger/transaction.spec.ts
+++ b/test/integration/services/ledger/transaction.spec.ts
@@ -249,8 +249,8 @@ describe("payment with lnd", () => {
 
 describe("on us payment via Ledger Service", () => {
   it("intraledger", async () => {
-    const payer = walletBTC
-    const payee = walletBTC2
+    const sender = walletBTC
+    const recipient = walletBTC2
 
     const price = await Prices.getCurrentPrice()
     expect(price).not.toBeInstanceOf(Error)
@@ -262,14 +262,14 @@ describe("on us payment via Ledger Service", () => {
     const usd = sats * price
     const usdFee = fee * price
 
-    const result = await LedgerService().addUsernameIntraledgerTxSend({
-      walletId: payer.walletId,
+    const result = await LedgerService().addWalletIdIntraledgerTxSend({
+      senderWalletId: sender.walletId,
       description: "desc",
       sats,
       fee: lnFee,
       usd,
       usdFee,
-      recipientWalletId: payee.walletId,
+      recipientWalletId: recipient.walletId,
       payerUsername: "payerUsername" as Username,
       recipientUsername: "recipientUsername" as Username,
       memoPayer: null,
@@ -281,8 +281,8 @@ describe("on us payment via Ledger Service", () => {
       if (tx instanceof Error) throw tx
       expect(tx.type).toBe(LedgerTransactionType.IntraLedger)
     }
-    await expectBalance({ account: payer.walletPath, currency: "BTC", balance: -1000 })
-    await expectBalance({ account: payee.walletPath, currency: "BTC", balance: 1000 })
+    await expectBalance({ account: sender.walletPath, currency: "BTC", balance: -1000 })
+    await expectBalance({ account: recipient.walletPath, currency: "BTC", balance: 1000 })
   })
 })
 


### PR DESCRIPTION
this mostly include nome renaming from payerWalletId and walletId to senderWallerId. there are more renaming from payer to sender to do on the codebase, but I just had extract the one I had encounter doing the add_earn use case refactoring