### PR TITLE
fix: return array for 'earnCompleted' old gql endpoint

### DIFF
--- a/src/servers/graphql-old-server.ts
+++ b/src/servers/graphql-old-server.ts
@@ -373,8 +373,17 @@ const resolvers = {
         return feeSatAmount
       },
     }),
-    earnCompleted: async (_, { ids }, { uid, logger }) =>
-      Accounts.addEarn({ quizQuestionId: ids[0], accountId: uid, logger }),
+    earnCompleted: async (_, { ids }, { uid, logger }) => {
+      const earnsList = await Promise.all(
+        ids.map((id) => Accounts.addEarn({ quizQuestionId: id, accountId: uid, logger })),
+      )
+      const error = earnsList.find((elem) => elem instanceof Error)
+      if (error) {
+        throw mapError(error as ApplicationError)
+      }
+
+      return earnsList
+    },
     onchain: (_, __, { wallet }) => ({
       getNewAddress: async () => {
         const address = await Wallets.createOnChainAddress(wallet.user.walletId)

--- a/src/servers/graphql-old-server.ts
+++ b/src/servers/graphql-old-server.ts
@@ -374,15 +374,13 @@ const resolvers = {
       },
     }),
     earnCompleted: async (_, { ids }, { uid, logger }) => {
-      const earnsList = await Promise.all(
-        ids.map((id) => Accounts.addEarn({ quizQuestionId: id, accountId: uid, logger })),
-      )
-      const error = earnsList.find((elem) => elem instanceof Error)
-      if (error) {
-        throw mapError(error as ApplicationError)
-      }
-
-      return earnsList
+      const earnCompleted = await Accounts.addEarn({
+        quizQuestionId: ids[0],
+        accountId: uid,
+        logger,
+      })
+      if (earnCompleted instanceof Error) throw mapError(earnCompleted)
+      return [earnCompleted]
     },
     onchain: (_, __, { wallet }) => ({
       getNewAddress: async () => {


### PR DESCRIPTION
### Description

Return array instead of single value for old api `earnCompleted` endpoint