### PR TITLE
fix(tracing): set span error event only for top-level grapqhl errors

### DIFF
--- a/src/graphql/root/mutation/user-quiz-question-update-completed.ts
+++ b/src/graphql/root/mutation/user-quiz-question-update-completed.ts
@@ -3,6 +3,11 @@ import { mapError } from "@graphql/error-map"
 import { GT } from "@graphql/index"
 
 import UserQuizQuestionUpdateCompletedPayload from "@graphql/types/payload/user-quiz-question-update-completed"
+import {
+  addAttributesToCurrentSpanAndPropagate,
+  SemanticAttributes,
+  ENDUSER_ALIAS,
+} from "@services/tracing"
 
 const UserQuizQuestionUpdateCompletedInput = new GT.Input({
   name: "UserQuizQuestionUpdateCompletedInput",
@@ -19,28 +24,39 @@ const UserQuizQuestionUpdateCompletedMutation = GT.Field({
   resolve: async (
     _,
     args,
-    { domainAccount, logger }: { domainAccount: Account; logger: Logger },
-  ) => {
-    const { id } = args.input
-
-    const question = await Accounts.addEarn({
-      quizQuestionId: id,
-      accountId: domainAccount.id,
+    {
+      domainUser,
+      domainAccount,
       logger,
-    })
-    if (question instanceof Error) {
-      const appErr = mapError(question)
-      return { errors: [{ message: appErr.message }] }
-    }
-
-    return {
-      errors: [],
-      userQuizQuestion: {
-        question,
-        completed: true,
+    }: { domainUser: User; domainAccount: Account; logger: Logger },
+  ) =>
+    addAttributesToCurrentSpanAndPropagate(
+      {
+        [SemanticAttributes.ENDUSER_ID]: domainUser.id,
+        [ENDUSER_ALIAS]: domainAccount.username,
       },
-    }
-  },
+      async () => {
+        const { id } = args.input
+
+        const question = await Accounts.addEarn({
+          quizQuestionId: id,
+          accountId: domainAccount.id,
+          logger,
+        })
+        if (question instanceof Error) {
+          const appErr = mapError(question)
+          return { errors: [{ message: appErr.message }] }
+        }
+
+        return {
+          errors: [],
+          userQuizQuestion: {
+            question,
+            completed: true,
+          },
+        }
+      },
+    ),
 })
 
 export default UserQuizQuestionUpdateCompletedMutation

--- a/src/services/tracing.ts
+++ b/src/services/tracing.ts
@@ -34,7 +34,9 @@ const gqlResponseHook = (span: Span, data: graphqlTypes.ExecutionResult) => {
   let isTopLevelErrorSet = false
 
   if (data.errors && data.errors.length > 0) {
-    recordGqlErrors({ errors: data.errors, span, subPathName: "" })
+    const args = { errors: data.errors, span, subPathName: "" }
+    triggerGqlErrorSpanEvent(args)
+    recordGqlErrors(args)
     isTopLevelErrorSet = true
   }
 
@@ -47,27 +49,25 @@ const gqlResponseHook = (span: Span, data: graphqlTypes.ExecutionResult) => {
     if (!nestedObjData) continue
 
     if (nestedObjData.errors && nestedObjData.errors.length > 0) {
+      const errors = nestedObjData.errors
       if (!isTopLevelErrorSet) {
-        recordFirstGqlError({ errors: nestedObjData.errors, span, subPathName: "" })
+        const args = { errors, span, subPathName: "" }
+        triggerGqlErrorSpanEvent(args)
+        recordFirstGqlError(args)
         isTopLevelErrorSet = true
       }
-      recordGqlErrors({ errors: nestedObjData.errors, span, subPathName: nestedObj })
+
+      recordGqlErrors({ errors, span, subPathName: nestedObj })
     }
   }
 }
 
-const recordFirstGqlError = ({ errors, span, subPathName }) => {
-  const configuredSpan = setupGqlErrorSpan({ errors, span, subPathName })
-  setAttributesFirstGqlError({ errors, span: configuredSpan, subPathName })
+const recordGqlErrors = (args) => {
+  recordFirstGqlError(args)
+  recordAllGqlErrorsByIndex(args)
 }
 
-const recordGqlErrors = ({ errors, span, subPathName }) => {
-  const configuredSpan = setupGqlErrorSpan({ errors, span, subPathName })
-  setAttributesFirstGqlError({ errors, span: configuredSpan, subPathName })
-  setAttributesAllGqlErrorsByIndex({ errors, span: configuredSpan, subPathName })
-}
-
-const setupGqlErrorSpan = ({ errors, span, subPathName }) => {
+const triggerGqlErrorSpanEvent = ({ errors, span, subPathName }) => {
   const subPath = subPathName ? `${subPathName}.` : ""
 
   span.recordException({
@@ -81,7 +81,7 @@ const setupGqlErrorSpan = ({ errors, span, subPathName }) => {
   return span
 }
 
-const setAttributesFirstGqlError = ({ errors, span, subPathName }) => {
+const recordFirstGqlError = ({ errors, span, subPathName }) => {
   const subPath = subPathName ? `${subPathName}.` : ""
 
   const firstErr = errors[0]
@@ -113,7 +113,7 @@ const setAttributesFirstGqlError = ({ errors, span, subPathName }) => {
   }
 }
 
-const setAttributesAllGqlErrorsByIndex = ({ errors, span, subPathName }) => {
+const recordAllGqlErrorsByIndex = ({ errors, span, subPathName }) => {
   const subPath = subPathName ? `${subPathName}.` : ""
 
   errors.forEach((err, idx) => {


### PR DESCRIPTION
## Description

This PR builds on the changes from #897 and #901.

Errors should only be marked as an `error` in honeycomb if they're system-level and at the top level of the response return on any graphql request. The errors nested within selection sets are usually considered as user errors and can be recorded in honeycomb but shouldn't be set as span error events.

This change returns us back to original state of these changes except with greater visibility into selection-set-level events at the span level only.

- **Sample trace:** [https://ui.honeycom...52f0](https://ui.honeycomb.io/galoy/datasets/arvin-dev/result/fhbVFoJTUA8/trace/HSziTJtaYQc?span=fb9f0c0b545a52f0)

### To improve in future

We currently still have system-level events that can be recorded at the user-level (selection set) level. We should filter for these and either:
1. Leave them at the selection set level, but add error span events for them
2. Throw them appropriately within resolvers so that they end up in the top level event