### PR TITLE
chore: update payment cleanup script

### DIFF
--- a/src/debug/delete-failed-payment.ts
+++ b/src/debug/delete-failed-payment.ts
@@ -1,7 +1,7 @@
-import { authenticatedLndGrpc, deleteFailedPayments } from "ln-service"
+import { authenticatedLndGrpc, deleteFailedPayAttempts } from "ln-service"
 
-// export LND1_TLS=$(kubectl exec lnd-0 -n mainnet  -- base64 /root/.lnd/tls.cert | tr -d '\n\r')
-// export LND1_MACAROON=$(kubectl exec lnd-0 -n mainnet -- base64 /root/.lnd/data/chain/bitcoin/mainnet/admin.macaroon | tr -d '\n\r')
+// export LND1_TLS=$(kubectl exec lnd1-0 -n galoy-bbw-bitcoin  -- base64 /root/.lnd/tls.cert | tr -d '\n\r')
+// export LND1_MACAROON=$(kubectl exec lnd1-0 -n galoy-bbw-bitcoin -- base64 /root/.lnd/data/chain/bitcoin/mainnet/admin.macaroon | tr -d '\n\r')
 
 const fn = async () => {
   try {
@@ -11,7 +11,8 @@ const fn = async () => {
       node: "localhost",
       port: 10009,
     })
-    console.log(await deleteFailedPayments({ lnd }))
+    console.log(await deleteFailedPayAttempts({ lnd }))
+    console.log("completed")
   } catch (err) {
     console.log({ err })
   }


### PR DESCRIPTION
we'll need to run this sooner than later because of the issues we have with lnd. probably related to the fact a lot of payment has been failing over the last month following the lack of route hint. this has bloated lnd and make it slow/unstable