### PR TITLE
refactor: re-assign admin gql secretPreImage type

### DIFF
--- a/src/graphql/admin/schema.graphql
+++ b/src/graphql/admin/schema.graphql
@@ -94,7 +94,7 @@ type LightningInvoice {
   isSettled: Boolean!
   received: SatAmount!
   request: LnPaymentRequest
-  secretPreImage: LnPaymentSecret!
+  secretPreImage: LnPaymentPreImage!
 }
 
 type LightningPayment {
@@ -103,7 +103,7 @@ type LightningPayment {
   createdAt: Timestamp
   destination: LnPubkey
   request: LnPaymentRequest
-  revealedPreImage: LnPaymentSecret
+  revealedPreImage: LnPaymentPreImage
   roundedUpFee: SatAmount
   status: LnPaymentStatus
 }

--- a/src/graphql/admin/types/object/lightning-invoice.ts
+++ b/src/graphql/admin/types/object/lightning-invoice.ts
@@ -1,6 +1,6 @@
 import { GT } from "@graphql/index"
+import LnPaymentPreImage from "@graphql/types/scalar/ln-payment-preimage"
 import LnPaymentRequest from "@graphql/types/scalar/ln-payment-request"
-import LnPaymentSecret from "@graphql/types/scalar/ln-payment-secret"
 import SatAmount from "@graphql/types/scalar/sat-amount"
 import Timestamp from "@graphql/types/scalar/timestamp"
 
@@ -14,7 +14,7 @@ const LightningInvoice = new GT.Object({
     isSettled: { type: GT.NonNull(GT.Boolean) },
     received: { type: GT.NonNull(SatAmount) },
     request: { type: LnPaymentRequest },
-    secretPreImage: { type: GT.NonNull(LnPaymentSecret) },
+    secretPreImage: { type: GT.NonNull(LnPaymentPreImage) },
   }),
 })
 

--- a/src/graphql/admin/types/object/lightning-payment.ts
+++ b/src/graphql/admin/types/object/lightning-payment.ts
@@ -2,9 +2,9 @@ import { GT } from "@graphql/index"
 import LnPubkey from "@graphql/types/scalar/ln-pubkey"
 import Timestamp from "@graphql/types/scalar/timestamp"
 import SatAmount from "@graphql/types/scalar/sat-amount"
-import LnPaymentSecret from "@graphql/types/scalar/ln-payment-secret"
 import LnPaymentStatus from "@graphql/types/scalar/ln-payment-status"
 import LnPaymentRequest from "@graphql/types/scalar/ln-payment-request"
+import LnPaymentPreImage from "@graphql/types/scalar/ln-payment-preimage"
 
 const LightningPayment = new GT.Object({
   name: "LightningPayment",
@@ -14,7 +14,7 @@ const LightningPayment = new GT.Object({
     createdAt: { type: Timestamp },
     confirmedAt: { type: Timestamp },
     amount: { type: SatAmount },
-    revealedPreImage: { type: LnPaymentSecret },
+    revealedPreImage: { type: LnPaymentPreImage },
     request: { type: LnPaymentRequest },
     destination: { type: LnPubkey },
   }),


### PR DESCRIPTION
## Description

Builds on #953

This PR is to also re-assign the correct type to the `secretPreImage` and `revealedPreImage` properties in admin graphql schema.