### PR TITLE
chore: add index for volume query

### DIFF
--- a/src/services/ledger/schema.ts
+++ b/src/services/ledger/schema.ts
@@ -147,6 +147,7 @@ const transactionSchema = new Schema({
 })
 
 //indexes used by our queries
+transactionSchema.index({ accounts: 1, type: 1, timestamp: -1 })
 transactionSchema.index({ type: 1, pending: 1, account_path: 1 })
 transactionSchema.index({ account_path: 1 })
 transactionSchema.index({ hash: 1 })


### PR DESCRIPTION
Transaction volume query is taking more than 6 seconds in production.

This is difficult to test but you can check index stats after run `TEST="01|02" make reset-integration` and you will notice that is the most used index (this is only a good indication that we need this index)

How to check index stats:
- Access db as a root
- Run `db.medici_transactions.aggregate([{ $indexStats: {} }])`
- Check `accesses.ops` value