### PR TITLE
fix: lnd status update in servers and integration test

### DIFF
--- a/src/servers/cron.ts
+++ b/src/servers/cron.ts
@@ -14,6 +14,7 @@ import {
   updateUsersPendingPayment,
 } from "@core/balance-sheet"
 import { SpecterWallet } from "@core/specter-wallet"
+import { activateLndHealthCheck } from "@services/lnd/health"
 
 const main = async () => {
   const mongoose = await setupMongoConnection()
@@ -59,6 +60,7 @@ const main = async () => {
 }
 
 try {
+  activateLndHealthCheck()
   main()
 } catch (err) {
   baseLogger.warn({ err }, "error in the cron job")

--- a/src/servers/exporter.ts
+++ b/src/servers/exporter.ts
@@ -7,6 +7,7 @@ import {
   getDealerWalletId,
   getFunderWalletId,
 } from "@services/ledger/accounts"
+import { activateLndHealthCheck } from "@services/lnd/health"
 import { getBosScore, lndsBalances } from "@services/lnd/utils"
 import { baseLogger } from "@services/logger"
 import { setupMongoConnection } from "@services/mongodb"
@@ -155,13 +156,14 @@ const main = async () => {
     healthzHandler({
       checkDbConnectionStatus: true,
       checkRedisStatus: false,
-      checkLndsStatus: false,
+      checkLndsStatus: true,
     }),
   )
 
   const port = process.env.PORT || 3000
   logger.info(`Server listening to ${port}, metrics exposed on /metrics endpoint`)
   await server.listen(port)
+  activateLndHealthCheck()
 }
 
 setupMongoConnection()

--- a/src/servers/graphql-admin-server.ts
+++ b/src/servers/graphql-admin-server.ts
@@ -5,6 +5,8 @@ import { and, shield } from "graphql-shield"
 import { baseLogger } from "@services/logger"
 import { setupMongoConnection } from "@services/mongodb"
 
+import { activateLndHealthCheck } from "@services/lnd/health"
+
 import { gqlAdminSchema } from "../graphql"
 
 import { startApolloServer, isAuthenticated, isEditor } from "./graphql-server"
@@ -42,6 +44,7 @@ if (require.main === module) {
   setupMongoConnection()
     .then(async () => {
       await startApolloServerForAdminSchema()
+      activateLndHealthCheck()
     })
     .catch((err) => graphqlLogger.error(err, "server error"))
 }

--- a/src/servers/trigger.ts
+++ b/src/servers/trigger.ts
@@ -257,7 +257,7 @@ const main = () => {
 
 const healthCheck = () => {
   const app = express()
-  const port = 8888
+  const port = process.env.PORT || 8888
   app.get(
     "/healthz",
     healthzHandler({

--- a/src/services/lnd/auth.ts
+++ b/src/services/lnd/auth.ts
@@ -4,22 +4,14 @@ import sortBy from "lodash.sortby"
 
 const inputs: LndParams[] = getLndParams()
 
-// is this file being imported from trigger.ts?
-// FIXME: this is a hacky workaround to get active = true
-// for params to make the tests working.
-// otherwise the tests will have to probe before being able to call lnd
-// TODO: use a mock instead.
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-const isTest = require.main!.filename.indexOf(".spec.") !== -1
-
-export const addProps = (array: LndParams[]) => {
+const addProps = (array: LndParams[]) => {
   const result: LndParamsAuthed[] = array.map((input) => {
     const socket = `${input.node}:${input.port}`
     return {
       ...input,
       socket,
       lnd: authenticatedLndGrpc({ ...input, socket }).lnd,
-      active: isTest,
+      active: false,
     }
   })
   return result

--- a/src/services/lnd/auth.ts
+++ b/src/services/lnd/auth.ts
@@ -11,8 +11,6 @@ const inputs: LndParams[] = getLndParams()
 // TODO: use a mock instead.
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const isTest = require.main!.filename.indexOf(".spec.") !== -1
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-const isTrigger = require.main!.filename.indexOf("trigger") !== -1
 
 export const addProps = (array: LndParams[]) => {
   const result: LndParamsAuthed[] = array.map((input) => {
@@ -21,12 +19,7 @@ export const addProps = (array: LndParams[]) => {
       ...input,
       socket,
       lnd: authenticatedLndGrpc({ ...input, socket }).lnd,
-
-      // FIXME: should be inactive first
-      // find a way to mock this up for jest
-      // for now only trigger is active = false at start
-      // because trigger will start listening to lnd event on lnd start/restart
-      active: isTest || !isTrigger,
+      active: isTest,
     }
   })
   return result

--- a/src/services/lnd/health.ts
+++ b/src/services/lnd/health.ts
@@ -13,12 +13,14 @@ import { params as authParams } from "./auth"
 /* eslint-disable @typescript-eslint/no-var-requires */
 const EventEmitter = require("events")
 
-const refresh_time = 10000 // ms
+const refreshTime = 10000 // ms
 
-const isUpLoop = (param) =>
+const isUpLoop = async (param) => {
+  await isUp(param)
   setInterval(async () => {
     await isUp(param)
-  }, refresh_time)
+  }, refreshTime)
+}
 
 export const isUp = async (param): Promise<void> => {
   let active = false

--- a/src/services/lnd/unauth.ts
+++ b/src/services/lnd/unauth.ts
@@ -4,22 +4,14 @@ import { getLndParams } from "@config/app"
 
 const inputs: LndParams[] = getLndParams()
 
-// is this file being imported from trigger.ts?
-// FIXME: this is a hacky workaround to get active = true
-// for params to make the tests working.
-// otherwise the tests will have to probe before being able to call lnd
-// TODO: use a mock instead.
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-const isTest = require.main!.filename.indexOf(".spec.") !== -1
-
-export const addProps = (array) =>
+const addProps = (array) =>
   array.map((input) => {
     const socket = `${input.node}:${input.port}`
     return {
       ...input,
       socket,
       lnd: unauthenticatedLndGrpc({ ...input, socket }).lnd,
-      active: isTest,
+      active: false,
     }
   })
 

--- a/src/services/lnd/unauth.ts
+++ b/src/services/lnd/unauth.ts
@@ -11,8 +11,6 @@ const inputs: LndParams[] = getLndParams()
 // TODO: use a mock instead.
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const isTest = require.main!.filename.indexOf(".spec.") !== -1
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-const isTrigger = require.main!.filename.indexOf("trigger") !== -1
 
 export const addProps = (array) =>
   array.map((input) => {
@@ -21,12 +19,7 @@ export const addProps = (array) =>
       ...input,
       socket,
       lnd: unauthenticatedLndGrpc({ ...input, socket }).lnd,
-
-      // FIXME: should be inactive first
-      // find a way to mock this up for jest
-      // for now only trigger is active = false at start
-      // because trigger will start listening to lnd event on lnd start/restart
-      active: isTest || !isTrigger,
+      active: isTest,
     }
   })
 

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -1,6 +1,18 @@
 const { redis, redisSub } = require("@services/redis")
 const { setupMongoConnection } = require("@services/mongodb")
 
+jest.mock("@services/lnd/auth", () => {
+  const module = jest.requireActual("@services/lnd/auth")
+  module.params = module.params.map((p) => ({ ...p, active: true }))
+  return module
+})
+
+jest.mock("@services/lnd/unauth", () => {
+  const module = jest.requireActual("@services/lnd/unauth")
+  module.params = module.params.map((p) => ({ ...p, active: true }))
+  return module
+})
+
 let mongoose
 
 beforeAll(async () => {


### PR DESCRIPTION
Fix lnd active param issue for servers. It should start inactive (false) and then updated the status with `activateLndHealthCheck` 

- Add `activateLndHealthCheck` to admin, exporter and cron
- Add integration test mocks to remove hacky workaround to udpate lnds statuses 
- Add PORT env config to trigger `healthz` 