### PR TITLE
fix: convert wallet volume to cents before comparing

### DIFF
--- a/src/app/wallets/check-limit-helpers.ts
+++ b/src/app/wallets/check-limit-helpers.ts
@@ -5,6 +5,7 @@ import { toCents } from "@domain/fiat"
 import { TwoFA, TwoFANewCodeNeededError } from "@domain/twoFA"
 import { WalletCurrency } from "@domain/wallets"
 import { LedgerService } from "@services/ledger"
+import { addAttributesToCurrentSpan } from "@services/tracing"
 import { mapObj } from "@utils"
 
 export const checkIntraledgerLimits = async ({
@@ -124,6 +125,7 @@ const limitCheckWithCurrencyConversion = ({
 }) => {
   const dCSatstoCents = (amount) => dCConverter.fromSatsToCents(toSats(amount))
 
+  addAttributesToCurrentSpan({ "txVolume.fromWalletCurrency": walletCurrency })
   if (walletCurrency === WalletCurrency.Usd) {
     return limitsCheckerFn({
       amount: toCents(amount),

--- a/src/app/wallets/check-limit-helpers.ts
+++ b/src/app/wallets/check-limit-helpers.ts
@@ -5,6 +5,7 @@ import { toCents } from "@domain/fiat"
 import { TwoFA, TwoFANewCodeNeededError } from "@domain/twoFA"
 import { WalletCurrency } from "@domain/wallets"
 import { LedgerService } from "@services/ledger"
+import { mapObj } from "@utils"
 
 export const checkIntraledgerLimits = async ({
   amount,
@@ -121,15 +122,17 @@ const limitCheckWithCurrencyConversion = ({
   dCConverter: DisplayCurrencyConverter
   limitsCheckerFn: LimitsCheckerFn
 }) => {
+  const dCSatstoCents = (amount) => dCConverter.fromSatsToCents(toSats(amount))
+
   if (walletCurrency === WalletCurrency.Usd) {
     return limitsCheckerFn({
       amount: toCents(amount),
-      walletVolume,
+      walletVolume: mapObj<TxBaseVolume, UsdCents>(walletVolume, toCents),
     })
   } else {
     return limitsCheckerFn({
-      amount: dCConverter.fromSatsToCents(toSats(amount)),
-      walletVolume,
+      amount: dCSatstoCents(amount),
+      walletVolume: mapObj<TxBaseVolume, UsdCents>(walletVolume, dCSatstoCents),
     })
   }
 }

--- a/src/domain/accounts/limits-checker.ts
+++ b/src/domain/accounts/limits-checker.ts
@@ -19,7 +19,7 @@ export const LimitsChecker = ({
     const limit = twoFALimits.threshold
     const volume = walletVolume.outgoingBaseAmount
     addAttributesToCurrentSpan({
-      "txVolume.volume": `${volume}`,
+      "txVolume.outgoingInBase": `${volume}`,
       "txVolume.threshold": `${limit}`,
       "txVolume.amountInBase": `${amount}`,
       "txVolume.limitCheck": "checkTwoFA",
@@ -39,7 +39,7 @@ export const LimitsChecker = ({
     const limit = accountLimits.intraLedgerLimit
     const volume = walletVolume.outgoingBaseAmount
     addAttributesToCurrentSpan({
-      "txVolume.volume": `${volume}`,
+      "txVolume.outgoingInBase": `${volume}`,
       "txVolume.threshold": `${limit}`,
       "txVolume.amountInBase": `${amount}`,
       "txVolume.limitCheck": "checkIntraledger",
@@ -61,7 +61,7 @@ export const LimitsChecker = ({
     const limit = accountLimits.withdrawalLimit
     const volume = walletVolume.outgoingBaseAmount
     addAttributesToCurrentSpan({
-      "txVolume.volume": `${volume}`,
+      "txVolume.outgoingInBase": `${volume}`,
       "txVolume.threshold": `${limit}`,
       "txVolume.amountInBase": `${amount}`,
       "txVolume.limitCheck": "checkWithdrawal",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -33,3 +33,14 @@ export const runInParallel = ({ iterator, processor, logger, workers = 5 }) => {
   const jobWorkers = new Array(workers).fill(iterator).map(runWorkerInParallel)
   return Promise.allSettled(jobWorkers)
 }
+
+export const mapObj = <T, R>(
+  obj: T,
+  fn: (arg: T[keyof T]) => R,
+): { [P in keyof T]: R } => {
+  const mappedObj: { [P in keyof T]: R } = {} as { [P in keyof T]: R }
+  for (const key in obj) {
+    mappedObj[key] = fn(obj[key])
+  }
+  return mappedObj
+}


### PR DESCRIPTION
## Description

Limits are denominated in cents now, so wallet volumes must be converted (in addition to payment amount) before doing limit checks.

Before this, the defined cents limit would be counted as sats for any payments (a much lower threshold).