### PR TITLE
feat: activate usd-fiat wallets in 'me' request

### DIFF
--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -132,6 +132,33 @@ enum ExchangeCurrencyUnit {
   USDCENT
 }
 
+type FiatWallet implements Wallet {
+  balance: SignedAmount!
+  id: ID!
+  transactions(
+    """
+    Returns the items in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the items in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first n items from the list.
+    """
+    first: Int
+
+    """
+    Returns the last n items from the list.
+    """
+    last: Int
+  ): TransactionConnection
+  walletCurrency: WalletCurrency!
+}
+
 """
 Provides global settings for the application which might have an impact for the user.
 """
@@ -887,6 +914,7 @@ interface Wallet {
 
 enum WalletCurrency {
   BTC
+  USD
 }
 
 """

--- a/src/graphql/types/index.ts
+++ b/src/graphql/types/index.ts
@@ -1,7 +1,7 @@
 // import BusinessAccount from "./object/business-account"
 import BTCWallet from "./object/btc-wallet"
 import ConsumerAccount from "./object/consumer-account"
-// import FiatWallet from "./object/fiat-wallet"
+import FiatWallet from "./object/fiat-wallet"
 import InputError from "./object/input-error"
 import PaymentError from "./object/payment-error"
 
@@ -14,5 +14,5 @@ export const ALL_INTERFACE_TYPES = [
   ConsumerAccount,
   // BusinessAccount,
   BTCWallet,
-  // FiatWallet,
+  FiatWallet,
 ]

--- a/src/graphql/types/object/btc-wallet.ts
+++ b/src/graphql/types/object/btc-wallet.ts
@@ -13,14 +13,14 @@ import { TransactionConnection } from "./transaction"
 const BTCWallet = GT.Object({
   name: "BTCWallet",
   interfaces: () => [IWallet],
-  isTypeOf: (source) => true || source.type === "btc", // TODO: make this work
+  isTypeOf: (source) => source.currency === "BTC",
   fields: () => ({
     id: {
       type: GT.NonNullID,
     },
     walletCurrency: {
       type: GT.NonNull(WalletCurrency),
-      resolve: () => "BTC",
+      resolve: (source: Wallet) => source.currency,
     },
     balance: {
       type: GT.NonNull(SignedAmount),

--- a/src/graphql/types/scalar/wallet-currency.ts
+++ b/src/graphql/types/scalar/wallet-currency.ts
@@ -4,6 +4,7 @@ const WalletCurrency = GT.Enum({
   name: "WalletCurrency",
   values: {
     BTC: {},
+    USD: {},
   },
 })
 


### PR DESCRIPTION
## Description

Display USD wallets as USD in graphql `me` query return.

### Current behaviour

These wallets are already coming back in the query return on staging where a USD wallet exists, but they are tagged as `BTC` wallets and they do not have an implemented `balance` resolver.