### PR TITLE
fix: skip running migrations for local dev deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BIN_DIR=node_modules/.bin
 
 start-deps:
-	docker compose up -d
+	docker compose up integration-deps -d
 	direnv reload
 
 start-old:


### PR DESCRIPTION
## Description

Fixes #951

The issue was that anytime we ran `make start-deps` after the initialization our dbs would be migrated with old migrations which would end up mutating the dev setup from the intialization.

This puts us back to just running `integration-deps` when starting the local dependencies.