### PR TITLE
feat: combine record from new metadata collection into domain LedgerTransaction type

### DIFF
--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -19,47 +19,53 @@ type LedgerJournal = {
   readonly transactionIds: LedgerTransactionId[]
 }
 
-// Differentiate fields depending on what 'type' we have (see domain/wallets/index.types.d.ts)
-type LedgerTransaction<S extends WalletCurrency> = {
-  readonly id: LedgerTransactionId
-  readonly walletId: WalletId | undefined // FIXME create a subclass so that this field is always set for liabilities wallets
-  readonly type: LedgerTransactionType
-  readonly debit: S extends "BTC" ? Satoshis : UsdCents
-  readonly credit: S extends "BTC" ? Satoshis : UsdCents
-  readonly fee: Satoshis
-  readonly currency: S
-  readonly timestamp: Date
-  readonly pendingConfirmation: boolean
-  readonly journalId: LedgerJournalId
-
-  readonly lnMemo?: string
-
-  readonly usd: number
-  readonly feeUsd: number
-
-  // for IntraLedger
-  readonly recipientWalletId?: WalletId
-  readonly username?: Username
-  readonly memoFromPayer?: string
-
+type PartialLedgerTransactionFromMetadata = {
   // for ln
-  readonly paymentHash?: PaymentHash
-  readonly pubkey?: Pubkey
-  readonly feeKnownInAdvance: boolean
-
-  readonly satsAmount?: Satoshis
-  readonly centsAmount?: UsdCents
-  readonly satsFee?: Satoshis
-  readonly centsFee?: UsdCents
-
-  readonly displayAmount?: DisplayCurrencyBaseAmount
-  readonly displayFee?: DisplayCurrencyBaseAmount
-  readonly displayCurrency?: DisplayCurrency
-
-  // for onchain
-  readonly address?: OnChainAddress
-  readonly txHash?: OnChainTxHash
+  readonly revealedPreImage?: RevealedPreImage
 }
+
+// Differentiate fields depending on what 'type' we have (see domain/wallets/index.types.d.ts)
+type LedgerTransaction<S extends WalletCurrency> =
+  PartialLedgerTransactionFromMetadata & {
+    readonly id: LedgerTransactionId
+    readonly walletId: WalletId | undefined // FIXME create a subclass so that this field is always set for liabilities wallets
+    readonly type: LedgerTransactionType
+    readonly debit: Satoshis | UsdCents
+    readonly credit: Satoshis | UsdCents
+    readonly fee: Satoshis
+    readonly currency: S
+    readonly timestamp: Date
+    readonly pendingConfirmation: boolean
+    readonly journalId: LedgerJournalId
+
+    readonly lnMemo?: string
+
+    readonly usd: number
+    readonly feeUsd: number
+
+    // for IntraLedger
+    readonly recipientWalletId?: WalletId
+    readonly username?: Username
+    readonly memoFromPayer?: string
+
+    // for ln
+    readonly paymentHash?: PaymentHash
+    readonly pubkey?: Pubkey
+    readonly feeKnownInAdvance: boolean
+
+    readonly satsAmount?: Satoshis
+    readonly centsAmount?: UsdCents
+    readonly satsFee?: Satoshis
+    readonly centsFee?: UsdCents
+
+    readonly displayAmount?: DisplayCurrencyBaseAmount
+    readonly displayFee?: DisplayCurrencyBaseAmount
+    readonly displayCurrency?: DisplayCurrency
+
+    // for onchain
+    readonly address?: OnChainAddress
+    readonly txHash?: OnChainTxHash
+  }
 
 type ReceiveOnChainTxArgs = {
   walletId: WalletId

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -38,7 +38,7 @@ type SettlementViaIntraledger = {
 
 type SettlementViaLn = {
   readonly type: "lightning"
-  revealedPreImage: RevealedPreImage | null
+  revealedPreImage: RevealedPreImage | undefined
 }
 
 type SettlementViaOnChain = {

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -33,7 +33,7 @@ type InitiationViaOnChainLegacy = {
 type SettlementViaIntraledger = {
   readonly type: "intraledger"
   readonly counterPartyWalletId: WalletId
-  readonly counterPartyUsername: Username | null
+  readonly counterPartyUsername: Username | undefined
 }
 
 type SettlementViaLn = {

--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -138,7 +138,7 @@ export const fromLedger = (
             settlementVia: {
               type: SettlementMethod.IntraLedger,
               counterPartyWalletId: recipientWalletId as WalletId,
-              counterPartyUsername: username || null,
+              counterPartyUsername: username,
             },
           }
           return walletTransaction
@@ -169,7 +169,7 @@ export const fromLedger = (
             settlementVia: {
               type: SettlementMethod.IntraLedger,
               counterPartyWalletId: recipientWalletId as WalletId,
-              counterPartyUsername: username || null,
+              counterPartyUsername: username,
             },
           }
           return walletTransaction
@@ -201,7 +201,7 @@ export const fromLedger = (
         settlementVia: {
           type: SettlementMethod.IntraLedger,
           counterPartyWalletId: recipientWalletId as WalletId,
-          counterPartyUsername: username || null,
+          counterPartyUsername: username,
         },
       }
       return walletTransaction

--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -66,6 +66,7 @@ export const fromLedger = (
       paymentHash,
       txHash,
       pubkey,
+      revealedPreImage,
       username,
       address,
       pendingConfirmation,
@@ -184,7 +185,7 @@ export const fromLedger = (
             },
             settlementVia: {
               type: SettlementMethod.Lightning,
-              revealedPreImage: null,
+              revealedPreImage,
             },
           }
           return walletTransaction

--- a/src/services/ledger/index.ts
+++ b/src/services/ledger/index.ts
@@ -4,6 +4,7 @@
  */
 
 import { toSats } from "@domain/bitcoin"
+import { toCents } from "@domain/fiat"
 import {
   LedgerTransactionType,
   liabilitiesMainAccount,
@@ -374,38 +375,44 @@ export const LedgerService = (): ILedgerService => {
   })
 }
 
-export const translateToLedgerTx = (tx): LedgerTransaction<WalletCurrency> => ({
-  id: tx.id,
-  walletId: toWalletId(tx.accounts),
-  type: tx.type,
+export const translateToLedgerTx = (
+  tx: TransactionRecord,
+): LedgerTransaction<WalletCurrency> => ({
+  id: tx.id as LedgerTransactionId,
+  walletId: toWalletId(tx.accounts as LiabilitiesWalletId),
+  type: tx.type as LedgerTransactionType,
   debit: toSats(tx.debit),
   credit: toSats(tx.credit),
   fee: toSats(tx.fee),
   usd: tx.usd,
   feeUsd: tx.feeUsd,
-  currency: tx.currency,
+  currency: tx.currency as WalletCurrency,
   timestamp: tx.timestamp,
   pendingConfirmation: tx.pending,
-  journalId: tx._journal.toString(),
+  journalId: tx._journal.toString() as LedgerJournalId,
   lnMemo: tx.memo,
-  username: tx.username,
+  username: (tx.username as Username) || undefined,
   memoFromPayer: tx.memoPayer,
-  paymentHash: tx.hash,
-  pubkey: tx.pubkey,
+  paymentHash: (tx.hash as PaymentHash) || undefined,
+  pubkey: (tx.pubkey as Pubkey) || undefined,
   address:
     tx.payee_addresses && tx.payee_addresses.length > 0
-      ? tx.payee_addresses[0]
+      ? (tx.payee_addresses[0] as OnChainAddress)
       : undefined,
-  txHash: tx.hash,
+  txHash: (tx.hash as OnChainTxHash) || undefined,
   feeKnownInAdvance: tx.feeKnownInAdvance || false,
 
-  satsAmount: tx?.satsAmount,
-  centsAmount: tx?.centsAmount,
-  satsFee: tx?.satsFee,
-  centsFee: tx?.centsFee,
-  displayAmount: tx?.displayAmount,
-  displayFee: tx?.displayFee,
-  displayCurrency: tx?.displayCurrency,
+  satsAmount: tx?.satsAmount ? toSats(tx.satsAmount) : undefined,
+  centsAmount: tx?.centsAmount ? toCents(tx.centsAmount) : undefined,
+  satsFee: tx?.satsFee ? toSats(tx.satsFee) : undefined,
+  centsFee: tx?.centsFee ? toCents(tx.centsFee) : undefined,
+  displayAmount: tx?.displayAmount
+    ? (tx.displayAmount as DisplayCurrencyBaseAmount)
+    : undefined,
+  displayFee: tx?.displayFee ? (tx.displayFee as DisplayCurrencyBaseAmount) : undefined,
+  displayCurrency: tx?.displayCurrency
+    ? (tx.displayCurrency as DisplayCurrency)
+    : undefined,
 })
 
 export const translateToLedgerJournal = (savedEntry): LedgerJournal => ({

--- a/src/services/ledger/schema.ts
+++ b/src/services/ledger/schema.ts
@@ -8,7 +8,7 @@ const Schema = mongoose.Schema
 
 const ledgerTransactionTypes = Object.values(LedgerTransactionType)
 
-const transactionSchema = new Schema({
+const transactionSchema = new Schema<TransactionRecord>({
   hash: {
     type: Schema.Types.String,
     ref: "invoiceusers",

--- a/src/services/ledger/schema.types.d.ts
+++ b/src/services/ledger/schema.types.d.ts
@@ -1,3 +1,44 @@
+interface TransactionRecord {
+  _id: ObjectId
+  _journal: ObjectId
+  _original_journal: ObjectId
+  id: string
+  hash?: string
+  txid?: string
+  type: string
+  pending: boolean
+  currency: string
+  fee: number
+  feeKnownInAdvance?: boolean
+  related_journal: string
+  payee_addresses?: string[]
+  memoPayer?: string
+  usd: number
+  sats?: number
+  feeUsd: number
+  username?: string
+  pubkey?: string
+  credit: number
+  debit: number
+  datetime: Date
+  account_path: string[]
+  accounts: string
+  book: string
+  memo: string
+  timestamp: Date
+  voided: boolean
+  void_reason?: string
+  approved: boolean
+
+  satsAmount: number
+  centsAmount: number
+  satsFee: number
+  centsFee: number
+  displayAmount: number
+  displayFee: number
+  displayCurrency: string
+}
+
 interface TransactionMetadataRecord {
   _id: ObjectId
 

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -601,6 +601,19 @@ describe("UserWallet - Lightning Pay", () => {
       }),
     )
 
+    // Test metadata is added back to ledger transactions correctly
+    const revealedPreImages = new Set(
+      txns.map((txn) =>
+        txn instanceof Error
+          ? txn
+          : "revealedPreImage" in txn
+          ? txn.revealedPreImage
+          : undefined,
+      ),
+    )
+    expect(revealedPreImages.size).toEqual(1)
+    expect(revealedPreImages.has(revealedPreImage)).toBeTruthy()
+
     // Test metadata is correctly persisted
     const txns_metadata = await Promise.all(
       txns.map(async (txn) => TransactionsMetadataRepository().findById(txn.id)),
@@ -611,7 +624,7 @@ describe("UserWallet - Lightning Pay", () => {
     expect(metadataCheck).toBeTruthy()
     if (!metadataCheck) throw txns_metadata.find((txn) => txn instanceof Error)
 
-    const revealedPreImages = new Set(
+    const revealedPreImagesInMetadata = new Set(
       txns_metadata.map((txn) =>
         txn instanceof Error
           ? txn
@@ -620,8 +633,8 @@ describe("UserWallet - Lightning Pay", () => {
           : undefined,
       ),
     )
-    expect(revealedPreImages.size).toEqual(1)
-    expect(revealedPreImages.has(revealedPreImage)).toBeTruthy()
+    expect(revealedPreImagesInMetadata.size).toEqual(1)
+    expect(revealedPreImagesInMetadata.has(revealedPreImage)).toBeTruthy()
 
     const paymentHashes = new Set(
       txns_metadata.map((txn) =>

--- a/test/unit/domain/wallets/tx-history.spec.ts
+++ b/test/unit/domain/wallets/tx-history.spec.ts
@@ -55,6 +55,7 @@ describe("WalletTransactionHistory.fromLedger", () => {
           paymentHash: "paymentHash" as PaymentHash,
           pubkey: "pubkey" as Pubkey,
           memoFromPayer: "SomeMemo",
+          revealedPreImage: "revealedPreImage" as RevealedPreImage,
         },
         {
           ...currencyBaseLedgerTxns,
@@ -131,7 +132,7 @@ describe("WalletTransactionHistory.fromLedger", () => {
           },
           settlementVia: {
             type: SettlementMethod.Lightning,
-            revealedPreImage: null,
+            revealedPreImage: "revealedPreImage" as RevealedPreImage,
           },
           memo: "SomeMemo",
         },
@@ -159,7 +160,7 @@ describe("WalletTransactionHistory.fromLedger", () => {
           settlementVia: {
             type: SettlementMethod.IntraLedger,
             counterPartyWalletId: "walletIdRecipient" as WalletId,
-            counterPartyUsername: null,
+            counterPartyUsername: undefined,
           },
           memo: null,
         },


### PR DESCRIPTION
## Description

_Builds on #1037_

This PR adds records from the new `medici_transaction_metadata` collection to `LedgerTransaction` objects returned from various queries in the Ledger service.

### Challenge
**How do we deal with partial failures since we are now doing 2 queries to build a single `LedgerTransaction`?:**
- ~my current approach is to only error on the first request to main collection, and to concatenate empty objects if the 2nd metadata query errors~
- ~a better approach may be to re-use the `PartialResult` type to indicate if the LedgerTransaction being returned is a partial because of some failure on the second request. Do we want to do this?~

- We decided to report & not return errors for the metadata request

### Open `TODO`s
- [x] Report errors on metadata request errors
- [x] Double-check unit testing for translation methods
- [x] Include metadata fetch in integration test