### PR TITLE
refactor: payment input validation

### DIFF
--- a/src/app/wallets/index.types.d.ts
+++ b/src/app/wallets/index.types.d.ts
@@ -98,6 +98,7 @@ type IntraLedgerPaymentSendWithTwoFAArgs = IntraLedgerPaymentSendUsernameArgs & 
 }
 
 type PayOnChainByWalletIdArgs = {
+  senderAccount: Account
   senderWalletId: WalletId
   amount: number
   address: string
@@ -107,6 +108,5 @@ type PayOnChainByWalletIdArgs = {
 }
 
 type PayOnChainByWalletIdWithTwoFAArgs = PayOnChainByWalletIdArgs & {
-  payerAccountId: AccountId
   twoFAToken: TwoFAToken
 }

--- a/src/app/wallets/pay-on-chain.ts
+++ b/src/app/wallets/pay-on-chain.ts
@@ -98,6 +98,7 @@ export const payOnChainByWalletId = async ({
     address,
     checkedAmount,
     memo,
+    sendAll,
   })
   const checkedAddress = checkedToOnChainAddress({
     network: BTC_NETWORK,

--- a/src/app/wallets/pay-on-chain.ts
+++ b/src/app/wallets/pay-on-chain.ts
@@ -87,7 +87,6 @@ export const payOnChainByWalletId = async ({
     amount: checkedAmount,
     senderAccount,
     senderWalletId,
-    recipientWalletId: null,
   })
   if (validationResult instanceof Error) return validationResult
 

--- a/src/domain/wallets/index.ts
+++ b/src/domain/wallets/index.ts
@@ -5,6 +5,7 @@ export { WalletTransactionHistory } from "./tx-history"
 export * from "./tx-methods"
 export * from "./tx-status"
 export * from "./withdrawal-fee-calculator"
+export * from "./payment-input-validator"
 export * from "./primitives"
 
 export const WalletIdRegex =

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -174,3 +174,25 @@ type WithdrawalFeeCalculator = {
   onChainWithdrawalFee({ onChainFee, walletFee }: OnChainWithdrawalFeeArgs): Satoshis
   onChainIntraLedgerFee(): Satoshis
 }
+
+type PaymentInputValidatorConfig = (
+  walletId: WalletId,
+) => Promise<Wallet | RepositoryError>
+
+type ValidatePaymentInputArgs = {
+  amount: number
+  senderWalletId: string
+  senderAccount: Account
+  recipientWalletId: string | null
+}
+type ValidatePaymentInputRet = {
+  amount: Satoshis
+  senderWallet: Wallet
+  recipientWallet: Wallet | null
+}
+
+type PaymentInputValidator = {
+  validatePaymentInput: (
+    args: ValidatePaymentInputArgs,
+  ) => Promise<ValidatePaymentInputRet | ValidationError | RepositoryError>
+}

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -183,12 +183,12 @@ type ValidatePaymentInputArgs = {
   amount: number
   senderWalletId: string
   senderAccount: Account
-  recipientWalletId: string | null
+  recipientWalletId?: string
 }
 type ValidatePaymentInputRet = {
   amount: Satoshis
   senderWallet: Wallet
-  recipientWallet: Wallet | null
+  recipientWallet?: Wallet
 }
 
 type PaymentInputValidator = {

--- a/src/domain/wallets/payment-input-validator.ts
+++ b/src/domain/wallets/payment-input-validator.ts
@@ -1,0 +1,50 @@
+import { checkedToSats } from "@domain/bitcoin"
+import {
+  SelfPaymentError,
+  InvalidWalletId,
+  InvalidAccountStatusError,
+} from "@domain/errors"
+import { AccountStatus } from "@domain/accounts"
+
+export const PaymentInputValidator = (
+  getWalletFn: PaymentInputValidatorConfig,
+): PaymentInputValidator => {
+  const validatePaymentInput = async ({
+    amount,
+    senderWalletId,
+    senderAccount,
+    recipientWalletId,
+  }) => {
+    const validAmount = checkedToSats(amount)
+    if (validAmount instanceof Error) return validAmount
+
+    if (senderAccount.status !== AccountStatus.Active) {
+      return new InvalidAccountStatusError()
+    }
+    const senderWallet = await getWalletFn(senderWalletId)
+    if (senderWallet instanceof Error) return senderWallet
+
+    if (senderWallet.accountId !== senderAccount.id) return new InvalidWalletId()
+
+    if (recipientWalletId != null) {
+      const recipientWallet = await getWalletFn(recipientWalletId)
+      if (recipientWallet instanceof Error) return recipientWallet
+      if (recipientWallet.id === senderWallet.id) return new SelfPaymentError()
+      return {
+        amount: validAmount,
+        senderWallet,
+        recipientWallet,
+      }
+    }
+
+    return {
+      amount: validAmount,
+      senderWallet,
+      recipientWallet: null,
+    }
+  }
+
+  return {
+    validatePaymentInput,
+  }
+}

--- a/src/graphql/root/mutation/onchain-payment-send-all.ts
+++ b/src/graphql/root/mutation/onchain-payment-send-all.ts
@@ -22,7 +22,7 @@ const OnChainPaymentSendAllMutation = GT.Field({
   args: {
     input: { type: GT.NonNull(OnChainPaymentSendAllInput) },
   },
-  resolve: async (_, args) => {
+  resolve: async (_, args, { domainAccount }) => {
     const { walletId, address, memo, targetConfirmations } = args.input
 
     for (const input of [walletId, memo, address, targetConfirmations]) {
@@ -32,6 +32,7 @@ const OnChainPaymentSendAllMutation = GT.Field({
     }
 
     const status = await Wallets.payOnChainByWalletId({
+      senderAccount: domainAccount,
       senderWalletId: walletId,
       amount: 0,
       address,

--- a/src/graphql/root/mutation/onchain-payment-send.ts
+++ b/src/graphql/root/mutation/onchain-payment-send.ts
@@ -24,7 +24,7 @@ const OnChainPaymentSendMutation = GT.Field({
   args: {
     input: { type: GT.NonNull(OnChainPaymentSendInput) },
   },
-  resolve: async (_, args) => {
+  resolve: async (_, args, { domainAccount }) => {
     const { walletId, address, amount, memo, targetConfirmations } = args.input
 
     for (const input of [walletId, amount, address, targetConfirmations, memo]) {
@@ -34,6 +34,7 @@ const OnChainPaymentSendMutation = GT.Field({
     }
 
     const status = await Wallets.payOnChainByWalletId({
+      senderAccount: domainAccount,
       senderWalletId: walletId,
       amount,
       address,

--- a/src/servers/graphql-old-server.ts
+++ b/src/servers/graphql-old-server.ts
@@ -410,7 +410,7 @@ const resolvers = {
         },
       ]
     },
-    onchain: (_, __, { wallet }) => ({
+    onchain: (_, __, { wallet, domainAccount }) => ({
       getNewAddress: async () => {
         const address = await Wallets.createOnChainAddress(wallet.user.defaultWalletId)
         if (address instanceof Error) throw mapError(address)
@@ -418,6 +418,7 @@ const resolvers = {
       },
       pay: async ({ address, amount, memo }) => {
         const status = await Wallets.payOnChainByWalletId({
+          senderAccount: domainAccount,
           senderWalletId: wallet.user.defaultWalletId,
           amount,
           address,
@@ -431,6 +432,7 @@ const resolvers = {
       },
       payAll: async ({ address, memo }) => {
         const status = await Wallets.payOnChainByWalletId({
+          senderAccount: domainAccount,
           senderWalletId: wallet.user.defaultWalletId,
           amount: 0,
           address,

--- a/test/unit/domain/wallets/payment-input-validator.spec.ts
+++ b/test/unit/domain/wallets/payment-input-validator.spec.ts
@@ -1,4 +1,5 @@
 import crypto from "crypto"
+
 import {
   InvalidSatoshiAmount,
   InvalidAccountStatusError,

--- a/test/unit/domain/wallets/payment-input-validator.spec.ts
+++ b/test/unit/domain/wallets/payment-input-validator.spec.ts
@@ -1,0 +1,146 @@
+import { WalletCurrency, WalletType, PaymentInputValidator } from "@domain/wallets"
+import { AccountLevel, AccountStatus } from "@domain/accounts"
+
+describe("PaymentInputValidator", () => {
+  const dummySenderWallet: Wallet = {
+    id: "senderWalletId" as WalletId,
+    accountId: "senderAccountId" as AccountId,
+    type: WalletType.Checking,
+    currency: WalletCurrency.Btc,
+    onChainAddressIdentifiers: [],
+    onChainAddresses: () => [],
+  }
+  const dummyRecipientWallet: Wallet = {
+    id: "recipientWalletId" as WalletId,
+    accountId: "recipientAccountId" as AccountId,
+    type: WalletType.Checking,
+    currency: WalletCurrency.Btc,
+    onChainAddressIdentifiers: [],
+    onChainAddresses: () => [],
+  }
+  const dummyAccount: Account = {
+    id: "senderAccountId" as AccountId,
+    createdAt: new Date(),
+    username: "username" as Username,
+    defaultWalletId: "senderWalletId" as WalletId,
+    ownerId: "ownerId" as UserId,
+    depositFeeRatio: 0 as DepositFeeRatio,
+    withdrawFee: 0 as WithdrawFee,
+    level: AccountLevel.One,
+    status: AccountStatus.Active,
+    title: "" as BusinessMapTitle,
+    coordinates: {
+      latitude: 0,
+      longitude: 0,
+    },
+    contacts: [],
+  }
+
+  it("returns the correct types when everything is valid", async () => {
+    const getWalletFn: PaymentInputValidatorConfig = (walletId: WalletId) => {
+      const wallet = {
+        senderWalletId: dummySenderWallet,
+        recipientWalletId: dummyRecipientWallet,
+      }[walletId]
+
+      return Promise.resolve(wallet)
+    }
+
+    const validator: PaymentInputValidator = PaymentInputValidator(getWalletFn)
+    const result = await validator.validatePaymentInput({
+      amount: 2,
+      senderWalletId: "senderWalletId",
+      senderAccount: dummyAccount,
+      recipientWalletId: "recipientWalletId",
+    })
+    if (result instanceof Error) throw result
+    const { amount, senderWallet } = result
+    expect(amount).toBe(2)
+    expect(senderWallet).toBe(dummySenderWallet)
+  })
+
+  it("Fails on invalid amount", async () => {
+    const getWalletFn: PaymentInputValidatorConfig = (walletId: WalletId) => {
+      const wallet = {
+        senderWalletId: dummySenderWallet,
+        recipientWalletId: dummyRecipientWallet,
+      }[walletId]
+
+      return Promise.resolve(wallet)
+    }
+
+    const validator: PaymentInputValidator = PaymentInputValidator(getWalletFn)
+    const result = await validator.validatePaymentInput({
+      amount: -1,
+      senderWalletId: "senderWalletId",
+      senderAccount: dummyAccount,
+      recipientWalletId: "recipientWalletId",
+    })
+    expect(result instanceof Error).toBe(true)
+  })
+
+  it("Fails when sender === recipient", async () => {
+    const getWalletFn: PaymentInputValidatorConfig = (walletId: WalletId) => {
+      const wallet = {
+        senderWalletId: dummySenderWallet,
+        recipientWalletId: dummyRecipientWallet,
+      }[walletId]
+
+      return Promise.resolve(wallet)
+    }
+
+    const validator: PaymentInputValidator = PaymentInputValidator(getWalletFn)
+    const result = await validator.validatePaymentInput({
+      amount: 2,
+      senderWalletId: "senderWalletId",
+      senderAccount: dummyAccount,
+      recipientWalletId: "senderWalletId",
+    })
+    expect(result instanceof Error).toBe(true)
+  })
+
+  it("Fails if the account is not active", async () => {
+    const getWalletFn: PaymentInputValidatorConfig = (walletId: WalletId) => {
+      const wallet = {
+        senderWalletId: dummySenderWallet,
+        recipientWalletId: dummyRecipientWallet,
+      }[walletId]
+
+      return Promise.resolve(wallet)
+    }
+
+    const validator: PaymentInputValidator = PaymentInputValidator(getWalletFn)
+    const result = await validator.validatePaymentInput({
+      amount: 2,
+      senderWalletId: "senderWalletId",
+      senderAccount: {
+        ...dummyAccount,
+        status: AccountStatus.Locked,
+      },
+      recipientWalletId: "recipientWalletId",
+    })
+    expect(result instanceof Error).toBe(true)
+  })
+
+  it("Returns null for recipient when id is null", async () => {
+    const getWalletFn: PaymentInputValidatorConfig = (walletId: WalletId) => {
+      const wallet = {
+        senderWalletId: dummySenderWallet,
+        recipientWalletId: dummyRecipientWallet,
+      }[walletId]
+
+      return Promise.resolve(wallet)
+    }
+
+    const validator: PaymentInputValidator = PaymentInputValidator(getWalletFn)
+    const result = await validator.validatePaymentInput({
+      amount: 2,
+      senderWalletId: "senderWalletId",
+      senderAccount: dummyAccount,
+      recipientWalletId: null,
+    })
+    if (result instanceof Error) throw result
+    const { recipientWallet } = result
+    expect(recipientWallet).toBe(null)
+  })
+})

--- a/test/unit/domain/wallets/payment-input-validator.spec.ts
+++ b/test/unit/domain/wallets/payment-input-validator.spec.ts
@@ -122,7 +122,7 @@ describe("PaymentInputValidator", () => {
     expect(result instanceof Error).toBe(true)
   })
 
-  it("Returns null for recipient when id is null", async () => {
+  it("Returns undefined for recipient when id is undefined", async () => {
     const getWalletFn: PaymentInputValidatorConfig = (walletId: WalletId) => {
       const wallet = {
         senderWalletId: dummySenderWallet,
@@ -137,10 +137,9 @@ describe("PaymentInputValidator", () => {
       amount: 2,
       senderWalletId: "senderWalletId",
       senderAccount: dummyAccount,
-      recipientWalletId: null,
     })
     if (result instanceof Error) throw result
     const { recipientWallet } = result
-    expect(recipientWallet).toBe(null)
+    expect(recipientWallet).toBe(undefined)
   })
 })


### PR DESCRIPTION
This PR introduces a (unit-tested) `PaymentInputValidator` to take care of some common validation that must happen for all payment use cases.

Its currently only introduced into OnChainPay (as it is the simplest place to introduce it) but will be introduced in the other use cases in subsequent PRs.