### PR TITLE
fix: minimize chance of small negative user balance from fee estimation

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -137,6 +137,7 @@ onChainWallet:
   scanDepth: 360
   scanDepthOutgoing: 2
   scanDepthChannelUpdate: 8
+  feeBuffer: 5000
 
 # TODO
 # carrierRegexFilter: ""

--- a/src/app/wallets/send-on-chain.ts
+++ b/src/app/wallets/send-on-chain.ts
@@ -310,32 +310,37 @@ const executePaymentViaOnChain = async ({
   })
   if (withdrawalLimitCheck instanceof Error) return withdrawalLimitCheck
 
-  const estimatedFee = await getOnChainFee({
-    walletId: senderWallet.id,
-    account: senderAccount,
-    amount,
-    address,
-    targetConfirmations,
-  })
+  const getFeeEstimate = () =>
+    getOnChainFee({
+      walletId: senderWallet.id,
+      account: senderAccount,
+      amount,
+      address,
+      targetConfirmations,
+    })
+
+  const onChainAvailableBalance = await onChainService.getBalance()
+  if (onChainAvailableBalance instanceof Error) return onChainAvailableBalance
+
+  const estimatedFee = await getFeeEstimate()
   if (estimatedFee instanceof Error) return estimatedFee
 
   const amountToSend = sendAll ? toSats(amount - estimatedFee) : amountSats
+  if (onChainAvailableBalance < amountToSend + estimatedFee)
+    return new RebalanceNeededError()
 
   if (amountToSend < dustThreshold)
     return new LessThanDustThresholdError(
       `Use lightning to send amounts less than ${dustThreshold}`,
     )
 
-  const onChainAvailableBalance = await onChainService.getBalance()
-  if (onChainAvailableBalance instanceof Error) return onChainAvailableBalance
-  if (onChainAvailableBalance < amountToSend + estimatedFee)
-    return new RebalanceNeededError()
-
   return LockService().lockWalletId(
     { walletId: senderWallet.id, logger },
     async (lock) => {
       const balance = await LedgerService().getWalletBalance(senderWallet.id)
       if (balance instanceof Error) return balance
+      const estimatedFee = await getFeeEstimate()
+      if (estimatedFee instanceof Error) return estimatedFee
       if (balance < amountToSend + estimatedFee) {
         return new InsufficientBalanceError(
           `${amountToSend + estimatedFee} exceeds balance ${balance}`,

--- a/src/app/wallets/send-on-chain.ts
+++ b/src/app/wallets/send-on-chain.ts
@@ -325,7 +325,7 @@ const executePaymentViaOnChain = async ({
   const estimatedFee = await getFeeEstimate()
   if (estimatedFee instanceof Error) return estimatedFee
 
-  const amountToSend = sendAll ? toSats(amount - estimatedFee) : amountSats
+  const amountToSend = sendAll ? toSats(amount - estimatedFee - feeBuffer) : amountSats
   if (onChainAvailableBalance < amountToSend + estimatedFee)
     return new RebalanceNeededError()
 

--- a/src/app/wallets/send-on-chain.ts
+++ b/src/app/wallets/send-on-chain.ts
@@ -34,7 +34,7 @@ import {
 } from "./check-limit-helpers"
 import { getOnChainFee } from "./get-on-chain-fee"
 
-const { dustThreshold } = getOnChainWalletConfig()
+const { dustThreshold, feeBuffer } = getOnChainWalletConfig()
 
 export const payOnChainByWalletIdWithTwoFA = async ({
   senderAccount,
@@ -341,9 +341,11 @@ const executePaymentViaOnChain = async ({
       if (balance instanceof Error) return balance
       const estimatedFee = await getFeeEstimate()
       if (estimatedFee instanceof Error) return estimatedFee
-      if (balance < amountToSend + estimatedFee) {
+      if (balance < amountToSend + estimatedFee + feeBuffer) {
         return new InsufficientBalanceError(
-          `${amountToSend + estimatedFee} exceeds balance ${balance}`,
+          `${
+            amountToSend + estimatedFee
+          } exceeds balance ${balance} (with ${feeBuffer} sats buffer)`,
         )
       }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -203,6 +203,7 @@ export const configSchema = {
         scanDepth: { type: "number" },
         scanDepthOutgoing: { type: "number" },
         scanDepthChannelUpdate: { type: "number" },
+        feeBuffer: { type: "number" },
       },
       required: [
         "dustThreshold",
@@ -210,6 +211,7 @@ export const configSchema = {
         "scanDepth",
         "scanDepthOutgoing",
         "scanDepthChannelUpdate",
+        "feeBuffer",
       ],
       additionalProperties: false,
     },

--- a/src/config/yaml.ts
+++ b/src/config/yaml.ts
@@ -159,6 +159,7 @@ export const getOnChainAddressCreateAttemptLimits = () =>
 
 export const getOnChainWalletConfig = () => ({
   dustThreshold: yamlConfig.onChainWallet.dustThreshold,
+  feeBuffer: yamlConfig.onChainWallet.feeBuffer,
 })
 
 export const getColdStorageConfig = (): ColdStorageConfig => {

--- a/src/core/types.d.ts
+++ b/src/core/types.d.ts
@@ -9,6 +9,7 @@ type Primitive = string | boolean | number
 
 type onChainWalletConfig = {
   dustThreshold: number
+  feeBuffer: number
 }
 
 type IpConfig = {


### PR DESCRIPTION
## Description

There is an edge-case where onchain fee estimation can be lower than the actual fee used for an onchain txn in the case where the fee environment is very volatile.

In these cases, it is possible for our balance check to be bypassed by a small amount which amounts to the difference the fee estimate is off by in sats. The highest we've seen this be off by so far is 3586 sats.

To help address this two measures are proposed in this PR:
1. Bring the estimate check closer to the actual send to reduce the effects from fee volatility

1. **(Feature change!)** Add a fee buffer when doing the balance check to help mitigate from the edge instances where the fee can still differ

   This 2nd measure effectively means that a user would not be able to empty their wallet via onchain, but can still do so over Lightning/Intraledger