### PR TITLE
refactor: rename payer to sender in ledger and perf improvement

### DIFF
--- a/src/app/wallets/intraledger-send-payment.ts
+++ b/src/app/wallets/intraledger-send-payment.ts
@@ -34,7 +34,7 @@ export const intraledgerPaymentSendUsername = async ({
   return intraLedgerSendPaymentUsername({
     payerAccountId,
     senderWalletId,
-    payerUsername: account.username,
+    senderUsername: account.username,
     recipientUsername,
     amount,
     memo: memo || "",
@@ -64,7 +64,7 @@ export const intraledgerPaymentSendWalletId = async ({
     recipientWalletId,
     amount,
     memoPayer: memo || "",
-    payerUsername: null,
+    senderUsername: null,
     logger,
   })
 
@@ -75,7 +75,7 @@ export const intraledgerPaymentSendWalletId = async ({
 export const intraledgerSendPaymentUsernameWithTwoFA = async ({
   twoFAToken,
   recipientUsername,
-  // payerUsername,
+  // senderUsername,
   amount,
   memo,
   senderWalletId,
@@ -108,7 +108,7 @@ export const intraledgerSendPaymentUsernameWithTwoFA = async ({
   return intraLedgerSendPaymentUsername({
     payerAccountId: user.defaultAccountId,
     senderWalletId,
-    payerUsername: account.username,
+    senderUsername: account.username,
     recipientUsername,
     amount,
     memo: memo || "",
@@ -119,7 +119,7 @@ export const intraledgerSendPaymentUsernameWithTwoFA = async ({
 const intraLedgerSendPaymentUsername = async ({
   payerAccountId,
   senderWalletId,
-  payerUsername,
+  senderUsername,
   recipientUsername,
   amount,
   memo,
@@ -127,7 +127,7 @@ const intraLedgerSendPaymentUsername = async ({
 }: {
   payerAccountId: AccountId
   senderWalletId: WalletId
-  payerUsername: Username
+  senderUsername: Username
   recipientUsername: Username
   amount: Satoshis
   memo: string
@@ -147,7 +147,7 @@ const intraLedgerSendPaymentUsername = async ({
     recipientWalletId,
     amount,
     memoPayer: memo || "",
-    payerUsername,
+    senderUsername,
     logger,
   })
   if (paymentSendStatus instanceof Error) return paymentSendStatus
@@ -158,13 +158,13 @@ const intraLedgerSendPaymentUsername = async ({
   })
   if (addContactToPayerResult instanceof Error) return addContactToPayerResult
 
-  if (payerUsername) {
+  if (senderUsername) {
     const recipientAccount = await AccountsRepository().findByUsername(recipientUsername)
     if (recipientAccount instanceof Error) return recipientAccount
 
     const addContactToPayeeResult = await addNewContact({
       accountId: recipientAccount.id,
-      contactUsername: payerUsername,
+      contactUsername: senderUsername,
     })
     if (addContactToPayeeResult instanceof Error) return addContactToPayeeResult
   }
@@ -174,7 +174,7 @@ const intraLedgerSendPaymentUsername = async ({
 
 const executePaymentViaIntraledger = async ({
   senderWalletId,
-  payerUsername,
+  senderUsername,
   recipientUsername,
   recipientWalletId,
   amount,
@@ -182,7 +182,7 @@ const executePaymentViaIntraledger = async ({
   logger,
 }: {
   senderWalletId: WalletId
-  payerUsername: Username | null
+  senderUsername: Username | null
   recipientUsername: Username | null
   recipientWalletId: WalletId
   amount: Satoshis
@@ -225,7 +225,7 @@ const executePaymentViaIntraledger = async ({
           usd,
           usdFee,
           recipientWalletId,
-          payerUsername,
+          senderUsername,
           recipientUsername,
           memoPayer,
         }),

--- a/src/app/wallets/ln-send-payment.ts
+++ b/src/app/wallets/ln-send-payment.ts
@@ -282,7 +282,7 @@ const lnSendPayment = async ({
       usdPerSat,
       memo,
       senderWalletId,
-      payerUsername: username,
+      senderUsername: username,
       lndService,
       logger,
     })
@@ -307,7 +307,7 @@ const executePaymentViaIntraledger = async ({
   usdPerSat,
   memo,
   senderWalletId,
-  payerUsername,
+  senderUsername,
   lndService,
   logger,
 }: {
@@ -317,7 +317,7 @@ const executePaymentViaIntraledger = async ({
   usdPerSat: UsdPerSat
   memo: string
   senderWalletId: WalletId
-  payerUsername: Username
+  senderUsername: Username
   lndService: ILightningService
   logger: Logger
 }): Promise<PaymentSendStatus | ApplicationError> => {
@@ -372,7 +372,7 @@ const executePaymentViaIntraledger = async ({
           usdFee,
           recipientWalletId,
           pubkey: lndService.defaultPubkey(),
-          payerUsername,
+          senderUsername,
           recipientUsername: null,
           memoPayer: memo,
         }),

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -117,7 +117,7 @@ type IntraledgerTxArgs = {
   description: string
   sats: Satoshis
   recipientWalletId: WalletId
-  payerUsername: Username | null
+  senderUsername: Username | null
   recipientUsername: Username | null
   memoPayer: string | null
 }

--- a/src/services/ledger/index.ts
+++ b/src/services/ledger/index.ts
@@ -475,7 +475,7 @@ export const LedgerService = (): ILedgerService => {
     usdFee,
     pubkey,
     recipientWalletId,
-    payerUsername,
+    senderUsername,
     recipientUsername,
     memoPayer,
   }: AddLnIntraledgerTxSendArgs): Promise<LedgerJournal | LedgerError> => {
@@ -498,7 +498,7 @@ export const LedgerService = (): ILedgerService => {
       description,
       sats,
       recipientWalletId,
-      payerUsername,
+      senderUsername,
       recipientUsername,
       memoPayer,
       shareMemoWithPayee: false,
@@ -561,7 +561,7 @@ export const LedgerService = (): ILedgerService => {
     payeeAddresses,
     sendAll,
     recipientWalletId,
-    payerUsername,
+    senderUsername,
     recipientUsername,
     memoPayer,
   }: AddOnChainIntraledgerTxSendArgs): Promise<LedgerJournal | LedgerError> => {
@@ -584,7 +584,7 @@ export const LedgerService = (): ILedgerService => {
       description,
       sats,
       recipientWalletId,
-      payerUsername,
+      senderUsername,
       recipientUsername,
       memoPayer,
       shareMemoWithPayee: false,
@@ -600,7 +600,7 @@ export const LedgerService = (): ILedgerService => {
     usd,
     usdFee,
     recipientWalletId,
-    payerUsername,
+    senderUsername,
     recipientUsername,
     memoPayer,
   }: addWalletIdIntraledgerTxSendArgs): Promise<LedgerJournal | LedgerError> => {
@@ -621,7 +621,7 @@ export const LedgerService = (): ILedgerService => {
       description,
       sats,
       recipientWalletId,
-      payerUsername,
+      senderUsername,
       recipientUsername,
       memoPayer,
       shareMemoWithPayee: true,
@@ -634,7 +634,7 @@ export const LedgerService = (): ILedgerService => {
     description,
     sats,
     recipientWalletId,
-    payerUsername,
+    senderUsername,
     recipientUsername,
     memoPayer,
     shareMemoWithPayee,
@@ -646,7 +646,7 @@ export const LedgerService = (): ILedgerService => {
     try {
       const creditMetadata = {
         ...metadata,
-        username: payerUsername,
+        username: senderUsername,
         memoPayer: shareMemoWithPayee ? memoPayer : null,
       }
       const debitMetadata = { ...metadata, username: recipientUsername, memoPayer }


### PR DESCRIPTION
Passing the `domainAccount` to the on chain pay use cases as a result of https://github.com/GaloyMoney/galoy/pull/998 means we don't have to reload the account to lookup the username.