### PR TITLE
ci: source code release pipeline

### DIFF
--- a/ci/config/vendor/git-cliff.toml
+++ b/ci/config/vendor/git-cliff.toml
@@ -1,0 +1,54 @@
+# configuration file for git-cliff (0.1.0)
+
+[changelog]
+# changelog header
+header = """"""
+
+# template for the changelog body
+# https://tera.netlify.app/docs/#introduction
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}\n
+"""
+# remove the leading and trailing whitespaces from the template
+trim = true
+# changelog footer
+footer = """"""
+
+[git]
+# parse the commits based on https://www.conventionalcommits.org
+conventional_commits = true
+# filter out the commits that are not conventional
+filter_unconventional = true
+# regex for parsing and grouping commits
+commit_parsers = [
+    { message = "^feat", group = "Features"},
+    { message = "^fix", group = "Bug Fixes"},
+    { message = "^doc", group = "Documentation"},
+    { message = "^perf", group = "Performance"},
+    { message = "^refactor", group = "Refactor"},
+    { message = "^style", group = "Styling"},
+    { message = "^test", group = "Testing"},
+    { message = "^chore\\(release\\): prepare for", skip = true},
+    { message = "^chore", group = "Miscellaneous Tasks"},
+    { body = ".*security", group = "Security"},
+]
+# filter out the commits that are not matched by commit parsers
+filter_commits = true
+# glob pattern for matching git tags
+tag_pattern = "v[0-9]*"
+# regex for skipping tags
+skip_tags = "v0.1.0-beta.1"
+# regex for ignoring tags
+ignore_tags = ""
+# sort the tags topologically
+topo_order = false
+# sort the commits inside sections by oldest/newest order
+sort_commits = "newest"

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -16,12 +16,24 @@
 #@   return data.values.docker_registry + "/galoy-app-migrate"
 #@ end
 
+#@ def release_pipeline_image():
+#@   return data.values.docker_registry + "/release-pipeline"
+#@ end
+
 #@ def task_image_config():
 type: registry-image
 source:
   username: #@ data.values.docker_registry_user
   password: #@ data.values.docker_registry_password
   repository: #@ pipeline_image()
+#@ end
+
+#@ def release_task_image_config():
+type: registry-image
+source:
+  username: #@ data.values.docker_registry_user
+  password: #@ data.values.docker_registry_password
+  repository: #@ release_pipeline_image()
 #@ end
 
 #@ def slack_failure_notification():
@@ -253,11 +265,53 @@ jobs:
     params:
       image: image/image.tar
 
+- name: release
+  plan:
+  - in_parallel:
+    - get: repo
+      trigger: true
+      passed: [ build-edge-image ]
+    - get: pipeline-tasks
+    - get: edge-image
+      passed: [ build-edge-image ]
+      params:
+        format: oci
+    - get: version
+    - get: charts-repo
+  - task: prep-release
+    config:
+      platform: linux
+      image_resource: #@ release_task_image_config()
+      inputs:
+      - name: repo
+      - name: edge-image
+      - name: pipeline-tasks
+      - name: version
+      outputs:
+      - name: version
+      - name: artifacts
+      params:
+        CHART: galoy
+      run:
+        path: pipeline-tasks/ci/tasks/vendor/prep-release-src.sh
+  - put: versioned-image
+    params:
+      image: edge-image/image.tar
+      additional_tags: artifacts/gh-release-tag
+  - put: gh-release
+    params:
+      name: artifacts/gh-release-name
+      tag: artifacts/gh-release-tag
+      body: artifacts/gh-release-notes.md
+  - put: version
+    params:
+      file: version/version
+
 - name: bump-image-in-chart
   plan:
   - in_parallel:
     - get: edge-image
-      passed: [build-edge-image]
+      passed: [release]
       params: { skip_download: true }
     - get: migrate-edge-image
       passed: [build-migrate-edge-image]
@@ -271,6 +325,10 @@ jobs:
       - build-debug-edge-image
       - build-migrate-edge-image
       - build-edge-image
+      - release
+    - get: version
+      trigger: true
+      passed: [ release ]
     - get: charts-repo
       params: { skip_download: true }
     - get: pipeline-tasks
@@ -315,6 +373,7 @@ resources:
   type: git
   source:
     ignore_paths: ["ci/*[^md]"]
+    fetch_tags: true
     uri: #@ data.values.git_uri
     branch: #@ data.values.git_branch
     private_key: #@ data.values.github_private_key
@@ -357,6 +416,13 @@ resources:
     password: #@ data.values.docker_registry_password
     repository: #@ migrate_galoy_image()
 
+- name: versioned-image
+  type: registry-image
+  source:
+    username: #@ data.values.docker_registry_user
+    password: #@ data.values.docker_registry_password
+    repository: #@ galoy_image()
+
 - name: deps
   type: git
   source:
@@ -368,7 +434,7 @@ resources:
 - name: pipeline-tasks
   type: git
   source:
-    paths: [ci/tasks/*, Makefile]
+    paths: [ci/tasks/*, ci/config/*, Makefile]
     uri: #@ data.values.git_uri
     branch: #@ data.values.git_branch
     private_key: #@ data.values.github_private_key
@@ -406,6 +472,23 @@ resources:
   type: slack-notification
   source:
     url: #@ data.values.slack_webhook_url
+
+- name: version
+  type: semver
+  source:
+    initial_version: 0.0.0
+    driver: git
+    file: galoy-src-version
+    uri: #@ data.values.meta_release_git_uri
+    branch: #@ data.values.meta_release_git_version_branch
+    private_key: #@ data.values.github_private_key
+
+- name: gh-release
+  type: github-release
+  source:
+    owner: #@ data.values.gh_org
+    repository: #@ data.values.gh_repository
+    access_token: #@ data.values.github_token
 
 resource_types:
 - name: gcs-resource

--- a/ci/tasks/bump-image-digest.sh
+++ b/ci/tasks/bump-image-digest.sh
@@ -5,12 +5,14 @@ set -eu
 export digest=$(cat ./edge-image/digest)
 export migrate_digest=$(cat ./migrate-edge-image/digest)
 export ref=$(cat ./repo/.git/short_ref)
+export app_version=$(cat version/version)
 
 pushd charts-repo
 
 yq -i e '.image.digest = strenv(digest)' ./charts/galoy/values.yaml
 yq -i e '.image.git_ref = strenv(ref)' ./charts/galoy/values.yaml
 yq -i e '.mongodbMigrateImage.digest = strenv(migrate_digest)' ./charts/galoy/values.yaml
+yq -i e '.appVersion = strenv(app_version)' ./charts/galoy/Chart.yaml
 
 if [[ -z $(git config --global user.email) ]]; then
   git config --global user.email "bot@galoy.io"

--- a/ci/tasks/vendor/prep-release-src.sh
+++ b/ci/tasks/vendor/prep-release-src.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -eu
+
+# ------------ CHANGELOG ------------
+
+pushd repo
+
+# First time
+if [[ $(cat ../version/version) == "0.0.0" ]]; then
+  git cliff --config ../pipeline-tasks/ci/config/vendor/git-cliff.toml > ../artifacts/gh-release-notes.md
+
+# Fetch changelog from last ref
+else
+  export prev_ref=$(git rev-list -n 1 $(cat ../version/version))
+  export new_ref=$(git rev-parse HEAD)
+
+  git cliff --config ../pipeline-tasks/ci/config/vendor/git-cliff.toml $prev_ref..$new_ref > ../artifacts/gh-release-notes.md
+fi
+
+popd
+
+# Generate Changelog
+echo "CHANGELOG:"
+echo "-------------------------------"
+cat artifacts/gh-release-notes.md
+echo "-------------------------------"
+
+# ------------ BUMP VERSION ------------
+
+echo -n "Prev Version: "
+cat version/version
+echo ""
+
+# Initial Version
+if [[ $(cat version/version) == "0.0.0" ]]; then
+  echo "0.1.0" > version/version
+# Figure out proper version to release
+elif [[ $(cat artifacts/gh-release-notes.md | grep breaking) != '' ]] || [[ $(cat artifacts/gh-release-notes.md | grep feature) != '' ]]; then
+  echo "Breaking change / Feature Addition found, bumping minor version..."
+  bump2version minor --current-version $(cat version/version) --allow-dirty version/version
+else
+  echo "Only patches and fixes found - no breaking changes, bumping patch version..."
+  bump2version patch --current-version $(cat version/version) --allow-dirty version/version
+fi
+
+echo -n "Release Version: "
+cat version/version
+echo ""
+
+# ------------ ARTIFACTS ------------
+
+cat version/version > artifacts/gh-release-tag
+echo "v$(cat version/version) Release" > artifacts/gh-release-name

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -15,6 +15,10 @@ artifacts_bucket_name: ((staging-gcp-creds.bucket_name))
 staging_inception_creds: ((staging-gcp-creds.creds_json))
 staging_ssh_private_key: ((staging-ssh.ssh_private_key))
 staging_ssh_pub_key: ((staging-ssh.ssh_public_key))
+meta_release_git_uri: git@github.com:GaloyMoney/meta-release.git
+meta_release_git_version_branch: versions
+gh_org: GaloyMoney
+gh_repository: galoy
 
 slack_channel: galoy-main-github
 slack_username: concourse

--- a/ci/vendir.lock.yml
+++ b/ci/vendir.lock.yml
@@ -1,0 +1,15 @@
+apiVersion: vendir.k14s.io/v1alpha1
+directories:
+- contents:
+  - git:
+      commitTitle: 'fix: git cliff config should be pulled from pipeline-tasks (#4)'
+      sha: fc36c9834e4da8374728298ffd362b7bc1280bc5
+    path: .
+  path: tasks/vendor
+- contents:
+  - git:
+      commitTitle: 'fix: git cliff config should be pulled from pipeline-tasks (#4)'
+      sha: fc36c9834e4da8374728298ffd362b7bc1280bc5
+    path: .
+  path: config/vendor
+kind: LockConfig

--- a/ci/vendir.yml
+++ b/ci/vendir.yml
@@ -1,0 +1,23 @@
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+
+directories:
+- path: tasks/vendor
+  contents:
+  - path: .
+    git:
+      url: https://github.com/GaloyMoney/concourse-shared.git
+      ref: fc36c9834e4da8374728298ffd362b7bc1280bc5
+    includePaths:
+    - tasks/**/*
+    newRootPath: tasks
+
+- path: config/vendor
+  contents:
+  - path: .
+    git:
+      url: https://github.com/GaloyMoney/concourse-shared.git
+      ref: fc36c9834e4da8374728298ffd362b7bc1280bc5
+    includePaths:
+    - config/**/*
+    newRootPath: config


### PR DESCRIPTION
This PR adds in releasing logic inside Concourse.
- After tests pass and docker image get built, the pipeline bumps `galoy` version using semantic versioning, releases starting at `0.1.0` (initial bump).
- Docker image also gets tagged with the version number, aside from already being tagged with `edge`.

Since there is a pattern of same CI task scripts being used across multiple repos, the CI task script required for releasing is being `vendir` synced in from [concourse-shared](https://github.com/GaloyMoney/concourse-shared)

Note: The pipeline haven't been updated yet, waiting for reviews/approvals before updating the CI.