### PR TITLE
fix: graphql errors parsing from returned object for traces

### DIFF
--- a/src/services/tracing.ts
+++ b/src/services/tracing.ts
@@ -34,73 +34,74 @@ const gqlResponseHook = (span: Span, data: graphqlTypes.ExecutionResult) => {
   if (data.data) {
     gqlQueries = Object.keys(data.data)
   }
-  const query = gqlQueries[0]
-  const queryData = data.data?.[query]
-  if (!queryData) return
+  for (const query of gqlQueries) {
+    const queryData = data.data?.[query]
+    if (!queryData) continue
 
-  if (queryData.errors && queryData.errors.length > 0) {
-    span.recordException({
-      name: `graphql.${query}.execution.error`,
-      message: JSON.stringify(queryData.errors),
-    })
-    span.setStatus({
-      code: SpanStatusCode.ERROR,
-    })
-    const firstErr = queryData.errors[0]
-    if (firstErr.message != "") {
-      span.setAttribute(`graphql.${query}.error.message`, firstErr.message)
-    }
-    if (firstErr.constructor?.name) {
-      span.setAttribute(`graphql.${query}.error.type`, firstErr.constructor.name)
-    }
-    if (firstErr.path) {
-      span.setAttribute(`graphql.${query}.error.path`, firstErr.path.join("."))
-    }
-    if (firstErr.extensions?.code) {
-      span.setAttribute(`graphql.${query}.error.code`, firstErr.extensions.code)
-    }
-    if (firstErr.originalError) {
-      if (firstErr.originalError.constructor?.name) {
-        span.setAttribute(
-          `graphql.${query}.error.original.type`,
-          firstErr.originalError.constructor.name,
-        )
+    if (queryData.errors && queryData.errors.length > 0) {
+      span.recordException({
+        name: `graphql.${query}.execution.error`,
+        message: JSON.stringify(queryData.errors),
+      })
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+      })
+      const firstErr = queryData.errors[0]
+      if (firstErr.message != "") {
+        span.setAttribute(`graphql.${query}.error.message`, firstErr.message)
       }
-      if (firstErr.originalError.message != "") {
-        span.setAttribute(
-          `graphql.${query}.error.original.message`,
-          firstErr.originalError.message,
-        )
+      if (firstErr.constructor?.name) {
+        span.setAttribute(`graphql.${query}.error.type`, firstErr.constructor.name)
       }
-    }
-    queryData.errors.forEach((err, idx) => {
-      if (err.message != "") {
-        span.setAttribute(`graphql.${query}.error.${idx}.message`, err.message)
+      if (firstErr.path) {
+        span.setAttribute(`graphql.${query}.error.path`, firstErr.path.join("."))
       }
-      if (err.constructor?.name) {
-        span.setAttribute(`graphql.${query}.error.${idx}.type`, err.constructor.name)
+      if (firstErr.extensions?.code) {
+        span.setAttribute(`graphql.${query}.error.code`, firstErr.extensions.code)
       }
-      if (err.path) {
-        span.setAttribute(`graphql.${query}.error.${idx}.path`, err.path.join("."))
-      }
-      if (err.extensions?.code) {
-        span.setAttribute(`graphql.${query}.error.${idx}.code`, err.extensions.code)
-      }
-      if (err.originalError) {
-        if (err.originalError.constructor?.name != "") {
+      if (firstErr.originalError) {
+        if (firstErr.originalError.constructor?.name) {
           span.setAttribute(
-            `graphql.${query}.error.${idx}.original.type`,
-            err.originalError.constructor.name,
+            `graphql.${query}.error.original.type`,
+            firstErr.originalError.constructor.name,
           )
         }
-        if (err.originalError.message != "") {
+        if (firstErr.originalError.message != "") {
           span.setAttribute(
-            `graphql.${query}.error.${idx}.original.message`,
-            err.originalError.message,
+            `graphql.${query}.error.original.message`,
+            firstErr.originalError.message,
           )
         }
       }
-    })
+      queryData.errors.forEach((err, idx) => {
+        if (err.message != "") {
+          span.setAttribute(`graphql.${query}.error.${idx}.message`, err.message)
+        }
+        if (err.constructor?.name) {
+          span.setAttribute(`graphql.${query}.error.${idx}.type`, err.constructor.name)
+        }
+        if (err.path) {
+          span.setAttribute(`graphql.${query}.error.${idx}.path`, err.path.join("."))
+        }
+        if (err.extensions?.code) {
+          span.setAttribute(`graphql.${query}.error.${idx}.code`, err.extensions.code)
+        }
+        if (err.originalError) {
+          if (err.originalError.constructor?.name != "") {
+            span.setAttribute(
+              `graphql.${query}.error.${idx}.original.type`,
+              err.originalError.constructor.name,
+            )
+          }
+          if (err.originalError.message != "") {
+            span.setAttribute(
+              `graphql.${query}.error.${idx}.original.message`,
+              err.originalError.message,
+            )
+          }
+        }
+      })
+    }
   }
 }
 

--- a/src/services/tracing.ts
+++ b/src/services/tracing.ts
@@ -30,56 +30,72 @@ propagation.setGlobalPropagator(new W3CTraceContextPropagator())
 // FYI this hook is executed BEFORE the `formatError` hook from apollo
 // The data.errors field here may still change before being returned to the client
 const gqlResponseHook = (span: Span, data: graphqlTypes.ExecutionResult) => {
-  if (data.errors && data.errors.length > 0) {
+  let gqlQueries: string[] = []
+  if (data.data) {
+    gqlQueries = Object.keys(data.data)
+  }
+  const query = gqlQueries[0]
+  const queryData = data.data?.[query]
+  if (!queryData) return
+
+  if (queryData.errors && queryData.errors.length > 0) {
     span.recordException({
-      name: "graphql.execution.error",
-      message: JSON.stringify(data.errors),
+      name: `graphql.${query}.execution.error`,
+      message: JSON.stringify(queryData.errors),
     })
     span.setStatus({
       code: SpanStatusCode.ERROR,
     })
-    const firstErr = data.errors[0]
+    const firstErr = queryData.errors[0]
     if (firstErr.message != "") {
-      span.setAttribute("graphql.error.message", firstErr.message)
+      span.setAttribute(`graphql.${query}.error.message`, firstErr.message)
     }
-    span.setAttribute("graphql.error.type", firstErr.constructor.name)
+    if (firstErr.constructor?.name) {
+      span.setAttribute(`graphql.${query}.error.type`, firstErr.constructor.name)
+    }
     if (firstErr.path) {
-      span.setAttribute("graphql.error.path", firstErr.path.join("."))
+      span.setAttribute(`graphql.${query}.error.path`, firstErr.path.join("."))
     }
     if (firstErr.extensions?.code) {
-      span.setAttribute(`graphql.error.code`, firstErr.extensions.code)
+      span.setAttribute(`graphql.${query}.error.code`, firstErr.extensions.code)
     }
     if (firstErr.originalError) {
-      span.setAttribute(
-        `graphql.error.original.type`,
-        firstErr.originalError.constructor.name,
-      )
+      if (firstErr.originalError.constructor?.name) {
+        span.setAttribute(
+          `graphql.${query}.error.original.type`,
+          firstErr.originalError.constructor.name,
+        )
+      }
       if (firstErr.originalError.message != "") {
         span.setAttribute(
-          `graphql.error.original.message`,
+          `graphql.${query}.error.original.message`,
           firstErr.originalError.message,
         )
       }
     }
-    data.errors.forEach((err, idx) => {
+    queryData.errors.forEach((err, idx) => {
       if (err.message != "") {
-        span.setAttribute(`graphql.error.${idx}.message`, err.message)
+        span.setAttribute(`graphql.${query}.error.${idx}.message`, err.message)
       }
-      span.setAttribute(`graphql.error.${idx}.type`, err.constructor.name)
+      if (err.constructor?.name) {
+        span.setAttribute(`graphql.${query}.error.${idx}.type`, err.constructor.name)
+      }
       if (err.path) {
-        span.setAttribute(`graphql.error.${idx}.path`, err.path.join("."))
+        span.setAttribute(`graphql.${query}.error.${idx}.path`, err.path.join("."))
       }
       if (err.extensions?.code) {
-        span.setAttribute(`graphql.error.${idx}.code`, err.extensions.code)
+        span.setAttribute(`graphql.${query}.error.${idx}.code`, err.extensions.code)
       }
       if (err.originalError) {
-        span.setAttribute(
-          `graphql.error.${idx}.original.type`,
-          err.originalError.constructor.name,
-        )
+        if (err.originalError.constructor?.name != "") {
+          span.setAttribute(
+            `graphql.${query}.error.${idx}.original.type`,
+            err.originalError.constructor.name,
+          )
+        }
         if (err.originalError.message != "") {
           span.setAttribute(
-            `graphql.error.${idx}.original.message`,
+            `graphql.${query}.error.${idx}.original.message`,
             err.originalError.message,
           )
         }


### PR DESCRIPTION
## Description

This fixes the extraction of errors from graphql query returns with `200 OK` status. It gets the `errors` object from the right layer of nesting and adds the ability to iterate over multiple sub-queries in a single query.

To observe changes:
- trace before: [https://ui.honeycom...47f8](https://ui.honeycomb.io/galoy/datasets/arvin-dev/result/sS6itB7yKfX/trace/d11y3EqoxDT?span=48c9af5f7c6a47f8)
- trace after: [https://ui.honeycom...eba8](https://ui.honeycomb.io/galoy/datasets/arvin-dev/result/y8881esnLSw/trace/cYbzQcFe2jS?span=020cbc96d4fdeba8)