### PR TITLE
feat: add new default-wallet-id query to support wallet currencies

### DIFF
--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -37,6 +37,7 @@ export class CouldNotFindPhoneCodeError extends CouldNotFindError {}
 export class CouldNotFindWalletFromIdError extends CouldNotFindError {}
 export class CouldNotListWalletsFromAccountIdError extends CouldNotFindError {}
 export class CouldNotFindWalletFromUsernameError extends CouldNotFindError {}
+export class CouldNotFindWalletFromUsernameAndCurrencyError extends CouldNotFindError {}
 export class CouldNotFindWalletFromOnChainAddressError extends CouldNotFindError {}
 export class CouldNotFindWalletFromOnChainAddressesError extends CouldNotFindError {}
 export class CouldNotFindLnPaymentFromHashError extends CouldNotFindError {}

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -261,6 +261,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "CouldNotFindWalletFromIdError":
     case "CouldNotListWalletsFromAccountIdError":
     case "CouldNotFindWalletFromUsernameError":
+    case "CouldNotFindWalletFromUsernameAndCurrencyError":
     case "CouldNotFindWalletFromOnChainAddressError":
     case "CouldNotFindWalletFromOnChainAddressesError":
     case "CouldNotFindLnPaymentFromHashError":

--- a/src/graphql/main/queries.ts
+++ b/src/graphql/main/queries.ts
@@ -4,6 +4,7 @@ import MeQuery from "@graphql/root/query/me"
 import GlobalsQuery from "@graphql/root/query/globals"
 import UsernameAvailableQuery from "@graphql/root/query/username-available"
 import AccountDefaultWalletIdQuery from "@graphql/root/query/account-default-wallet-id"
+import AccountDefaultWalletQuery from "@graphql/root/query/account-default-wallet"
 import BusinessMapMarkersQuery from "@graphql/root/query/business-map-markers"
 import MobileVersionsQuery from "@graphql/root/query/mobile-versions"
 import QuizQuestionsQuery from "@graphql/root/query/quiz-questions"
@@ -19,6 +20,7 @@ const QueryType = GT.Object({
     me: MeQuery,
     usernameAvailable: UsernameAvailableQuery,
     userDefaultWalletId: AccountDefaultWalletIdQuery, // FIXME: migrate to AccountDefaultWalletId
+    accountDefaultWallet: AccountDefaultWalletQuery,
     businessMapMarkers: BusinessMapMarkersQuery,
     mobileVersions: MobileVersionsQuery,
     quizQuestions: QuizQuestionsQuery,

--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -744,8 +744,17 @@ type PricePoint {
   timestamp: Timestamp!
 }
 
+"""
+A public view of a generic wallet which stores value in one of our supported currencies.
+"""
+type PublicWallet {
+  id: ID!
+  walletCurrency: WalletCurrency!
+}
+
 type Query {
   accountApiKeys: [AccountApiKeyHashed]
+  accountDefaultWallet(username: Username!, walletCurrency: WalletCurrency): PublicWallet!
   btcPrice: Price
   btcPriceList(range: PriceGraphRange!): [PricePoint]
   businessMapMarkers: [MapMarker]

--- a/src/graphql/root/query/account-default-wallet.ts
+++ b/src/graphql/root/query/account-default-wallet.ts
@@ -1,0 +1,46 @@
+import { Wallets } from "@app"
+import { CouldNotFindWalletFromUsernameAndCurrencyError } from "@domain/errors"
+import { mapError } from "@graphql/error-map"
+import { GT } from "@graphql/index"
+import Username from "@graphql/types/scalar/username"
+import WalletCurrency from "@graphql/types/scalar/wallet-currency"
+import PublicWallet from "@graphql/types/abstract/public-wallet"
+import { AccountsRepository } from "@services/mongoose"
+
+const AccountDefaultWalletQuery = GT.Field({
+  type: GT.NonNull(PublicWallet),
+  args: {
+    username: {
+      type: GT.NonNull(Username),
+    },
+    walletCurrency: { type: WalletCurrency },
+  },
+  resolve: async (_, args) => {
+    const { username, walletCurrency } = args
+
+    if (username instanceof Error) {
+      throw username
+    }
+
+    const account = await AccountsRepository().findByUsername(username)
+    if (account instanceof Error) {
+      return mapError(account)
+    }
+
+    const wallets = await Wallets.listWalletsByAccountId(account.id)
+    if (wallets instanceof Error) throw wallets
+
+    if (!walletCurrency) {
+      return wallets.find((wallet) => wallet.id === account.defaultWalletId)
+    }
+
+    const wallet = wallets.find((wallet) => wallet.currency === walletCurrency)
+    if (!wallet) {
+      return mapError(new CouldNotFindWalletFromUsernameAndCurrencyError(username))
+    }
+
+    return wallet
+  },
+})
+
+export default AccountDefaultWalletQuery

--- a/src/graphql/types/abstract/public-wallet.ts
+++ b/src/graphql/types/abstract/public-wallet.ts
@@ -1,0 +1,20 @@
+import { GT } from "@graphql/index"
+
+import WalletCurrency from "../scalar/wallet-currency"
+
+const IPublicWallet = GT.Object<Wallet>({
+  name: "PublicWallet",
+  description:
+    "A public view of a generic wallet which stores value in one of our supported currencies.",
+  fields: () => ({
+    id: {
+      type: GT.NonNullID,
+    },
+    walletCurrency: {
+      type: GT.NonNull(WalletCurrency),
+      resolve: (source) => source.currency,
+    },
+  }),
+})
+
+export default IPublicWallet


### PR DESCRIPTION
## Description

This PR adds a new query to:
1. return the wallet currency for a user's `defaultWalletId`
2. return the `defaultWalletId(ByCurrency)` based on an optional specified currency

### Context

We need this to know what type of wallet we are working with in places like for our `galoy-pay` repo. Right now, galoy-pay breaks if the user's default wallet is `USD` and they try to set an amount in the interface because the `lnInvoiceSendOnBehalfOfRecipient` mutation does not support USD wallets. We would need to know the wallet type to be able to switch on:
- `lnInvoiceSendOnBehalfOfRecipient`
- `lnUsdInvoiceSendOnBehalfOfRecipient`