### PR TITLE
fix: add delay as workaround to core dump error

### DIFF
--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -392,6 +392,8 @@ describe("UserWallet - onChainPay", () => {
       expect(settledTx.memo).toBe(memo)
     }
 
+    // Delay as workaround for occasional core-dump error
+    await new Promise((resolve) => setImmediate(resolve))
     sub.removeAllListeners()
   })
 


### PR DESCRIPTION
## Description

There's been a consistent `core dump` error that I've only been able to observe locally when running tests for some time now. 

```
/home/arvin/.nodenv/versions/16.1.0/bin/node[212027]: ../src/node_http2.cc:450:void node::http2::Http2Session::CheckAllocatedSize(size_t) const: Assertion `(current_nghttp2_memory_) >= (previous_size)' failed.
 1: 0xb12b40 node::Abort() [/home/arvin/.nodenv/versions/16.1.0/bin/node]
 2: 0xb12bbe  [/home/arvin/.nodenv/versions/16.1.0/bin/node]
 3: 0xb4c37d node::mem::NgLibMemoryManager<node::http2::Http2Session, nghttp2_mem>::ReallocImpl(void*, unsigned long, void*) [/home/arvin/.nodenv/versions/16.1.0/bin/node]
 4: 0xb4c4e3 node::mem::NgLibMemoryManager<node::http2::Http2Session, nghttp2_mem>::FreeImpl(void*, void*) [/home/arvin/.nodenv/versions/16.1.0/bin/node]
 5: 0x1aa2541 nghttp2_session_close_stream [/home/arvin/.nodenv/versions/16.1.0/bin/node]
 6: 0x1aa8c9d nghttp2_session_mem_recv [/home/arvin/.nodenv/versions/16.1.0/bin/node]
 7: 0xb405c4 node::http2::Http2Session::ConsumeHTTP2Data() [/home/arvin/.nodenv/versions/16.1.0/bin/node]
 8: 0xb409d2 node::http2::Http2Session::OnStreamRead(long, uv_buf_t const&) [/home/arvin/.nodenv/versions/16.1.0/bin/node]
 9: 0xcc0310 node::crypto::TLSWrap::ClearOut() [/home/arvin/.nodenv/versions/16.1.0/bin/node]
10: 0xcc0e50 node::crypto::TLSWrap::OnStreamRead(long, uv_buf_t const&) [/home/arvin/.nodenv/versions/16.1.0/bin/node]
11: 0xbf7e38 node::LibuvStreamWrap::OnUvRead(long, uv_buf_t const*) [/home/arvin/.nodenv/versions/16.1.0/bin/node]
12: 0x15947b7  [/home/arvin/.nodenv/versions/16.1.0/bin/node]
13: 0x1595170  [/home/arvin/.nodenv/versions/16.1.0/bin/node]
14: 0x159bc55  [/home/arvin/.nodenv/versions/16.1.0/bin/node]
15: 0x15897f8 uv_run [/home/arvin/.nodenv/versions/16.1.0/bin/node]
16: 0xa55fd5 node::SpinEventLoop(node::Environment*) [/home/arvin/.nodenv/versions/16.1.0/bin/node]
17: 0xb547c7 node::NodeMainInstance::Run(node::EnvSerializeInfo const*) [/home/arvin/.nodenv/versions/16.1.0/bin/node]
18: 0xadae62 node::Start(int, char**) [/home/arvin/.nodenv/versions/16.1.0/bin/node]
19: 0x7fed2cc5cfd0  [/lib/x86_64-linux-gnu/libc.so.6]
20: 0x7fed2cc5d07d __libc_start_main [/lib/x86_64-linux-gnu/libc.so.6]
21: 0xa52f5c  [/home/arvin/.nodenv/versions/16.1.0/bin/node]
Aborted (core dumped)
Done in 102.39s.
```

After doing some investigations today, I've managed to isolate it to happening in a single test just before we call `sub.removeAllListeners()` for some reason. It was introduced for me in PR #1079, but I can't tell what is directly different in this PR to cause this.

Isolating the exact location this was happening in was especially difficult because we had started skipping some of those tests unintentionally for a few commits on `main` branch (eventually unskipped in #1120) which obscured where the actual change was introduced that caused the error to start showing up.

## Investigation

I found [this thread](https://github.com/wechaty/grpc/issues/130) describing the exact error I was getting. In it, their workaround solution ended up being to add a `await new Promise((resolve) => setImmediate(resolve))` statement to introduce a delay.

## Solution

We call `sub.removeAllListeners()` in multiple places, but it seems that it's only one place in particular that causes the error for me. Adding the delay statement just before that call fixes the issue for me locally.