### PR TITLE
fix: bug conversion?

### DIFF
--- a/src/app/wallets/get-lightning-fee.ts
+++ b/src/app/wallets/get-lightning-fee.ts
@@ -78,7 +78,7 @@ const feeProbe = async ({
 
   const key = CachedRouteLookupKeyFactory().create({
     paymentHash,
-    milliSats: toMilliSatsFromNumber(paymentAmount * 1000),
+    milliSats: toMilliSatsFromNumber(paymentAmount / 1000),
   })
   const routeFromCache = await RoutesCache().findByKey(key)
   const validCachedRoute = !(routeFromCache instanceof Error)
@@ -126,7 +126,7 @@ const noAmountProbeForFee = async ({
 
   const key = CachedRouteLookupKeyFactory().create({
     paymentHash,
-    milliSats: toMilliSatsFromNumber(paymentAmount * 1000),
+    milliSats: toMilliSatsFromNumber(paymentAmount / 1000),
   })
   const routeFromCache = await RoutesCache().findByKey(key)
   const validCachedRoute = !(routeFromCache instanceof Error)


### PR DESCRIPTION
paymentAmount is type as Satoshis. If we want to go to MilliSats, then we want to divide by 1000, not the way around?