### PR TITLE
feat: make playgroundUrl configurable

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -152,6 +152,7 @@ onChainWallet:
 
 apollo:
   playground: true
+  playgroundUrl: "https://api.staging.galoy.io/graphql"
 
 twoFA:
   threshold: 300000 # sats

--- a/src/core/types.d.ts
+++ b/src/core/types.d.ts
@@ -48,6 +48,7 @@ type IpConfig = {
 
 type ApolloConfig = {
   playground: boolean
+  playgroundUrl: string
 }
 
 type TwoFAConfig = {

--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -157,7 +157,7 @@ export const startApolloServer = async ({
           settings: { "schema.polling.enable": false },
           tabs: [
             {
-              endpoint: "https://api.staging.galoy.io/graphql",
+              endpoint: apolloConfig.playgroundUrl,
               ...playgroundTabs.default,
             },
           ],


### PR DESCRIPTION
In client environments that expose the playground the url is pointing to our staging instead of the environment its deployed too.