### PR TITLE
fix: onChain/offChain fee estimation error handling

### DIFF
--- a/src/domain/bitcoin/lightning/errors.ts
+++ b/src/domain/bitcoin/lightning/errors.ts
@@ -27,6 +27,7 @@ export class RouteNotFoundError extends LightningServiceError {}
 export class InsufficientBalanceForRoutingError extends LightningServiceError {}
 export class InvoiceExpiredOrBadPaymentHashError extends LightningServiceError {}
 export class PaymentAttemptsTimedOutError extends LightningServiceError {}
+export class ProbeForRouteTimedOutError extends LightningServiceError {}
 export class UnknownRouteNotFoundError extends LightningServiceError {
   level = ErrorLevel.Critical
 }

--- a/src/domain/bitcoin/onchain/errors.ts
+++ b/src/domain/bitcoin/onchain/errors.ts
@@ -5,6 +5,9 @@ export class OnChainError extends DomainError {}
 export class TransactionDecodeError extends OnChainError {}
 
 export class OnChainServiceError extends OnChainError {}
+export class InsufficientOnChainFundsError extends OnChainServiceError {
+  level = ErrorLevel.Critical
+}
 export class UnknownOnChainServiceError extends OnChainServiceError {
   level = ErrorLevel.Critical
 }

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -182,6 +182,10 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       message = "Unable to find a route for payment."
       return new RouteFindingError({ message, logger: baseLogger })
 
+    case "ProbeForRouteTimedOutError":
+      message = "Unable to find a route for payment."
+      return new RouteFindingError({ message, logger: baseLogger })
+
     case "UnknownRouteNotFoundError":
       message = "Unknown error occurred when trying to find a route for payment."
       return new RouteFindingError({ message, logger: baseLogger })
@@ -285,6 +289,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "OnChainError":
     case "TransactionDecodeError":
     case "OnChainServiceError":
+    case "InsufficientOnChainFundsError":
     case "UnknownOnChainServiceError":
     case "CouldNotFindOnChainTransactionError":
     case "OnChainServiceUnavailableError":

--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -16,6 +16,7 @@ import {
   CorruptLndDbError,
   InvoiceExpiredOrBadPaymentHashError,
   PaymentAttemptsTimedOutError,
+  ProbeForRouteTimedOutError,
 } from "@domain/bitcoin/lightning"
 import lnService from "ln-service"
 import {
@@ -146,6 +147,8 @@ export const LndService = (): ILightningService | LightningServiceError => {
       switch (errDetails) {
         case KnownLndErrorDetails.InsufficientBalance:
           return new InsufficientBalanceForRoutingError()
+        case KnownLndErrorDetails.ProbeForRouteTimedOut:
+          return new ProbeForRouteTimedOutError()
         default:
           return new UnknownRouteNotFoundError(err)
       }
@@ -603,6 +606,7 @@ const KnownLndErrorDetails = {
   LndDbCorruption: "payment isn't initiated",
   PaymentRejectedByDestination: "PaymentRejectedByDestination",
   PaymentAttemptsTimedOut: "PaymentAttemptsTimedOut",
+  ProbeForRouteTimedOut: "ProbeForRouteTimedOut",
 } as const
 
 const translateLnPaymentLookup = (p): LnPaymentLookup => ({


### PR DESCRIPTION
- Fix false alert on lightning fee probing https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/J3QUuxve9dm/trace/xR9YhiDopQs?span=4919e42e210b3266
- Add custom error for insufficient funds available for on-chain transactions https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/jKzXBzcPvjQ/trace/mN9h85vZ8Bn?span=774e3069e1e455d4