### PR TITLE
fix: payment attempts timed out

### DIFF
--- a/src/domain/bitcoin/lightning/errors.ts
+++ b/src/domain/bitcoin/lightning/errors.ts
@@ -21,6 +21,7 @@ export class PaymentNotFoundError extends LightningServiceError {}
 export class RouteNotFoundError extends LightningServiceError {}
 export class InsufficientBalanceForRoutingError extends LightningServiceError {}
 export class InvoiceExpiredOrBadPaymentHashError extends LightningServiceError {}
+export class PaymentAttemptsTimedOutError extends LightningServiceError {}
 export class UnknownRouteNotFoundError extends LightningServiceError {
   level = ErrorLevel.Critical
 }

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -59,6 +59,10 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       message = `Temporary failure when trying to pay, please retry payment`
       return new LightningPaymentError({ message, logger: baseLogger })
 
+    case "PaymentAttemptsTimedOutError":
+      message = `Temporary failure when trying to pay, please try again later`
+      return new LightningPaymentError({ message, logger: baseLogger })
+
     case "InvoiceExpiredOrBadPaymentHashError":
       message = `Invoice already expired, or has bad payment hash`
       return new LightningPaymentError({ message, logger: baseLogger })

--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -16,6 +16,7 @@ import {
   BadPaymentDataError,
   CorruptLndDbError,
   InvoiceExpiredOrBadPaymentHashError,
+  PaymentAttemptsTimedOutError,
 } from "@domain/bitcoin/lightning"
 import lnService from "ln-service"
 import {
@@ -403,8 +404,12 @@ export const LndService = (): ILightningService | LightningServiceError => {
       switch (errDetails) {
         case KnownLndErrorDetails.InvoiceAlreadyPaid:
           return new LnAlreadyPaidError()
+        case KnownLndErrorDetails.UnableToFindRoute:
+          return new RouteNotFoundError()
         case KnownLndErrorDetails.PaymentRejectedByDestination:
           return new InvoiceExpiredOrBadPaymentHashError(paymentHash)
+        case KnownLndErrorDetails.PaymentAttemptsTimedOut:
+          return new PaymentAttemptsTimedOutError()
         default:
           return new UnknownLightningServiceError(err)
       }
@@ -476,6 +481,8 @@ export const LndService = (): ILightningService | LightningServiceError => {
           return new RouteNotFoundError()
         case KnownLndErrorDetails.PaymentRejectedByDestination:
           return new InvoiceExpiredOrBadPaymentHashError(decodedInvoice.paymentHash)
+        case KnownLndErrorDetails.PaymentAttemptsTimedOut:
+          return new PaymentAttemptsTimedOutError()
         default:
           return new UnknownLightningServiceError(err)
       }
@@ -611,6 +618,7 @@ const KnownLndErrorDetails = {
   UnableToFindRoute: "PaymentPathfindingFailedToFindPossibleRoute",
   LndDbCorruption: "payment isn't initiated",
   PaymentRejectedByDestination: "PaymentRejectedByDestination",
+  PaymentAttemptsTimedOut: "PaymentAttemptsTimedOut",
 } as const
 
 const translateLnPaymentLookup = (p): LnPaymentLookup => ({


### PR DESCRIPTION
fix false alert with timed outs payment attempts https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/rabLPua7kGP/trace/nkzpNpCdkw7?span=f25d4846b5090929

this was validated with Alex
```
you can check on trackpayment but should be not pending
pathfinding is try route a, try route b, etc until timeout hits, then ignore route c
so it should fire this error after route b attempt was tried and conclusively failed
```