### PR TITLE
chore: update error structure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ These are types mostly used in function signature type definitions. They derive 
 
 For example, an error may be defined in a module's `error.ts` file like this:
 ```
-export class LightningError extends Error {
+export class LightningError extends DomainError {
   name = this.constructor.name
 }
 ```

--- a/src/app/users/request-phone-code.ts
+++ b/src/app/users/request-phone-code.ts
@@ -1,6 +1,5 @@
 import { getGaloyInstanceName, getTestAccounts } from "@config"
 import { TestAccountsChecker } from "@domain/accounts/test-accounts-checker"
-import { UnknownPhoneProviderServiceError } from "@domain/phone-provider"
 import { RateLimitConfig } from "@domain/rate-limit"
 import { RateLimiterExceededError } from "@domain/rate-limit/errors"
 import { checkedToPhoneNumber } from "@domain/users"
@@ -55,7 +54,7 @@ export const requestPhoneCode = async ({
   phone: string
   logger: Logger
   ip: IpAddress
-}): Promise<true | UnknownPhoneProviderServiceError> => {
+}): Promise<true | PhoneProviderServiceError> => {
   logger.info({ phone, ip }, "RequestPhoneCode called")
 
   const phoneNumberValid = checkedToPhoneNumber(phone)

--- a/src/domain/accounts/errors.ts
+++ b/src/domain/accounts/errors.ts
@@ -1,6 +1,6 @@
-export class AccountError extends Error {
-  name = this.constructor.name
-}
+import { DomainError } from "@domain/errors"
+
+export class AccountError extends DomainError {}
 
 export class ApiKeyError extends AccountError {}
 export class ApiKeyHashError extends ApiKeyError {}

--- a/src/domain/bitcoin/lightning/errors.ts
+++ b/src/domain/bitcoin/lightning/errors.ts
@@ -1,14 +1,18 @@
-export class LightningError extends Error {
-  name = this.constructor.name
-}
+import { DomainError, ErrorLevel } from "@domain/errors"
+
+export class LightningError extends DomainError {}
 
 export class LnInvoiceDecodeError extends LightningError {}
 export class LnInvoiceMissingPaymentSecretError extends LnInvoiceDecodeError {}
-export class UnknownLnInvoiceDecodeError extends LnInvoiceDecodeError {}
+export class UnknownLnInvoiceDecodeError extends LnInvoiceDecodeError {
+  level = ErrorLevel.Critical
+}
 
 export class LightningServiceError extends LightningError {}
 export class CouldNotDecodeReturnedPaymentRequest extends LightningServiceError {}
-export class UnknownLightningServiceError extends LightningServiceError {}
+export class UnknownLightningServiceError extends LightningServiceError {
+  level = ErrorLevel.Critical
+}
 export class InvoiceNotFoundError extends LightningServiceError {}
 export class LnPaymentPendingError extends LightningServiceError {}
 export class LnAlreadyPaidError extends LightningServiceError {}
@@ -16,6 +20,8 @@ export class NoValidNodeForPubkeyError extends LightningServiceError {}
 export class PaymentNotFoundError extends LightningServiceError {}
 export class RouteNotFoundError extends LightningServiceError {}
 export class InsufficientBalanceForRoutingError extends LightningServiceError {}
-export class UnknownRouteNotFoundError extends LightningServiceError {}
+export class UnknownRouteNotFoundError extends LightningServiceError {
+  level = ErrorLevel.Critical
+}
 export class BadPaymentDataError extends LightningServiceError {}
 export class CorruptLndDbError extends LightningServiceError {}

--- a/src/domain/bitcoin/onchain/errors.ts
+++ b/src/domain/bitcoin/onchain/errors.ts
@@ -1,10 +1,12 @@
-export class OnChainError extends Error {
-  name = this.constructor.name
-}
+import { DomainError, ErrorLevel } from "@domain/errors"
+
+export class OnChainError extends DomainError {}
 
 export class TransactionDecodeError extends OnChainError {}
 
 export class OnChainServiceError extends OnChainError {}
-export class UnknownOnChainServiceError extends OnChainServiceError {}
+export class UnknownOnChainServiceError extends OnChainServiceError {
+  level = ErrorLevel.Critical
+}
 export class CouldNotFindOnChainTransactionError extends OnChainServiceError {}
 export class OnChainServiceUnavailableError extends OnChainServiceError {}

--- a/src/domain/cache/errors.ts
+++ b/src/domain/cache/errors.ts
@@ -1,8 +1,10 @@
-export class CacheError extends Error {
-  name = this.constructor.name
-}
+import { DomainError, ErrorLevel } from "@domain/errors"
+
+export class CacheError extends DomainError {}
 
 export class LocalCacheServiceError extends CacheError {}
 export class LocalCacheNotAvailableError extends LocalCacheServiceError {}
 export class LocalCacheUndefinedError extends LocalCacheServiceError {}
-export class UnknownLocalCacheServiceError extends LocalCacheServiceError {}
+export class UnknownLocalCacheServiceError extends LocalCacheServiceError {
+  level = ErrorLevel.Critical
+}

--- a/src/domain/captcha/error.ts
+++ b/src/domain/captcha/error.ts
@@ -1,6 +1,8 @@
-export class CaptchaError extends Error {
-  name = this.constructor.name
-}
+import { DomainError, ErrorLevel } from "@domain/errors"
+
+export class CaptchaError extends DomainError {}
 
 export class CaptchaUserFailToPassError extends CaptchaError {}
-export class UnknownCaptchaError extends CaptchaError {}
+export class UnknownCaptchaError extends CaptchaError {
+  level = ErrorLevel.Critical
+}

--- a/src/domain/cold-storage/errors.ts
+++ b/src/domain/cold-storage/errors.ts
@@ -1,8 +1,10 @@
-export class ColdStorageError extends Error {
-  name = this.constructor.name
-}
+import { DomainError, ErrorLevel } from "@domain/errors"
+
+export class ColdStorageError extends DomainError {}
 
 export class ColdStorageServiceError extends ColdStorageError {}
 export class InvalidCurrentColdStorageWalletServiceError extends ColdStorageServiceError {}
 export class InsufficientBalanceForRebalanceError extends ColdStorageServiceError {}
-export class UnknownColdStorageServiceError extends ColdStorageServiceError {}
+export class UnknownColdStorageServiceError extends ColdStorageServiceError {
+  level = ErrorLevel.Critical
+}

--- a/src/domain/cold-storage/errors.ts
+++ b/src/domain/cold-storage/errors.ts
@@ -5,6 +5,7 @@ export class ColdStorageError extends DomainError {}
 export class ColdStorageServiceError extends ColdStorageError {}
 export class InvalidCurrentColdStorageWalletServiceError extends ColdStorageServiceError {}
 export class InsufficientBalanceForRebalanceError extends ColdStorageServiceError {}
+export class InvalidOrNonWalletTransactionError extends ColdStorageServiceError {}
 export class UnknownColdStorageServiceError extends ColdStorageServiceError {
   level = ErrorLevel.Critical
 }

--- a/src/domain/dealer-price/errors.ts
+++ b/src/domain/dealer-price/errors.ts
@@ -1,6 +1,8 @@
-export class DealerPriceError extends Error {
-  name = this.constructor.name
-}
+import { DomainError, ErrorLevel } from "@domain/errors"
+
+export class DealerPriceError extends DomainError {}
 
 export class DealerPriceServiceError extends DealerPriceError {}
-export class UnknownDealerPriceServiceError extends DealerPriceServiceError {}
+export class UnknownDealerPriceServiceError extends DealerPriceServiceError {
+  level = ErrorLevel.Critical
+}

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -1,13 +1,27 @@
-export class InconsistentDataError extends Error {}
+export const ErrorLevel = {
+  Info: "info",
+  Warn: "warn",
+  Critical: "critical",
+} as const
 
-class DomainError extends Error {
-  name = this.constructor.name
+export class DomainError extends Error {
+  name: string
+  level?: ErrorLevel
+  constructor(message?: string) {
+    super(message)
+    this.name = this.constructor.name
+    this.level = ErrorLevel.Info
+  }
 }
+
+export class InconsistentDataError extends DomainError {}
 
 export class AuthorizationError extends DomainError {}
 
 export class RepositoryError extends DomainError {}
-export class UnknownRepositoryError extends RepositoryError {}
+export class UnknownRepositoryError extends RepositoryError {
+  level = ErrorLevel.Critical
+}
 export class PersistError extends RepositoryError {}
 export class DuplicateError extends RepositoryError {}
 

--- a/src/domain/errors.types.d.ts
+++ b/src/domain/errors.types.d.ts
@@ -1,3 +1,5 @@
+type ErrorLevel =
+  typeof import("./errors").ErrorLevel[keyof typeof import("./errors").ErrorLevel]
 type AuthorizationError = import("./errors").AuthorizationError
 type RepositoryError = import("./errors").RepositoryError
 type ValidationError = import("./errors").ValidationError

--- a/src/domain/ipfetcher/errors.ts
+++ b/src/domain/ipfetcher/errors.ts
@@ -1,6 +1,8 @@
-export class IpFetcherError extends Error {
-  name = this.constructor.name
-}
+import { DomainError, ErrorLevel } from "@domain/errors"
+
+export class IpFetcherError extends DomainError {}
 
 export class IpFetcherServiceError extends IpFetcherError {}
-export class UnknownIpFetcherServiceError extends IpFetcherError {}
+export class UnknownIpFetcherServiceError extends IpFetcherError {
+  level = ErrorLevel.Critical
+}

--- a/src/domain/ledger/errors.ts
+++ b/src/domain/ledger/errors.ts
@@ -1,9 +1,11 @@
-export class LedgerError extends Error {
-  name = this.constructor.name
-}
+import { DomainError, ErrorLevel } from "@domain/errors"
+
+export class LedgerError extends DomainError {}
 
 export class LedgerServiceError extends LedgerError {}
 export class FeeDifferenceError extends LedgerError {}
 export class CouldNotFindTransactionError extends LedgerError {}
 export class NoTransactionToSettleError extends LedgerServiceError {}
-export class UnknownLedgerError extends LedgerServiceError {}
+export class UnknownLedgerError extends LedgerServiceError {
+  level = ErrorLevel.Critical
+}

--- a/src/domain/lock/errors.ts
+++ b/src/domain/lock/errors.ts
@@ -1,6 +1,8 @@
-export class LockError extends Error {
-  name = this.constructor.name
-}
+import { DomainError, ErrorLevel } from "@domain/errors"
+
+export class LockError extends DomainError {}
 
 export class LockServiceError extends LockError {}
-export class UnknownLockServiceError extends LockServiceError {}
+export class UnknownLockServiceError extends LockServiceError {
+  level = ErrorLevel.Critical
+}

--- a/src/domain/notifications/errors.ts
+++ b/src/domain/notifications/errors.ts
@@ -1,5 +1,5 @@
-export class NotificationsError extends Error {
-  name = this.constructor.name
-}
+import { DomainError } from "@domain/errors"
+
+export class NotificationsError extends DomainError {}
 
 export class NotificationsServiceError extends NotificationsError {}

--- a/src/domain/phone-provider/errors.ts
+++ b/src/domain/phone-provider/errors.ts
@@ -1,6 +1,8 @@
-export class PhoneProviderServiceError extends Error {
-  name = this.constructor.name
-}
+import { DomainError, ErrorLevel } from "@domain/errors"
+
+export class PhoneProviderServiceError extends DomainError {}
 
 export class InvalidPhoneNumberPhoneProviderError extends PhoneProviderServiceError {}
-export class UnknownPhoneProviderServiceError extends PhoneProviderServiceError {}
+export class UnknownPhoneProviderServiceError extends PhoneProviderServiceError {
+  level = ErrorLevel.Critical
+}

--- a/src/domain/phone-provider/index.types.d.ts
+++ b/src/domain/phone-provider/index.types.d.ts
@@ -9,12 +9,10 @@ type SendTextArguments = {
 }
 
 interface IPhoneProviderService {
-  getCarrier(
-    phone: PhoneNumber,
-  ): Promise<PhoneMetadata | UnknownPhoneProviderServiceError>
+  getCarrier(phone: PhoneNumber): Promise<PhoneMetadata | PhoneProviderServiceError>
   sendText({
     body,
     to,
     logger,
-  }: SendTextArguments): Promise<true | UnknownPhoneProviderServiceError>
+  }: SendTextArguments): Promise<true | PhoneProviderServiceError>
 }

