### PR TITLE
refactor: separate PaymentSecret type into 3 types

### DIFF
--- a/src/domain/bitcoin/index.ts
+++ b/src/domain/bitcoin/index.ts
@@ -38,6 +38,9 @@ export const checkedToTargetConfs = (
   return toTargetConfs(confs)
 }
 
+// Check for hexadecimal (case insensitive) 64-char SHA-256 hash
+export const isSha256Hash = (value: string): boolean => !!value.match(/^[a-f0-9]{64}$/i)
+
 export const BtcNetwork = {
   mainnet: "mainnet",
   testnet: "testnet",

--- a/src/domain/bitcoin/lightning/index.types.d.ts
+++ b/src/domain/bitcoin/lightning/index.types.d.ts
@@ -6,7 +6,9 @@ type RouteNotFoundError = import("./errors").RouteNotFoundError
 type InvoiceExpiration = Date & { readonly brand: unique symbol }
 type EncodedPaymentRequest = string & { readonly brand: unique symbol }
 type PaymentHash = string & { readonly brand: unique symbol }
-type PaymentSecret = string & { readonly brand: unique symbol }
+type SecretPreImage = string & { readonly brand: unique symbol }
+type RevealedPreImage = string & { readonly brand: unique symbol }
+type PaymentIdentifyingSecret = string & { readonly brand: unique symbol }
 type FeatureBit = number & { readonly brand: unique symbol }
 type FeatureType = string & { readonly brand: unique symbol }
 
@@ -41,7 +43,7 @@ type LnInvoiceLookup = {
   readonly isSettled: boolean
   readonly received: Satoshis
   readonly request: string | undefined
-  readonly secret: PaymentSecret
+  readonly secretPreImage: SecretPreImage
 }
 
 type LnPaymentLookup = {
@@ -51,7 +53,7 @@ type LnPaymentLookup = {
   readonly createdAt: Date
   readonly confirmedAt: Date | undefined
   readonly amount: Satoshis
-  readonly secret: PaymentSecret
+  readonly revealedPreImage: RevealedPreImage
   readonly request: string | undefined
   readonly destination: Pubkey
 }
@@ -65,7 +67,7 @@ type LnInvoice = {
   readonly cltvDelta: number | null
   readonly amount: Satoshis | null
   readonly routeHints: Hop[][]
-  readonly paymentSecret: PaymentSecret | null
+  readonly paymentSecret: PaymentIdentifyingSecret | null
   readonly features: LnInvoiceFeature[]
 }
 

--- a/src/domain/bitcoin/lightning/ln-invoice.ts
+++ b/src/domain/bitcoin/lightning/ln-invoice.ts
@@ -22,7 +22,7 @@ export const decodeInvoice = (
   if (!decodedInvoice.payment) {
     return new LnInvoiceMissingPaymentSecretError()
   }
-  const paymentSecret: PaymentSecret = decodedInvoice.payment
+  const paymentSecret: PaymentIdentifyingSecret = decodedInvoice.payment
   const amount: Satoshis | null = decodedInvoice.tokens
     ? toSats(decodedInvoice.tokens)
     : null

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -41,7 +41,7 @@ type SettlementViaIntraledger = {
 
 type SettlementViaLn = {
   readonly type: SettlementMethod["Lightning"]
-  paymentSecret: PaymentSecret | null
+  revealedPreImage: RevealedPreImage | null
 }
 
 type SettlementViaOnChain = {

--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -186,7 +186,7 @@ export const fromLedger = (
             },
             settlementVia: {
               type: SettlementMethod.Lightning,
-              paymentSecret: null,
+              revealedPreImage: null,
             },
           }
           return walletTransaction

--- a/src/graphql/admin/schema.graphql
+++ b/src/graphql/admin/schema.graphql
@@ -108,6 +108,8 @@ type LightningPayment {
   status: LnPaymentStatus
 }
 
+scalar LnPaymentPreImage
+
 """
 BOLT11 lightning invoice payment request with the amount included
 """
@@ -197,6 +199,10 @@ type SettlementViaIntraLedger {
 
 type SettlementViaLn {
   paymentSecret: LnPaymentSecret
+    @deprecated(
+      reason: "Shifting property to 'preImage' to improve granularity of the LnPaymentSecret type"
+    )
+  preImage: LnPaymentPreImage
 }
 
 type SettlementViaOnChain {

--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -266,6 +266,8 @@ input LnNoAmountInvoicePaymentInput {
   walletId: WalletId!
 }
 
+scalar LnPaymentPreImage
+
 """
 BOLT11 lightning invoice payment request with the amount included
 """
@@ -554,6 +556,10 @@ type SettlementViaIntraLedger {
 
 type SettlementViaLn {
   paymentSecret: LnPaymentSecret
+    @deprecated(
+      reason: "Shifting property to 'preImage' to improve granularity of the LnPaymentSecret type"
+    )
+  preImage: LnPaymentPreImage
 }
 
 type SettlementViaOnChain {

--- a/src/graphql/types/abstract/settlement-via.ts
+++ b/src/graphql/types/abstract/settlement-via.ts
@@ -7,6 +7,7 @@ import { SettlementMethod } from "@domain/wallets"
 import WalletId from "../scalar/wallet-id"
 import Username from "../scalar/username"
 import OnChainTxHash from "../scalar/onchain-tx-hash"
+import LnPaymentPreImage from "../scalar/ln-payment-preimage"
 import LnPaymentSecret from "../scalar/ln-payment-secret"
 
 const SettlementViaIntraLedger = new GT.Object({
@@ -26,10 +27,17 @@ const SettlementViaIntraLedger = new GT.Object({
 
 const SettlementViaLn = new GT.Object({
   name: "SettlementViaLn",
-  isTypeOf: (source) => source.type === SettlementMethod.Lightning,
+  isTypeOf: (source: SettlementViaLn) => source.type === SettlementMethod.Lightning,
   fields: () => ({
     paymentSecret: {
       type: LnPaymentSecret,
+      resolve: (source: SettlementViaLn) => source.revealedPreImage,
+      deprecationReason:
+        "Shifting property to 'preImage' to improve granularity of the LnPaymentSecret type",
+    },
+    preImage: {
+      type: LnPaymentPreImage,
+      resolve: (source: SettlementViaLn) => source.revealedPreImage,
     },
   }),
 })

--- a/src/graphql/types/scalar/ln-payment-preimage.ts
+++ b/src/graphql/types/scalar/ln-payment-preimage.ts
@@ -1,0 +1,25 @@
+import { GT } from "@graphql/index"
+import { UserInputError } from "apollo-server-errors"
+
+const LnPaymentPreImage = new GT.Scalar({
+  name: "LnPaymentPreImage",
+  parseValue(value) {
+    return validLnPaymentPreImage(value)
+  },
+  parseLiteral(ast) {
+    if (ast.kind === GT.Kind.STRING) {
+      return validLnPaymentPreImage(ast.value)
+    }
+    return new UserInputError("Invalid type for LnPaymentPreImage")
+  },
+})
+
+function validLnPaymentPreImage(value) {
+  // TODO: verify/improve
+  if (value.match(/^[A-Fa-f0-9]{64}$/)) {
+    return value
+  }
+  return new UserInputError("Invalid value for LnPaymentPreImage")
+}
+
+export default LnPaymentPreImage

--- a/src/graphql/types/scalar/ln-payment-preimage.ts
+++ b/src/graphql/types/scalar/ln-payment-preimage.ts
@@ -1,3 +1,4 @@
+import { isSha256Hash } from "@domain/bitcoin"
 import { GT } from "@graphql/index"
 import { UserInputError } from "apollo-server-errors"
 
@@ -15,11 +16,9 @@ const LnPaymentPreImage = new GT.Scalar({
 })
 
 function validLnPaymentPreImage(value) {
-  // TODO: verify/improve
-  if (value.match(/^[A-Fa-f0-9]{64}$/)) {
-    return value
-  }
-  return new UserInputError("Invalid value for LnPaymentPreImage")
+  return isSha256Hash(value)
+    ? value
+    : new UserInputError("Invalid value for LnPaymentPreImage")
 }
 
 export default LnPaymentPreImage

--- a/src/graphql/types/scalar/ln-payment-secret.ts
+++ b/src/graphql/types/scalar/ln-payment-secret.ts
@@ -1,3 +1,4 @@
+import { isSha256Hash } from "@domain/bitcoin"
 import { GT } from "@graphql/index"
 import { UserInputError } from "apollo-server-errors"
 
@@ -15,11 +16,9 @@ const LnPaymentSecret = new GT.Scalar({
 })
 
 function validLnPaymentSecret(value) {
-  // TODO: verify/improve
-  if (value.match(/^[A-Fa-f0-9]{64}$/)) {
-    return value
-  }
-  return new UserInputError("Invalid value for LnPaymentSecret")
+  return isSha256Hash(value)
+    ? value
+    : new UserInputError("Invalid value for LnPaymentSecret")
 }
 
 export default LnPaymentSecret

--- a/src/graphql/types/scalar/onchain-tx-hash.ts
+++ b/src/graphql/types/scalar/onchain-tx-hash.ts
@@ -1,3 +1,4 @@
+import { isSha256Hash } from "@domain/bitcoin"
 import { GT } from "@graphql/index"
 import { UserInputError } from "apollo-server-errors"
 
@@ -15,11 +16,9 @@ const OnChainTxHash = new GT.Scalar({
 })
 
 function validOnChainTxHash(value) {
-  // TODO: verify/improve
-  if (value.match(/^[a-f0-9]{64}$/i)) {
-    return value
-  }
-  return new UserInputError("Invaild value for OnChainTxHash")
+  return isSha256Hash(value)
+    ? value
+    : new UserInputError("Invalid value for OnChainTxHash")
 }
 
 export default OnChainTxHash

--- a/src/graphql/types/scalar/payment-hash.ts
+++ b/src/graphql/types/scalar/payment-hash.ts
@@ -1,3 +1,4 @@
+import { isSha256Hash } from "@domain/bitcoin"
 import { GT } from "@graphql/index"
 import { UserInputError } from "apollo-server-errors"
 
@@ -15,11 +16,7 @@ const PaymentHash = new GT.Scalar({
 })
 
 function validPaymentHash(value) {
-  // TODO: verify/improve
-  if (value.match(/^[a-f0-9]{64}$/i)) {
-    return value
-  }
-  return new UserInputError("Invaild value for PaymentHash")
+  return isSha256Hash(value) ? value : new UserInputError("Invalid value for PaymentHash")
 }
 
 export default PaymentHash

--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -223,7 +223,7 @@ export const LndService = (): ILightningService | LightningServiceError => {
         isSettled: !!invoice.is_confirmed,
         received: toSats(invoice.received),
         request: invoice.request,
-        secret: invoice.secret as PaymentSecret,
+        secretPreImage: invoice.secret as SecretPreImage,
       }
     } catch (err) {
       const errDetails = parseLndErrorDetails(err)
@@ -441,7 +441,7 @@ const lookupPaymentByPubkeyAndHash = async ({
       destination: "" as Pubkey,
       roundedUpFee: toSats(0),
       milliSatsAmount: toMilliSatsFromNumber(0),
-      secret: "" as PaymentSecret,
+      revealedPreImage: "" as RevealedPreImage,
       request: undefined,
       status,
     }
@@ -455,7 +455,7 @@ const lookupPaymentByPubkeyAndHash = async ({
         request: payment.request,
         roundedUpFee: toSats(payment.safe_fee),
         milliSatsAmount: toMilliSatsFromString(payment.mtokens),
-        secret: payment.secret as PaymentSecret,
+        revealedPreImage: payment.secret as RevealedPreImage,
         status,
       })
     }

--- a/test/unit/domain/wallet-invoices/wallet-invoice-factory.spec.ts
+++ b/test/unit/domain/wallet-invoices/wallet-invoice-factory.spec.ts
@@ -12,7 +12,7 @@ describe("wallet invoice factory methods", () => {
     const registeredInvoice: RegisteredInvoice = {
       invoice: {
         paymentHash: "paymentHash" as PaymentHash,
-        paymentSecret: "paymentSecret" as PaymentSecret,
+        paymentSecret: "paymentSecret" as PaymentIdentifyingSecret,
         paymentRequest: "paymentRequest" as EncodedPaymentRequest,
         routeHints: [],
         cltvDelta: null,
@@ -40,7 +40,7 @@ describe("wallet invoice factory methods", () => {
     const registeredInvoice = {
       invoice: {
         paymentHash: "paymentHash" as PaymentHash,
-        paymentSecret: "paymentSecret" as PaymentSecret,
+        paymentSecret: "paymentSecret" as PaymentIdentifyingSecret,
         paymentRequest: "paymentRequest" as EncodedPaymentRequest,
         routeHints: [],
         cltvDelta: null,

--- a/test/unit/domain/wallets/tx-history.spec.ts
+++ b/test/unit/domain/wallets/tx-history.spec.ts
@@ -104,7 +104,7 @@ describe("WalletTransactionHistory.fromLedger", () => {
         memo: "SomeMemo",
         settlementVia: {
           type: SettlementMethod.Lightning,
-          paymentSecret: null,
+          revealedPreImage: null,
         },
         settlementAmount,
         settlementFee: toSats(0),


### PR DESCRIPTION
## Description

This PR is to fix two wrongly conflated concepts into the single `PaymentSecret` type.

### Background
There are two types of secrets associated with payment requests:
- payment identifying secret (included in encoded request)
- preimage (stored locally in lnd db)

We need to decide how to name these within our domain, and how to handle some considerations around the preimage.

#### Preimage
In the simplest use-case, a preimage is either generated if we are the recipient or received against payment if we are the sender.

- for preimages that we generate, this should never be shared/revealed in our domain code before the given invoice it is associated with is paid

- for preimages that we receive, this can be revealed since it acts as a proof-of-payment for the payment sent

## ~Feedback required~

1. ~[Two new types](https://github.com/GaloyMoney/galoy/pull/906/files#diff-da98a1543d9a0ee6bbbc2bd61e7c2b5800683f2daf2c6d6044ee77297d7a8fc3R9) have been created to represent preimages that are safe to share and ones that are not. Does this approach of having two preimage types make sense?~ ✅ 

2. ~We've had to clean up this conflation at the GraphQL level too which would mean [one small change](https://github.com/GaloyMoney/galoy/pull/906/files#diff-c4f4521cdf4877b970c28bba5e1258f07252e75f47ba97f5515cc4ae303bbc40R31) to our API. Are the changes I made here ok (breaking changes) or should they be done in some other way?~ **(see [comment](https://github.com/GaloyMoney/galoy/pull/906#issuecomment-1007999011))**

## Open `TODO`s
- [x]  deprecate `paymentSecret` field in gql instead of deleting it
