### PR TITLE
chore: add account walletId property to span attributes

### DIFF
--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -338,7 +338,7 @@ type Mutation {
   userUpdateLanguage(input: UserUpdateLanguageInput!): UserUpdateLanguagePayload!
   userUpdateUsername(input: UserUpdateUsernameInput!): UserUpdateUsernamePayload!
     @deprecated(
-      reason: "Username will be moved to @Handle in Accounts. Also SetUsername should be used instead of UpdateUpdate to reflect the idempotenty of Handles"
+      reason: "Username will be moved to @Handle in Accounts. Also SetUsername should be used instead of UpdateUsername to reflect the idempotency of Handles"
     )
 }
 

--- a/src/graphql/root/mutation/ln-invoice-payment-send.ts
+++ b/src/graphql/root/mutation/ln-invoice-payment-send.ts
@@ -9,7 +9,9 @@ import {
   addAttributesToCurrentSpanAndPropagate,
   SemanticAttributes,
   ENDUSER_ALIAS,
+  ENDUSER_PUBLICID,
 } from "@services/tracing"
+import getUuidByString from "uuid-by-string"
 
 const LnInvoicePaymentInput = new GT.Input({
   name: "LnInvoicePaymentInput",
@@ -29,6 +31,9 @@ const LnInvoicePaymentSendMutation = GT.Field({
     addAttributesToCurrentSpanAndPropagate(
       {
         [SemanticAttributes.ENDUSER_ID]: domainUser?.id,
+        [ENDUSER_PUBLICID]: domainUser?.id
+          ? getUuidByString(domainUser?.id)
+          : domainUser?.id,
         [ENDUSER_ALIAS]: domainUser?.username,
         [SemanticAttributes.HTTP_CLIENT_IP]: ip,
       },

--- a/src/graphql/root/mutation/ln-invoice-payment-send.ts
+++ b/src/graphql/root/mutation/ln-invoice-payment-send.ts
@@ -9,7 +9,6 @@ import {
   addAttributesToCurrentSpanAndPropagate,
   SemanticAttributes,
   ENDUSER_ALIAS,
-  ENDACCOUNT_DEFAULTWALLETID,
 } from "@services/tracing"
 
 const LnInvoicePaymentInput = new GT.Input({
@@ -26,12 +25,11 @@ const LnInvoicePaymentSendMutation = GT.Field({
   args: {
     input: { type: GT.NonNull(LnInvoicePaymentInput) },
   },
-  resolve: async (_, args, { ip, domainUser, domainAccount, logger }) =>
+  resolve: async (_, args, { ip, domainUser, logger }) =>
     addAttributesToCurrentSpanAndPropagate(
       {
         [SemanticAttributes.ENDUSER_ID]: domainUser?.id,
         [ENDUSER_ALIAS]: domainUser?.username,
-        [ENDACCOUNT_DEFAULTWALLETID]: domainAccount?.defaultWalletId,
         [SemanticAttributes.HTTP_CLIENT_IP]: ip,
       },
       async () => {

--- a/src/graphql/root/mutation/ln-invoice-payment-send.ts
+++ b/src/graphql/root/mutation/ln-invoice-payment-send.ts
@@ -9,6 +9,7 @@ import {
   addAttributesToCurrentSpanAndPropagate,
   SemanticAttributes,
   ENDUSER_ALIAS,
+  ENDACCOUNT_DEFAULTWALLETID,
 } from "@services/tracing"
 
 const LnInvoicePaymentInput = new GT.Input({
@@ -25,11 +26,12 @@ const LnInvoicePaymentSendMutation = GT.Field({
   args: {
     input: { type: GT.NonNull(LnInvoicePaymentInput) },
   },
-  resolve: async (_, args, { ip, domainUser, logger }) =>
+  resolve: async (_, args, { ip, domainUser, domainAccount, logger }) =>
     addAttributesToCurrentSpanAndPropagate(
       {
         [SemanticAttributes.ENDUSER_ID]: domainUser?.id,
         [ENDUSER_ALIAS]: domainUser?.username,
+        [ENDACCOUNT_DEFAULTWALLETID]: domainAccount?.defaultWalletId,
         [SemanticAttributes.HTTP_CLIENT_IP]: ip,
       },
       async () => {

--- a/src/graphql/root/query/me.ts
+++ b/src/graphql/root/query/me.ts
@@ -2,10 +2,12 @@ import {
   addAttributesToCurrentSpanAndPropagate,
   SemanticAttributes,
   ENDUSER_ALIAS,
+  ENDUSER_PUBLICID,
 } from "@services/tracing"
 import { GT } from "@graphql/index"
 
 import GraphQLUser from "@graphql/types/object/graphql-user"
+import getUuidByString from "uuid-by-string"
 
 const MeQuery = GT.Field({
   type: GraphQLUser,
@@ -21,6 +23,9 @@ const MeQuery = GT.Field({
     addAttributesToCurrentSpanAndPropagate(
       {
         [SemanticAttributes.ENDUSER_ID]: domainUser?.id,
+        [ENDUSER_PUBLICID]: domainUser?.id
+          ? getUuidByString(domainUser?.id)
+          : domainUser?.id,
         [ENDUSER_ALIAS]: domainAccount?.username,
         [SemanticAttributes.HTTP_CLIENT_IP]: ip,
       },

--- a/src/graphql/root/query/me.ts
+++ b/src/graphql/root/query/me.ts
@@ -2,6 +2,7 @@ import {
   addAttributesToCurrentSpanAndPropagate,
   SemanticAttributes,
   ENDUSER_ALIAS,
+  ENDACCOUNT_DEFAULTWALLETID,
 } from "@services/tracing"
 import { GT } from "@graphql/index"
 
@@ -22,6 +23,7 @@ const MeQuery = GT.Field({
       {
         [SemanticAttributes.ENDUSER_ID]: domainUser?.id,
         [ENDUSER_ALIAS]: domainAccount?.username,
+        [ENDACCOUNT_DEFAULTWALLETID]: domainAccount?.defaultWalletId,
         [SemanticAttributes.HTTP_CLIENT_IP]: ip,
       },
       () => domainUser,

--- a/src/graphql/root/query/me.ts
+++ b/src/graphql/root/query/me.ts
@@ -2,7 +2,6 @@ import {
   addAttributesToCurrentSpanAndPropagate,
   SemanticAttributes,
   ENDUSER_ALIAS,
-  ENDACCOUNT_DEFAULTWALLETID,
 } from "@services/tracing"
 import { GT } from "@graphql/index"
 
@@ -23,7 +22,6 @@ const MeQuery = GT.Field({
       {
         [SemanticAttributes.ENDUSER_ID]: domainUser?.id,
         [ENDUSER_ALIAS]: domainAccount?.username,
-        [ENDACCOUNT_DEFAULTWALLETID]: domainAccount?.defaultWalletId,
         [SemanticAttributes.HTTP_CLIENT_IP]: ip,
       },
       () => domainUser,

--- a/src/servers/graphql-old-server.ts
+++ b/src/servers/graphql-old-server.ts
@@ -32,6 +32,7 @@ import {
   addAttributesToCurrentSpanAndPropagate,
   SemanticAttributes,
   ENDUSER_ALIAS,
+  ENDACCOUNT_DEFAULTWALLETID,
 } from "@services/tracing"
 import { PriceInterval, PriceRange } from "@domain/price"
 import { LnPaymentRequestZeroAmountRequiredError } from "@domain/errors"
@@ -85,11 +86,12 @@ const translateWalletTx = (txs: WalletTransaction[]) => {
 
 const resolvers = {
   Query: {
-    me: (_, __, { uid, user, ip, domainUser }) =>
+    me: (_, __, { uid, user, ip, domainUser, domainAccount }) =>
       addAttributesToCurrentSpanAndPropagate(
         {
           [SemanticAttributes.ENDUSER_ID]: domainUser?.id,
           [ENDUSER_ALIAS]: domainUser?.username,
+          [ENDACCOUNT_DEFAULTWALLETID]: domainAccount?.defaultWalletId,
           [SemanticAttributes.HTTP_CLIENT_IP]: ip,
         },
         async () => {
@@ -308,11 +310,16 @@ const resolvers = {
         if (result instanceof Error) throw result
         return result
       },
-      payInvoice: async ({ invoice, amount, memo }, _, { ip, domainUser }) =>
+      payInvoice: async (
+        { invoice, amount, memo },
+        _,
+        { ip, domainUser, domainAccount },
+      ) =>
         addAttributesToCurrentSpanAndPropagate(
           {
             [SemanticAttributes.ENDUSER_ID]: domainUser?.id,
             [ENDUSER_ALIAS]: domainUser?.username,
+            [ENDACCOUNT_DEFAULTWALLETID]: domainAccount?.defaultWalletId,
             [SemanticAttributes.HTTP_CLIENT_IP]: ip,
           },
           async () => {

--- a/src/servers/graphql-old-server.ts
+++ b/src/servers/graphql-old-server.ts
@@ -32,7 +32,6 @@ import {
   addAttributesToCurrentSpanAndPropagate,
   SemanticAttributes,
   ENDUSER_ALIAS,
-  ENDACCOUNT_DEFAULTWALLETID,
 } from "@services/tracing"
 import { PriceInterval, PriceRange } from "@domain/price"
 import { LnPaymentRequestZeroAmountRequiredError } from "@domain/errors"
@@ -86,12 +85,11 @@ const translateWalletTx = (txs: WalletTransaction[]) => {
 
 const resolvers = {
   Query: {
-    me: (_, __, { uid, user, ip, domainUser, domainAccount }) =>
+    me: (_, __, { uid, user, ip, domainUser }) =>
       addAttributesToCurrentSpanAndPropagate(
         {
           [SemanticAttributes.ENDUSER_ID]: domainUser?.id,
           [ENDUSER_ALIAS]: domainUser?.username,
-          [ENDACCOUNT_DEFAULTWALLETID]: domainAccount?.defaultWalletId,
           [SemanticAttributes.HTTP_CLIENT_IP]: ip,
         },
         async () => {
@@ -310,16 +308,11 @@ const resolvers = {
         if (result instanceof Error) throw result
         return result
       },
-      payInvoice: async (
-        { invoice, amount, memo },
-        _,
-        { ip, domainUser, domainAccount },
-      ) =>
+      payInvoice: async ({ invoice, amount, memo }, _, { ip, domainUser }) =>
         addAttributesToCurrentSpanAndPropagate(
           {
             [SemanticAttributes.ENDUSER_ID]: domainUser?.id,
             [ENDUSER_ALIAS]: domainUser?.username,
-            [ENDACCOUNT_DEFAULTWALLETID]: domainAccount?.defaultWalletId,
             [SemanticAttributes.HTTP_CLIENT_IP]: ip,
           },
           async () => {

--- a/src/servers/graphql-old-server.ts
+++ b/src/servers/graphql-old-server.ts
@@ -32,9 +32,12 @@ import {
   addAttributesToCurrentSpanAndPropagate,
   SemanticAttributes,
   ENDUSER_ALIAS,
+  ENDUSER_PUBLICID,
 } from "@services/tracing"
 import { PriceInterval, PriceRange } from "@domain/price"
 import { LnPaymentRequestZeroAmountRequiredError } from "@domain/errors"
+
+import getUuidByString from "uuid-by-string"
 
 import { startApolloServer, isAuthenticated } from "./graphql-server"
 
@@ -89,6 +92,9 @@ const resolvers = {
       addAttributesToCurrentSpanAndPropagate(
         {
           [SemanticAttributes.ENDUSER_ID]: domainUser?.id,
+          [ENDUSER_PUBLICID]: domainUser?.id
+            ? getUuidByString(domainUser?.id)
+            : domainUser?.id,
           [ENDUSER_ALIAS]: domainUser?.username,
           [SemanticAttributes.HTTP_CLIENT_IP]: ip,
         },
@@ -312,6 +318,9 @@ const resolvers = {
         addAttributesToCurrentSpanAndPropagate(
           {
             [SemanticAttributes.ENDUSER_ID]: domainUser?.id,
+            [ENDUSER_PUBLICID]: domainUser?.id
+              ? getUuidByString(domainUser?.id)
+              : domainUser?.id,
             [ENDUSER_ALIAS]: domainUser?.username,
             [SemanticAttributes.HTTP_CLIENT_IP]: ip,
           },

--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -10,6 +10,7 @@ import {
   addAttributesToCurrentSpan,
   addAttributesToCurrentSpanAndPropagate,
   ENDUSER_ALIAS,
+  ENDUSER_PUBLICID,
   SemanticAttributes,
 } from "@services/tracing"
 import { ApolloServerPluginUsageReporting } from "apollo-server-core"
@@ -25,6 +26,7 @@ import pino from "pino"
 import PinoHttp from "pino-http"
 import { SubscriptionServer } from "subscriptions-transport-ws"
 import { v4 as uuidv4 } from "uuid"
+import getUuidByString from "uuid-by-string"
 
 import { playgroundTabs } from "../graphql/playground"
 
@@ -81,6 +83,7 @@ const sessionContext = ({
   return addAttributesToCurrentSpanAndPropagate(
     {
       [SemanticAttributes.ENDUSER_ID]: userId,
+      [ENDUSER_PUBLICID]: userId ? getUuidByString(userId) : userId,
       [SemanticAttributes.HTTP_CLIENT_IP]: ip,
     },
     async () => {

--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -9,6 +9,7 @@ import { User } from "@services/mongoose/schema"
 import {
   addAttributesToCurrentSpan,
   addAttributesToCurrentSpanAndPropagate,
+  ENDACCOUNT_DEFAULTWALLETID,
   ENDUSER_ALIAS,
   SemanticAttributes,
 } from "@services/tracing"
@@ -115,7 +116,10 @@ const sessionContext = ({
         account = loggedInAccount
       }
 
-      addAttributesToCurrentSpan({ [ENDUSER_ALIAS]: domainAccount?.username })
+      addAttributesToCurrentSpan({
+        [ENDUSER_ALIAS]: domainAccount?.username,
+        [ENDACCOUNT_DEFAULTWALLETID]: domainAccount?.defaultWalletId,
+      })
 
       return {
         logger,

--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -9,7 +9,6 @@ import { User } from "@services/mongoose/schema"
 import {
   addAttributesToCurrentSpan,
   addAttributesToCurrentSpanAndPropagate,
-  ENDACCOUNT_DEFAULTWALLETID,
   ENDUSER_ALIAS,
   SemanticAttributes,
 } from "@services/tracing"
@@ -116,10 +115,7 @@ const sessionContext = ({
         account = loggedInAccount
       }
 
-      addAttributesToCurrentSpan({
-        [ENDUSER_ALIAS]: domainAccount?.username,
-        [ENDACCOUNT_DEFAULTWALLETID]: domainAccount?.defaultWalletId,
-      })
+      addAttributesToCurrentSpan({ [ENDUSER_ALIAS]: domainAccount?.username })
 
       return {
         logger,

--- a/src/services/tracing.ts
+++ b/src/services/tracing.ts
@@ -278,3 +278,4 @@ export const addAttributesToCurrentSpanAndPropagate = <F extends () => ReturnTyp
 export { SemanticAttributes, SemanticResourceAttributes }
 
 export const ENDUSER_ALIAS = "enduser.alias"
+export const ENDUSER_PUBLICID = "enduser.publicId"

--- a/src/services/tracing.ts
+++ b/src/services/tracing.ts
@@ -278,3 +278,4 @@ export const addAttributesToCurrentSpanAndPropagate = <F extends () => ReturnTyp
 export { SemanticAttributes, SemanticResourceAttributes }
 
 export const ENDUSER_ALIAS = "enduser.alias"
+export const ENDACCOUNT_DEFAULTWALLETID = "endaccount.defaultWalletId"

--- a/src/services/tracing.ts
+++ b/src/services/tracing.ts
@@ -278,4 +278,3 @@ export const addAttributesToCurrentSpanAndPropagate = <F extends () => ReturnTyp
 export { SemanticAttributes, SemanticResourceAttributes }
 
 export const ENDUSER_ALIAS = "enduser.alias"
-export const ENDACCOUNT_DEFAULTWALLETID = "endaccount.defaultWalletId"


### PR DESCRIPTION
## Description

Add account `defaultWalletId` values alongside username values in spans. This should with querying traces help since the `walletId` is mandatory but the `username` can be unset.

**Sample trace:** [https://ui.honeycom...298f2cf](https://ui.honeycomb.io/galoy/datasets/arvin-dev/result/2HCZradDVY6/trace/xLHgf5CgnXN?span=50c82e5a7298f2cf)