### PR TITLE
chore: better user feedback when providing a bad phone number

### DIFF
--- a/src/domain/phone-provider/errors.ts
+++ b/src/domain/phone-provider/errors.ts
@@ -2,4 +2,5 @@ export class PhoneProviderServiceError extends Error {
   name = this.constructor.name
 }
 
+export class InvalidPhoneNumberPhoneProviderError extends PhoneProviderServiceError {}
 export class UnknownPhoneProviderServiceError extends PhoneProviderServiceError {}

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -105,6 +105,10 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       message = "Invoice must be a zero-amount invoice"
       return new ValidationInternalError({ message, logger: baseLogger })
 
+    case "InvalidPhoneNumberPhoneProviderError":
+      message = "Phone number is not a valid phone number"
+      return new ValidationInternalError({ message, logger: baseLogger })
+
     case "InvoiceCreateRateLimiterExceededError":
       message = "Too many invoices creation, please wait for a while and try again."
       return new TooManyRequestError({ message, logger: baseLogger })

--- a/src/services/twilio.ts
+++ b/src/services/twilio.ts
@@ -1,5 +1,8 @@
 import { getTwilioConfig } from "@config/app"
-import { UnknownPhoneProviderServiceError } from "@domain/phone-provider"
+import {
+  InvalidPhoneNumberPhoneProviderError,
+  UnknownPhoneProviderServiceError,
+} from "@domain/phone-provider"
 import { baseLogger } from "@services/logger"
 import twilio from "twilio"
 
@@ -16,6 +19,9 @@ export const TwilioClient = (): IPhoneProviderService => {
       })
     } catch (err) {
       logger.error({ err }, "impossible to send text")
+      if (err.message.includes("not a valid phone number")) {
+        return new InvalidPhoneNumberPhoneProviderError(err)
+      }
       return new UnknownPhoneProviderServiceError(err)
     }
 


### PR DESCRIPTION
Currently the response when requesting a phone code for a bad phone number is:
```
{
  "errors": [
    {
      "message": "Unknown error occurred (code: UnknownPhoneProviderServiceError)",
      "code": "UNKNOWN_CLIENT_ERROR"
    }
  ],
  "data": null
}
```
from the log output I can see that twilio is returning a useful error message:
```
"err":{"type":"RestException","message":"The 'To' number +123456 is not a valid phone number."
```

So I've added some translation to return this to the user.