### PR TITLE
fix: remove null values from business map query

### DIFF
--- a/src/servers/graphql-old-server.ts
+++ b/src/servers/graphql-old-server.ts
@@ -204,8 +204,8 @@ const resolvers = {
       // TODO: caching
       const users = await User.find(
         {
-          title: { $exists: true },
-          coordinates: { $exists: true },
+          title: { $exists: true, $ne: null },
+          coordinates: { $exists: true, $ne: null },
         },
         { username: 1, title: 1, coordinates: 1 },
       )

--- a/src/services/mongoose/accounts.ts
+++ b/src/services/mongoose/accounts.ts
@@ -85,8 +85,8 @@ export const AccountsRepository = (): IAccountsRepository => {
     try {
       const accounts: UserType[] = await User.find(
         {
-          title: { $exists: true },
-          coordinates: { $exists: true },
+          title: { $exists: true, $ne: null },
+          coordinates: { $exists: true, $ne: null },
         },
         { username: 1, title: 1, coordinates: 1 },
       )


### PR DESCRIPTION
Fix a production issue that is crashing the app in the map view.

We should investigate a bit more about why we have some users with null values in title and/or coordinates