### PR TITLE
fix: add earn memos as valid to the memo filter

### DIFF
--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -235,13 +235,8 @@ const shouldDisplayMemo = ({
   return isAuthorizedMemo(memo) || credit === 0 || credit >= MEMO_SHARING_SATS_THRESHOLD
 }
 
-const isAuthorizedMemo = (memo: string | undefined): boolean => {
-  if (memo && Object.keys(onboardingEarn).includes(memo)) {
-    return true
-  }
-
-  return false
-}
+const isAuthorizedMemo = (memo: string | undefined): boolean =>
+  !!memo && Object.keys(onboardingEarn).includes(memo)
 
 export const translateDescription = ({
   memoFromPayer,

--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -1,6 +1,6 @@
 import { toSats } from "@domain/bitcoin"
 import { ExtendedLedgerTransactionType, LedgerTransactionType } from "@domain/ledger"
-import { MEMO_SHARING_SATS_THRESHOLD } from "@config/app"
+import { MEMO_SHARING_SATS_THRESHOLD, onboardingEarn } from "@config/app"
 
 import { SettlementMethod, PaymentInitiationMethod } from "./tx-methods"
 import { TxStatus } from "./tx-status"
@@ -225,8 +225,18 @@ export const fromLedger = (
   }
 }
 
-const shouldDisplayMemo = (credit: number) => {
-  return credit === 0 || credit >= MEMO_SHARING_SATS_THRESHOLD
+const shouldDisplayMemo = ({
+  memo,
+  credit,
+}: {
+  memo: string | undefined
+  credit: number
+}) => {
+  return (
+    (memo && Object.keys(onboardingEarn).includes(memo)) ||
+    credit === 0 ||
+    credit >= MEMO_SHARING_SATS_THRESHOLD
+  )
 }
 
 export const translateDescription = ({
@@ -242,7 +252,7 @@ export const translateDescription = ({
   type: LedgerTransactionType
   credit: number
 }): string => {
-  if (shouldDisplayMemo(credit)) {
+  if (shouldDisplayMemo({ memo: memoFromPayer, credit })) {
     if (memoFromPayer) {
       return memoFromPayer
     }
@@ -271,7 +281,7 @@ export const translateMemo = ({
   lnMemo?: string
   credit: number
 }): string | null => {
-  if (shouldDisplayMemo(credit)) {
+  if (shouldDisplayMemo({ memo: memoFromPayer, credit })) {
     if (memoFromPayer) {
       return memoFromPayer
     }

--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -232,11 +232,15 @@ const shouldDisplayMemo = ({
   memo: string | undefined
   credit: number
 }) => {
-  return (
-    (memo && Object.keys(onboardingEarn).includes(memo)) ||
-    credit === 0 ||
-    credit >= MEMO_SHARING_SATS_THRESHOLD
-  )
+  return isAuthorizedMemo(memo) || credit === 0 || credit >= MEMO_SHARING_SATS_THRESHOLD
+}
+
+const isAuthorizedMemo = (memo: string | undefined): boolean => {
+  if (memo && Object.keys(onboardingEarn).includes(memo)) {
+    return true
+  }
+
+  return false
 }
 
 export const translateDescription = ({

--- a/test/integration/02-user-wallet/02-receive-rewards.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-rewards.spec.ts
@@ -1,10 +1,12 @@
-import { MS_PER_DAY, onboardingEarn } from "@config/app"
+import { MEMO_SHARING_SATS_THRESHOLD, MS_PER_DAY, onboardingEarn } from "@config/app"
 import find from "lodash.find"
 import difference from "lodash.difference"
 
 import { addEarn } from "@app/accounts/add-earn"
+import { getTransactionsForWalletId, intraledgerPaymentSendWalletId } from "@app/wallets"
 
 import { baseLogger } from "@services/logger"
+import { getFunderWalletId } from "@services/ledger/accounts"
 
 import { checkIsBalanced, getAndCreateUserWallet } from "test/helpers"
 import { resetSelfWalletIdLimits } from "test/helpers/rate-limit"
@@ -66,5 +68,41 @@ describe("UserWallet - addEarn", () => {
     // yet, if we do it another time, the balance should not increase,
     // because all the rewards has already been been consumed:
     await getAndVerifyRewards()
+  })
+
+  it("receives transaction with reward memo", async () => {
+    const onboardingEarnIds = Object.keys(onboardingEarn)
+    expect(onboardingEarnIds.length).toBeGreaterThanOrEqual(1)
+
+    const { result: transactionsBefore } = await getTransactionsForWalletId({
+      walletId: userWallet1.user.walletId,
+    })
+
+    let onboardingEarnId = ""
+    let txCheck: WalletTransaction | undefined
+    for (onboardingEarnId of onboardingEarnIds) {
+      txCheck = transactionsBefore?.find((tx) => tx.memo === onboardingEarnId)
+      if (!txCheck) break
+    }
+    expect(txCheck).toBeUndefined()
+
+    const amount = onboardingEarn[onboardingEarnId]
+    expect(amount).toBeLessThan(MEMO_SHARING_SATS_THRESHOLD)
+
+    const funderWalletId = await getFunderWalletId()
+    const payment = await intraledgerPaymentSendWalletId({
+      senderWalletId: funderWalletId,
+      recipientWalletId: userWallet1.user.walletId,
+      amount,
+      memo: onboardingEarnId,
+      logger: baseLogger,
+    })
+    if (payment instanceof Error) return payment
+
+    const { result: transactionsAfter } = await getTransactionsForWalletId({
+      walletId: userWallet1.user.walletId,
+    })
+    const rewardTx = transactionsAfter?.find((tx) => tx.memo === onboardingEarnId)
+    expect(rewardTx).not.toBeUndefined()
   })
 })


### PR DESCRIPTION
## Description

This includes a fix to exclude onboarding earn memos from our memo filter.

I had originally tried to implement this using "approved walletIds" (like the `funder`) that would be excluded from the filter, but it turned out that it wasn't easy to get the sender's walletId for an intraledger transaction with the info we have on any given medici transaction record without going back to the journal.