### PR TITLE
fix: htlc stuck after output channel close

### DIFF
--- a/src/domain/cache/index.ts
+++ b/src/domain/cache/index.ts
@@ -4,4 +4,5 @@ export const CacheKeys = {
   CurrentPrice: "price:current",
   PriceHistory: "price:history",
   BlockHeight: "bitcoin:blockHeight",
+  ClosedChannels: "lnd:closedChannels",
 } as const

--- a/src/domain/cache/index.types.d.ts
+++ b/src/domain/cache/index.types.d.ts
@@ -9,8 +9,17 @@ type LocalCacheSetArgs<T> = {
   ttlSecs: Seconds
 }
 
+type LocalCacheGetOrSetArgs<F extends () => ReturnType<F>> = {
+  key: CacheKeys | string
+  fn: F
+  ttlSecs: Seconds
+}
+
 interface ILocalCacheService {
   set<T>(args: LocalCacheSetArgs<T>): Promise<T | LocalCacheServiceError>
   get<T>(key: CacheKeys | string): Promise<T | LocalCacheServiceError>
+  getOrSet<F extends () => ReturnType<F>>(
+    args: LocalCacheGetOrSetArgs<F>,
+  ): Promise<ReturnType<F>>
   clear(key: CacheKeys | string): Promise<true | LocalCacheServiceError>
 }

--- a/src/services/cache/index.ts
+++ b/src/services/cache/index.ts
@@ -32,6 +32,19 @@ export const LocalCacheService = (): ILocalCacheService => {
     }
   }
 
+  const getOrSet = async <F extends () => ReturnType<F>>({
+    key,
+    fn,
+    ttlSecs,
+  }: LocalCacheGetOrSetArgs<F>): Promise<ReturnType<F>> => {
+    const cachedData = await get<ReturnType<F>>(key)
+    if (!(cachedData instanceof Error)) return cachedData
+
+    const data = await fn()
+    set<ReturnType<F>>({ key, value: data, ttlSecs })
+    return data
+  }
+
   const clear = (key: CacheKeys | string): Promise<true | LocalCacheServiceError> => {
     try {
       localCache.del(key)
@@ -41,5 +54,5 @@ export const LocalCacheService = (): ILocalCacheService => {
     }
   }
 
-  return { set, get, clear }
+  return { set, get, getOrSet, clear }
 }


### PR DESCRIPTION
add additional validation to resolve payment status.

If payment is pending:
- Check payment timeout against current block height
- If transaction has expired then check that all the output channels (in paths) are closed