### PR TITLE
fix: update parse ip to support ip string array

### DIFF
--- a/src/domain/users-ips/index.ts
+++ b/src/domain/users-ips/index.ts
@@ -1,13 +1,23 @@
 export const parseIps = (ips: undefined | string | string[]): IpAddress | undefined => {
   if (!ips) return undefined
 
-  let ip: IpAddress | undefined = undefined
-
-  if (ips && Array.isArray(ips) && ips.length) {
-    ip = ips[0] as IpAddress
-  } else if (typeof ips === "string") {
-    ip = ips as IpAddress
+  if (Array.isArray(ips) && ips.length) {
+    return toIpAddress(ips[0])
   }
 
-  return ip
+  if (typeof ips === "string") {
+    if (ips.includes(",")) return toIpAddress(ips.split(",")[0])
+    return toIpAddress(ips)
+  }
+
+  return undefined
+}
+
+const toIpAddress = (ip: string): IpAddress | undefined => {
+  if (!ip) return undefined
+
+  const trimmedIp = ip.trim()
+  if (!trimmedIp) return undefined
+
+  return trimmedIp as IpAddress
 }

--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -147,7 +147,9 @@ export const startApolloServer = async ({
 
       const body = context.req?.body ?? null
 
-      const ipString = isDev ? context.req?.ip : context.req?.headers["x-real-ip"]
+      const ipString = isDev
+        ? context.req?.ip
+        : context.req?.headers["x-real-ip"] || context.req?.headers["x-forwarded-for"]
 
       const ip = parseIps(ipString)
 

--- a/test/unit/domain/users-ips/parse-ips.spec.ts
+++ b/test/unit/domain/users-ips/parse-ips.spec.ts
@@ -1,0 +1,36 @@
+import { parseIps } from "@domain/users-ips"
+
+describe("parseIps", () => {
+  it("returns undefined if ip is empty", () => {
+    let ip = parseIps(undefined)
+    expect(ip).toBe(undefined)
+
+    ip = parseIps("")
+    expect(ip).toBe(undefined)
+
+    ip = parseIps([])
+    expect(ip).toBe(undefined)
+
+    ip = parseIps([""])
+    expect(ip).toBe(undefined)
+
+    ip = parseIps(", 192.168.0.2")
+    expect(ip).toBe(undefined)
+  })
+
+  it("returns first ip from array", () => {
+    const ip = parseIps(["192.168.0.1", "192.168.0.2"])
+    expect(ip).toBe("192.168.0.1")
+  })
+
+  it("returns first ip from string array", () => {
+    let ip = parseIps("192.168.0.1, 192.168.0.2")
+    expect(ip).toBe("192.168.0.1")
+
+    ip = parseIps("192.168.0.1 , 192.168.0.2")
+    expect(ip).toBe("192.168.0.1")
+
+    ip = parseIps(" 192.168.0.2, 192.168.0.3")
+    expect(ip).toBe("192.168.0.2")
+  })
+})


### PR DESCRIPTION
- Add support for ips string array
- Add `x-forwarded-for` fallback (required when galoy instance is not behind a balancer) 