### PR TITLE
fix: addEarn method return handling in new graphql endpoint

### DIFF
--- a/src/app/accounts/add-earn.ts
+++ b/src/app/accounts/add-earn.ts
@@ -19,7 +19,7 @@ export const addEarn = async ({
   quizQuestionId: QuizQuestionId
   accountId: AccountId /* AccountId: aid validation */
   logger: Logger
-}) => {
+}): Promise<QuizQuestion | ApplicationError> => {
   const amount = onboardingEarn[quizQuestionId]
   if (!amount) {
     return new ValidationError("incorrect reward id")
@@ -55,5 +55,5 @@ export const addEarn = async ({
   })
   if (payment instanceof Error) return payment
 
-  return { id: quizQuestionId, value: amount, completed: true }
+  return { id: quizQuestionId, earnAmount: amount }
 }

--- a/src/app/accounts/add-earn.ts
+++ b/src/app/accounts/add-earn.ts
@@ -21,7 +21,7 @@ export const addEarn = async ({
   logger: Logger
 }): Promise<QuizQuestion | ApplicationError> => {
   const amount = onboardingEarn[quizQuestionId]
-  if (amount === undefined) return new InvalidQuizQuestionIdError()
+  if (!amount) return new InvalidQuizQuestionIdError()
 
   const funderWalletId = await getFunderWalletId()
 

--- a/src/app/accounts/add-earn.ts
+++ b/src/app/accounts/add-earn.ts
@@ -2,9 +2,9 @@ import { getUser } from "@app/users"
 import { intraledgerPaymentSendWalletId } from "@app/wallets"
 import { onboardingEarn } from "@config/app"
 import {
+  InvalidQuizQuestionIdError,
   RewardMissingMetadataError,
   RewardNonValidTypeError,
-  ValidationError,
 } from "@domain/errors"
 import { getFunderWalletId } from "@services/ledger/accounts"
 import { RewardsRepository } from "@services/mongoose"
@@ -21,9 +21,7 @@ export const addEarn = async ({
   logger: Logger
 }): Promise<QuizQuestion | ApplicationError> => {
   const amount = onboardingEarn[quizQuestionId]
-  if (!amount) {
-    return new ValidationError("incorrect reward id")
-  }
+  if (amount === undefined) return new InvalidQuizQuestionIdError()
 
   const funderWalletId = await getFunderWalletId()
 

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -28,9 +28,7 @@ export class CouldNotFindWalletFromOnChainAddressesError extends CouldNotFindErr
 export class CouldNotFindAccountFromUsernameError extends CouldNotFindError {}
 export class CouldNotFindAccountFromPhoneError extends CouldNotFindError {}
 
-export class RewardMissingMetadataError extends DomainError {}
 export class RewardAlreadyPresentError extends DomainError {}
-export class RewardNonValidTypeError extends DomainError {}
 
 export class ValidationError extends DomainError {}
 export class ContactNotExistantError extends DomainError {}
@@ -57,6 +55,9 @@ export class LnPaymentRequestZeroAmountRequiredError extends ValidationError {}
 export class NoWalletExistsForUserError extends ValidationError {}
 export class RebalanceNeededError extends ValidationError {}
 export class InvalidQuizQuestionIdError extends ValidationError {}
+export class MissingPhoneMetadataError extends ValidationError {}
+export class InvalidPhoneMetadataTypeError extends ValidationError {}
+export class InvalidPhoneMetadataForRewardError extends ValidationError {}
 
 export class LimitsExceededError extends ValidationError {}
 export class WithdrawalLimitsExceededError extends LimitsExceededError {}

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -56,6 +56,7 @@ export class LnPaymentRequestNonZeroAmountRequiredError extends ValidationError 
 export class LnPaymentRequestZeroAmountRequiredError extends ValidationError {}
 export class NoWalletExistsForUserError extends ValidationError {}
 export class RebalanceNeededError extends ValidationError {}
+export class InvalidQuizQuestionIdError extends ValidationError {}
 
 export class LimitsExceededError extends ValidationError {}
 export class WithdrawalLimitsExceededError extends LimitsExceededError {}

--- a/src/domain/users/index.types.d.ts
+++ b/src/domain/users/index.types.d.ts
@@ -60,6 +60,10 @@ type NewUserInfo = {
   phoneMetadata: PhoneMetadata | null
 }
 
+type PhoneMetadataValidator = {
+  validate(phoneMetadata: PhoneMetadata | null): true | ApplicationError
+}
+
 interface IUsersRepository {
   findById(userId: UserId): Promise<User | RepositoryError>
   findByPhone(phone: PhoneNumber): Promise<User | RepositoryError>

--- a/src/domain/users/phone-metadata-validator.ts
+++ b/src/domain/users/phone-metadata-validator.ts
@@ -1,0 +1,16 @@
+import { MissingPhoneMetadataError, InvalidPhoneMetadataTypeError } from "@domain/errors"
+
+export const PhoneMetadataValidator = (): PhoneMetadataValidator => {
+  const validate = (phoneMetadata: PhoneMetadata | null): true | ApplicationError => {
+    if (phoneMetadata === null || !phoneMetadata.carrier)
+      return new MissingPhoneMetadataError()
+
+    if (phoneMetadata.carrier.type === "voip") return new InvalidPhoneMetadataTypeError()
+
+    return true
+  }
+
+  return {
+    validate,
+  }
+}

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -135,6 +135,10 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       message = "Invalid quiz question id was passed."
       return new ValidationInternalError({ message, logger: baseLogger })
 
+    case "RewardAlreadyPresentError":
+      message = "Reward for quiz question was already claimed."
+      return new ValidationInternalError({ message, logger: baseLogger })
+
     case "RouteNotFoundError":
       message = "Unable to find a route for payment."
       return new RouteFindingError({ message, logger: baseLogger })
@@ -262,7 +266,6 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "UnknownPhoneProviderServiceError":
     case "RewardMissingMetadataError":
     case "RewardNonValidTypeError":
-    case "RewardAlreadyPresentError":
     case "InvalidAccountStatusError":
     case "InvalidOnChainAddress":
     case "InvalidScanDepthAmount":

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -139,6 +139,10 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       message = "Reward for quiz question was already claimed."
       return new ValidationInternalError({ message, logger: baseLogger })
 
+    case "InvalidPhoneMetadataForRewardError":
+      message = "Unsupported phone carrier for rewards."
+      return new ValidationInternalError({ message, logger: baseLogger })
+
     case "RouteNotFoundError":
       message = "Unable to find a route for payment."
       return new RouteFindingError({ message, logger: baseLogger })
@@ -264,8 +268,8 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "UserPhoneCodeAttemptIpRateLimiterExceededError":
     case "PhoneProviderServiceError":
     case "UnknownPhoneProviderServiceError":
-    case "RewardMissingMetadataError":
-    case "RewardNonValidTypeError":
+    case "MissingPhoneMetadataError":
+    case "InvalidPhoneMetadataTypeError":
     case "InvalidAccountStatusError":
     case "InvalidOnChainAddress":
     case "InvalidScanDepthAmount":

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -131,6 +131,10 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       message = "Invalid or incorrect phone entered."
       return new PhoneCodeError({ message, logger: baseLogger })
 
+    case "InvalidQuizQuestionIdError":
+      message = "Invalid quiz question id was passed."
+      return new ValidationInternalError({ message, logger: baseLogger })
+
     case "RouteNotFoundError":
       message = "Unable to find a route for payment."
       return new RouteFindingError({ message, logger: baseLogger })

--- a/src/graphql/root/mutation/user-quiz-question-update-completed.ts
+++ b/src/graphql/root/mutation/user-quiz-question-update-completed.ts
@@ -1,5 +1,4 @@
 import { Accounts } from "@app"
-import { onboardingEarn } from "@config/app"
 import { mapError } from "@graphql/error-map"
 import { GT } from "@graphql/index"
 
@@ -19,10 +18,6 @@ const UserQuizQuestionUpdateCompletedMutation = GT.Field({
   },
   resolve: async (_, args, { uid, logger }) => {
     const { id } = args.input
-
-    if (!onboardingEarn[id]) {
-      return { errors: [{ message: "Invalid input" }] }
-    }
 
     const question = await Accounts.addEarn({
       quizQuestionId: id,

--- a/src/graphql/root/mutation/user-quiz-question-update-completed.ts
+++ b/src/graphql/root/mutation/user-quiz-question-update-completed.ts
@@ -16,12 +16,16 @@ const UserQuizQuestionUpdateCompletedMutation = GT.Field({
   args: {
     input: { type: GT.NonNull(UserQuizQuestionUpdateCompletedInput) },
   },
-  resolve: async (_, args, { uid, logger }) => {
+  resolve: async (
+    _,
+    args,
+    { domainAccount, logger }: { domainAccount: Account; logger: Logger },
+  ) => {
     const { id } = args.input
 
     const question = await Accounts.addEarn({
       quizQuestionId: id,
-      accountId: uid,
+      accountId: domainAccount.id,
       logger,
     })
     if (question instanceof Error) {

--- a/src/graphql/root/mutation/user-quiz-question-update-completed.ts
+++ b/src/graphql/root/mutation/user-quiz-question-update-completed.ts
@@ -30,7 +30,7 @@ const UserQuizQuestionUpdateCompletedMutation = GT.Field({
     })
     if (question instanceof Error) {
       const appErr = mapError(question)
-      return { errors: [{ message: appErr.message || appErr.name }] }
+      return { errors: [{ message: appErr.message }] }
     }
 
     return {

--- a/src/servers/graphql-old-server.ts
+++ b/src/servers/graphql-old-server.ts
@@ -380,13 +380,20 @@ const resolvers = {
       },
     }),
     earnCompleted: async (_, { ids }, { uid, logger }) => {
-      const earnCompleted = await Accounts.addEarn({
+      const quizQuestion = await Accounts.addEarn({
         quizQuestionId: ids[0],
         accountId: uid,
         logger,
       })
-      if (earnCompleted instanceof Error) throw mapError(earnCompleted)
-      return [earnCompleted]
+      if (quizQuestion instanceof Error) throw mapError(quizQuestion)
+
+      return [
+        {
+          id: quizQuestion.id,
+          value: quizQuestion.earnAmount,
+          completed: true,
+        },
+      ]
     },
     onchain: (_, __, { wallet }) => ({
       getNewAddress: async () => {


### PR DESCRIPTION
## Description

This PR adds types to the `addEarn` use-case method and refactors the return type from that method. It also refactors some of the error types and handling in the method.

### The Issue
Marking as **draft** until we can figure out why this doesn't break in the currently deployed app (cc @daviroo). It's also curious that we haven't been able to observe the `Cannot read properties of undefined (reading 'id')` in honeycomb as yet anywhere.


This is the response we get back when we call `userQuizQuestionUpdateCompleted` right now directly from something like Postman on both prod and dev:
```ts
{
    "data": {
        "userQuizQuestionUpdateCompleted": {
            "userQuizQuestion": null,
            "errors": [
                {
                    "message": "Cannot read properties of undefined (reading 'id')"
                }
            ]
        }
    }
}
```
