### PR TITLE
refactor: Remove redundant use-case

### DIFF
--- a/src/app/accounts/send-default-wallet-balance-to-users.ts
+++ b/src/app/accounts/send-default-wallet-balance-to-users.ts
@@ -1,6 +1,6 @@
 import { getCurrentPrice } from "@app/prices"
-import { getBalanceForWalletId } from "@app/wallets"
 import { NotificationsService } from "@services/notifications"
+import { LedgerService } from "@services/ledger"
 
 import { getRecentlyActiveAccounts } from "./active-accounts"
 
@@ -11,7 +11,7 @@ export const sendDefaultWalletBalanceToUsers = async (logger: Logger) => {
   const price = await getCurrentPrice()
 
   for (const account of accounts) {
-    const balance = await getBalanceForWalletId(account.defaultWalletId)
+    const balance = await LedgerService().getWalletBalance(account.defaultWalletId)
     if (balance instanceof Error) throw balance
 
     await NotificationsService(logger).sendBalance({

--- a/src/app/wallets/get-balance-for-wallet.ts
+++ b/src/app/wallets/get-balance-for-wallet.ts
@@ -26,14 +26,5 @@ export const getBalanceForWallet = async ({
   ])
   if (updatePaymentsResult instanceof Error) return updatePaymentsResult
 
-  return getBalanceForWalletId(walletId)
-}
-
-export const getBalanceForWalletId = async (
-  walletId: WalletId,
-): Promise<Satoshis | ApplicationError> => {
-  const balance = await LedgerService().getWalletBalance(walletId)
-  if (balance instanceof Error) return balance
-
-  return balance
+  return LedgerService().getWalletBalance(walletId)
 }

--- a/src/app/wallets/get-lightning-fee.ts
+++ b/src/app/wallets/get-lightning-fee.ts
@@ -7,9 +7,8 @@ import {
 import { CachedRouteLookupKeyFactory } from "@domain/routes/key-factory"
 import { checkedToWalletId } from "@domain/wallets"
 import { LndService } from "@services/lnd"
+import { LedgerService } from "@services/ledger"
 import { RoutesCache } from "@services/redis/routes"
-
-import { getBalanceForWalletId } from "./get-balance-for-wallet"
 
 export const getLightningFee = async ({
   walletId,
@@ -63,7 +62,7 @@ const feeProbe = async ({
   const walletIdChecked = checkedToWalletId(walletId)
   if (walletIdChecked instanceof Error) return walletIdChecked
 
-  const balance = await getBalanceForWalletId(walletId)
+  const balance = await LedgerService().getWalletBalance(walletId)
   if (balance instanceof Error) return balance
   if (balance < paymentAmount) {
     return new InsufficientBalanceError(
@@ -111,7 +110,7 @@ const noAmountProbeForFee = async ({
   const walletIdChecked = checkedToWalletId(walletId)
   if (walletIdChecked instanceof Error) return walletIdChecked
 
-  const balance = await getBalanceForWalletId(walletId)
+  const balance = await LedgerService().getWalletBalance(walletId)
   if (balance instanceof Error) return balance
   if (balance < paymentAmount) {
     return new InsufficientBalanceError(

--- a/src/app/wallets/get-on-chain-fee.ts
+++ b/src/app/wallets/get-on-chain-fee.ts
@@ -9,8 +9,7 @@ import {
   LessThanDustThresholdError,
   InsufficientBalanceError,
 } from "@domain/errors"
-
-import { getBalanceForWalletId } from "./get-balance-for-wallet"
+import { LedgerService } from "@services/ledger"
 
 const { dustThreshold } = getOnChainWalletConfig()
 
@@ -35,7 +34,7 @@ export const getOnChainFee = async ({
       `Use lightning to send amounts less than ${dustThreshold}`,
     )
 
-  const balance = await getBalanceForWalletId(wallet.id)
+  const balance = await LedgerService().getWalletBalance(wallet.id)
   if (balance instanceof Error) return balance
 
   // avoids lnd balance sniffing attack

--- a/src/app/wallets/intraledger-send-payment.ts
+++ b/src/app/wallets/intraledger-send-payment.ts
@@ -15,7 +15,6 @@ import { AccountsRepository } from "@services/mongoose"
 import { NotificationsService } from "@services/notifications"
 
 import { checkAndVerifyTwoFA, checkIntraledgerLimits } from "./check-limit-helpers"
-import { getBalanceForWalletId } from "./get-balance-for-wallet"
 
 export const intraledgerPaymentSendUsername = async ({
   recipientUsername,
@@ -206,7 +205,7 @@ const executePaymentViaIntraledger = async ({
   return LockService().lockWalletId(
     { walletId: senderWalletId, logger },
     async (lock) => {
-      const balance = await getBalanceForWalletId(senderWalletId)
+      const balance = await LedgerService().getWalletBalance(senderWalletId)
       if (balance instanceof Error) return balance
       if (balance < sats) {
         return new InsufficientBalanceError(

--- a/src/app/wallets/ln-send-payment.ts
+++ b/src/app/wallets/ln-send-payment.ts
@@ -1,6 +1,6 @@
 import { getCurrentPrice } from "@app/prices"
 import { getUser } from "@app/users"
-import { getBalanceForWalletId, getWallet } from "@app/wallets"
+import { getWallet } from "@app/wallets"
 import {
   checkAndVerifyTwoFA,
   checkIntraledgerLimits,
@@ -353,7 +353,7 @@ const executePaymentViaIntraledger = async ({
   return LockService().lockWalletId(
     { walletId: senderWalletId, logger },
     async (lock) => {
-      const balance = await getBalanceForWalletId(senderWalletId)
+      const balance = await LedgerService().getWalletBalance(senderWalletId)
       if (balance instanceof Error) return balance
       if (balance < sats) {
         return new InsufficientBalanceError(
@@ -453,7 +453,7 @@ const executePaymentViaLn = async ({
   return LockService().lockWalletId(
     { walletId: senderWalletId, logger },
     async (lock) => {
-      const balance = await getBalanceForWalletId(senderWalletId)
+      const balance = await LedgerService().getWalletBalance(senderWalletId)
       if (balance instanceof Error) return balance
       if (balance < sats) {
         return new InsufficientBalanceError(

--- a/src/app/wallets/pay-on-chain.ts
+++ b/src/app/wallets/pay-on-chain.ts
@@ -28,7 +28,6 @@ import {
   checkIntraledgerLimits,
   checkWithdrawalLimits,
 } from "./check-limit-helpers"
-import { getBalanceForWalletId } from "./get-balance-for-wallet"
 import { getOnChainFeeByWalletId } from "./get-on-chain-fee"
 
 const { dustThreshold } = getOnChainWalletConfig()
@@ -44,7 +43,7 @@ export const payOnChainByWalletIdWithTwoFA = async ({
   twoFAToken,
 }: PayOnChainByWalletIdWithTwoFAArgs): Promise<PaymentSendStatus | ApplicationError> => {
   const checkedAmount = sendAll
-    ? await getBalanceForWalletId(senderWalletId)
+    ? await LedgerService().getWalletBalance(senderWalletId)
     : checkedToSats(amount)
   if (checkedAmount instanceof Error) return checkedAmount
 
@@ -101,7 +100,7 @@ export const payOnChainByWalletId = async ({
   if (checkedTargetConfirmations instanceof Error) return checkedTargetConfirmations
 
   const checkedAmount = sendAll
-    ? await getBalanceForWalletId(senderWalletId)
+    ? await LedgerService().getWalletBalance(senderWalletId)
     : checkedToSats(amount)
   if (checkedAmount instanceof Error) return checkedAmount
 
@@ -176,7 +175,7 @@ const executePaymentViaIntraledger = async ({
   return LockService().lockWalletId(
     { walletId: senderWalletId, logger },
     async (lock) => {
-      const balance = await getBalanceForWalletId(senderWalletId)
+      const balance = await LedgerService().getWalletBalance(senderWalletId)
       if (balance instanceof Error) return balance
       if (balance < sats)
         return new InsufficientBalanceError(
@@ -294,7 +293,7 @@ const executePaymentViaOnChain = async ({
   return LockService().lockWalletId(
     { walletId: senderWalletId, logger },
     async (lock) => {
-      const balance = await getBalanceForWalletId(senderWalletId)
+      const balance = await LedgerService().getWalletBalance(senderWalletId)
       if (balance instanceof Error) return balance
       if (balance < amountToSend + estimatedFee)
         return new InsufficientBalanceError(

--- a/src/servers/exporter.ts
+++ b/src/servers/exporter.ts
@@ -1,4 +1,3 @@
-import { Wallets } from "@app"
 import { balanceSheetIsBalanced, getLedgerAccounts } from "@core/balance-sheet"
 import { toSats } from "@domain/bitcoin"
 import { getBalancesDetail } from "@services/bitcoind"
@@ -7,6 +6,7 @@ import {
   getDealerWalletId,
   getFunderWalletId,
 } from "@services/ledger/accounts"
+import { LedgerService } from "@services/ledger"
 import { activateLndHealthCheck } from "@services/lnd/health"
 import { getBosScore, lndsBalances } from "@services/lnd/utils"
 import { baseLogger } from "@services/logger"
@@ -116,13 +116,13 @@ const main = async () => {
 
     for (const index in roles) {
       const role = roles[index]
-      const account = await accountRoles[index]()
+      const walletId = await accountRoles[index]()
 
       let balance: Satoshis
 
-      const balanceSats = await Wallets.getBalanceForWalletId(account)
+      const balanceSats = await LedgerService().getWalletBalance(walletId)
       if (balanceSats instanceof Error) {
-        baseLogger.warn({ account, role, balanceSats }, "impossible to get balance")
+        baseLogger.warn({ walletId, role, balanceSats }, "impossible to get balance")
         balance = toSats(0)
       } else {
         balance = balanceSats

--- a/test/helpers/bitcoin-core.ts
+++ b/test/helpers/bitcoin-core.ts
@@ -2,10 +2,10 @@ import {
   addInvoiceByWalletId,
   createOnChainAddress,
   getBalanceForWallet,
-  getBalanceForWalletId,
 } from "@app/wallets"
 import { bitcoindDefaultClient, BitcoindWalletClient } from "@services/bitcoind"
 import { baseLogger } from "@services/logger"
+import { LedgerService } from "@services/ledger"
 import { pay } from "lightning"
 
 import { lndOutside1, waitUntilBlockHeight } from "."
@@ -89,7 +89,7 @@ export const fundWalletIdFromOnchain = async ({
   })
   await waitUntilBlockHeight({ lnd })
 
-  const balance = await getBalanceForWalletId(walletId)
+  const balance = await LedgerService().getWalletBalance(walletId)
   if (balance instanceof Error) throw balance
 }
 

--- a/test/integration/01-setup/01-funds-bitcoind-lnds.spec.ts
+++ b/test/integration/01-setup/01-funds-bitcoind-lnds.spec.ts
@@ -1,4 +1,4 @@
-import { getBalanceForWalletId } from "@app/wallets"
+import { LedgerService } from "@services/ledger"
 import { btc2sat } from "@domain/bitcoin"
 import { BitcoindWalletClient } from "@services/bitcoind"
 import { getFunderWalletId } from "@services/ledger/accounts"
@@ -78,7 +78,7 @@ describe("Bitcoind", () => {
 
     await checkIsBalanced()
 
-    const balanceFunderWalletId = await getBalanceForWalletId(funderWalletId)
+    const balanceFunderWalletId = await LedgerService().getWalletBalance(funderWalletId)
     balanceFunderWalletId
     // console.log({ balanceFunderWalletId }, "funderWalletId")
     // FIXME: this test is broken


### PR DESCRIPTION
The use case `getBalanceForWalletId` was exported but never used from GQL layer - so there is no reason to export it as a top level use case.
For app layer internal usage it is also not necessary as it is simply wrapping 1 line.