### PR TITLE
refactor: include new fields in mongoose/schema.types.d.ts

### DIFF
--- a/src/services/mongodb/index.ts
+++ b/src/services/mongodb/index.ts
@@ -10,16 +10,25 @@ import { User, Transaction, InvoiceUser } from "../mongoose/schema"
 
 export const ledger = loadLedger({
   bankOwnerWalletResolver: async () => {
-    const { walletId } = await User.findOne({ role: "bankowner" }, { walletId: 1 })
-    return walletId
+    const { defaultWalletId, walletId } = await User.findOne(
+      { role: "bankowner" },
+      { defaultWalletId: 1, walletId: 1 },
+    )
+    return defaultWalletId || walletId
   },
   dealerWalletResolver: async () => {
-    const { walletId } = await User.findOne({ role: "dealer" }, { walletId: 1 })
-    return walletId
+    const { defaultWalletId, walletId } = await User.findOne(
+      { role: "dealer" },
+      { defaultWalletId: 1, walletId: 1 },
+    )
+    return defaultWalletId || walletId
   },
   funderWalletResolver: async () => {
-    const { walletId } = await User.findOne({ role: "funder" }, { walletId: 1 })
-    return walletId
+    const { defaultWalletId, walletId } = await User.findOne(
+      { role: "funder" },
+      { defaultWalletId: 1, walletId: 1 },
+    )
+    return defaultWalletId || walletId
   },
 })
 

--- a/src/services/mongoose/accounts.ts
+++ b/src/services/mongoose/accounts.ts
@@ -35,12 +35,23 @@ export const AccountsRepository = (): IAccountsRepository => {
   const findByWalletId = async (
     walletId: WalletId,
   ): Promise<Account | RepositoryError> => {
+    const oldFindUser = async () => {
+      try {
+        const result: UserType = await User.findOne({ walletId }, projection)
+        if (!result) return new CouldNotFindError("Invalid wallet")
+        return translateToAccount(result)
+      } catch (err) {
+        return new UnknownRepositoryError(err)
+      }
+    }
     try {
-      const result: UserType = await User.findOne({ walletId }, projection)
-      if (!result) return new CouldNotFindError("Invalid wallet")
+      const result: UserType = await User.findOne({ walletIds: walletId }, projection)
+      if (!result) {
+        return oldFindUser()
+      }
       return translateToAccount(result)
     } catch (err) {
-      return new UnknownRepositoryError(err)
+      return oldFindUser()
     }
   }
 
@@ -106,6 +117,8 @@ export const AccountsRepository = (): IAccountsRepository => {
     contacts,
     title,
     username,
+    walletIds,
+    defaultWalletId,
   }: Account): Promise<Account | RepositoryError> => {
     try {
       const result = await User.findOneAndUpdate(
@@ -123,6 +136,8 @@ export const AccountsRepository = (): IAccountsRepository => {
               transactionsCount,
             }),
           ),
+          walletIds,
+          defaultWalletId,
         },
         {
           new: true,
@@ -152,13 +167,13 @@ export const AccountsRepository = (): IAccountsRepository => {
 const translateToAccount = (result: UserType): Account => ({
   id: result.id as AccountId,
   createdAt: new Date(result.created_at),
-  defaultWalletId: result.walletId as WalletId, // TODO: add defaultWalletId at the persistence layer when Account have multiple wallet
+  defaultWalletId: (result.defaultWalletId || result.walletId) as WalletId,
   username: result.username as Username,
   level: (result.level as AccountLevel) || AccountLevel.One,
   status: (result.status as AccountStatus) || AccountStatus.Active,
   title: result.title as BusinessMapTitle,
   coordinates: result.coordinates as Coordinates,
-  walletIds: [result.walletId as WalletId],
+  walletIds: (result.walletIds || [result.walletId]) as WalletId[],
   ownerId: result.id as UserId,
   contacts: result.contacts.reduce(
     (res: AccountContact[], contact: ContactObjectForUser): AccountContact[] => {
@@ -183,6 +198,8 @@ const projection = {
   status: 1,
   coordinates: 1,
   walletId: 1,
+  walletIds: 1,
+  defaultWalletId: 1,
   username: 1,
   title: 1,
   created_at: 1,

--- a/src/services/mongoose/schema.types.d.ts
+++ b/src/services/mongoose/schema.types.d.ts
@@ -68,6 +68,8 @@ interface UserType {
   onchain: OnChainObjectForUser[]
   twoFA: TwoFAForUser
   walletId: WalletId
+  walletIds: WalletId[] | undefined
+  defaultWalletId: WalletId | undefined
 
   // business:
   title?: string


### PR DESCRIPTION
This PR prepares the upcoming migration to the user schema by merging the old and new types in mongoose/schema.types.d.ts.

I'm suggesting this be part of a 4 part roll out of https://github.com/GaloyMoney/galoy/pull/921.
Step 1 merge old/new types for user
Step 2 add migration for fields on user and delete code for old user type
step 3 merge old/new types for wallet
step 4 add migration for user -> wallet and delete old types