### PR TITLE
chore: persist lnpayments before deleting failed attempts in cron

### DIFF
--- a/src/servers/cron.ts
+++ b/src/servers/cron.ts
@@ -47,12 +47,12 @@ const main = async () => {
     updateEscrows,
     updatePendingLightningInvoices,
     updatePendingLightningPayments,
+    updateLnPaymentsCollection,
     deleteExpiredInvoices,
     deleteFailedPaymentsAttemptAllLnds,
     updateRoutingRevenues,
     updateOnChainReceipt,
     ...(cronConfig.rebalanceEnabled ? [rebalance] : []),
-    updateLnPaymentsCollection,
   ]
 
   for (const task of tasks) {


### PR DESCRIPTION
## Description

We noticed all `lnpayment` objects with `failed` status in the `lnpayments` collection had empty arrays for their `attempts` property. This is to fix that by persisting first before deleting attempts.