### PR TITLE
fix: graceful shutdown of tracing in cron

### DIFF
--- a/src/servers/cron.ts
+++ b/src/servers/cron.ts
@@ -1,5 +1,5 @@
 import { getSpecterWalletConfig } from "@config/app"
-import { asyncRunInSpan, SemanticAttributes } from "@services/tracing"
+import { asyncRunInSpan, SemanticAttributes, shutdownTracing } from "@services/tracing"
 
 import {
   deleteExpiredInvoiceUser,
@@ -74,6 +74,8 @@ const main = async () => {
       await mongoose.connection.close()
     },
   )
+
+  await shutdownTracing()
 
   // FIXME: we need to exit because we may have some pending promise
   process.exit(results.every((r) => r) ? 0 : 99)

--- a/src/services/tracing.ts
+++ b/src/services/tracing.ts
@@ -302,6 +302,10 @@ export const addAttributesToCurrentSpanAndPropagate = <F extends () => ReturnTyp
   return context.with(propagation.setBaggage(ctx, baggage), fn)
 }
 
+export const shutdownTracing = async () => {
+  provider.shutdown()
+}
+
 export { SemanticAttributes, SemanticResourceAttributes }
 
 export const ENDUSER_ALIAS = "enduser.alias"


### PR DESCRIPTION
This is to flush all the spans before the process completes