### PR TITLE
test: check transactions are sorted in reverse chronologically

### DIFF
--- a/test/integration/02-user-wallet/02-tx-ordering.spec.ts
+++ b/test/integration/02-user-wallet/02-tx-ordering.spec.ts
@@ -1,0 +1,35 @@
+import { Wallets } from "@app"
+
+import {
+  createUserWalletFromUserRef,
+  getDefaultWalletIdByTestUserRef,
+} from "test/helpers"
+
+let walletIdA: WalletId
+
+beforeAll(async () => {
+  await createUserWalletFromUserRef("A")
+  walletIdA = await getDefaultWalletIdByTestUserRef("A")
+})
+
+describe("UserWallet - Transactions ordering", () => {
+  // Medici internally returns transactions to us in the order: { $sort: { datetime: -1, timestamp: -1 }
+  // This is to explicitly capture this behaviour in our tests.
+
+  it("transactions are in reverse chronological order", async () => {
+    const txResult = await Wallets.getTransactionsForWalletId({
+      walletId: walletIdA,
+    })
+    const txns = txResult.result
+    expect(txns).not.toBeNull()
+    if (!txns) return
+
+    expect(txns.length).toBeGreaterThan(1)
+    expect(txns).toEqual([...txns].sort(walletTransactionsReverseByCreatedAt))
+  })
+})
+
+const walletTransactionsReverseByCreatedAt = (
+  { createdAt: a }: WalletTransaction,
+  { createdAt: b }: WalletTransaction,
+) => (a > b ? -1 : a < b ? 1 : 0)

--- a/test/integration/02-user-wallet/02-tx-ordering.spec.ts
+++ b/test/integration/02-user-wallet/02-tx-ordering.spec.ts
@@ -1,15 +1,35 @@
 import { Wallets } from "@app"
+import { MEMO_SHARING_SATS_THRESHOLD } from "@config"
+import { toSats } from "@domain/bitcoin"
+import { baseLogger } from "@services/logger"
 
 import {
   createUserWalletFromUserRef,
+  getAccountByTestUserRef,
   getDefaultWalletIdByTestUserRef,
+  getUserRecordByTestUserRef,
 } from "test/helpers"
 
+let userTypeA: UserRecord
+
+let usernameA: Username
+
+let accountB: Account
+
 let walletIdA: WalletId
+let walletIdB: WalletId
 
 beforeAll(async () => {
   await createUserWalletFromUserRef("A")
+  await createUserWalletFromUserRef("B")
+
+  accountB = await getAccountByTestUserRef("B")
+
   walletIdA = await getDefaultWalletIdByTestUserRef("A")
+  walletIdB = await getDefaultWalletIdByTestUserRef("B")
+
+  userTypeA = await getUserRecordByTestUserRef("A")
+  usernameA = userTypeA.username as Username
 })
 
 describe("UserWallet - Transactions ordering", () => {
@@ -17,6 +37,21 @@ describe("UserWallet - Transactions ordering", () => {
   // This is to explicitly capture this behaviour in our tests.
 
   it("transactions are in reverse chronological order", async () => {
+    const count = 3
+    const getMemo = (i) => `Test transaction ordering - ${i}`
+    for (let i = 1; i <= count; i++) {
+      const res = await Wallets.intraledgerPaymentSendUsername({
+        recipientUsername: usernameA,
+        memo: getMemo(i),
+        amount: toSats(MEMO_SHARING_SATS_THRESHOLD + 1),
+        senderWalletId: walletIdB,
+        senderAccount: accountB,
+        logger: baseLogger,
+      })
+      expect(res).not.toBeInstanceOf(Error)
+      if (res instanceof Error) throw res
+    }
+
     const txResult = await Wallets.getTransactionsForWalletId({
       walletId: walletIdA,
     })
@@ -24,8 +59,9 @@ describe("UserWallet - Transactions ordering", () => {
     expect(txns).not.toBeNull()
     if (!txns) return
 
-    expect(txns.length).toBeGreaterThan(1)
+    expect(txns.length).toBeGreaterThanOrEqual(count)
     expect(txns).toEqual([...txns].sort(walletTransactionsReverseByCreatedAt))
+    expect(txns[0].memo).toBe(getMemo(count))
   })
 })
 


### PR DESCRIPTION
## Description

This is an implicit condition I discovered (internal to Medici) in PR #1044 that I thought we should capture explicitly in our tests.