### PR TITLE
fix: WalletInvoice.update should not create new records

### DIFF
--- a/src/domain/wallet-invoices/index.types.d.ts
+++ b/src/domain/wallet-invoices/index.types.d.ts
@@ -13,13 +13,7 @@ type WalletInvoiceValidator = {
 interface IWalletInvoicesRepository {
   persistNew: (invoice: WalletInvoice) => Promise<WalletInvoice | RepositoryError>
 
-  update: ({
-    paymentHash,
-    paid,
-  }: {
-    paymentHash: PaymentHash
-    paid: boolean
-  }) => Promise<WalletInvoice | RepositoryError>
+  update: (walletInvoice: WalletInvoice) => Promise<WalletInvoice | RepositoryError>
 
   findByPaymentHash: (
     paymentHash: PaymentHash,

--- a/src/services/mongoose/wallet-invoices.ts
+++ b/src/services/mongoose/wallet-invoices.ts
@@ -31,15 +31,10 @@ export const WalletInvoicesRepository = (): IWalletInvoicesRepository => {
   const update = async ({
     paymentHash,
     paid,
-  }: {
-    paymentHash: PaymentHash
-    paid: boolean
-  }): Promise<WalletInvoice | RepositoryError> => {
+  }: WalletInvoice): Promise<WalletInvoice | RepositoryError> => {
     try {
       const data = { paid }
-      const invoiceUser = await InvoiceUser.findOneAndUpdate({ _id: paymentHash }, data, {
-        new: true,
-      })
+      const invoiceUser = await InvoiceUser.findOneAndUpdate({ _id: paymentHash }, data)
       if (!invoiceUser) {
         return new RepositoryError("Couldn't update invoice for payment hash")
       }


### PR DESCRIPTION
due to concern that we may inadvertently circumvent the `readonly` type assertions by creating a new object that we pass to the `WalletInvoiceRepository` we should also make sure that it is a true `update` instead of an `upsert`.