### PR TITLE
ci: release after tests pass, fix blank `appVersion` and added slack

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -344,6 +344,7 @@ jobs:
       - name: migrate-edge-image
       - name: pipeline-tasks
       - name: charts-repo
+      - name: version
       outputs:
       - name: charts-repo
       params:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -271,7 +271,13 @@ jobs:
   - in_parallel:
     - get: repo
       trigger: true
-      passed: [ build-edge-image ]
+      passed:
+      - check-code
+      - test-unit
+      - test-integration
+      - build-debug-edge-image
+      - build-migrate-edge-image
+      - build-edge-image
     - get: pipeline-tasks
     - get: edge-image
       passed: [ build-edge-image ]

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -56,6 +56,7 @@ groups:
   - build-debug-edge-image
   - build-migrate-edge-image
   - install-deps
+  - release
   - bump-image-in-chart
 - name: image
   jobs: [ build-pipeline-image ]
@@ -306,6 +307,7 @@ jobs:
   - put: version
     params:
       file: version/version
+  on_failure: #@ slack_failure_notification()
 
 - name: bump-image-in-chart
   plan:


### PR DESCRIPTION
https://github.com/GaloyMoney/charts/pull/577 was a bad PR caused because `version` was not present as an input to the `bump-image-in-chart` job, this PR fixes it.

It also adds the `release` job to the `galoy` group for visibility and uses the `on_failure` hook to notify if release went wrong.

Have updated the pipeline.