### PR TITLE
fix: use getBalanceForWalletId instead of getBalanceForWallet for internal queries

### DIFF
--- a/src/app/accounts/send-balance-to-accounts.ts
+++ b/src/app/accounts/send-balance-to-accounts.ts
@@ -1,6 +1,6 @@
 import { getRecentlyActiveAccounts } from "@app/accounts/active-accounts"
 import { getCurrentPrice } from "@app/prices"
-import { getBalanceForWallet } from "@app/wallets"
+import { getBalanceForWalletId } from "@app/wallets"
 import { NotificationsService } from "@services/notifications"
 
 export const sendBalanceToAccounts = async (logger: Logger) => {
@@ -10,10 +10,7 @@ export const sendBalanceToAccounts = async (logger: Logger) => {
   const price = await getCurrentPrice()
 
   for (const account of accounts) {
-    const balance = await getBalanceForWallet({
-      walletId: account.defaultWalletId,
-      logger,
-    })
+    const balance = await getBalanceForWalletId(account.defaultWalletId)
     if (balance instanceof Error) throw balance
 
     await NotificationsService(logger).sendBalance({

--- a/src/app/wallets/intraledger-send-payment.ts
+++ b/src/app/wallets/intraledger-send-payment.ts
@@ -16,7 +16,7 @@ import { LockService } from "@services/lock"
 import { UsersRepository } from "@services/mongoose"
 import { NotificationsService } from "@services/notifications"
 import { checkAndVerifyTwoFA, checkIntraledgerLimits } from "./check-limit-helpers"
-import { getBalanceForWallet } from "./get-balance-for-wallet"
+import { getBalanceForWalletId } from "./get-balance-for-wallet"
 
 export const intraledgerPaymentSendUsername = async ({
   recipientUsername,
@@ -219,7 +219,7 @@ const executePaymentViaIntraledger = async ({
   return LockService().lockWalletId(
     { walletId: senderWalletId, logger },
     async (lock) => {
-      const balance = await getBalanceForWallet({ walletId: senderWalletId, logger })
+      const balance = await getBalanceForWalletId(senderWalletId)
       if (balance instanceof Error) return balance
       if (balance < sats) {
         return new InsufficientBalanceError(

--- a/src/app/wallets/ln-send-payment.ts
+++ b/src/app/wallets/ln-send-payment.ts
@@ -1,7 +1,7 @@
 import { getAccount } from "@app/accounts"
 import { getCurrentPrice } from "@app/prices"
 import { getUser } from "@app/users"
-import { getBalanceForWallet, getWallet } from "@app/wallets"
+import { getBalanceForWalletId, getWallet } from "@app/wallets"
 import {
   checkAndVerifyTwoFA,
   checkIntraledgerLimits,
@@ -355,7 +355,7 @@ const executePaymentViaIntraledger = async ({
   return LockService().lockWalletId(
     { walletId: senderWalletId, logger },
     async (lock) => {
-      const balance = await getBalanceForWallet({ walletId: senderWalletId, logger })
+      const balance = await getBalanceForWalletId(senderWalletId)
       if (balance instanceof Error) return balance
       if (balance < sats) {
         return new InsufficientBalanceError(
@@ -456,7 +456,7 @@ const executePaymentViaLn = async ({
   return LockService().lockWalletId(
     { walletId: senderWalletId, logger },
     async (lock) => {
-      const balance = await getBalanceForWallet({ walletId: senderWalletId, logger })
+      const balance = await getBalanceForWalletId(senderWalletId)
       if (balance instanceof Error) return balance
       if (balance < sats) {
         return new InsufficientBalanceError(

--- a/src/core/on-chain/index.ts
+++ b/src/core/on-chain/index.ts
@@ -76,11 +76,7 @@ export const OnChainMixin = (superclass) =>
 
       const walletId_ = this.user.walletId // FIXME: just set this variable for easier code review. long variable would trigger adding a tab and much bigger diff
       return redlock({ path: walletId_, logger: onchainLogger }, async (lock) => {
-        const balanceSats = await Wallets.getBalanceForWallet({
-          walletId: this.user.walletId,
-          logger: onchainLogger,
-          lock,
-        })
+        const balanceSats = await Wallets.getBalanceForWalletId(this.user.walletId)
         if (balanceSats instanceof Error) throw balanceSats
 
         onchainLogger = onchainLogger.child({ balanceSats })

--- a/src/graphql/root/mutation/ln-invoice-fee-probe.ts
+++ b/src/graphql/root/mutation/ln-invoice-fee-probe.ts
@@ -18,7 +18,7 @@ const LnInvoiceFeeProbeMutation = GT.Field({
   args: {
     input: { type: GT.NonNull(LnInvoiceFeeProbeInput) },
   },
-  resolve: async (_, args, { logger }) => {
+  resolve: async (_, args) => {
     const { walletId, paymentRequest } = args.input
 
     for (const input of [walletId, paymentRequest]) {
@@ -30,7 +30,6 @@ const LnInvoiceFeeProbeMutation = GT.Field({
     const feeSatAmount = await Wallets.getLightningFee({
       walletId,
       paymentRequest,
-      logger,
     })
     if (feeSatAmount instanceof Error) {
       const appErr = mapError(feeSatAmount)

--- a/src/graphql/root/mutation/ln-noamount-invoice-fee-probe.ts
+++ b/src/graphql/root/mutation/ln-noamount-invoice-fee-probe.ts
@@ -20,7 +20,7 @@ const LnNoAmountInvoiceFeeProbeMutation = GT.Field({
   args: {
     input: { type: GT.NonNull(LnNoAmountInvoiceFeeProbeInput) },
   },
-  resolve: async (_, args, { logger }) => {
+  resolve: async (_, args) => {
     const { walletId, paymentRequest, amount } = args.input
 
     for (const input of [walletId, paymentRequest, amount]) {
@@ -33,7 +33,6 @@ const LnNoAmountInvoiceFeeProbeMutation = GT.Field({
       walletId,
       amount,
       paymentRequest,
-      logger,
     })
     if (feeSatAmount instanceof Error) {
       const appErr = mapError(feeSatAmount)

--- a/src/servers/graphql-old-server.ts
+++ b/src/servers/graphql-old-server.ts
@@ -359,7 +359,6 @@ const resolvers = {
             walletId: wallet.user.walletId,
             amount,
             paymentRequest: invoice,
-            logger,
           })
           if (!(feeSatAmount instanceof Error)) return feeSatAmount
           if (!(feeSatAmount instanceof LnPaymentRequestZeroAmountRequiredError))
@@ -369,7 +368,6 @@ const resolvers = {
         feeSatAmount = await Wallets.getLightningFee({
           walletId: wallet.user.walletId,
           paymentRequest: invoice,
-          logger,
         })
         if (feeSatAmount instanceof Error) throw mapError(feeSatAmount)
         return feeSatAmount

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -515,7 +515,6 @@ describe("UserWallet - Lightning Pay", () => {
           const feeFromProbe = await Wallets.getLightningFee({
             walletId: wallet.user.walletId,
             paymentRequest: input.invoice,
-            logger: wallet.logger,
           })
           if (feeFromProbe instanceof Error) throw feeFromProbe
           const paymentResult = await Wallets.lnInvoicePaymentSendWithTwoFA({


### PR DESCRIPTION
- We only need to update pending invoices and payments when user request the balance
- the use of getBalanceForWallet is not necessary in internal methods