### PR TITLE
fix: integration test open handles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,8 @@ trigger: start-deps
 	. ./.envrc && yarn tsnd --respawn --files -r tsconfig-paths/register -r src/services/tracing.ts \
 		src/servers/trigger.ts | yarn pino-pretty -c -l
 
-start-servers-ci:
-	yarn build
-	. ./.envrc && node lib/servers/graphql-main-server.js & node lib/servers/trigger.js
+start-api-ci:
+	node lib/servers/graphql-main-server.js
 
 exporter: start-deps
 	. ./.envrc && yarn tsnd --respawn --files -r tsconfig-paths/register -r src/services/tracing.ts \
@@ -58,9 +57,9 @@ reset-integration: reset-deps integration
 
 integration-in-ci:
 	. ./.envrc && \
-		NODE_ENV=test LOGLEVEL=error $(BIN_DIR)/jest --config ./test/jest-integration.config.js --bail --runInBand --ci --reporters=default --reporters=jest-junit && \
-		yarn build && \
-		LOGLEVEL=error node lib/servers/cron.js
+	yarn build && \
+	NODE_ENV=test LOGLEVEL=error $(BIN_DIR)/jest --config ./test/jest-integration.config.js --bail --runInBand --ci --reporters=default --reporters=jest-junit && \
+	LOGLEVEL=error node lib/servers/cron.js
 
 unit-in-ci:
 	. ./.envrc && \

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -8,12 +8,15 @@ import { generateToken } from "node-2fa"
 
 import { waitUntilChannelBalanceSyncAll } from "./lightning"
 
+export * from "./apollo-client"
 export * from "./bitcoin-core"
+export * from "./integration-server"
 export * from "./lightning"
 export * from "./user"
 export * from "./redis"
 export * from "./wallet"
 export * from "./price"
+export * from "./rate-limit"
 
 export const amountAfterFeeDeduction = ({
   amount,

--- a/test/helpers/integration-server.ts
+++ b/test/helpers/integration-server.ts
@@ -5,16 +5,10 @@ import kill from "tree-kill"
 
 export type PID = number & { readonly brand: unique symbol }
 
-let serverPid: PID = 0 as PID
-
 export const startServer = async (serverStartMessage = "Server ready"): Promise<PID> => {
   return new Promise<PID>((resolve) => {
-    if (serverPid) {
-      resolve(serverPid)
-      return
-    }
-    const serverProcess = childProcess.spawn("make", ["start-servers-ci"])
-    serverPid = serverProcess.pid as PID
+    const serverProcess = childProcess.spawn("make", ["start-api-ci"])
+    const serverPid = serverProcess.pid as PID
     serverProcess.stdout.on("data", (data) => {
       if (data.includes(serverStartMessage)) {
         resolve(serverPid)
@@ -24,9 +18,7 @@ export const startServer = async (serverStartMessage = "Server ready"): Promise<
   })
 }
 
-const killAsync = promisify(kill)
+const killAsync = promisify<number, string>(kill)
 
-export const killServer = async (): Promise<void> => {
-  await killAsync(serverPid)
-  serverPid = 0 as PID
-}
+export const killServer = async (serverPid: PID): Promise<void> =>
+  killAsync(serverPid, "SIGKILL")

--- a/test/integration/servers/graphql-main-server/galoy-pay-testing.spec.ts
+++ b/test/integration/servers/graphql-main-server/galoy-pay-testing.spec.ts
@@ -17,28 +17,25 @@ import {
   clearAccountLocks,
   clearLimiters,
   getDefaultWalletIdByTestUserIndex,
-} from "test/helpers"
-
-import {
   createApolloClient,
   getSubscriptionNext,
   defaultTestClientConfig,
-} from "test/helpers/apollo-client"
-
-import { startServer, killServer } from "test/helpers/integration-server"
-
-jest.setTimeout(120000)
+  startServer,
+  killServer,
+  PID,
+} from "test/helpers"
 
 let apolloClient: ApolloClient<NormalizedCacheObject>,
   disposeClient: () => void,
-  receivingWalletId: WalletId
+  receivingWalletId: WalletId,
+  serverPid: PID
 const receivingUsername = "user0"
 const receivingUserIndex = 0
 const sendingUserIndex = 4
 const { phone, code } = yamlConfig.test_accounts[sendingUserIndex]
 
 beforeAll(async () => {
-  await startServer()
+  serverPid = await startServer()
   ;({ apolloClient, disposeClient } = createApolloClient(defaultTestClientConfig()))
   const input = { phone, code: `${code}` }
   const result = await apolloClient.mutate({ mutation: USER_LOGIN, variables: { input } })
@@ -57,7 +54,7 @@ beforeEach(async () => {
 
 afterAll(async () => {
   disposeClient()
-  await killServer()
+  await killServer(serverPid)
 })
 
 describe("galoy-pay", () => {

--- a/test/integration/servers/graphql-main-server/no-auth-requests.spec.ts
+++ b/test/integration/servers/graphql-main-server/no-auth-requests.spec.ts
@@ -16,28 +16,30 @@ import USER_REQUEST_AUTH_CODE from "./mutations/user-request-auth-code.gql"
 import USER_LOGIN from "./mutations/user-login.gql"
 import MAIN from "./queries/main.gql"
 
-import { clearAccountLocks, clearLimiters } from "test/helpers"
 import {
+  clearAccountLocks,
+  clearLimiters,
   resetUserPhoneCodeAttemptIp,
   resetUserPhoneCodeAttemptPhone,
   resetUserLoginIpRateLimits,
   resetUserLoginPhoneRateLimits,
   resetUserPhoneCodeAttemptPhoneMinIntervalLimits,
-} from "test/helpers/rate-limit"
-
-import { startServer, killServer } from "test/helpers/integration-server"
-import { createApolloClient, defaultTestClientConfig } from "test/helpers/apollo-client"
-
-jest.setTimeout(300000)
+  startServer,
+  killServer,
+  createApolloClient,
+  defaultTestClientConfig,
+  PID,
+} from "test/helpers"
 
 let correctCode: PhoneCode,
   apolloClient: ApolloClient<NormalizedCacheObject>,
-  disposeClient: () => void
+  disposeClient: () => void,
+  serverPid: PID
 const { phone, code } = yamlConfig.test_accounts[9]
 
 beforeAll(async () => {
   correctCode = `${code}` as PhoneCode
-  await startServer()
+  serverPid = await startServer()
   ;({ apolloClient, disposeClient } = createApolloClient(defaultTestClientConfig()))
 })
 
@@ -48,7 +50,7 @@ beforeEach(async () => {
 
 afterAll(async () => {
   disposeClient()
-  await killServer()
+  await killServer(serverPid)
 })
 
 describe("graphql", () => {


### PR DESCRIPTION
- Removes trigger from background and from spawn process. Issue similar to https://github.com/GaloyMoney/galoy/issues/951#issuecomment-1013223870
- Change kill to use `SIGKILL`
- Helpers should not keep state of `pid`, moved to test files
- Add `yarn build` at the begining of `integration-in-ci` so `start-api-ci` does not have to do it (faster execution)

Please notice that we will need to test in CI env.