### PR TITLE
fix: unsubscribed recipient error from twilio

### DIFF
--- a/src/domain/phone-provider/errors.ts
+++ b/src/domain/phone-provider/errors.ts
@@ -4,6 +4,7 @@ export class PhoneProviderServiceError extends DomainError {}
 
 export class InvalidPhoneNumberPhoneProviderError extends PhoneProviderServiceError {}
 export class RestrictedRegionPhoneProviderError extends PhoneProviderServiceError {}
+export class UnsubscribedRecipientPhoneProviderError extends PhoneProviderServiceError {}
 export class UnknownPhoneProviderServiceError extends PhoneProviderServiceError {
   level = ErrorLevel.Critical
 }

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -118,6 +118,10 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       message = "Phone number is not from a valid region"
       return new ValidationInternalError({ message, logger: baseLogger })
 
+    case "UnsubscribedRecipientPhoneProviderError":
+      message = "Phone number has opted out of receiving messages"
+      return new ValidationInternalError({ message, logger: baseLogger })
+
     case "InvalidContactAlias":
       message = "ContactAlias has incorrect characters or length"
       return new ValidationInternalError({ message, logger: baseLogger })

--- a/src/services/twilio.ts
+++ b/src/services/twilio.ts
@@ -5,6 +5,7 @@ import {
   InvalidPhoneNumberPhoneProviderError,
   RestrictedRegionPhoneProviderError,
   UnknownPhoneProviderServiceError,
+  UnsubscribedRecipientPhoneProviderError,
 } from "@domain/phone-provider"
 import { baseLogger } from "@services/logger"
 import { wrapAsyncFunctionsToRunInSpan } from "@services/tracing"
@@ -30,6 +31,10 @@ export const TwilioClient = (): IPhoneProviderService => {
 
       if (err.message.includes("has not been enabled for the region")) {
         return new RestrictedRegionPhoneProviderError(err)
+      }
+
+      if (err.message.includes("unsubscribed recipient")) {
+        return new UnsubscribedRecipientPhoneProviderError(err)
       }
 
       return new UnknownPhoneProviderServiceError(err)


### PR DESCRIPTION
fix false alert when recipient has opted out of receiving messages

https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/ikLL52B3Hdn/trace/hghBVTWmUAb?span=fec6edd473d42101

https://www.twilio.com/docs/api/errors/21610#:~:text=Attempt%20to%20send%20to%20unsubscribed,one%20of%20your%20previous%20messages.