### PR TITLE
feat: Add cron config

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -160,3 +160,6 @@ apollo:
   playgroundUrl: "https://api.staging.galoy.io/graphql"
 
 userActivenessMonthlyVolumeThreshold: 100 # cents
+
+cronConfig:
+  rebalanceEnabled: true

--- a/src/config/yaml.ts
+++ b/src/config/yaml.ts
@@ -199,3 +199,5 @@ export const LND_SCB_BACKUP_BUCKET_NAME = yamlConfig.lndScbBackupBucketName
 
 export const getTestAccounts = (config = yamlConfig): TestAccount[] =>
   config.test_accounts
+
+export const getCronConfig = (config = yamlConfig): CronConfig => config.cronConfig

--- a/src/core/types.d.ts
+++ b/src/core/types.d.ts
@@ -69,3 +69,7 @@ type TransactionType =
   | "deposit_fee"
   | "routing_fee"
   | "onchain_receipt_pending" // only for notification, not persistent in mongodb
+
+type CronConfig = {
+  rebalanceEnabled: boolean
+}

--- a/src/servers/cron.ts
+++ b/src/servers/cron.ts
@@ -11,10 +11,12 @@ import { setupMongoConnection } from "@services/mongodb"
 
 import { activateLndHealthCheck } from "@services/lnd/health"
 import { ColdStorage, Lightning, Wallets } from "@app"
+import { getCronConfig } from "@config"
 
 const logger = baseLogger.child({ module: "cron" })
 
 const main = async () => {
+  const cronConfig = getCronConfig()
   const results: Array<boolean> = []
   const mongoose = await setupMongoConnection()
 
@@ -49,7 +51,7 @@ const main = async () => {
     deleteFailedPaymentsAttemptAllLnds,
     updateRoutingRevenues,
     updateOnChainReceipt,
-    rebalance,
+    ...(cronConfig.rebalanceEnabled ? [rebalance] : []),
     updateLnPaymentsCollection,
   ]
 


### PR DESCRIPTION
This PR modifies the cron job to disable rebalancing in environments which have the `rebalanceEnabled` flag set to false.

Related PR in galoy-deployments to add the new variable: https://github.com/GaloyMoney/galoy-deployments/pull/1241