### PR TITLE
chore!: modify twilio to use auth token

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -82,6 +82,5 @@ export GEETEST_ID="geetest_id"
 export GEETEST_KEY="geetest_key"
 
 export TWILIO_ACCOUNT_SID="AC_twilio_id"
-export TWILIO_API_KEY="twilio_secret"
-export TWILIO_API_SECRET="twilio_api"
+export TWILIO_AUTH_TOKEN="AC_twilio_auth_token"
 export TWILIO_PHONE_NUMBER="twilio_phone"

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -217,25 +217,22 @@ export const getSpecterWalletConfig = (): SpecterWalletConfig => {
 
 type TwilioConfig = {
   accountSid: string
-  apiKey: string
-  apiSecret: string
+  authToken: string
   twilioPhoneNumber: string
 }
 
 export const getTwilioConfig = (): TwilioConfig => {
   const accountSid = process.env.TWILIO_ACCOUNT_SID
-  const apiKey = process.env.TWILIO_API_KEY
-  const apiSecret = process.env.TWILIO_API_SECRET
+  const authToken = process.env.TWILIO_AUTH_TOKEN
   const twilioPhoneNumber = process.env.TWILIO_PHONE_NUMBER
 
-  if (!accountSid || !apiKey || !apiSecret || !twilioPhoneNumber) {
+  if (!accountSid || !authToken || !twilioPhoneNumber) {
     throw new ConfigError("missing key for twilio")
   }
 
   return {
     accountSid,
-    apiKey,
-    apiSecret,
+    authToken,
     twilioPhoneNumber,
   }
 }

--- a/src/services/twilio.ts
+++ b/src/services/twilio.ts
@@ -4,9 +4,7 @@ import { baseLogger } from "@services/logger"
 import twilio from "twilio"
 
 export const TwilioClient = (): IPhoneProviderService => {
-  const client = twilio(getTwilioConfig().apiKey, getTwilioConfig().apiSecret, {
-    accountSid: getTwilioConfig().accountSid,
-  })
+  const client = twilio(getTwilioConfig().accountSid, getTwilioConfig().authToken)
 
   const sendText = async ({ body, to, logger }: SendTextArguments) => {
     const twilioPhoneNumber = getTwilioConfig().twilioPhoneNumber


### PR DESCRIPTION
Twilio Sub-Accounts get an `Auth Token` and `Account SID` by default. 
I couldn't find a way to access a Sub-Account using API Keys and only found ways to create a Sub-Account by using the Main Account API Keys.

For us to use multiple environments, wherein each environment runs on a seperate Twilio Sub-Account, the Galoy codebase needs to use the Twilio Sub-Account credential, or `Auth Token` + `Account SID` approach.