### PR TITLE
chore: add cold storage instrumentation

### DIFF
--- a/src/domain/cold-storage/errors.ts
+++ b/src/domain/cold-storage/errors.ts
@@ -5,4 +5,5 @@ export class ColdStorageError extends Error {
 export class ColdStorageServiceError extends ColdStorageError {}
 export class InvalidCurrentColdStorageWalletServiceError extends ColdStorageServiceError {}
 export class InsufficientBalanceForRebalanceError extends ColdStorageServiceError {}
+export class InvalidOrNonWalletTransactionError extends ColdStorageServiceError {}
 export class UnknownColdStorageServiceError extends ColdStorageServiceError {}

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -301,6 +301,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "ColdStorageServiceError":
     case "InvalidCurrentColdStorageWalletServiceError":
     case "InsufficientBalanceForRebalanceError":
+    case "InvalidOrNonWalletTransactionError":
     case "UnknownColdStorageServiceError":
     case "FeeDifferenceError":
     case "NoTransactionToSettleError":

--- a/src/services/cold-storage/index.ts
+++ b/src/services/cold-storage/index.ts
@@ -4,9 +4,11 @@ import { BTC_NETWORK, getBitcoinCoreRPCConfig, getColdStorageConfig } from "@con
 import {
   InsufficientBalanceForRebalanceError,
   InvalidCurrentColdStorageWalletServiceError,
+  InvalidOrNonWalletTransactionError,
   UnknownColdStorageServiceError,
 } from "@domain/cold-storage/errors"
 import { checkedToOnChainAddress } from "@domain/bitcoin/onchain"
+import { wrapAsyncFunctionsToRunInSpan } from "@services/tracing"
 
 const { onChainWallet, walletPattern } = getColdStorageConfig()
 
@@ -104,6 +106,9 @@ export const ColdStorageService = async (): Promise<
       const { amount } = await bitcoindCurrentWalletClient.getTransaction(txHash)
       return amount < 0
     } catch (err) {
+      if (err && err.message === "Invalid or non-wallet transaction id") {
+        return new InvalidOrNonWalletTransactionError(err)
+      }
       return new UnknownColdStorageServiceError(err)
     }
   }
@@ -119,14 +124,17 @@ export const ColdStorageService = async (): Promise<
     }
   }
 
-  return {
-    getBalances,
-    createPsbt,
-    createOnChainAddress,
-    isDerivedAddress,
-    isWithdrawalTransaction,
-    lookupTransactionFee,
-  }
+  return wrapAsyncFunctionsToRunInSpan({
+    namespace: "service.coldstorage",
+    fns: {
+      getBalances,
+      createPsbt,
+      createOnChainAddress,
+      isDerivedAddress,
+      isWithdrawalTransaction,
+      lookupTransactionFee,
+    },
+  })
 }
 
 const getBitcoindClient = (wallet?: string) => {


### PR DESCRIPTION
When we query loop-out onchain transactions bitcoind returns a 500 error contributing to create false alerts because auto-instrumentation made by HttpInstrumentation.

- Add helper method to add instrumentation to service response
- Add parent attributes to HttpInstrumentation (this will allow to filter `Invalid or non-wallet transaction id` 500 errors from cron alerts)