### PR TITLE
fix: mongoose type and migration

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -84,3 +84,7 @@ export GEETEST_KEY="geetest_key"
 export TWILIO_ACCOUNT_SID="AC_twilio_id"
 export TWILIO_AUTH_TOKEN="AC_twilio_auth_token"
 export TWILIO_PHONE_NUMBER="twilio_phone"
+
+export COMMITHASH="hash"
+export BUILDTIME="2022"
+export HELMREVISION="1"

--- a/src/core/user-wallet.ts
+++ b/src/core/user-wallet.ts
@@ -13,7 +13,7 @@ export class UserWallet {
   static lastPrice: number
 
   // FIXME typing : https://thecodebarbarian.com/working-with-mongoose-in-typescript.html
-  user: UserType // mongoose object
+  user: UserRecord // mongoose object
   readonly logger: Logger
   readonly config: UserWalletConfig
 
@@ -105,7 +105,7 @@ export class UserWallet {
   async setUsername({ username }): Promise<{ username: string | undefined; id: string }> {
     try {
       const result = await User.findOneAndUpdate(
-        { _id: this.user.id, username: { $in: [null, ""] } },
+        { _id: String(this.user._id), username: { $in: [null, ""] } },
         { username },
       )
 
@@ -116,7 +116,7 @@ export class UserWallet {
           level: "warn",
         })
       }
-      return { username, id: this.user.id }
+      return { username, id: String(this.user._id) }
     } catch (err) {
       this.logger.error({ err })
       throw new DbError("error updating username", {

--- a/src/core/user-wallet.ts
+++ b/src/core/user-wallet.ts
@@ -105,7 +105,7 @@ export class UserWallet {
   async setUsername({ username }): Promise<{ username: string | undefined; id: string }> {
     try {
       const result = await User.findOneAndUpdate(
-        { _id: String(this.user._id), username: { $in: [null, ""] } },
+        { _id: this.user._id, username: { $in: [null, ""] } },
         { username },
       )
 

--- a/src/core/user-wallet.types.d.ts
+++ b/src/core/user-wallet.types.d.ts
@@ -6,7 +6,7 @@ type UserWalletConfig = {
 }
 
 type UserWalletConstructorArgs = {
-  user: UserType
+  user: UserRecord
   logger: Logger
   config: UserWalletConfig
 }

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -21,6 +21,7 @@ export class CouldNotFindUserFromPhoneError extends CouldNotFindError {}
 export class CouldNotFindUserFromWalletIdError extends CouldNotFindError {}
 export class CouldNotFindPhoneCodeError extends CouldNotFindError {}
 export class CouldNotFindWalletFromIdError extends CouldNotFindError {}
+export class CouldNotListWalletsFromAccountIdError extends CouldNotFindError {}
 export class CouldNotFindWalletFromUsernameError extends CouldNotFindError {}
 export class CouldNotFindWalletFromOnChainAddressError extends CouldNotFindError {}
 export class CouldNotFindWalletFromOnChainAddressesError extends CouldNotFindError {}

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -247,6 +247,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "NoWalletExistsForUserError":
     case "LimitsExceededError":
     case "CouldNotFindWalletFromIdError":
+    case "CouldNotListWalletsFromAccountIdError":
     case "CouldNotFindWalletFromUsernameError":
     case "CouldNotFindWalletFromOnChainAddressError":
     case "CouldNotFindWalletFromOnChainAddressesError":

--- a/src/migrations/20220111173334-separate-wallet-collection.ts
+++ b/src/migrations/20220111173334-separate-wallet-collection.ts
@@ -27,7 +27,7 @@ module.exports = {
 
       const wallet = {
         id: user.defaultWalletId,
-        accountId: String(user._id),
+        _accountId: user._id,
         type: "checking",
         currency: "BTC",
         onchain: user.onchain,

--- a/src/migrations/migrate-mongo-config.js
+++ b/src/migrations/migrate-mongo-config.js
@@ -17,7 +17,7 @@ const config = {
   },
 
   // The migrations dir, can be an relative or absolute path. Only edit this when really necessary.
-  migrationsDir: "./src/migrations",
+  migrationsDir: ".",
 
   // The mongodb collection where the applied changes are stored. Only edit this when really necessary.
   changelogCollectionName: "changelog",

--- a/src/servers/graphql-main-server.ts
+++ b/src/servers/graphql-main-server.ts
@@ -73,7 +73,7 @@ export async function startApolloServerForCoreSchema() {
 }
 
 if (require.main === module) {
-  setupMongoConnection(true)
+  setupMongoConnection(false)
     .then(async () => {
       await startApolloServerForCoreSchema()
       activateLndHealthCheck()

--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -26,6 +26,8 @@ import PinoHttp from "pino-http"
 import { SubscriptionServer } from "subscriptions-transport-ws"
 import { v4 as uuidv4 } from "uuid"
 
+import { Types as MongooseTypes } from "mongoose"
+
 import { playgroundTabs } from "../graphql/playground"
 
 import healthzHandler from "./middlewares/healthz"
@@ -98,7 +100,7 @@ const sessionContext = ({
         if (loggedInDomainAccount instanceof Error) throw Error
         domainAccount = loggedInDomainAccount
 
-        user = await User.findOne({ _id: userId })
+        user = await User.findOne({ _id: new MongooseTypes.ObjectId(userId) })
         wallet =
           !!user && user.status === "active"
             ? await WalletFactory({ user, logger })

--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -71,7 +71,7 @@ const sessionContext = ({
   }
 
   let wallet, user
-  // FIXME: type issue with let wallet: LightningUserWallet | null, user: UserType | null
+  // FIXME: type issue with let wallet: LightningUserWallet | null, user: UserRecord | null
 
   // TODO move from id: uuidv4() to a Jaeger standard
   const logger = graphqlLogger.child({ token, id: uuidv4(), body })

--- a/src/services/ledger/transaction.ts
+++ b/src/services/ledger/transaction.ts
@@ -20,7 +20,7 @@ export const addLndReceipt = async ({
   lastPrice,
 }: {
   description: string
-  payeeUser: UserType // FIXME: move it to User
+  payeeUser: UserRecord // FIXME: move it to User
   metadata: Record<string, unknown>
   sats: Satoshis
   lastPrice: number

--- a/src/services/ledger/transaction.types.d.ts
+++ b/src/services/ledger/transaction.types.d.ts
@@ -3,8 +3,8 @@ type IAddTransactionOnUsPayment = {
   description: string
   sats: number
   metadata: Record<string, unknown>
-  payerUser: UserType // FIXME: move it to User
-  payeeUser: UserType // FIXME: move it to User
+  payerUser: UserRecord // FIXME: move it to User
+  payeeUser: UserRecord // FIXME: move it to User
   memoPayer?: string
   shareMemoWithPayee?: boolean
   lastPrice: number

--- a/src/services/mongoose/accounts.ts
+++ b/src/services/mongoose/accounts.ts
@@ -7,6 +7,8 @@ import {
 } from "@domain/errors"
 import { User } from "@services/mongoose/schema"
 
+import { Types as MongooseTypes } from "mongoose"
+
 import { caseInsensitiveRegex } from "."
 
 export const AccountsRepository = (): IAccountsRepository => {
@@ -24,7 +26,7 @@ export const AccountsRepository = (): IAccountsRepository => {
   const findById = async (accountId: AccountId): Promise<Account | RepositoryError> => {
     try {
       const result: UserRecord /* UserRecord actually not correct with {projection} */ =
-        await User.findOne({ _id: accountId }, projection)
+        await User.findOne({ _id: new MongooseTypes.ObjectId(accountId) }, projection)
       if (!result) return new CouldNotFindError()
       return translateToAccount(result)
     } catch (err) {
@@ -98,7 +100,7 @@ export const AccountsRepository = (): IAccountsRepository => {
   }: Account): Promise<Account | RepositoryError> => {
     try {
       const result = await User.findOneAndUpdate(
-        { _id: id },
+        { _id: new MongooseTypes.ObjectId(id) },
         {
           level,
           status,

--- a/src/services/mongoose/accounts.ts
+++ b/src/services/mongoose/accounts.ts
@@ -12,7 +12,7 @@ import { caseInsensitiveRegex } from "."
 export const AccountsRepository = (): IAccountsRepository => {
   const listUnlockedAccounts = async (): Promise<Account[] | RepositoryError> => {
     try {
-      const result: UserType[] /* UserType actually not correct with {projection} */ =
+      const result: UserRecord[] /* UserRecord actually not correct with {projection} */ =
         await User.find({ status: AccountStatus.Active }, projection)
       if (result.length === 0) return new CouldNotFindError()
       return result.map((a) => translateToAccount(a))
@@ -23,7 +23,7 @@ export const AccountsRepository = (): IAccountsRepository => {
 
   const findById = async (accountId: AccountId): Promise<Account | RepositoryError> => {
     try {
-      const result: UserType /* UserType actually not correct with {projection} */ =
+      const result: UserRecord /* UserRecord actually not correct with {projection} */ =
         await User.findOne({ _id: accountId }, projection)
       if (!result) return new CouldNotFindError()
       return translateToAccount(result)
@@ -61,7 +61,7 @@ export const AccountsRepository = (): IAccountsRepository => {
     BusinessMapMarker[] | RepositoryError
   > => {
     try {
-      const accounts: UserType[] = await User.find(
+      const accounts: UserRecord[] = await User.find(
         {
           title: { $exists: true, $ne: null },
           coordinates: { $exists: true, $ne: null },
@@ -138,8 +138,8 @@ export const AccountsRepository = (): IAccountsRepository => {
   }
 }
 
-const translateToAccount = (result: UserType): Account => ({
-  id: result.id as AccountId,
+const translateToAccount = (result: UserRecord): Account => ({
+  id: String(result._id) as AccountId,
   createdAt: new Date(result.created_at),
   defaultWalletId: result.defaultWalletId as WalletId,
   username: result.username as Username,
@@ -147,7 +147,7 @@ const translateToAccount = (result: UserType): Account => ({
   status: (result.status as AccountStatus) || AccountStatus.Active,
   title: result.title as BusinessMapTitle,
   coordinates: result.coordinates as Coordinates,
-  ownerId: result.id as UserId,
+  ownerId: result._id as UserId,
   contacts: result.contacts.reduce(
     (res: AccountContact[], contact: ContactObjectForUser): AccountContact[] => {
       if (contact.id) {

--- a/src/services/mongoose/rewards.ts
+++ b/src/services/mongoose/rewards.ts
@@ -1,5 +1,7 @@
 import { RewardAlreadyPresentError, UnknownRepositoryError } from "@domain/errors"
 
+import { Types as MongooseTypes } from "mongoose"
+
 import { User } from "./schema"
 
 // FIXME: improve boundary
@@ -8,7 +10,7 @@ export const RewardsRepository = (accountId: AccountId) => {
     try {
       // by default, mongodb return the previous state before the update
       const oldState = await User.findOneAndUpdate(
-        { _id: accountId },
+        { _id: new MongooseTypes.ObjectId(accountId) },
         { $push: { earn: quizQuestionId } },
         // { upsert: true },
       )

--- a/src/services/mongoose/schema.types.d.ts
+++ b/src/services/mongoose/schema.types.d.ts
@@ -53,10 +53,15 @@ type CoordinateObjectForUser = {
   longitude: number
 }
 
+type OnChainMongooseType = {
+  pubkey: string
+  address: string
+}
+
 // ?: improve this
-interface UserType {
+interface UserRecord {
   _id: string
-  id: string
+
   username: string | null
   phone: string
   role: string
@@ -91,7 +96,7 @@ interface UserType {
   remainingWithdrawalLimit: () => Promise<number>
 
   // mongoose in-built functions
-  save: () => Promise<UserType>
+  save: () => Promise<UserRecord>
 }
 
 // ?: improve this

--- a/src/services/mongoose/users-ips.ts
+++ b/src/services/mongoose/users-ips.ts
@@ -7,11 +7,13 @@ import {
   UnknownRepositoryError,
 } from "@domain/errors"
 
+import { Types as MongooseTypes } from "mongoose"
+
 export const UsersIpRepository = (): IUsersIPsRepository => {
   const update = async (userIp: UserIPs): Promise<true | RepositoryError> => {
     try {
       const result = await User.updateOne(
-        { _id: userIp.id },
+        { _id: new MongooseTypes.ObjectId(userIp.id) },
         { $set: { lastConnection: new Date(), lastIPs: userIp.lastIPs } },
       )
 
@@ -31,7 +33,10 @@ export const UsersIpRepository = (): IUsersIPsRepository => {
 
   const findById = async (userId: UserId): Promise<UserIPs | RepositoryError> => {
     try {
-      const result = await User.findOne({ _id: userId }, { lastIPs: 1 })
+      const result = await User.findOne(
+        { _id: new MongooseTypes.ObjectId(userId) },
+        { lastIPs: 1 },
+      )
       if (!result) {
         return new CouldNotFindUserFromIdError(userId)
       }

--- a/src/services/mongoose/users.ts
+++ b/src/services/mongoose/users.ts
@@ -7,6 +7,7 @@ import {
   UnknownRepositoryError,
 } from "@domain/errors"
 import { User } from "@services/mongoose/schema"
+import { Types as MongooseTypes } from "mongoose"
 
 export const caseInsensitiveRegex = (input: string) => {
   return new RegExp(`^${input}$`, "i")
@@ -15,7 +16,10 @@ export const caseInsensitiveRegex = (input: string) => {
 export const UsersRepository = (): IUsersRepository => {
   const findById = async (userId: UserId): Promise<User | RepositoryError> => {
     try {
-      const result = await User.findOne({ _id: userId }, projection)
+      const result = await User.findOne(
+        { _id: new MongooseTypes.ObjectId(userId) },
+        projection,
+      )
       if (!result) {
         return new CouldNotFindUserFromIdError(userId)
       }
@@ -89,8 +93,8 @@ export const UsersRepository = (): IUsersRepository => {
   }
 }
 
-const userFromRaw = (result: UserType): User => ({
-  id: result.id as UserId,
+const userFromRaw = (result: UserRecord): User => ({
+  id: String(result._id) as UserId,
   phone: result.phone as PhoneNumber,
   language: result.language as UserLanguage,
   twoFA: result.twoFA as TwoFAForUser,
@@ -104,7 +108,7 @@ const userFromRaw = (result: UserType): User => ({
         completed: true,
       }),
     ) || [],
-  defaultAccountId: result.id as AccountId,
+  defaultAccountId: result._id as AccountId,
   deviceTokens: (result.deviceToken || []) as DeviceToken[],
   createdAt: new Date(result.created_at),
   phoneMetadata: result.twilio as PhoneMetadata,

--- a/src/services/mongoose/users.ts
+++ b/src/services/mongoose/users.ts
@@ -72,10 +72,14 @@ export const UsersRepository = (): IUsersRepository => {
         deviceToken: deviceTokens,
         twoFA,
       }
-      const result = await User.findOneAndUpdate({ _id: id }, data, {
-        projection,
-        new: 1,
-      })
+      const result = await User.findOneAndUpdate(
+        { _id: new MongooseTypes.ObjectId(id) },
+        data,
+        {
+          projection,
+          new: 1,
+        },
+      )
       if (!result) {
         return new RepositoryError("Couldn't update user")
       }

--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -10,7 +10,6 @@ import {
   UsersRepository,
   WalletsRepository,
 } from "@services/mongoose"
-import { User } from "@services/mongoose/schema"
 import pubsub from "@services/pubsub"
 
 import { sendNotification } from "./notification"
@@ -257,10 +256,10 @@ export const NotificationsService = (logger: Logger): INotificationsService => {
       `sending balance notification to user`,
     )
 
-    // FIXME:
-    const user = await User.find({ id: userId })
+    const user = await UsersRepository().findById(userId)
     if (user instanceof Error) {
       logger.warn({ user }, "impossible to fetch user to send transaction")
+      return
     }
 
     await sendNotification({

--- a/test/helpers/user.ts
+++ b/test/helpers/user.ts
@@ -51,11 +51,11 @@ export const getDefaultWalletByTestUserIndex = async (index: number) => {
   return user
 }
 
-export const getUserTypeByTestUserIndex = async (index: number) => {
+export const getUserRecordByTestUserIndex = async (index: number) => {
   const entry = yamlConfig.test_accounts[index]
   const phone = entry.phone as PhoneNumber
 
-  return User.findOne({ phone }) as UserType
+  return User.findOne({ phone }) as UserRecord
 }
 
 export const createMandatoryUsers = async () => {

--- a/test/integration/02-user-wallet/02-index.spec.ts
+++ b/test/integration/02-user-wallet/02-index.spec.ts
@@ -14,10 +14,10 @@ import {
   getAccountIdByTestUserIndex,
   getDefaultWalletIdByTestUserIndex,
   getUserIdByTestUserIndex,
-  getUserTypeByTestUserIndex,
+  getUserRecordByTestUserIndex,
 } from "test/helpers"
 
-let userType0: UserType, userType2: UserType
+let userType0: UserRecord, userType2: UserRecord
 let walletId0: WalletId
 let accountId0: AccountId, accountId1: AccountId, accountId2: AccountId
 let userId0: UserId
@@ -33,8 +33,8 @@ describe("UserWallet", () => {
     // load edit for admin-panel manual testing
     await createUserWallet(13)
 
-    userType0 = await getUserTypeByTestUserIndex(0)
-    userType2 = await getUserTypeByTestUserIndex(2)
+    userType0 = await getUserRecordByTestUserIndex(0)
+    userType2 = await getUserRecordByTestUserIndex(2)
 
     walletId0 = await getDefaultWalletIdByTestUserIndex(0)
 
@@ -46,7 +46,7 @@ describe("UserWallet", () => {
   })
 
   it("has a role if it was configured", async () => {
-    const dealer = await getUserTypeByTestUserIndex(6)
+    const dealer = await getUserRecordByTestUserIndex(6)
     expect(dealer.role).toBe("dealer")
   })
 
@@ -193,7 +193,7 @@ describe("UserWallet", () => {
       const secret = await enable2FA(userId0)
       if (secret instanceof Error) return secret
 
-      userType0 = await getUserTypeByTestUserIndex(0)
+      userType0 = await getUserRecordByTestUserIndex(0)
       expect(userType0.twoFA.secret).toBe(secret)
     })
   })
@@ -207,7 +207,7 @@ describe("UserWallet", () => {
       const token = generateTokenHelper(userType0.twoFA.secret)
       const result = await delete2fa({ token, userId: userId0 })
       expect(result).toBeTruthy()
-      userType0 = await getUserTypeByTestUserIndex(0)
+      userType0 = await getUserRecordByTestUserIndex(0)
       expect(userType0.twoFA.secret).toBeNull()
     })
   })

--- a/test/integration/02-user-wallet/02-receive-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-onchain.spec.ts
@@ -24,7 +24,7 @@ import {
   createMandatoryUsers,
   createUserWallet,
   getDefaultWalletIdByTestUserIndex,
-  getUserTypeByTestUserIndex,
+  getUserRecordByTestUserIndex,
   lndonchain,
   RANDOM_ADDRESS,
   sendToAddressAndConfirm,
@@ -279,7 +279,7 @@ describe("UserWallet - On chain", () => {
   it("allows fee exemption for specific users", async () => {
     const amountSats = getRandomAmountOfSats()
 
-    const userType2 = await getUserTypeByTestUserIndex(2)
+    const userType2 = await getUserRecordByTestUserIndex(2)
     userType2.depositFeeRatio = 0
     await userType2.save()
     const wallet2 = await getDefaultWalletIdByTestUserIndex(2)

--- a/test/integration/02-user-wallet/02-receive-rewards.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-rewards.spec.ts
@@ -12,7 +12,7 @@ import {
   createUserWallet,
   getAccountIdByTestUserIndex,
   getDefaultWalletIdByTestUserIndex,
-  getUserTypeByTestUserIndex,
+  getUserRecordByTestUserIndex,
 } from "test/helpers"
 import { resetSelfWalletIdLimits } from "test/helpers/rate-limit"
 import { getBTCBalance } from "test/helpers/wallet"
@@ -54,7 +54,7 @@ describe("UserWallet - addEarn", () => {
 
     const initialBalance = await getBTCBalance(walletId1)
 
-    const userType1BeforeEarn = await getUserTypeByTestUserIndex(1)
+    const userType1BeforeEarn = await getUserRecordByTestUserIndex(1)
 
     const getAndVerifyRewards = async () => {
       const promises = onBoardingEarnIds.map((onBoardingEarnId) =>

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -39,7 +39,7 @@ import {
   getHash,
   getUserIdByTestUserIndex,
   getDefaultWalletIdByTestUserIndex,
-  getUserTypeByTestUserIndex,
+  getUserRecordByTestUserIndex,
   createUserWallet,
   getAccountIdByTestUserIndex,
 } from "test/helpers"
@@ -54,7 +54,7 @@ const amountInvoice = 1000
 const userLimits = getUserLimits({ level: 1 })
 
 const invoicesRepo = WalletInvoicesRepository()
-let userType0: UserType
+let userType0: UserRecord
 
 let userId0: UserId
 
@@ -85,13 +85,13 @@ beforeAll(async () => {
   walletId1 = await getDefaultWalletIdByTestUserIndex(1)
   walletId2 = await getDefaultWalletIdByTestUserIndex(2)
 
-  userType0 = await getUserTypeByTestUserIndex(0)
+  userType0 = await getUserRecordByTestUserIndex(0)
   username0 = userType0.username as Username
 
-  const userType1 = await getUserTypeByTestUserIndex(1)
+  const userType1 = await getUserRecordByTestUserIndex(1)
   username1 = userType1.username as Username
 
-  const userType2 = await getUserTypeByTestUserIndex(2)
+  const userType2 = await getUserRecordByTestUserIndex(2)
   username2 = userType2.username as Username
 })
 
@@ -257,8 +257,8 @@ describe("UserWallet - Lightning Pay", () => {
     const oldFields1 = userTransaction1[0].deprecated
     expect(oldFields1).toHaveProperty("description", `to ${username0}`)
 
-    let userType0 = await getUserTypeByTestUserIndex(0)
-    let userType1 = await getUserTypeByTestUserIndex(1)
+    let userType0 = await getUserRecordByTestUserIndex(0)
+    let userType1 = await getUserRecordByTestUserIndex(1)
 
     expect(userType0.contacts).toEqual(
       expect.arrayContaining([expect.objectContaining({ id: username1 })]),
@@ -288,7 +288,7 @@ describe("UserWallet - Lightning Pay", () => {
     if (res2 instanceof Error) throw res2
     expect(res2).toBe(PaymentSendStatus.Success)
 
-    userType0 = await getUserTypeByTestUserIndex(0)
+    userType0 = await getUserRecordByTestUserIndex(0)
     expect(userType0.contacts).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -297,7 +297,7 @@ describe("UserWallet - Lightning Pay", () => {
         }),
       ]),
     )
-    userType1 = await getUserTypeByTestUserIndex(1)
+    userType1 = await getUserRecordByTestUserIndex(1)
     expect(userType1.contacts).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -413,8 +413,8 @@ describe("UserWallet - Lightning Pay", () => {
     )
 
     // check contacts being added
-    const userType0 = await getUserTypeByTestUserIndex(0)
-    const userType1 = await getUserTypeByTestUserIndex(1)
+    const userType0 = await getUserRecordByTestUserIndex(0)
+    const userType1 = await getUserRecordByTestUserIndex(1)
 
     expect(userType0.contacts).toEqual(
       expect.arrayContaining([expect.objectContaining({ id: username1 })]),
@@ -750,7 +750,7 @@ describe("UserWallet - Lightning Pay", () => {
         //     .mockReturnValueOnce(addProps(inputs.shift()))
         // }))
         // await paymentOtherGaloyUser({walletPayee: userWallet1, walletPayer: userWallet2})
-        const userType0 = await getUserTypeByTestUserIndex(0)
+        const userType0 = await getUserRecordByTestUserIndex(0)
         expect(userType0.contacts).toEqual(
           expect.not.arrayContaining([expect.objectContaining({ id: username2 })]),
         )
@@ -896,7 +896,7 @@ describe("UserWallet - Lightning Pay", () => {
         }
 
         const secret = await enable2FA(userId0)
-        userType0 = await getUserTypeByTestUserIndex(0)
+        userType0 = await getUserRecordByTestUserIndex(0)
         expect(secret).toBe(userType0.twoFA.secret)
 
         const remainingLimit = await getRemainingTwoFALimit(walletId0)
@@ -918,7 +918,7 @@ describe("UserWallet - Lightning Pay", () => {
 
       it(`Makes large payment with a 2fa code`, async () => {
         await enable2FA(userId0)
-        const userType0 = await getUserTypeByTestUserIndex(0)
+        const userType0 = await getUserRecordByTestUserIndex(0)
         const secret = userType0.twoFA.secret
 
         const { request } = await createInvoice({

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -42,7 +42,7 @@ import {
   getAccountIdByTestUserIndex,
   getDefaultWalletIdByTestUserIndex,
   getUserIdByTestUserIndex,
-  getUserTypeByTestUserIndex,
+  getUserRecordByTestUserIndex,
   lndonchain,
   lndOutside1,
   mineBlockAndSync,
@@ -59,7 +59,7 @@ const date = Date.now() + 1000 * 60 * 60 * 24 * 8
 jest.spyOn(global.Date, "now").mockImplementation(() => new Date(date).valueOf())
 
 let initialBalanceUser0: Satoshis
-let user0: UserType
+let user0: UserRecord
 
 let accountId0: AccountId
 
@@ -83,7 +83,7 @@ beforeAll(async () => {
   await createUserWallet(11)
   await createUserWallet(12)
 
-  user0 = await getUserTypeByTestUserIndex(0)
+  user0 = await getUserRecordByTestUserIndex(0)
   walletId0 = await getDefaultWalletIdByTestUserIndex(0)
   userId0 = await getUserIdByTestUserIndex(0)
   accountId0 = await getAccountIdByTestUserIndex(0)

--- a/test/integration/graphql/admin/mutations.spec.ts
+++ b/test/integration/graphql/admin/mutations.spec.ts
@@ -3,7 +3,7 @@ import { graphql } from "graphql"
 import { User } from "@services/mongoose/schema"
 import { gqlAdminSchema } from "@graphql/admin"
 
-let user
+let user: UserRecord
 
 beforeAll(async () => {
   user = await User.findOne({ username: "tester", phone: "+19876543210" })
@@ -16,7 +16,7 @@ describe("GraphQLMutationRoot", () => {
   it("exposes accountUpdateLevel", async () => {
     const mutation = `
       mutation {
-        accountUpdateLevel(input: { uid: "${user.id}", level: TWO}) {
+        accountUpdateLevel(input: { uid: "${user._id}", level: TWO}) {
           errors {
             message
           }
@@ -56,7 +56,7 @@ describe("GraphQLMutationRoot", () => {
   it("exposes accountUpdateStatus", async () => {
     const mutation = `
       mutation {
-        accountUpdateStatus(input: { uid: "${user.id}", status: LOCKED}) {
+        accountUpdateStatus(input: { uid: "${user._id}", status: LOCKED}) {
           errors {
             message
           }

--- a/test/integration/servers/trigger.spec.ts
+++ b/test/integration/servers/trigger.spec.ts
@@ -19,7 +19,7 @@ import {
   getHash,
   getInvoice,
   getUserIdByTestUserIndex,
-  getUserTypeByTestUserIndex,
+  getUserRecordByTestUserIndex,
   lnd1,
   lndOutside1,
   mineBlockAndSyncAll,
@@ -42,8 +42,8 @@ let walletId12: WalletId
 
 let userId12: UserId
 
-let userType0: UserType
-let userType3: UserType
+let userType0: UserRecord
+let userType3: UserRecord
 
 beforeAll(async () => {
   await bitcoindClient.loadWallet({ filename: "outside" })
@@ -58,8 +58,8 @@ beforeAll(async () => {
 
   userId12 = await getUserIdByTestUserIndex(12)
 
-  userType0 = await getUserTypeByTestUserIndex(0)
-  userType3 = await getUserTypeByTestUserIndex(3)
+  userType0 = await getUserRecordByTestUserIndex(0)
+  userType3 = await getUserRecordByTestUserIndex(3)
 })
 
 beforeEach(() => {
@@ -153,7 +153,7 @@ describe("onchainBlockEventhandler", () => {
       address,
     }: {
       walletId: WalletId
-      userType: UserType
+      userType: UserRecord
       initialState: WalletState
       amount: Satoshis
       address: string


### PR DESCRIPTION
- There was a mix between ObjectId and String in the domain code.
when using `collection._id` from mongoose, the value being returned is an ObjectId. 
when using `collection.id` from mongoose, by default, the value being returned is a string, casted from ObjectId

but MongoDb is not compatible between ObjectId and String. If you do a Colleciton.find({ accountId }), and this is saved as a string within mongodb, then the result is empty. (and vice et versa, if this is saved as a string but the query is with a ObjectId)

so this collection aimed at fixing this with:
- disabling the default .id on User with `{ id: false }` to avoid future confusion
- migration is removing the cast on String (will need to run again on staging)
- making sure the boundary for the core domain are respected, so that ObjectId only lives in the repository, but are passed to String when entering the domain, and passed back as ObjectId when querying over mongodb.