### PR TITLE
fix: change tokens value we compare for route validation

### DIFF
--- a/src/app/lightning/route-validator.ts
+++ b/src/app/lightning/route-validator.ts
@@ -2,8 +2,9 @@ import { BadAmountForRouteError } from "@domain/errors"
 
 export const RouteValidator = (rawRoute: RawRoute): RouteValidator => {
   const validate = (amount): true | ApplicationError => {
-    if (amount !== rawRoute.tokens) {
-      return new BadAmountForRouteError(`${amount} !== ${rawRoute.tokens}`)
+    const rawTokens = Math.floor(parseInt(rawRoute.total_mtokens || "0", 10) / 1000)
+    if (amount !== rawTokens) {
+      return new BadAmountForRouteError(`${amount} !== ${rawTokens}`)
     }
 
     return true

--- a/src/domain/routes/index.types.d.ts
+++ b/src/domain/routes/index.types.d.ts
@@ -4,9 +4,8 @@ type RawHopWithNumbers = NonNullable<ProbeForRouteArgs["routes"]>[number][number
 type PayViaPaymentDetailsArgs = import("lightning").PayViaPaymentDetailsArgs
 type RawHopWithStrings = NonNullable<PayViaPaymentDetailsArgs["routes"]>[number][number]
 
-type PayViaRoutesArgs = import("lightning").PayViaRoutesArgs
-type RawRouteFromProbe = PayViaRoutesArgs["routes"][number]
-type RawRoute = { safe_fee: number } & RawRouteFromProbe
+type ProbeForRouteResult = import("lightning").ProbeForRouteResult
+type RawRoute = NonNullable<ProbeForRouteResult["route"]>
 type Route = { roundedUpFee: Satoshis }
 
 type CachedRoute = { pubkey: Pubkey; route: RawRoute }


### PR DESCRIPTION
## Description

This fixes the validation for routes.

### Background

For a 1234 sats invoice, the `rawRoute` object looks like this:
```
{
  confidence: 857375,
  fee: 2,
  fee_mtokens: '2002',
  hops: [
    {
      channel: '1970341x11x0',
      channel_capacity: 344646,
      fee: 1,
      fee_mtokens: '1001',
      forward: 1235,
      forward_mtokens: '1235001',
      public_key: '028ec70462207b57e3d4d9332d9e0aee676c92d89b7c9fb0850fc2a24814d4d83c',
      timeout: 2163503
    },
    {
      channel: '1970331x22x0',
      channel_capacity: 344646,
      fee: 1,
      fee_mtokens: '1001',
      forward: 1234,
      forward_mtokens: '1234000',
      public_key: '02eadbd9e7557375161df8b646776a547c5cbc2e95b3071ec81553f8ec2cea3b8c',
      timeout: 2163463
    },
    {
      channel: '2100720x63x0',
      channel_capacity: 1234,
      fee: 0,
      fee_mtokens: '0',
      forward: 1234,
      forward_mtokens: '1234000',
      public_key: '0322a1ff92b8e627db8b10b8034903d6134b00273a008cf5ada2a0ba86901a3745',
      timeout: 2163463
    }
  ],
  messages: [],
  mtokens: '1236002',
  safe_fee: 3,
  safe_tokens: 1237,
  timeout: 2163543,
  tokens: 1236,
  payment: '39377199af9c3f4a76d8dcce54cf1522a08a093111ffbe200adf33c34e922540',
  total_mtokens: '1234000'
}
```