### PR TITLE
refactor: separate 'listSettledAndFailed' method

### DIFF
--- a/src/app/lightning/update-ln-payments.ts
+++ b/src/app/lightning/update-ln-payments.ts
@@ -13,17 +13,20 @@ export const updateLnPayments = async (): Promise<true | ApplicationError> => {
   const lndService = LndService()
   if (lndService instanceof Error) return lndService
 
-  const listFns = [lndService.listSettledPayments, lndService.listFailedPayments]
+  const listFns: ListLnPayments[] = [
+    lndService.listSettledPayments,
+    lndService.listFailedPayments,
+  ]
   const pubkeys = lndService
     .listActivePubkeys()
     .filter((pubkey) => pubkeysFromPayments.has(pubkey))
 
   for (const listFn of listFns) {
-    for (const key of pubkeys) {
+    for (const pubkey of pubkeys) {
       processedLnPaymentsHashes = await updateLnPaymentsByFunction({
         processedLnPaymentsHashes,
         incompleteLnPayments,
-        pubkey: key as Pubkey,
+        pubkey,
         listFn,
       })
     }

--- a/src/app/lightning/update-ln-payments.ts
+++ b/src/app/lightning/update-ln-payments.ts
@@ -39,6 +39,11 @@ const updateLnPaymentsByFunction = async ({
   incompleteLnPayments,
   pubkey,
   listFn,
+}: {
+  processedLnPaymentsHashes: PaymentHash[]
+  incompleteLnPayments: PersistedLnPaymentLookup[]
+  pubkey: Pubkey
+  listFn: ListLnPayments
 }): Promise<PaymentHash[]> => {
   let after: PagingStartToken | PagingContinueToken | PagingStopToken = undefined
   while (

--- a/src/app/lightning/update-ln-payments.ts
+++ b/src/app/lightning/update-ln-payments.ts
@@ -18,57 +18,71 @@ export const updateLnPayments = async (): Promise<true | ApplicationError> => {
 
   for (const key of pubkeys) {
     const pubkey = key as Pubkey
-
-    let after: PagingStartToken | PagingContinueToken | PagingStopToken = undefined
-    while (
-      processedLnPaymentsHashes.length < incompleteLnPayments.length &&
-      after !== false
-    ) {
-      // Fetch from Lightning service
-      const results: ListLnPaymentsResult | LightningServiceError =
-        await lndService.listSettledAndFailedPayments({
-          pubkey,
-          after,
-        })
-      if (results instanceof Error) {
-        baseLogger.error(
-          { error: results },
-          `Could not fetch payments for pubkey ${pubkey}`,
-        )
-        break
-      }
-      if (after === results.endCursor) break
-      after = results.endCursor
-
-      // Update LnPayments repository
-      for (const payment of results.lnPayments) {
-        const persistedPaymentLookup = incompleteLnPayments.find(
-          (elem) => elem.paymentHash === payment.paymentHash,
-        )
-        if (!persistedPaymentLookup) continue
-
-        persistedPaymentLookup.createdAt = payment.createdAt
-        persistedPaymentLookup.status = payment.status
-        persistedPaymentLookup.milliSatsAmount = payment.milliSatsAmount
-        persistedPaymentLookup.roundedUpAmount = payment.roundedUpAmount
-        persistedPaymentLookup.confirmedDetails = payment.confirmedDetails
-        persistedPaymentLookup.attempts = payment.attempts
-
-        persistedPaymentLookup.isCompleteRecord = true
-
-        const updatedPaymentLookup = await LnPaymentsRepository().update(
-          persistedPaymentLookup,
-        )
-        if (updatedPaymentLookup instanceof Error) {
-          baseLogger.error(
-            { error: updatedPaymentLookup },
-            "Could not update LnPayments repository",
-          )
-          continue
-        }
-        processedLnPaymentsHashes.push(payment.paymentHash)
-      }
-    }
+    await updateLnPaymentsByFunction({
+      processedLnPaymentsHashes,
+      incompleteLnPayments,
+      pubkey,
+      listFn: lndService.listSettledAndFailedPayments,
+    })
   }
   return true
+}
+
+const updateLnPaymentsByFunction = async ({
+  processedLnPaymentsHashes,
+  incompleteLnPayments,
+  pubkey,
+  listFn,
+}) => {
+  let after: PagingStartToken | PagingContinueToken | PagingStopToken = undefined
+  while (
+    processedLnPaymentsHashes.length < incompleteLnPayments.length &&
+    after !== false
+  ) {
+    // Fetch from Lightning service
+    const results: ListLnPaymentsResult | LightningServiceError = await listFn({
+      pubkey,
+      after,
+    })
+    if (results instanceof Error) {
+      baseLogger.error(
+        { error: results },
+        `Could not fetch payments for pubkey ${pubkey}`,
+      )
+      break
+    }
+    if (after === results.endCursor) break
+    after = results.endCursor
+
+    // Update LnPayments repository
+    for (const payment of results.lnPayments) {
+      const persistedPaymentLookup = incompleteLnPayments.find(
+        (elem) => elem.paymentHash === payment.paymentHash,
+      )
+      if (!persistedPaymentLookup) continue
+
+      persistedPaymentLookup.createdAt = payment.createdAt
+      persistedPaymentLookup.status = payment.status
+      persistedPaymentLookup.milliSatsAmount = payment.milliSatsAmount
+      persistedPaymentLookup.roundedUpAmount = payment.roundedUpAmount
+      persistedPaymentLookup.confirmedDetails = payment.confirmedDetails
+      persistedPaymentLookup.attempts = payment.attempts
+
+      persistedPaymentLookup.isCompleteRecord = true
+
+      const updatedPaymentLookup = await LnPaymentsRepository().update(
+        persistedPaymentLookup,
+      )
+      if (updatedPaymentLookup instanceof Error) {
+        baseLogger.error(
+          { error: updatedPaymentLookup },
+          "Could not update LnPayments repository",
+        )
+        continue
+      }
+      processedLnPaymentsHashes.push(payment.paymentHash)
+    }
+  }
+
+  return processedLnPaymentsHashes
 }

--- a/src/domain/bitcoin/lightning/index.types.d.ts
+++ b/src/domain/bitcoin/lightning/index.types.d.ts
@@ -185,10 +185,6 @@ interface ILightningService {
     args: ListLnPaymentsArgs,
   ): Promise<ListLnPaymentsResult | LightningServiceError>
 
-  listSettledAndFailedPayments(
-    args: ListLnPaymentsArgs,
-  ): Promise<ListLnPaymentsResult | LightningServiceError>
-
   cancelInvoice({
     pubkey,
     paymentHash,

--- a/src/domain/bitcoin/lightning/index.types.d.ts
+++ b/src/domain/bitcoin/lightning/index.types.d.ts
@@ -132,6 +132,10 @@ type ListLnPaymentsResult = {
   endCursor: PagingContinueToken | PagingStopToken
 }
 
+type ListLnPayments = (
+  args: ListLnPaymentsArgs,
+) => Promise<ListLnPaymentsResult | LightningError>
+
 interface ILightningService {
   isLocal(pubkey: Pubkey): boolean | LightningServiceError
 
@@ -177,13 +181,9 @@ interface ILightningService {
     paymentHash: PaymentHash
   }): Promise<LnPaymentLookup | LnFailedPartialPaymentLookup | LightningServiceError>
 
-  listSettledPayments(
-    args: ListLnPaymentsArgs,
-  ): Promise<ListLnPaymentsResult | LightningServiceError>
+  listSettledPayments: ListLnPayments
 
-  listFailedPayments(
-    args: ListLnPaymentsArgs,
-  ): Promise<ListLnPaymentsResult | LightningServiceError>
+  listFailedPayments: ListLnPayments
 
   cancelInvoice({
     pubkey,

--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -300,22 +300,6 @@ export const LndService = (): ILightningService | LightningServiceError => {
     }
   }
 
-  const listSettledAndFailedPayments = async (args: {
-    after: PagingStartToken | PagingContinueToken
-    pubkey: Pubkey
-  }): Promise<ListLnPaymentsResult | LightningServiceError> => {
-    const settledPayments = await listSettledPayments(args)
-    if (settledPayments instanceof Error) return settledPayments
-
-    const failedPayments = await listFailedPayments(args)
-    if (failedPayments instanceof Error) return failedPayments
-
-    return {
-      lnPayments: [...settledPayments.lnPayments, ...failedPayments.lnPayments],
-      endCursor: settledPayments.endCursor,
-    }
-  }
-
   const cancelInvoice = async ({
     pubkey,
     paymentHash,
@@ -461,7 +445,6 @@ export const LndService = (): ILightningService | LightningServiceError => {
     lookupPayment,
     listSettledPayments,
     listFailedPayments,
-    listSettledAndFailedPayments,
     cancelInvoice,
     payInvoiceViaRoutes,
     payInvoiceViaPaymentDetails,

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -1,6 +1,6 @@
 import { createHash, randomBytes } from "crypto"
 
-import { Wallets } from "@app"
+import { Wallets, Lightning } from "@app"
 import { getUserLimits } from "@config"
 import { FEECAP_PERCENT, toSats } from "@domain/bitcoin"
 import {
@@ -25,7 +25,6 @@ import { LndService } from "@services/lnd"
 
 import { sleep } from "@utils"
 
-import { updateLnPayments } from "@app/lightning"
 import { delete2fa } from "@app/users"
 
 import {
@@ -813,7 +812,7 @@ describe("UserWallet - Lightning Pay", () => {
         expect(lnPaymentOnPay.status).toBeUndefined()
 
         // Run update task
-        const lnPaymentUpdateOnPending = await updateLnPayments()
+        const lnPaymentUpdateOnPending = await Lightning.updateLnPayments()
         if (lnPaymentUpdateOnPending instanceof Error) throw lnPaymentUpdateOnPending
 
         // Test 'lnpayment' is pending
@@ -863,7 +862,7 @@ describe("UserWallet - Lightning Pay", () => {
         await waitUntilChannelBalanceSyncAll()
 
         // Run update task
-        const lnPaymentUpdateOnSettled = await updateLnPayments()
+        const lnPaymentUpdateOnSettled = await Lightning.updateLnPayments()
         if (lnPaymentUpdateOnSettled instanceof Error) throw lnPaymentUpdateOnSettled
 
         // Test 'lnpayment' is complete


### PR DESCRIPTION
## Description

When testing on our prod lnd payments set, I noticed that the `token` returned by the `getPayments` vs the `getFailedPayments` calls to lnd were not always consistent for the same start token as previously assumed. Because of this, we won't be able to paginate those two methods together, and so this PR is to separate the calling of the joined `listSettledAndFailedPayments` into two separate calls wherever it is currently used.

For context, this is the reason that both methods paginate differently on bigger databases with selectively cleaned payments already removed: [`getPayments`](https://github.com/alexbosworth/lightning/blob/3eaa5541e8f542ebd15e7d2da5e685aba6ea99f1/lnd_methods/offchain/get_payments.js#L135) vs. [`getFailedPayments`](https://github.com/alexbosworth/lightning/blob/3eaa5541e8f542ebd15e7d2da5e685aba6ea99f1/lnd_methods/offchain/get_failed_payments.js#L130)