### PR TITLE
chore: make all usernames lowercase

### DIFF
--- a/src/domain/accounts/index.ts
+++ b/src/domain/accounts/index.ts
@@ -51,10 +51,11 @@ export const checkedAccountStatus = (status: string) => {
 export const UsernameRegex = /(?!^(1|3|bc1|lnbc1))^[0-9a-z_]{3,50}$/i
 
 export const checkedToUsername = (username: string): Username | ValidationError => {
-  if (!username.match(UsernameRegex)) {
+  const lowerCaseUsername = username.toLowerCase()
+  if (!lowerCaseUsername.match(UsernameRegex)) {
     return new InvalidUsername(username)
   }
-  return username as Username
+  return lowerCaseUsername as Username
 }
 
 export const ContactAliasRegex = /^[0-9A-Za-z_]{3,50}$/i


### PR DESCRIPTION
To improve query times, we will remove the use of case insensitive regex and replace it by having all usernames be lowercase. The change has three parts:
1. This PR: Ensure all new usernames are lowercase
2. Future PR: Migrate all existing usernames to lowercase
3. Future PR: Remove the use of regex when finding a user by username