### PR TITLE
refactor: invoices and payments updates in cron

### DIFF
--- a/src/app/wallets/get-balance-for-wallet.ts
+++ b/src/app/wallets/get-balance-for-wallet.ts
@@ -1,7 +1,7 @@
 import { LedgerService } from "@services/ledger"
 
-import { updatePendingInvoices } from "./update-pending-invoices"
-import { updatePendingPayments } from "./update-pending-payments"
+import { updatePendingInvoicesByWalletId } from "./update-pending-invoices"
+import { updatePendingPaymentsByWalletId } from "./update-pending-payments"
 
 export const getBalanceForWallet = async ({
   walletId,
@@ -13,18 +13,18 @@ export const getBalanceForWallet = async ({
   logger: Logger
 }): Promise<Satoshis | ApplicationError> => {
   const [, updatePaymentsResult] = await Promise.all([
-    updatePendingInvoices({
+    updatePendingInvoicesByWalletId({
       walletId,
       lock,
       logger,
     }),
-    updatePendingPayments({
+    updatePendingPaymentsByWalletId({
       walletId,
       lock,
       logger,
     }),
   ])
-  if (updatePaymentsResult instanceof Error) throw updatePaymentsResult
+  if (updatePaymentsResult instanceof Error) return updatePaymentsResult
 
   return getBalanceForWalletId(walletId)
 }

--- a/src/app/wallets/update-on-chain-receipt.ts
+++ b/src/app/wallets/update-on-chain-receipt.ts
@@ -55,6 +55,8 @@ export const updateOnChainReceipt = async ({
     }
   }
 
+  logger.info(`finish updating onchain receipts with ${onChainTxs.length} transactions`)
+
   return onChainTxs.length
 }
 

--- a/src/core/user-wallet.ts
+++ b/src/core/user-wallet.ts
@@ -34,12 +34,12 @@ export class UserWallet {
 
   async getBalances(lock?): Promise<Balances> {
     // was the await omit on purpose?
-    await Wallets.updatePendingInvoices({
+    await Wallets.updatePendingInvoicesByWalletId({
       walletId: this.user.walletId as WalletId,
       lock,
       logger: this.logger,
     })
-    const result = await Wallets.updatePendingPayments({
+    const result = await Wallets.updatePendingPaymentsByWalletId({
       walletId: this.user.walletId as WalletId,
       lock,
       logger: this.logger,

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -223,4 +223,6 @@ interface ILedgerService {
   ): Promise<void | LedgerServiceError>
 
   getWalletIdByTransactionHash(hash): Promise<WalletId | LedgerServiceError>
+
+  listWalletIdsWithPendingPayments: () => AsyncGenerator<WalletId> | LedgerServiceError
 }

--- a/src/services/ledger/query.ts
+++ b/src/services/ledger/query.ts
@@ -8,7 +8,6 @@ import {
   lndAccountingPath,
 } from "./accounts"
 import { MainBook } from "./books"
-import { Transaction } from "./schema"
 
 export const getAllAccounts = () => {
   return MainBook.listAccounts()
@@ -18,19 +17,6 @@ const getWalletBalance = async (account: string, query = {}) => {
   const params = { account, currency: "BTC", ...query }
   const { balance } = await MainBook.balance(params)
   return balance
-}
-
-export async function* getAccountsWithPendingTransactions(query = {}) {
-  const transactions = Transaction.aggregate([
-    { $match: { "pending": true, "account_path.0": liabilitiesMainAccount, ...query } },
-    { $group: { _id: "$accounts" } },
-  ])
-    .cursor({ batchSize: 100 })
-    .exec()
-
-  for await (const { _id } of transactions) {
-    yield _id
-  }
 }
 
 export const getAssetsBalance = (currency = "BTC") =>

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -821,7 +821,7 @@ describe("UserWallet - Lightning Pay", () => {
         })
 
         await waitFor(async () => {
-          const updatedPayments = await Wallets.updatePendingPayments({
+          const updatedPayments = await Wallets.updatePendingPaymentsByWalletId({
             walletId: walletId1,
             logger: baseLogger,
           })
@@ -862,7 +862,7 @@ describe("UserWallet - Lightning Pay", () => {
         await cancelHodlInvoice({ id, lnd: lndOutside1 })
 
         await waitFor(async () => {
-          const updatedPayments = await Wallets.updatePendingPayments({
+          const updatedPayments = await Wallets.updatePendingPaymentsByWalletId({
             walletId: walletId1,
             logger: baseLogger,
           })


### PR DESCRIPTION
1st PR to remove `balance-sheet` from `core`

- Move `updatePendingLightningInvoices` and `updatePendingLightningPayments` to app layer
- Move `listWalletIdsWithPendingPayments` to main ledger service
- Update cron server with updated methods