### PR TITLE
chore: add top-level attributes to all queries/mutations

### DIFF
--- a/src/graphql/main/queries.ts
+++ b/src/graphql/main/queries.ts
@@ -12,21 +12,47 @@ import BtcPriceListQuery from "@graphql/root/query/btc-price-list"
 import OnChainTxFeeQuery from "@graphql/root/query/on-chain-tx-fee-query"
 import BtcPriceQuery from "@graphql/root/query/btc-price"
 
+import {
+  addAttributesToCurrentSpanAndPropagate,
+  SemanticAttributes,
+  ACCOUNT_USERNAME,
+} from "@services/tracing"
+
+const fields = {
+  globals: GlobalsQuery,
+  me: MeQuery,
+  usernameAvailable: UsernameAvailableQuery,
+  userDefaultWalletId: AccountDefaultWalletIdQuery, // FIXME: migrate to AccountDefaultWalletId
+  accountDefaultWallet: AccountDefaultWalletQuery,
+  businessMapMarkers: BusinessMapMarkersQuery,
+  mobileVersions: MobileVersionsQuery,
+  quizQuestions: QuizQuestionsQuery,
+  btcPrice: BtcPriceQuery,
+  btcPriceList: BtcPriceListQuery,
+  onChainTxFee: OnChainTxFeeQuery,
+}
+
+const addTracing = (fields) => {
+  for (const key in fields) {
+    const original = fields[key].resolve
+    fields[key].resolve = (_, args, context) => {
+      const { ip, domainAccount, domainUser } = context
+      return addAttributesToCurrentSpanAndPropagate(
+        {
+          [SemanticAttributes.ENDUSER_ID]: domainUser?.id,
+          [ACCOUNT_USERNAME]: domainAccount?.username,
+          [SemanticAttributes.HTTP_CLIENT_IP]: ip,
+        },
+        () => original(_, args, context),
+      )
+    }
+  }
+  return fields
+}
+
 const QueryType = GT.Object({
   name: "Query",
-  fields: () => ({
-    globals: GlobalsQuery,
-    me: MeQuery,
-    usernameAvailable: UsernameAvailableQuery,
-    userDefaultWalletId: AccountDefaultWalletIdQuery, // FIXME: migrate to AccountDefaultWalletId
-    accountDefaultWallet: AccountDefaultWalletQuery,
-    businessMapMarkers: BusinessMapMarkersQuery,
-    mobileVersions: MobileVersionsQuery,
-    quizQuestions: QuizQuestionsQuery,
-    btcPrice: BtcPriceQuery,
-    btcPriceList: BtcPriceListQuery,
-    onChainTxFee: OnChainTxFeeQuery,
-  }),
+  fields: () => addTracing(fields),
 })
 
 export default QueryType

--- a/src/graphql/root/query/me.ts
+++ b/src/graphql/root/query/me.ts
@@ -1,23 +1,10 @@
-import {
-  addAttributesToCurrentSpanAndPropagate,
-  SemanticAttributes,
-  ACCOUNT_USERNAME,
-} from "@services/tracing"
 import { GT } from "@graphql/index"
 
 import GraphQLUser from "@graphql/types/object/graphql-user"
 
 const MeQuery = GT.Field({
   type: GraphQLUser,
-  resolve: async (_, __, { ip, domainUser, domainAccount }) =>
-    addAttributesToCurrentSpanAndPropagate(
-      {
-        [SemanticAttributes.ENDUSER_ID]: domainUser?.id,
-        [ACCOUNT_USERNAME]: domainAccount?.username,
-        [SemanticAttributes.HTTP_CLIENT_IP]: ip,
-      },
-      () => domainUser,
-    ),
+  resolve: async (_, __, { domainUser }) => domainUser,
 })
 
 export default MeQuery


### PR DESCRIPTION
## Description

This PR adds properties like `enduser.id` to all mutations and queries. Sparked from exploring the balance bug from PR #1153.