### PR TITLE
feat: dedicated migration image

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -14,4 +14,4 @@ jobs:
     - uses: actions/setup-node@v2
     - run: yarn install
     - name: Run integration tests
-      run: docker compose up -d && make integration-in-ci
+      run: docker compose build && docker compose up -d && make integration-in-ci

--- a/Dockerfile-migrate
+++ b/Dockerfile-migrate
@@ -1,0 +1,36 @@
+FROM node:16-alpine AS BUILD_IMAGE
+
+WORKDIR /app
+
+RUN apk update && apk add git
+
+COPY ./*.json ./yarn.lock ./
+
+RUN yarn install --frozen-lockfile
+
+COPY ./src ./src
+COPY ./test ./test
+
+RUN yarn build
+
+FROM node:16-alpine
+COPY --from=BUILD_IMAGE /app/lib /app/lib
+COPY --from=BUILD_IMAGE /app/node_modules /app/node_modules
+
+WORKDIR /app
+COPY ./*.js ./default.yaml ./package.json ./tsconfig.json ./yarn.lock ./.env ./
+
+### debug only
+COPY --from=BUILD_IMAGE /app/src /app/src
+COPY --from=BUILD_IMAGE /app/test /app/test
+COPY ./junit.xml ./
+###
+
+USER 1000
+
+ARG BUILDTIME
+ARG COMMITHASH
+ENV BUILDTIME ${BUILDTIME}
+ENV COMMITHASH ${COMMITHASH}
+
+CMD ["node_modules/.bin/migrate-mongo", "up", "-f", "src/migrations/migrate-mongo-config.js"]

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ integration:
 reset-integration: reset-deps integration
 
 integration-in-ci:
+	docker compose run galoy-migrate
 	. ./.envrc && \
 		NODE_ENV=test LOGLEVEL=error $(BIN_DIR)/jest --config ./test/jest-integration.config.js --bail --runInBand --ci --reporters=default --reporters=jest-junit && \
 		yarn build && \

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -12,6 +12,10 @@
 #@   return data.values.docker_registry + "/galoy-app-debug"
 #@ end
 
+#@ def migrate_galoy_image():
+#@   return data.values.docker_registry + "/galoy-app-migrate"
+#@ end
+
 #@ def task_image_config():
 type: registry-image
 source:
@@ -38,6 +42,7 @@ groups:
   - check-code
   - build-edge-image
   - build-debug-edge-image
+  - build-migrate-edge-image
   - install-deps
   - bump-image-in-chart
 - name: image
@@ -222,12 +227,42 @@ jobs:
     params:
       image: image/image.tar
 
+- name: build-migrate-edge-image
+  serial: true
+  plan:
+  - { get: repo, trigger: true }
+  - task: build
+    privileged: true
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      inputs:
+      - name: repo
+      outputs:
+      - name: image
+      params:
+        CONTEXT: repo
+        BUILD_ARGS_FILE: repo/.env
+        DOCKERFILE: "repo/Dockerfile-migrate"
+      run:
+        path: build
+  - put: migrate-edge-image
+    params:
+      image: image/image.tar
+
 - name: bump-image-in-chart
   plan:
   - in_parallel:
     - get: edge-image
       trigger: true
       passed: [build-edge-image]
+      params: { skip_download: true }
+    - get: migrate-edge-image
+      trigger: true
+      passed: [build-migrate-edge-image]
       params: { skip_download: true }
     - get: repo
       trigger: true
@@ -236,6 +271,7 @@ jobs:
       - test-unit
       - test-integration
       - build-debug-edge-image
+      - build-migrate-edge-image
       - build-edge-image
     - get: charts-repo
       params: { skip_download: true }
@@ -312,6 +348,14 @@ resources:
     username: #@ data.values.docker_registry_user
     password: #@ data.values.docker_registry_password
     repository: #@ debug_galoy_image()
+
+- name: migrate-edge-image
+  type: registry-image
+  source:
+    tag: edge
+    username: #@ data.values.docker_registry_user
+    password: #@ data.values.docker_registry_password
+    repository: #@ migrate_galoy_image()
 
 - name: deps
   type: git

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,13 @@ services:
     environment:
     - ALLOW_EMPTY_PASSWORD=yes
     - REDIS_DISABLE_COMMANDS=FLUSHDB,FLUSHALL
+  galoy-migrate:
+    depends_on: [mongodb]
+    build:
+      context: .
+      dockerfile: Dockerfile-migrate
+    environment:
+    - MONGODB_ADDRESS=mongodb
   mongodb:
     image: bitnami/mongodb:4.4.6-debian-10-r0
     ports:


### PR DESCRIPTION
For our next db migration we would like to have at least some level of
automation. Here we are adding an image to execute the migrations and
test-run them as part of the `integration-in-ci` make task.

Next step will be to add a job to the chart that can be used to execute the migration using this image.

Note I have used
```
FROM nodejs:16-alpine
```
for the image instead of a distroless one because `mongodb-migrate` depends on `/bin/sh` which isn't present in distroless. I haven't investigated wether or not there is a good alternative to alpine for this.