### PR TITLE
feat: add support for the x-forwarded-for header if x-real-ip is not set

### DIFF
--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -68,7 +68,7 @@ const sessionContext = ({
   if (ips && Array.isArray(ips) && ips.length) {
     ip = ips[0]
   } else if (typeof ips === "string") {
-    ip = ips
+    ip = ips.split(',')[0]
   }
 
   let wallet, user
@@ -175,7 +175,7 @@ export const startApolloServer = async ({
       // @ts-expect-error: TODO
       const apiSecret = context.req?.apiSecret ?? null
 
-      const ips = context.req?.headers["x-real-ip"]
+      const ips = context.req?.headers["x-real-ip"] || context.req?.headers['x-forwarded-for']
       const body = context.req?.body ?? null
 
       return sessionContext({ token, apiKey, apiSecret, ips, body })

--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -68,7 +68,7 @@ const sessionContext = ({
   if (ips && Array.isArray(ips) && ips.length) {
     ip = ips[0]
   } else if (typeof ips === "string") {
-    ip = ips.split(',')[0]
+    ip = ips.split(",")[0]
   }
 
   let wallet, user
@@ -175,7 +175,8 @@ export const startApolloServer = async ({
       // @ts-expect-error: TODO
       const apiSecret = context.req?.apiSecret ?? null
 
-      const ips = context.req?.headers["x-real-ip"] || context.req?.headers['x-forwarded-for']
+      const ips =
+        context.req?.headers["x-real-ip"] || context.req?.headers["x-forwarded-for"]
       const body = context.req?.body ?? null
 
       return sessionContext({ token, apiKey, apiSecret, ips, body })


### PR DESCRIPTION
This PR adds support for using the `x-forwarded-for` request header to determine the user's IP if `x-real-ip` isn't set. `x-forwarded-for` can contain a comma separated string of IPs, and we only want to keep the first one.