### PR TITLE
chore: make subscription updates from the accountId

### DIFF
--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -49,7 +49,7 @@ export const BTC_PRICE_PRECISION_OFFSET = 4
 export const lnPaymentStatusEvent = (paymentHash: PaymentHash) =>
   `LN-PAYMENT-STATUS-${paymentHash}`
 
-export const walletUpdateEvent = (walletId: WalletId) => `WALLET_UPDATE-${walletId}`
+export const accountUpdateEvent = (accountId: AccountId) => `ACCOUNT_UPDATE-${accountId}`
 
 let customContent, customConfig
 

--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -181,6 +181,7 @@ type IntraLedgerUpdate {
   amount: SatAmount!
   txNotificationType: TxNotificationType!
   usdPerSat: Float!
+  walletId: WalletId!
 }
 
 enum InvoicePaymentStatus {
@@ -281,6 +282,7 @@ scalar LnPaymentSecret
 type LnUpdate {
   paymentHash: PaymentHash!
   status: InvoicePaymentStatus!
+  walletId: WalletId!
 }
 
 type MapInfo {
@@ -398,6 +400,7 @@ type OnChainUpdate {
   txHash: OnChainTxHash!
   txNotificationType: TxNotificationType!
   usdPerSat: Float!
+  walletId: WalletId!
 }
 
 """

--- a/src/graphql/root/subscription/my-updates.ts
+++ b/src/graphql/root/subscription/my-updates.ts
@@ -3,7 +3,7 @@ import { GT } from "@graphql/index"
 import {
   SAT_PRICE_PRECISION_OFFSET,
   USER_PRICE_UPDATE_EVENT,
-  walletUpdateEvent,
+  accountUpdateEvent,
 } from "@config/app"
 import pubsub from "@services/pubsub"
 import { Prices } from "@app"
@@ -15,6 +15,7 @@ import SatAmount from "@graphql/types/scalar/sat-amount"
 import OnChainTxHash from "@graphql/types/scalar/onchain-tx-hash"
 import TxNotificationType from "@graphql/types/scalar/tx-notification-type"
 import GraphQLUser from "@graphql/types/object/graphql-user"
+import WalletId from "@graphql/types/scalar/wallet-id"
 
 const IntraLedgerUpdate = new GT.Object({
   name: "IntraLedgerUpdate",
@@ -22,6 +23,7 @@ const IntraLedgerUpdate = new GT.Object({
     txNotificationType: { type: GT.NonNull(TxNotificationType) },
     amount: { type: GT.NonNull(SatAmount) },
     usdPerSat: { type: GT.NonNull(GT.Float) },
+    walletId: { type: GT.NonNull(WalletId) },
   }),
 })
 
@@ -30,6 +32,7 @@ const LnUpdate = new GT.Object({
   fields: () => ({
     paymentHash: { type: GT.NonNull(PaymentHash) },
     status: { type: GT.NonNull(InvoicePaymentStatus) },
+    walletId: { type: GT.NonNull(WalletId) },
   }),
 })
 
@@ -40,6 +43,7 @@ const OnChainUpdate = new GT.Object({
     txHash: { type: GT.NonNull(OnChainTxHash) },
     amount: { type: GT.NonNull(SatAmount) },
     usdPerSat: { type: GT.NonNull(GT.Float) },
+    walletId: { type: GT.NonNull(WalletId) },
   }),
 })
 
@@ -114,7 +118,7 @@ const MeSubscription = {
 
     return pubsub.asyncIterator([
       USER_PRICE_UPDATE_EVENT,
-      walletUpdateEvent(ctx.domainAccount.defaultWalletId),
+      accountUpdateEvent(ctx.domainAccount.id),
     ])
   },
 }


### PR DESCRIPTION
 make subscription updates from the accountId, instead of the walletId, so that a subscription get all the updates from the same account with a single sub 