### PR TITLE
fix: Fix addEarn call

### DIFF
--- a/src/app/accounts/add-earn.ts
+++ b/src/app/accounts/add-earn.ts
@@ -54,5 +54,5 @@ export const addEarn = async ({
   })
   if (payment instanceof Error) return payment
 
-  return { id: quizQuestionId, value: amount, completed: true }
+  return [{ id: quizQuestionId, value: amount, completed: true }]
 }


### PR DESCRIPTION
The addEarn call currently returns a single quiz question but the graphql expects an array of quiz questions as can be seen in this line https://github.com/GaloyMoney/galoy/blob/3bd8eb7882ce382b5d169e545ca8774e9ee76946/src/graphql/old-schema.graphql#L272.