### PR TITLE
chore: Updated Dev Documentation In DEV.md And Node Engine Minimum Version

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -14,7 +14,7 @@ $ jq --version
 jq-1.6
 $ docker --version
 Docker version 20.10.7, build f0df350
-$ docker compose version
+$ docker-compose --version
 Docker Compose version 2.0.0
 ```
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build-docs": "npx spectaql spectaql-config.yml -1"
   },
   "engines": {
-    "node": "16"
+    "node": ">=14"
   },
   "dependencies": {
     "@google-cloud/storage": "^5.8.5",


### PR DESCRIPTION
This PR fixes 2 things
1 - A typo in the dev documentation for verifying the docker compose version 
2 - The node engine in package.json to allow to run the project on node version greater than or equal to v14. (Base Version Specified On The Dev Documentation)