### PR TITLE
feat: convert LND SCB backup GCS bucket name to yaml config variable

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -36,6 +36,8 @@ rebalancing:
   # specter wallet always
   onchainWallet: "specter"
 
+lndScbBackupBucketName: "lnd-static-channel-backups"
+
 test_accounts:
 - phone: "+16505554321" # user0
   code: 321321

--- a/src/app/admin/backup.ts
+++ b/src/app/admin/backup.ts
@@ -1,4 +1,9 @@
-import { BTC_NETWORK, DropboxAccessToken, GcsApplicationCredentials } from "@config"
+import {
+  BTC_NETWORK,
+  DropboxAccessToken,
+  GcsApplicationCredentials,
+  LND_SCB_BACKUP_BUCKET_NAME,
+} from "@config"
 import { Storage } from "@google-cloud/storage"
 import { Dropbox } from "dropbox"
 
@@ -21,7 +26,7 @@ export const uploadBackup =
       const storage = new Storage({
         keyFilename: GcsApplicationCredentials,
       })
-      const bucket = storage.bucket("lnd-static-channel-backups")
+      const bucket = storage.bucket(LND_SCB_BACKUP_BUCKET_NAME)
       const file = bucket.file(`${filename}`)
       await file.save(backup)
       logger.info({ backup }, "scb backed up on gcs successfully")

--- a/src/config/yaml.ts
+++ b/src/config/yaml.ts
@@ -192,5 +192,7 @@ export const getIpConfig = (config = yamlConfig): IpConfig => ({
 export const getApolloConfig = (config = yamlConfig): ApolloConfig => config.apollo
 export const getTwoFAConfig = (config = yamlConfig): TwoFAConfig => config.twoFA
 
+export const LND_SCB_BACKUP_BUCKET_NAME = yamlConfig.lndScbBackupBucketName
+
 export const getTestAccounts = (config = yamlConfig): TestAccount[] =>
   config.test_accounts


### PR DESCRIPTION
This PR takes the LND SCB backup GCS bucket name and extracts it to a yaml config variable. This allows each instance to set the backup bucket name as needed, as bucket names are globally unique across GCS.