### PR TITLE
fix: use getBalanceForWalletId in btc wallet

### DIFF
--- a/src/graphql/types/object/btc-wallet.ts
+++ b/src/graphql/types/object/btc-wallet.ts
@@ -11,7 +11,7 @@ import { Wallets } from "@app"
 const BTCWallet = new GT.Object({
   name: "BTCWallet",
   interfaces: () => [IWallet],
-  isTypeOf: (source) => true || source.type === "btc", // TODO: make this work
+  isTypeOf: () => true, // TODO: make this work
   fields: () => ({
     id: {
       type: GT.NonNullID,
@@ -22,11 +22,8 @@ const BTCWallet = new GT.Object({
     },
     balance: {
       type: GT.NonNull(SignedAmount),
-      resolve: async (source: Wallet, __, { logger }) => {
-        const balanceSats = await Wallets.getBalanceForWallet({
-          walletId: source.id,
-          logger,
-        })
+      resolve: async (source: Wallet) => {
+        const balanceSats = await Wallets.getBalanceForWalletId(source.id)
         if (balanceSats instanceof Error) throw balanceSats
         return balanceSats
       },


### PR DESCRIPTION
Issue: MyUpdatesSubscription triggers every time price is updated (every 30 seconds)

This is a problem because we query the balance in each update https://github.com/GaloyMoney/galoy-mobile/blob/main/app/hooks/user-hooks.ts#L49 so we do all invoices and payments lookups for a user (lnd) every 30 seconds.

The solution is to separate price subscription from my updates but we cant change mobile app quickly so we will need to trust trigger until this is fixed.