### PR TITLE
fix: round cents down if not rounded int

### DIFF
--- a/src/app/wallets/get-lightning-fee.ts
+++ b/src/app/wallets/get-lightning-fee.ts
@@ -99,7 +99,11 @@ const feeProbe = async ({
   let balanceInSats: Satoshis
   if (walletCurrency === WalletCurrency.Usd) {
     const dealer = DealerPriceService()
-    const sats_ = await dealer.getSatsFromCentsForImmediateSell(toCents(balance))
+
+    // FIXME: this is to get around a serialization problem for long floats and the grpc interface
+    const roundedBalance = Math.floor(balance)
+    const sats_ = await dealer.getSatsFromCentsForImmediateSell(toCents(roundedBalance))
+
     if (sats_ instanceof Error) return sats_
     balanceInSats = sats_
   } else {


### PR DESCRIPTION
## Description

We've noticed that we get [this dealer error](https://ui.honeycomb.io/galoy/datasets/galoy-hack/result/CMXV2Fnj8FY/trace/8nPgLTPFKQ4?span=e8bc65978cbe0d3c) for wallets with a non-rounded-integer balance.

This is an attempt to fix this.