### PR TITLE
fix: adjust price tick counts down to account for Feb

### DIFF
--- a/test/integration/01-setup/01-price-history.spec.ts
+++ b/test/integration/01-setup/01-price-history.spec.ts
@@ -13,8 +13,9 @@ describe("Price history", () => {
       "pair.exchange.name": exchange,
     })
 
+    const HOURS_IN_YEAR = 8772
     if (doc) {
-      expect(doc.pair.exchange.price.length).toBeGreaterThanOrEqual(8780)
+      expect(doc.pair.exchange.price.length).toBeGreaterThanOrEqual(HOURS_IN_YEAR)
       return
     }
 

--- a/test/integration/services/price.spec.ts
+++ b/test/integration/services/price.spec.ts
@@ -6,7 +6,7 @@ describe("Price", () => {
     const rangesIntervalsToTest = [
       { range: PriceRange.OneDay, interval: PriceInterval.OneHour, ticks: 23 },
       { range: PriceRange.OneWeek, interval: PriceInterval.FourHours, ticks: 42 },
-      { range: PriceRange.OneMonth, interval: PriceInterval.OneDay, ticks: 30 },
+      { range: PriceRange.OneMonth, interval: PriceInterval.OneDay, ticks: 29 }, // 29 to accommodate for February
       { range: PriceRange.OneYear, interval: PriceInterval.OneWeek, ticks: 52 },
     ]
     rangesIntervalsToTest.forEach(({ range, interval, ticks }) => {


### PR DESCRIPTION
**Context for the `HOURS_IN_YEAR` change**

![image](https://user-images.githubusercontent.com/17693119/156211647-b171b648-983a-49d0-bc03-ec476eaf0460.png)
