### PR TITLE
fix: throw, not return, for tests

### DIFF
--- a/test/integration/02-user-wallet/02-invoice.spec.ts
+++ b/test/integration/02-user-wallet/02-invoice.spec.ts
@@ -30,7 +30,7 @@ describe("UserWallet - addInvoice", () => {
       walletId: walletId1,
       amount: toSats(1000),
     })
-    if (lnInvoice instanceof Error) return lnInvoice
+    if (lnInvoice instanceof Error) throw lnInvoice
     const { paymentRequest: request } = lnInvoice
 
     expect(request.startsWith("lnbcrt10")).toBeTruthy()
@@ -44,7 +44,7 @@ describe("UserWallet - addInvoice", () => {
     const lnInvoice = await Wallets.addInvoiceNoAmount({
       walletId: walletId1,
     })
-    if (lnInvoice instanceof Error) return lnInvoice
+    if (lnInvoice instanceof Error) throw lnInvoice
     const { paymentRequest: request } = lnInvoice
 
     const result = await walletInvoices.findByPaymentHash(getHash(request))


### PR DESCRIPTION
if we simply return on error for test, the tests will exit succesfully and not execute what is after the `return error`

to make the test fails if something happen, it's necessary to throw instead of return

I came around this issue working on the fiat integration. I have not in other tests whether this issue is other places.