### PR TITLE
test: make rate limit checks less self-referential

### DIFF
--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -124,6 +124,15 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
         "Too many onchain addresses creation, please wait for a while and try again."
       return new TooManyRequestError({ message, logger: baseLogger })
 
+    case "UserPhoneCodeAttemptPhoneRateLimiterExceededError":
+      message = "Too many phone code attempts, please wait for a while and try again."
+      return new TooManyRequestError({ message, logger: baseLogger })
+
+    case "UserPhoneCodeAttemptIpRateLimiterExceededError":
+      message =
+        "Too many phone code attempts on same network, please wait for a while and try again."
+      return new TooManyRequestError({ message, logger: baseLogger })
+
     case "CouldNotFindPhoneCodeError":
       message = "Invalid or incorrect phone code entered."
       return new PhoneCodeError({ message, logger: baseLogger })
@@ -131,6 +140,15 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "CouldNotFindAccountFromPhoneError":
       message = "Invalid or incorrect phone entered."
       return new PhoneCodeError({ message, logger: baseLogger })
+
+    case "UserLoginPhoneRateLimiterExceededError":
+      message = "Too many login attempts, please wait for a while and try again."
+      return new TooManyRequestError({ message, logger: baseLogger })
+
+    case "UserLoginIpRateLimiterExceededError":
+      message =
+        "Too many login attempts on same network, please wait for a while and try again."
+      return new TooManyRequestError({ message, logger: baseLogger })
 
     case "InvalidQuizQuestionIdError":
       message = "Invalid quiz question id was passed."
@@ -263,11 +281,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "LocalCacheServiceError":
     case "LocalCacheUndefinedError":
     case "UnknownLocalCacheServiceError":
-    case "UserLoginIpRateLimiterExceededError":
-    case "UserLoginPhoneRateLimiterExceededError":
-    case "UserPhoneCodeAttemptPhoneRateLimiterExceededError":
     case "UserPhoneCodeAttemptPhoneMinIntervalRateLimiterExceededError":
-    case "UserPhoneCodeAttemptIpRateLimiterExceededError":
     case "PhoneProviderServiceError":
     case "UnknownPhoneProviderServiceError":
     case "MissingPhoneMetadataError":

--- a/test/integration/servers/graphql-main-server/no-auth-requests.spec.ts
+++ b/test/integration/servers/graphql-main-server/no-auth-requests.spec.ts
@@ -306,11 +306,13 @@ const testPhoneCodeAttemptPerPhone = async (mutation) => {
   }
 
   // Check limiter is exhausted
+  const expectedErrorMessage =
+    "Too many phone code attempts, please wait for a while and try again."
   const {
     errors: [{ message }],
   } = await mutate(mutation, { variables: { input } })
   expect(new error()).toBeInstanceOf(UserPhoneCodeAttemptPhoneRateLimiterExceededError)
-  expect(message).toMatch(new RegExp(`.*${error.name}.*`))
+  expect(message).toBe(expectedErrorMessage)
 }
 
 const testPhoneCodeAttemptPerIp = async (mutation) => {
@@ -348,11 +350,13 @@ const testPhoneCodeAttemptPerIp = async (mutation) => {
   }
 
   // Check limiter is exhausted
+  const expectedErrorMessage =
+    "Too many phone code attempts on same network, please wait for a while and try again."
   const {
     errors: [{ message }],
   } = await mutate(mutation, { variables: { input } })
   expect(new error()).toBeInstanceOf(UserPhoneCodeAttemptIpRateLimiterExceededError)
-  expect(message).toMatch(new RegExp(`.*${error.name}.*`))
+  expect(message).toBe(expectedErrorMessage)
 }
 
 const testRateLimitLoginByPhone = async ({
@@ -386,13 +390,12 @@ const testRateLimitLoginByPhone = async ({
   }
 
   // Check limiter is exhausted
-  const messageRegex = new RegExp(`.*${error.name}.*`)
+  const expectedErrorMessage =
+    "Too many login attempts, please wait for a while and try again."
   const result = await mutate(mutation, { variables: { input } })
   expect(new error()).toBeInstanceOf(UserLoginPhoneRateLimiterExceededError)
   expect(result.data.userLogin.errors).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({ message: expect.stringMatching(messageRegex) }),
-    ]),
+    expect.arrayContaining([expect.objectContaining({ message: expectedErrorMessage })]),
   )
 }
 