--- a/src/domain/price/errors.ts
+++ b/src/domain/price/errors.ts
@@ -1,8 +1,10 @@
-export class PriceError extends Error {
-  name = this.constructor.name
-}
+import { DomainError, ErrorLevel } from "@domain/errors"
+
+export class PriceError extends DomainError {}
 
 export class PriceServiceError extends PriceError {}
 export class PriceNotAvailableError extends PriceServiceError {}
 export class PriceHistoryNotAvailableError extends PriceServiceError {}
-export class UnknownPriceServiceError extends PriceServiceError {}
+export class UnknownPriceServiceError extends PriceServiceError {
+  level = ErrorLevel.Critical
+}

--- a/src/domain/rate-limit/errors.ts
+++ b/src/domain/rate-limit/errors.ts
@@ -1,9 +1,11 @@
-export class RateLimitError extends Error {
-  name = this.constructor.name
-}
+import { DomainError, ErrorLevel } from "@domain/errors"
+
+export class RateLimitError extends DomainError {}
 
 export class RateLimitServiceError extends RateLimitError {}
-export class UnknownRateLimitServiceError extends RateLimitServiceError {}
+export class UnknownRateLimitServiceError extends RateLimitServiceError {
+  level = ErrorLevel.Critical
+}
 
 export class RateLimiterExceededError extends RateLimitServiceError {}
 export class UserPhoneCodeAttemptPhoneRateLimiterExceededError extends RateLimiterExceededError {}

