### PR TITLE
refactor: bootstrap default wallet in createUser

### DIFF
--- a/src/app/accounts/add-earn.ts
+++ b/src/app/accounts/add-earn.ts
@@ -7,9 +7,7 @@ import {
 } from "@domain/errors"
 import { PhoneMetadataValidator } from "@domain/users/phone-metadata-validator"
 import { getFunderWalletId } from "@services/ledger/accounts"
-import { RewardsRepository } from "@services/mongoose"
-
-import { getAccount } from "."
+import { RewardsRepository, AccountsRepository } from "@services/mongoose"
 
 export const addEarn = async ({
   quizQuestionId,
@@ -25,7 +23,7 @@ export const addEarn = async ({
 
   const funderWalletId = await getFunderWalletId()
 
-  const recipientAccount = await getAccount(accountId)
+  const recipientAccount = await AccountsRepository().findById(accountId)
   if (recipientAccount instanceof Error) return recipientAccount
 
   const user = await getUser(recipientAccount.ownerId)

--- a/src/app/accounts/index.ts
+++ b/src/app/accounts/index.ts
@@ -23,7 +23,9 @@ export * from "./update-default-walletid"
 
 const accounts = AccountsRepository()
 
-export const getAccount = async (accountId: AccountId) => {
+export const getAccount = async (
+  accountId: AccountId,
+): Promise<Account | RepositoryError> => {
   return accounts.findById(accountId)
 }
 

--- a/src/app/accounts/index.ts
+++ b/src/app/accounts/index.ts
@@ -19,8 +19,7 @@ export * from "./username-available"
 export * from "./get-contact-by-username"
 export * from "./update-contact-alias"
 export * from "./add-new-contact"
-export * from "./add-wallet"
-export * from "./set-default-walletid"
+export * from "./update-default-walletid"
 
 const accounts = AccountsRepository()
 

--- a/src/app/accounts/update-default-walletid.ts
+++ b/src/app/accounts/update-default-walletid.ts
@@ -2,7 +2,7 @@ import { InvalidWalletId } from "@domain/errors"
 import { listWalletIdsByAccountId } from "@domain/wallets"
 import { AccountsRepository } from "@services/mongoose"
 
-export const setDefaultWalletId = async ({
+export const updateDefaultWalletId = async ({
   accountId,
   walletId,
 }: {

--- a/src/app/wallets/intraledger-send-payment.ts
+++ b/src/app/wallets/intraledger-send-payment.ts
@@ -1,4 +1,3 @@
-import { getAccount } from "@app/accounts"
 import { addNewContact } from "@app/accounts/add-new-contact"
 import { getCurrentPrice } from "@app/prices"
 import { getUser } from "@app/users"
@@ -30,7 +29,7 @@ export const intraledgerPaymentSendUsername = async ({
     return new SatoshiAmountRequiredError()
   }
 
-  const account = await getAccount(payerAccountId)
+  const account = await AccountsRepository().findById(payerAccountId)
   if (account instanceof Error) return account
 
   return intraLedgerSendPaymentUsername({

--- a/src/app/wallets/ln-send-payment.ts
+++ b/src/app/wallets/ln-send-payment.ts
@@ -1,4 +1,3 @@
-import { getAccount } from "@app/accounts"
 import { getCurrentPrice } from "@app/prices"
 import { getUser } from "@app/users"
 import { getBalanceForWalletId, getWallet } from "@app/wallets"
@@ -29,7 +28,7 @@ import { PaymentInitiationMethod, SettlementMethod } from "@domain/wallets"
 import { LedgerService } from "@services/ledger"
 import { LndService } from "@services/lnd"
 import { LockService } from "@services/lock"
-import { WalletInvoicesRepository } from "@services/mongoose"
+import { WalletInvoicesRepository, AccountsRepository } from "@services/mongoose"
 import { NotificationsService } from "@services/notifications"
 import { RoutesCache } from "@services/redis/routes"
 import { addAttributesToCurrentSpan } from "@services/tracing"
@@ -54,7 +53,8 @@ export const lnInvoicePaymentSendWithTwoFA = async ({
     return new LnPaymentRequestNonZeroAmountRequiredError()
   }
 
-  const account = await getAccount(payerAccountId)
+  const account = await AccountsRepository().findById(payerAccountId)
+
   if (account instanceof Error) return account
 
   const user = await getUser(account.ownerId)
@@ -118,7 +118,7 @@ export const lnInvoicePaymentSend = async ({
     return new LnPaymentRequestNonZeroAmountRequiredError()
   }
 
-  const account = await getAccount(payerAccountId)
+  const account = await AccountsRepository().findById(payerAccountId)
   if (account instanceof Error) return account
 
   const { username } = account
@@ -160,7 +160,8 @@ export const lnNoAmountInvoicePaymentSendWithTwoFA = async ({
     return new SatoshiAmountRequiredError()
   }
 
-  const account = await getAccount(payerAccountId)
+  const account = await AccountsRepository().findById(payerAccountId)
+
   if (account instanceof Error) return account
 
   const user = await getUser(account.ownerId)
@@ -227,7 +228,7 @@ export const lnNoAmountInvoicePaymentSend = async ({
     return new LnPaymentRequestZeroAmountRequiredError()
   }
 
-  const account = await getAccount(payerAccountId)
+  const account = await AccountsRepository().findById(payerAccountId)
   if (account instanceof Error) return account
 
   const { username } = account

--- a/test/integration/app/multiple-wallet-account.spec.ts
+++ b/test/integration/app/multiple-wallet-account.spec.ts
@@ -1,17 +1,8 @@
-import { addWallet, getAccount, setDefaultWalletId } from "@app/accounts"
-import { listWalletIdsByAccountId, WalletCurrency, WalletType } from "@domain/wallets"
+import * as Accounts from "@app/accounts"
+import * as Users from "@app/users"
+import { WalletType, WalletCurrency } from "@domain/wallets"
 import { setupMongoConnection } from "@services/mongodb"
-
-import {
-  createUserWallet,
-  getAccountIdByTestUserIndex,
-  getDefaultWalletIdByTestUserIndex,
-  getUserTypeByTestUserIndex,
-} from "test/helpers"
-
-let walletId0: WalletId
-let walletIdNew: WalletId
-let accountId0: AccountId
+import { AccountsRepository, WalletsRepository } from "@services/mongoose"
 
 let mongoose
 
@@ -19,49 +10,34 @@ beforeAll(async () => {
   mongoose = await setupMongoConnection()
   await mongoose.connection.db.dropCollection("users")
   await mongoose.connection.db.dropCollection("wallets")
-
-  await createUserWallet(0)
-
-  walletId0 = await getDefaultWalletIdByTestUserIndex(0)
-  accountId0 = await getAccountIdByTestUserIndex(0)
 })
 
 afterAll(async () => {
   await mongoose.connection.close()
 })
 
-it("add a wallet to account0", async () => {
-  const wallet = await addWallet({
-    accountId: accountId0,
+it("change default walletId of account", async () => {
+  const user = await Users.createUser({ phone: "+123456789", phoneMetadata: null })
+  if (user instanceof Error) throw user
+
+  const accountId = user.defaultAccountId
+  const account = await AccountsRepository().findById(accountId)
+
+  if (account instanceof Error) throw account
+
+  const newWallet = await WalletsRepository().persistNew({
+    accountId,
     type: WalletType.Checking,
     currency: WalletCurrency.Btc,
   })
-  if (wallet instanceof Error) return Error
+  if (newWallet instanceof Error) throw newWallet
 
-  expect(wallet).toBeTruthy()
-  expect(walletId0).not.toBe(wallet.id)
+  const newAccount = await Accounts.updateDefaultWalletId({
+    accountId: accountId,
+    walletId: newWallet.id,
+  })
 
-  walletIdNew = wallet.id
-
-  const userType0 = await getUserTypeByTestUserIndex(0)
-  expect(userType0.defaultWalletId).toBe(walletId0)
-
-  const walletIds = await listWalletIdsByAccountId(accountId0)
-  if (walletIds instanceof Error) throw walletIds
-
-  expect(walletIds).toEqual([walletId0, wallet.id])
-})
-
-it("change default walletId of account0", async () => {
-  const account = await getAccount(accountId0)
-  if (account instanceof Error) throw account
-
-  expect(account.defaultWalletId).toBe(walletId0)
-
-  await setDefaultWalletId({ accountId: accountId0, walletId: walletIdNew })
-  const newAccount = await getAccount(accountId0)
   if (newAccount instanceof Error) throw newAccount
 
-  expect(newAccount.defaultWalletId).toBe(walletIdNew)
-  expect(newAccount.defaultWalletId).not.toBe(walletId0)
+  expect(newAccount.defaultWalletId).toBe(newWallet.id)
 })


### PR DESCRIPTION
When removing bootstrap related code from `addWallet` it collapses simply to a `WalletsRepository.persistNew` so I have deleted that use case completely.

Also renamed `setDefaultWalletId` to `updateDefaultWalletId` as it can be changed more than 1 time.