### PR TITLE
fix: update default ps with procps

### DIFF
--- a/ci/image/Dockerfile
+++ b/ci/image/Dockerfile
@@ -3,6 +3,7 @@ FROM node:16-alpine
 RUN apk update \
   && apk add bash make git docker curl python3 jq rsync openssh wget \
   && apk add yq --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
+  && apk --no-cache add procps
 
 RUN mkdir -p /usr/local/lib/docker/cli-plugins \
   && curl -SL https://github.com/docker/compose/releases/download/v2.0.1/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose \


### PR DESCRIPTION
Kill tree use ps command to build process tree but default ps in our docker image does not support the params used by the package. https://github.com/pkrumins/node-tree-kill/blob/master/index.js#L45

You can test (if you have a linux machine) running the next cmd in your machine and in ci machine (it should fail): `ps -o pid --no-headers` 

Response with default `ps`
```
bash-5.1# ps -o pid --no-headers
ps: unrecognized option: no-headers
BusyBox v1.33.1 () multi-call binary.

Usage: ps [-o COL1,COL2=HEADER] [-T]

Show list of processes

	-o COL1,COL2=HEADER	Select columns for display
	-T			Show threads
```
after run `apk --no-cache add procps`
```
bash-5.1# ps -o pid --no-headers
    331
    569
```