--- a/src/domain/twoFA/errors.ts
+++ b/src/domain/twoFA/errors.ts
@@ -1,9 +1,11 @@
-export class TwoFAError extends Error {
-  name = this.constructor.name
-}
+import { DomainError, ErrorLevel } from "@domain/errors"
+
+export class TwoFAError extends DomainError {}
 
 export class TwoFAValidationError extends TwoFAError {}
 export class TwoFAAlreadySetError extends TwoFAError {}
 export class TwoFANewCodeNeededError extends TwoFAError {}
-export class UnknownTwoFAError extends TwoFAError {}
+export class UnknownTwoFAError extends TwoFAError {
+  level = ErrorLevel.Critical
+}
 export class TwoFANeedToBeSetBeforeDeletionError extends TwoFAError {}

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -301,6 +301,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "ColdStorageServiceError":
     case "InvalidCurrentColdStorageWalletServiceError":
     case "InsufficientBalanceForRebalanceError":
+    case "InvalidOrNonWalletTransactionError":
     case "UnknownColdStorageServiceError":
     case "FeeDifferenceError":
     case "NoTransactionToSettleError":

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -24,7 +24,7 @@ const assertUnreachable = (x: never): never => {
 }
 
 export const mapError = (error: ApplicationError): CustomApolloError => {
-  const errorName = error.constructor.name as ApplicationErrorKey
+  const errorName = error.name as ApplicationErrorKey
   let message = error.message || errorName || ""
   switch (errorName) {
     case "WithdrawalLimitsExceededError":
@@ -311,6 +311,8 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "DealerPriceServiceError":
     case "UnknownDealerPriceServiceError":
     case "InvalidNegativeAmountError":
+    case "DomainError":
+    case "ErrorLevel":
       message = `Unknown error occurred (code: ${error.name})`
       return new UnknownClientError({ message, logger: baseLogger })
 

--- a/src/services/tracing.ts
+++ b/src/services/tracing.ts
@@ -25,6 +25,7 @@ import {
   Exception,
 } from "@opentelemetry/api"
 import { tracingConfig } from "@config"
+import { ErrorLevel } from "@domain/errors"
 
 propagation.setGlobalPropagator(new W3CTraceContextPropagator())
 
@@ -197,10 +198,10 @@ export const addEventToCurrentSpan = (
 }
 
 export const recordException = (span: Span, exception: Exception, level?: ErrorLevel) => {
-  const errorLevel = level || exception["level"] || "warn"
+  const errorLevel = level || exception["level"] || ErrorLevel.Info
   span.setAttribute("error.level", errorLevel)
   span.recordException(exception)
-  if (errorLevel === "critical") span.setStatus({ code: SpanStatusCode.ERROR })
+  span.setStatus({ code: SpanStatusCode.ERROR })
 }
 
 export const asyncRunInSpan = <F extends () => ReturnType<F>>(


### PR DESCRIPTION
- Update error structure, now all domain errors extends `DomainError`
- Add error level to `DomainError` (default to Info and Critical for Unknown extended errors)
- Update tracing service to support error level.
- All catch (throws) are recorded as `critical`
- Add first example on how to handle an exception with `isWithdrawalTransaction` (500 error from bitcoind)