### PR TITLE
chore: improve UserUpdateUsername returns

### DIFF
--- a/src/graphql/types/object/graphql-user.ts
+++ b/src/graphql/types/object/graphql-user.ts
@@ -35,7 +35,7 @@ const GraphQLUser = GT.Object({
       type: Username,
       description: "Optional immutable user friendly identifier.",
       resolve: async (source, args, { domainAccount }) => {
-        return domainAccount?.username
+        return domainAccount?.username || source.username
       },
       deprecationReason: "will be moved to @Handle in Account and Wallet",
     },


### PR DESCRIPTION
## Description

Improve the responses from the `UserUpdateUsername` mutation:
- on success, includes the username instead of `null` in the response
- on "is immutable" edge case, still returns a user object as feedback (didn't before this)