### PR TITLE
feat: add build information to global query

### DIFF
--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -92,6 +92,14 @@ export const USER_ACTIVENESS_MONTHLY_VOLUME_THRESHOLD = toSats(
 
 export const getGaloyInstanceName = (): string => yamlConfig.name
 
+export const getGaloyBuildInformation = () => {
+  return {
+    commitHash: process.env.COMMITHASH,
+    buildTime: process.env.BUILDTIME,
+    helmRevision: process.env.HELMREVISION,
+  }
+}
+
 export const getGeetestConfig = () => {
   const config = {
     id: process.env.GEETEST_ID,

--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -73,6 +73,12 @@ type BTCWallet implements Wallet {
   walletCurrency: WalletCurrency!
 }
 
+type BuildInformation {
+  buildTime: Timestamp
+  commitHash: String
+  helmRevision: Int
+}
+
 type CaptchaCreateChallengePayload {
   errors: [Error!]!
   result: CaptchaCreateChallengeResult
@@ -130,6 +136,8 @@ enum ExchangeCurrencyUnit {
 Provides global settings for the application which might have an impact for the user.
 """
 type Globals {
+  buildInformation: BuildInformation!
+
   """
   A list of public keys for the running lightning nodes.
   This can be used to know if an invoice belongs to one of our nodes.

--- a/src/graphql/root/query/globals.ts
+++ b/src/graphql/root/query/globals.ts
@@ -1,3 +1,4 @@
+import { getGaloyBuildInformation } from "@config/app"
 import { GT } from "@graphql/index"
 import Globals from "@graphql/types/object/globals"
 import { getActiveOnchainLnd } from "@services/lnd/utils"
@@ -8,6 +9,7 @@ const GlobalsQuery = GT.Field({
     const { pubkey } = getActiveOnchainLnd()
     return {
       nodesIds: [pubkey],
+      buildInformation: getGaloyBuildInformation(),
     }
   },
 })

--- a/src/graphql/types/object/build-information.ts
+++ b/src/graphql/types/object/build-information.ts
@@ -1,0 +1,13 @@
+import { GT } from "@graphql/index"
+import Timestamp from "@graphql/types/scalar/timestamp"
+
+const BuildInformation = new GT.Object({
+  name: "BuildInformation",
+  fields: () => ({
+    commitHash: { type: GT.String },
+    buildTime: { type: Timestamp },
+    helmRevision: { type: GT.Int },
+  }),
+})
+
+export default BuildInformation

--- a/src/graphql/types/object/globals.ts
+++ b/src/graphql/types/object/globals.ts
@@ -1,6 +1,8 @@
 import dedent from "dedent"
 import { GT } from "@graphql/index"
 
+import BuildInformation from "./build-information"
+
 const Globals = new GT.Object({
   name: "Globals",
   description:
@@ -11,6 +13,7 @@ const Globals = new GT.Object({
       description: dedent`A list of public keys for the running lightning nodes.
         This can be used to know if an invoice belongs to one of our nodes.`,
     },
+    buildInformation: { type: GT.NonNull(BuildInformation) },
     // TODO: include GlobalSettings
   }),
 })


### PR DESCRIPTION
Add build information to global query

### how to test:
#### Query
```
query {
  globals {
    nodesIds
    buildInformation {
      commitHash
      buildTime
      helmRevision
    }
  }
}
```
you have to setup `COMMITHASH`, `BUILDTIME` and `HELMREVISION` as env variables