### PR TITLE
fix: filter voided txs from txVolumeSince

### DIFF
--- a/src/services/ledger/index.ts
+++ b/src/services/ledger/index.ts
@@ -227,6 +227,8 @@ export const LedgerService = (): ILedgerService => {
         {
           $match: {
             accounts: liabilitiesWalletId,
+            voided: false, // avoid to sum voided transactions to outgoingSats
+            _original_journal: { $exists: false }, // avoid to sum voided transactions to incomingSats
             $or: txnTypesObj,
             $and: [{ timestamp: { $gte: timestamp } }],
           },

--- a/test/helpers/wallet.ts
+++ b/test/helpers/wallet.ts
@@ -39,7 +39,7 @@ export const getRemainingWithdrawalLimit = async ({
   walletId: WalletId
   accountLevel: AccountLevel
 }): Promise<Satoshis | ApplicationError> => {
-  const timestamp1Day = new Date(Date.now() - MS_PER_DAY)
+  const timestamp1Day = new Date(jest.getRealSystemTime() - MS_PER_DAY)
   const walletVolume = await LedgerService().externalPaymentVolumeSince({
     walletId,
     timestamp: timestamp1Day,
@@ -52,7 +52,7 @@ export const getRemainingWithdrawalLimit = async ({
 }
 
 export const getRemainingTwoFALimit = async (
-  walletId,
+  walletId: WalletId,
 ): Promise<Satoshis | ApplicationError> => {
   const timestamp1Day = new Date(Date.now() - MS_PER_DAY)
   const walletVolume = await LedgerService().externalPaymentVolumeSince({


### PR DESCRIPTION
Fix an issue reported by an user that hit the daily limit without successful transactions (verified with logs)

How to test:
- Run `TEST="01|02" make reset-integration`
- Query `walletId` for `user1`
- Run the next query:
```js
db.getCollection('medici_transactions').aggregate([{
  $match: {
    accounts: "Liabilities:<user1.walletId>",
    voided: false,
    _original_journal:{ $exists: false},
  },
},
{
  $group: {
    _id: null,
    outgoingSats: { $sum: "$debit" },
    incomingSats: { $sum: "$credit" },
  },
}])
```
- Run the same query without `voided` and `_original_journal` conditions