### PR TITLE
feat: add env port config to v2 and admin servers

### DIFF
--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -14,6 +14,9 @@ export class ConfigError extends Error {
   name = this.constructor.name
 }
 
+export const GALOY_API_PORT = process.env.GALOY_API_PORT || 4002
+export const GALOY_ADMIN_PORT = process.env.GALOY_ADMIN_PORT || 4001
+
 const jwtSecret = process.env.JWT_SECRET
 if (!jwtSecret) {
   throw new ConfigError("missing JWT_SECRET")

--- a/src/servers/graphql-admin-server.ts
+++ b/src/servers/graphql-admin-server.ts
@@ -7,6 +7,8 @@ import { setupMongoConnection } from "@services/mongodb"
 
 import { activateLndHealthCheck } from "@services/lnd/health"
 
+import { GALOY_ADMIN_PORT } from "@config/app"
+
 import { gqlAdminSchema } from "../graphql"
 
 import { startApolloServer, isAuthenticated, isEditor } from "./graphql-server"
@@ -37,7 +39,7 @@ export async function startApolloServerForAdminSchema() {
   )
 
   const schema = applyMiddleware(gqlAdminSchema, permissions)
-  return startApolloServer({ schema, port: 4001 })
+  return startApolloServer({ schema, port: GALOY_ADMIN_PORT })
 }
 
 if (require.main === module) {

--- a/src/servers/graphql-main-server.ts
+++ b/src/servers/graphql-main-server.ts
@@ -6,6 +6,8 @@ import { setupMongoConnection } from "@services/mongodb"
 import { activateLndHealthCheck } from "@services/lnd/health"
 import { baseLogger } from "@services/logger"
 
+import { GALOY_API_PORT } from "@config/app"
+
 import { gqlMainSchema } from "../graphql"
 
 import {
@@ -63,7 +65,11 @@ export async function startApolloServerForCoreSchema() {
   )
 
   const schema = applyMiddleware(gqlMainSchema, permissions, walletIdMiddleware)
-  return startApolloServer({ schema, port: 4002, startSubscriptionServer: true })
+  return startApolloServer({
+    schema,
+    port: GALOY_API_PORT,
+    startSubscriptionServer: true,
+  })
 }
 
 if (require.main === module) {


### PR DESCRIPTION
Add env PORT configs to allow port update in api and admin servers (this is not an issue in our infra but may be useful in dev environments)

reported by @fiatjaf 