@@ -436,12 +439,11 @@ const testRateLimitLoginByIp = async ({
   expect(resetPhone).not.toBeInstanceOf(Error)
   if (resetPhone instanceof Error) return resetPhone
 
-  const messageRegex = new RegExp(`.*${error.name}.*`)
+  const expectedErrorMessage =
+    "Too many login attempts on same network, please wait for a while and try again."
   const result = await mutate(mutation, { variables: { input } })
   expect(new error()).toBeInstanceOf(UserLoginIpRateLimiterExceededError)
   expect(result.data.userLogin.errors).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({ message: expect.stringMatching(messageRegex) }),
-    ]),
+    expect.arrayContaining([expect.objectContaining({ message: expectedErrorMessage })]),
   )
 }

--- a/test/integration/servers/graphql-main-server/no-auth-requests.spec.ts
+++ b/test/integration/servers/graphql-main-server/no-auth-requests.spec.ts
@@ -6,6 +6,13 @@ import * as jwt from "jsonwebtoken"
 
 import { sleep } from "@utils"
 import { RateLimitConfig } from "@domain/rate-limit"
+import {
+  UserLoginIpRateLimiterExceededError,
+  UserLoginPhoneRateLimiterExceededError,
+  UserPhoneCodeAttemptIpRateLimiterExceededError,
+  UserPhoneCodeAttemptPhoneMinIntervalRateLimiterExceededError,
+  UserPhoneCodeAttemptPhoneRateLimiterExceededError,
+} from "@domain/rate-limit/errors"
 
 import USER_REQUEST_AUTH_CODE from "./mutations/user-request-auth-code.gql"
 import USER_LOGIN from "./mutations/user-login.gql"
@@ -258,6 +265,9 @@ const testPhoneCodeAttemptPerPhoneMinInterval = async (mutation) => {
   const {
     errors: [{ message }],
   } = await mutate(mutation, { variables: { input } })
+  expect(new error()).toBeInstanceOf(
+    UserPhoneCodeAttemptPhoneMinIntervalRateLimiterExceededError,
+  )
   expect(message).toMatch(new RegExp(`.*${error.name}.*`))
 }
 
@@ -299,6 +309,7 @@ const testPhoneCodeAttemptPerPhone = async (mutation) => {
   const {
     errors: [{ message }],
   } = await mutate(mutation, { variables: { input } })
+  expect(new error()).toBeInstanceOf(UserPhoneCodeAttemptPhoneRateLimiterExceededError)
   expect(message).toMatch(new RegExp(`.*${error.name}.*`))
 }
 
@@ -340,6 +351,7 @@ const testPhoneCodeAttemptPerIp = async (mutation) => {
   const {
     errors: [{ message }],
   } = await mutate(mutation, { variables: { input } })
+  expect(new error()).toBeInstanceOf(UserPhoneCodeAttemptIpRateLimiterExceededError)
   expect(message).toMatch(new RegExp(`.*${error.name}.*`))
 }
 
@@ -376,6 +388,7 @@ const testRateLimitLoginByPhone = async ({
   // Check limiter is exhausted
   const messageRegex = new RegExp(`.*${error.name}.*`)
   const result = await mutate(mutation, { variables: { input } })
+  expect(new error()).toBeInstanceOf(UserLoginPhoneRateLimiterExceededError)
   expect(result.data.userLogin.errors).toEqual(
     expect.arrayContaining([
       expect.objectContaining({ message: expect.stringMatching(messageRegex) }),
@@ -425,6 +438,7 @@ const testRateLimitLoginByIp = async ({
 
   const messageRegex = new RegExp(`.*${error.name}.*`)
   const result = await mutate(mutation, { variables: { input } })
+  expect(new error()).toBeInstanceOf(UserLoginIpRateLimiterExceededError)
   expect(result.data.userLogin.errors).toEqual(
     expect.arrayContaining([
       expect.objectContaining({ message: expect.stringMatching(messageRegex) }),


### PR DESCRIPTION
## Description

Improvement from changes in #932 to explicitly include errors type checks in rate limit tests.