### PR TITLE
refactor: add default 'createdAt' value for lnPayment objects in db

### DIFF
--- a/src/services/lnd/schema.ts
+++ b/src/services/lnd/schema.ts
@@ -30,7 +30,10 @@ const confirmedDetailsSchema = new Schema<LnPaymentConfirmedDetails>({
 const paymentAttemptSchema = Schema.Types.Mixed
 
 const paymentSchema = new Schema<LnPaymentType>({
-  createdAt: Date,
+  createdAt: {
+    type: Date,
+    default: Date.now,
+  },
   status: {
     type: String,
     enum: Object.values(PaymentStatus),

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -823,6 +823,7 @@ describe("UserWallet - Lightning Pay", () => {
         expect(lnPaymentOnPay.paymentHash).toBe(id)
         expect(lnPaymentOnPay.paymentRequest).toBe(request)
         expect(lnPaymentOnPay.isCompleteRecord).toBeFalsy()
+        expect(lnPaymentOnPay.createdAt).toBeInstanceOf(Date)
         expect(lnPaymentOnPay.status).toBeUndefined()
 
         // Run update task
@@ -839,6 +840,7 @@ describe("UserWallet - Lightning Pay", () => {
         expect(lnPaymentOnPay.paymentHash).toBe(id)
         expect(lnPaymentOnPay.paymentRequest).toBe(request)
         expect(lnPaymentOnPay.isCompleteRecord).toBeFalsy()
+        expect(lnPaymentOnPay.createdAt).toBeInstanceOf(Date)
         expect(lnPaymentOnPay.status).toBeUndefined()
 
         const lndService = LndService()


### PR DESCRIPTION
## Description

Adding back after thinking some more about [this comment](https://github.com/GaloyMoney/galoy/pull/848#discussion_r786650986).

Adding for easy debug purposes in the case where we'd like to know how long a payment has been sitting as "incomplete" in the db.

**Note:**

- objects _**always**_ get the `createdAt` property populated from lnd on settlement or failure when we persist the rest of the object and mark it as `isCompleteRecord: true`. The `createdAt` value will be overwritten at that point with whatever exists in `lnd`

- in the case of pending payments not persisted fully as yet, we can also always retrieve the actual `createdAt` value by querying lnd