### PR TITLE
fix: add resolvers for admin gql Invoice/Payment selections

### DIFF
--- a/src/graphql/admin/types/object/lightning-invoice.ts
+++ b/src/graphql/admin/types/object/lightning-invoice.ts
@@ -9,11 +9,23 @@ const LightningInvoice = new GT.Object({
   fields: () => ({
     createdAt: { type: GT.NonNull(Timestamp) },
     confirmedAt: { type: Timestamp },
-    description: { type: GT.NonNull(GT.String) },
-    expiresAt: { type: Timestamp },
+    description: {
+      type: GT.NonNull(GT.String),
+      resolve: (source: LnInvoiceLookup) => source.lnInvoice.description,
+    },
+    expiresAt: {
+      type: Timestamp,
+      resolve: (source: LnInvoiceLookup) => source.lnInvoice.expiresAt,
+    },
     isSettled: { type: GT.NonNull(GT.Boolean) },
-    received: { type: GT.NonNull(SatAmount) },
-    request: { type: LnPaymentRequest },
+    received: {
+      type: GT.NonNull(SatAmount),
+      resolve: (source: LnInvoiceLookup) => source.roundedDownReceived,
+    },
+    request: {
+      type: LnPaymentRequest,
+      resolve: (source: LnInvoiceLookup) => source.lnInvoice.paymentRequest,
+    },
     secretPreImage: { type: GT.NonNull(LnPaymentPreImage) },
   }),
 })

--- a/src/graphql/admin/types/object/lightning-payment.ts
+++ b/src/graphql/admin/types/object/lightning-payment.ts
@@ -10,13 +10,31 @@ const LightningPayment = new GT.Object({
   name: "LightningPayment",
   fields: () => ({
     status: { type: LnPaymentStatus },
-    roundedUpFee: { type: SatAmount },
+    roundedUpFee: {
+      type: SatAmount,
+      resolve: (source: LnPaymentLookup) => source.confirmedDetails?.roundedUpFee,
+    },
     createdAt: { type: Timestamp },
-    confirmedAt: { type: Timestamp },
-    amount: { type: SatAmount },
-    revealedPreImage: { type: LnPaymentPreImage },
-    request: { type: LnPaymentRequest },
-    destination: { type: LnPubkey },
+    confirmedAt: {
+      type: Timestamp,
+      resolve: (source: LnPaymentLookup) => source.confirmedDetails?.confirmedAt,
+    },
+    amount: {
+      type: SatAmount,
+      resolve: (source: LnPaymentLookup) => source.roundedUpAmount,
+    },
+    revealedPreImage: {
+      type: LnPaymentPreImage,
+      resolve: (source: LnPaymentLookup) => source.confirmedDetails?.revealedPreImage,
+    },
+    request: {
+      type: LnPaymentRequest,
+      resolve: (source: LnPaymentLookup) => source.paymentRequest,
+    },
+    destination: {
+      type: LnPubkey,
+      resolve: (source: LnPaymentLookup) => source.confirmedDetails?.destination,
+    },
   }),
 })
 


### PR DESCRIPTION
## Description

Builds on changes introduced in #848

This PR adds the missing resolvers after the domain type changes, for the `LnInvoice` and `LnPayment` objects in the admin graphql schema.