### PR TITLE
fix: broken route translation for ln invoices to domain

### DIFF
--- a/src/domain/bitcoin/lightning/ln-invoice.ts
+++ b/src/domain/bitcoin/lightning/ln-invoice.ts
@@ -28,19 +28,17 @@ export const decodeInvoice = (
     ? decodedInvoice.cltv_delta
     : null
 
-  const routeHints: Hop[][] = []
+  let routeHints: Hop[][] = []
   if (decodedInvoice.routes) {
-    decodedInvoice.routes.forEach((rawRoute) => {
-      const route: Hop[] = []
-      route.push({
-        baseFeeMTokens: rawRoute.base_fee_mtokens,
-        channel: rawRoute.channel,
-        cltvDelta: rawRoute.cltv_delta,
-        feeRate: rawRoute.fee_rate,
-        nodePubkey: rawRoute.public_key as Pubkey,
-      })
-      routeHints.push(route)
-    })
+    routeHints = decodedInvoice.routes.map((rawRoute) =>
+      rawRoute.map((route) => ({
+        baseFeeMTokens: route.base_fee_mtokens,
+        channel: route.channel,
+        cltvDelta: route.cltv_delta,
+        feeRate: route.fee_rate,
+        nodePubkey: route.public_key as Pubkey,
+      })),
+    )
   }
 
   return {


### PR DESCRIPTION
## Description

Routes hints from ln invoices were not being translated to our domain properly and so were returning `undefined` values when converted back to pass into the `lightning` library's `payViaPaymentDetails` method.

The end result of this bug was that we weren't able to pay any invoices where there were route hints and the final destination was a private node/channel.