### PR TITLE
fix: remove directConnection option from migrate config

### DIFF
--- a/src/migrations/migrate-mongo-config.js
+++ b/src/migrations/migrate-mongo-config.js
@@ -11,7 +11,6 @@ const config = {
     options: {
       useNewUrlParser: true, // removes a deprecation warning when connecting
       useUnifiedTopology: true, // removes a deprecating warning when connecting
-      directConnection: true,
       //   connectTimeoutMS: 3600000, // increase connection timeout to 1 hour
       //   socketTimeoutMS: 3600000, // increase socket timeout to 1 hour
     },


### PR DESCRIPTION
Hopefully this fixes the current error on staging:
```
$ k -n galoy-testflight-af1d92a logs galoy-mongodb-migrate-1-zt6vn
ERROR: directConnection option requires exactly one host MongoParseError: directConnection option requires exactly one host
    at parseConnectionString (/app/node_modules/migrate-mongo/node_modules/mongodb/lib/core/uri_parser.js:711:21)
    at connect (/app/node_modules/migrate-mongo/node_modules/mongodb/lib/operations/connect.js:283:3)
    at /app/node_modules/migrate-mongo/node_modules/mongodb/lib/mongo_client.js:284:5
    at maybePromise (/app/node_modules/migrate-mongo/node_modules/mongodb/lib/utils.js:692:3)
    at MongoClient.connect (/app/node_modules/migrate-mongo/node_modules/mongodb/lib/mongo_client.js:280:10)
    at Function.MongoClient.connect (/app/node_modules/migrate-mongo/node_modules/mongodb/lib/mongo_client.js:426:22)
    at Object.connect (/app/node_modules/migrate-mongo/lib/env/database.js:16:38)
ERROR: directConnection option requires exactly one host MongoParseError: directConnection option requires exactly one host
    at parseConnectionString (/app/node_modules/migrate-mongo/node_modules/mongodb/lib/core/uri_parser.js:711:21)
    at connect (/app/node_modules/migrate-mongo/node_modules/mongodb/lib/operations/connect.js:283:3)
    at /app/node_modules/migrate-mongo/node_modules/mongodb/lib/mongo_client.js:284:5
    at maybePromise (/app/node_modules/migrate-mongo/node_modules/mongodb/lib/utils.js:692:3)
    at MongoClient.connect (/app/node_modules/migrate-mongo/node_modules/mongodb/lib/mongo_client.js:280:10)
    at Function.MongoClient.connect (/app/node_modules/migrate-mongo/node_modules/mongodb/lib/mongo_client.js:426:22)
    at Object.connect (/app/node_modules/migrate-mongo/lib/env/database.js:16:38)
ERROR: directConnection option requires exactly one host MongoParseError: directConnection option requires exactly one host
    at parseConnectionString (/app/node_modules/migrate-mongo/node_modules/mongodb/lib/core/uri_parser.js:711:21)
    at connect (/app/node_modules/migrate-mongo/node_modules/mongodb/lib/operations/connect.js:283:3)
    at /app/node_modules/migrate-mongo/node_modules/mongodb/lib/mongo_client.js:284:5
    at maybePromise (/app/node_modules/migrate-mongo/node_modules/mongodb/lib/utils.js:692:3)
    at MongoClient.connect (/app/node_modules/migrate-mongo/node_modules/mongodb/lib/mongo_client.js:280:10)
    at Function.MongoClient.connect (/app/node_modules/migrate-mongo/node_modules/mongodb/lib/mongo_client.js:426:22)
    at Object.connect (/app/node_modules/migrate-mongo/lib/env/database.js:16:38)
    ```