### PR TITLE
feat: populate preimage in ledger transactions from lnpayments

### DIFF
--- a/src/app/wallets/ln-send-payment.ts
+++ b/src/app/wallets/ln-send-payment.ts
@@ -455,11 +455,17 @@ const executePaymentViaLn = async ({
           })
 
       // Fire-and-forget update to 'lnPayments' collection
-      LnPaymentsRepository().persistNew({
-        paymentHash: decodedInvoice.paymentHash,
-        paymentRequest: decodedInvoice.paymentRequest,
-        sentFromPubkey: rawRoute ? pubkey : lndService.defaultPubkey(),
-      })
+      if (!(payResult instanceof LnAlreadyPaidError)) {
+        LnPaymentsRepository().persistNew({
+          paymentHash: decodedInvoice.paymentHash,
+          paymentRequest: decodedInvoice.paymentRequest,
+          sentFromPubkey: rawRoute ? pubkey : lndService.defaultPubkey(),
+          confirmedDetails:
+            payResult instanceof Error
+              ? undefined
+              : { revealedPreImage: payResult.revealedPreImage },
+        })
+      }
 
       if (payResult instanceof LnPaymentPendingError) return PaymentSendStatus.Pending
 

--- a/src/domain/bitcoin/lightning/index.types.d.ts
+++ b/src/domain/bitcoin/lightning/index.types.d.ts
@@ -119,6 +119,7 @@ type LnFeeCalculator = {
 
 type PayInvoiceResult = {
   roundedUpFee: Satoshis
+  revealedPreImage: RevealedPreImage
   sentFromPubkey: Pubkey
 }
 

--- a/src/domain/bitcoin/lightning/payments/index.types.d.ts
+++ b/src/domain/bitcoin/lightning/payments/index.types.d.ts
@@ -1,6 +1,7 @@
 type LnPaymentPartial = {
   readonly paymentHash: PaymentHash
   readonly paymentRequest: EncodedPaymentRequest
+  readonly confirmedDetails: { revealedPreImage: RevealedPreImage } | undefined
   readonly sentFromPubkey: Pubkey
 }
 

--- a/src/domain/bitcoin/lightning/payments/index.types.d.ts
+++ b/src/domain/bitcoin/lightning/payments/index.types.d.ts
@@ -15,6 +15,10 @@ type PersistedLnPaymentLookup = Writeable<LnPaymentLookup, "paymentHash"> & {
   isCompleteRecord: boolean
 }
 
+type LnPaymentUpdatePreImage = Pick<LnPaymentLookup, "paymentHash"> & {
+  readonly confirmedDetails: Pick<LnPaymentConfirmedDetails, "revealedPreImage">
+}
+
 interface ILnPaymentsRepository {
   findByPaymentHash(
     paymentHash: PaymentHash,
@@ -24,6 +28,6 @@ interface ILnPaymentsRepository {
     lnPaymentPartial: LnPaymentPartial,
   ): Promise<LnPaymentPartial | RepositoryError>
   update(
-    lnPayment: PersistedLnPaymentLookup,
+    lnPayment: PersistedLnPaymentLookup | LnPaymentUpdatePreImage,
   ): Promise<PersistedLnPaymentLookup | RepositoryError>
 }

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -47,6 +47,7 @@ type LedgerTransaction = {
   readonly paymentHash?: PaymentHash
   readonly pubkey?: Pubkey
   readonly feeKnownInAdvance: boolean
+  readonly revealedPreImage?: RevealedPreImage
 
   // for onchain
   readonly address?: OnChainAddress

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -41,7 +41,7 @@ type InitiationViaOnChainLegacy = {
 type SettlementViaIntraledger = {
   readonly type: SettlementMethod["IntraLedger"]
   readonly counterPartyWalletId: WalletId
-  readonly counterPartyUsername: Username | null
+  readonly counterPartyUsername: Username | undefined
 }
 
 type SettlementViaLn = {

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -46,7 +46,7 @@ type SettlementViaIntraledger = {
 
 type SettlementViaLn = {
   readonly type: SettlementMethod["Lightning"]
-  revealedPreImage: RevealedPreImage | null
+  revealedPreImage: RevealedPreImage | undefined
 }
 
 type SettlementViaOnChain = {

--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -64,6 +64,7 @@ export const fromLedger = (
       paymentHash,
       txHash,
       pubkey,
+      revealedPreImage,
       username,
       address,
       pendingConfirmation,
@@ -186,7 +187,7 @@ export const fromLedger = (
             },
             settlementVia: {
               type: SettlementMethod.Lightning,
-              revealedPreImage: null,
+              revealedPreImage,
             },
           }
           return walletTransaction

--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -140,7 +140,7 @@ export const fromLedger = (
             settlementVia: {
               type: SettlementMethod.IntraLedger,
               counterPartyWalletId: recipientWalletId as WalletId,
-              counterPartyUsername: username || null,
+              counterPartyUsername: username,
             },
           }
           return walletTransaction
@@ -171,7 +171,7 @@ export const fromLedger = (
             settlementVia: {
               type: SettlementMethod.IntraLedger,
               counterPartyWalletId: recipientWalletId as WalletId,
-              counterPartyUsername: username || null,
+              counterPartyUsername: username,
             },
           }
           return walletTransaction
@@ -203,7 +203,7 @@ export const fromLedger = (
         settlementVia: {
           type: SettlementMethod.IntraLedger,
           counterPartyWalletId: recipientWalletId as WalletId,
-          counterPartyUsername: username || null,
+          counterPartyUsername: username,
         },
       }
       return walletTransaction

--- a/src/services/ledger/index.ts
+++ b/src/services/ledger/index.ts
@@ -241,8 +241,8 @@ export const LedgerService = (): ILedgerService => {
   }
 }
 
-export const translateToLedgerTx = (tx): LedgerTransaction => ({
-  id: tx.id,
+const translateToLedgerTx = (tx): LedgerTransaction => ({
+  id: tx.id || tx._id,
   walletId: toWalletId(tx.accounts),
   type: tx.type,
   debit: toSats(tx.debit),

--- a/src/services/ledger/index.ts
+++ b/src/services/ledger/index.ts
@@ -259,6 +259,7 @@ export const translateToLedgerTx = (tx): LedgerTransaction => ({
   memoFromPayer: tx.memoPayer,
   paymentHash: tx.hash,
   pubkey: tx.pubkey,
+  revealedPreImage: tx.revealedPreImage,
   address:
     tx.payee_addresses && tx.payee_addresses.length > 0
       ? tx.payee_addresses[0]

--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -350,6 +350,7 @@ export const LndService = (): ILightningService | LightningServiceError => {
       ])) as PayViaRoutesResult
       return {
         roundedUpFee: toSats(paymentResult.safe_fee),
+        revealedPreImage: paymentResult.secret as RevealedPreImage,
         sentFromPubkey: pubkey,
       }
     } catch (err) {
@@ -417,6 +418,7 @@ export const LndService = (): ILightningService | LightningServiceError => {
       ])) as PayViaPaymentDetailsResult
       return {
         roundedUpFee: toSats(paymentResult.safe_fee),
+        revealedPreImage: paymentResult.secret as RevealedPreImage,
         sentFromPubkey: defaultPubkey,
       }
     } catch (err) {

--- a/src/services/lnd/schema.ts
+++ b/src/services/lnd/schema.ts
@@ -4,26 +4,11 @@ import * as mongoose from "mongoose"
 const Schema = mongoose.Schema
 
 const confirmedDetailsSchema = new Schema<LnPaymentConfirmedDetails>({
-  confirmedAt: {
-    type: Date,
-    required: true,
-  },
-  destination: {
-    type: String,
-    required: true,
-  },
-  revealedPreImage: {
-    type: String,
-    required: true,
-  },
-  roundedUpFee: {
-    type: Number,
-    required: true,
-  },
-  milliSatsFee: {
-    type: Number,
-    required: true,
-  },
+  confirmedAt: Date,
+  destination: String,
+  revealedPreImage: String,
+  roundedUpFee: Number,
+  milliSatsFee: Number,
   hopPubkeys: [String],
 })
 

--- a/src/services/mongoose/ln-payments.ts
+++ b/src/services/mongoose/ln-payments.ts
@@ -97,5 +97,8 @@ const lnPaymentFromRaw = (result: LnPaymentType): PersistedLnPaymentLookup => ({
 const lnPaymentPartialFromRaw = (result: LnPaymentType): LnPaymentPartial => ({
   paymentHash: result.paymentHash as PaymentHash,
   paymentRequest: result.paymentRequest as EncodedPaymentRequest,
+  confirmedDetails: result?.confirmedDetails?.revealedPreImage
+    ? { revealedPreImage: result.confirmedDetails.revealedPreImage }
+    : undefined,
   sentFromPubkey: result.sentFromPubkey as Pubkey,
 })

--- a/src/services/mongoose/ln-payments.ts
+++ b/src/services/mongoose/ln-payments.ts
@@ -49,7 +49,7 @@ export const LnPaymentsRepository = (): ILnPaymentsRepository => {
   }
 
   const update = async (
-    payment: PersistedLnPaymentLookup,
+    payment: PersistedLnPaymentLookup | LnPaymentUpdatePreImage,
   ): Promise<PersistedLnPaymentLookup | RepositoryError> => {
     try {
       const result = await LnPayment.findOneAndUpdate(

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -806,6 +806,7 @@ describe("UserWallet - Lightning Pay", () => {
         expect(lnPaymentOnPay.isCompleteRecord).toBeFalsy()
         expect(lnPaymentOnPay.createdAt).toBeInstanceOf(Date)
         expect(lnPaymentOnPay.status).toBeUndefined()
+        expect(lnPaymentOnPay.confirmedDetails).toBeUndefined()
 
         // Run lnPayments update task
         const lnPaymentUpdateOnPending = await Lightning.updateLnPayments()
@@ -823,6 +824,7 @@ describe("UserWallet - Lightning Pay", () => {
         expect(lnPaymentOnPending.isCompleteRecord).toBeFalsy()
         expect(lnPaymentOnPending.createdAt).toBeInstanceOf(Date)
         expect(lnPaymentOnPending.status).toBeUndefined()
+        expect(lnPaymentOnPending.confirmedDetails).toBeUndefined()
 
         const lndService = LndService()
         if (lndService instanceof Error) throw lndService

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -818,11 +818,11 @@ describe("UserWallet - Lightning Pay", () => {
         expect(lnPaymentOnPending).not.toBeInstanceOf(Error)
         if (lnPaymentOnPending instanceof Error) throw lnPaymentOnPending
 
-        expect(lnPaymentOnPay.paymentHash).toBe(id)
-        expect(lnPaymentOnPay.paymentRequest).toBe(request)
-        expect(lnPaymentOnPay.isCompleteRecord).toBeFalsy()
-        expect(lnPaymentOnPay.createdAt).toBeInstanceOf(Date)
-        expect(lnPaymentOnPay.status).toBeUndefined()
+        expect(lnPaymentOnPending.paymentHash).toBe(id)
+        expect(lnPaymentOnPending.paymentRequest).toBe(request)
+        expect(lnPaymentOnPending.isCompleteRecord).toBeFalsy()
+        expect(lnPaymentOnPending.createdAt).toBeInstanceOf(Date)
+        expect(lnPaymentOnPending.status).toBeUndefined()
 
         const lndService = LndService()
         if (lndService instanceof Error) throw lndService


### PR DESCRIPTION
## Description

This is the first proposal to populate the `revealedPreImage` property in `WalletTransaction` objects that eventually get returned out via the api under `settlementVia`.

The approach here was to:
- record the preimage on successful send to `lnpayments` collection
- record the preimage on update of settled pending  payment to `lnpayments` collection
- add the `revealedPreImage` property to `LedgerTransaction` type and implement with a join from the LedgerService requests to the `lnpayments` collection.

### Feedback

We decided that this approach isn't ideal for 2 reasons:
- the dependency from LedgerService on `lnpayments` collection is dirty
- the join approach may be unnecessary premature optimization

Our first alternative discussed was to simply add a new `revealedPreImage` property in the metadata for transactions.
- this solves the join complexity
- this is bad because we would have to edit transactions after-the-fact (on pending payment update) and we'd ideally like to have transactions be immutable

Our second alternative was to create a new `transactions_metadata` collection to store mutable metadata related to transactions to:
- this would live within the Ledger service and solves the crossing-boundaries issue
- this would solve the "immutable transactions" issue because we would only update this other collection
- we will do 2 separate calls instead of a single join for simplicity to start, and will re-visit alternatives if performance becomes an issue

## Conclusion

This PR will be closed in favour a new one where we implement the new `transactions_metadata` collection and write/read the `revealedPreImage` property from there.