### PR TITLE
refactor: add LedgerFacade with new entry builder

### DIFF
--- a/src/app/wallets/send-intraledger.ts
+++ b/src/app/wallets/send-intraledger.ts
@@ -230,7 +230,7 @@ const executePaymentViaIntraledger = async ({
           amountDisplayCurrency,
           recipientWalletId,
           recipientWalletCurrency: recipientWallet.currency,
-          recipientUsername,
+          recipientUsername: recipientUsername || undefined,
           memoPayer,
         }),
       )

--- a/src/app/wallets/send-lightning.ts
+++ b/src/app/wallets/send-lightning.ts
@@ -487,7 +487,7 @@ const executePaymentViaIntraledger = async ({
           amountDisplayCurrency,
           recipientWalletId,
           recipientWalletCurrency: recipientWallet.currency,
-          recipientUsername: null,
+          recipientUsername: undefined,
           pubkey: lndService.defaultPubkey(),
           memoPayer: memo,
         }),

--- a/src/app/wallets/send-lightning.ts
+++ b/src/app/wallets/send-lightning.ts
@@ -27,7 +27,12 @@ import { toCents } from "@domain/fiat"
 import { DisplayCurrencyConverter } from "@domain/fiat/display-currency"
 import { CachedRouteLookupKeyFactory } from "@domain/routes/key-factory"
 import { WalletInvoiceValidator } from "@domain/wallet-invoices"
-import { WalletCurrency } from "@domain/shared"
+import {
+  AmountMathWrapper,
+  paymentAmountFromCents,
+  paymentAmountFromSats,
+  WalletCurrency,
+} from "@domain/shared"
 import {
   PaymentInitiationMethod,
   PaymentInputValidator,
@@ -48,6 +53,9 @@ import { RoutesCache } from "@services/redis/routes"
 import { addAttributesToCurrentSpan } from "@services/tracing"
 
 import { DealerPriceServiceError } from "@domain/dealer-price"
+
+import * as LedgerFacade from "@services/ledger/facade"
+import { UnknownLedgerError } from "@domain/ledger"
 
 import { getNoAmountLightningFee, getRoutingFee } from "./get-lightning-fee"
 
@@ -646,39 +654,70 @@ const executePaymentViaLn = async ({
   return LockService().lockWalletId(
     { walletId: senderWallet.id, logger },
     async (lock) => {
-      const balance = await LedgerService().getWalletBalance(senderWallet.id)
+      const ledgerService = LedgerService()
+      const balance = await LedgerFacade.getLedgerAccountBalanceForWalletId({
+        id: senderWallet.id,
+        currency: senderWallet.currency,
+      })
+
       if (balance instanceof Error) return balance
+
+      const lnTxSendMetadata = LedgerFacade.LnSendLedgerMetadata({
+        paymentHash,
+        fee: paymentAmountFromSats(feeRouting),
+        feeDisplayUsd: feeRoutingDisplayCurrency,
+        amountDisplayUsd: amountDisplayCurrency,
+        pubkey,
+        feeKnownInAdvance: !!rawRoute,
+      })
+
+      let journal: LockServiceError | LedgerJournal | UnknownLedgerError
 
       if (senderWallet.currency === WalletCurrency.Usd) {
         if (cents === undefined) return new NotReachableError("cents is set here")
-        if (balance < cents)
+
+        if (AmountMathWrapper(balance).lessThan(paymentAmountFromCents(cents)))
           return new InsufficientBalanceError(
             `Payment amount '${cents}' cents exceeds balance '${balance}'`,
           )
-      }
 
-      if (senderWallet.currency === WalletCurrency.Btc && balance < sats) {
-        return new InsufficientBalanceError(
-          `Payment amount '${sats}' sats exceeds balance '${balance}'`,
+        journal = await LockService().extendLock({ logger, lock }, async () =>
+          LedgerFacade.recordSend({
+            description: decodedInvoice.description,
+            senderWalletDescriptor: {
+              id: senderWallet.id,
+              currency: senderWallet.currency,
+            },
+            amount: {
+              usd: paymentAmountFromCents(cents as UsdCents),
+              btc: paymentAmountFromSats(sats),
+            },
+            fee: paymentAmountFromSats(feeRouting),
+            metadata: lnTxSendMetadata,
+          }),
+        )
+      }
+      // Wallet curreny = BTC
+      else {
+        if (AmountMathWrapper(balance).lessThan(paymentAmountFromSats(sats)))
+          return new InsufficientBalanceError(
+            `Payment amount '${sats}' sats exceeds balance '${balance}'`,
+          )
+
+        journal = await LockService().extendLock({ logger, lock }, async () =>
+          LedgerFacade.recordSend({
+            description: decodedInvoice.description,
+            senderWalletDescriptor: {
+              id: senderWallet.id,
+              currency: senderWallet.currency,
+            },
+            amount: paymentAmountFromSats(sats),
+            fee: paymentAmountFromSats(feeRouting),
+            metadata: lnTxSendMetadata,
+          }),
         )
       }
 
-      const ledgerService = LedgerService()
-      const journal = await LockService().extendLock({ logger, lock }, async () =>
-        ledgerService.addLnTxSend({
-          walletId: senderWallet.id,
-          walletCurrency: senderWallet.currency,
-          paymentHash,
-          description: decodedInvoice.description,
-          sats,
-          cents,
-          feeRouting,
-          amountDisplayCurrency,
-          feeRoutingDisplayCurrency,
-          pubkey,
-          feeKnownInAdvance: !!rawRoute,
-        }),
-      )
       if (journal instanceof Error) return journal
       const { journalId } = journal
 

--- a/src/app/wallets/send-on-chain.ts
+++ b/src/app/wallets/send-on-chain.ts
@@ -241,7 +241,7 @@ const executePaymentViaIntraledger = async ({
             recipientWalletId: recipientWallet.id,
             recipientWalletCurrency: recipientWallet.currency,
             recipientUsername: recipientAccount.username,
-            memoPayer: memo ?? null,
+            memoPayer: memo || undefined,
           }),
       )
       if (journal instanceof Error) return journal

--- a/src/domain/ledger/index.ts
+++ b/src/domain/ledger/index.ts
@@ -37,7 +37,7 @@ export const LedgerTransactionType = {
   Escrow: "escrow",
 
   // TODO: rename. should be routing_revenue
-  RoutingFee: "routing_fee", // channel-related
+  RoutingRevenue: "routing_fee", // channel-related
   ExchangeRebalance: "exchange_rebalance", // send/receive btc from the exchange
   UserRebalance: "user_rebalance", // buy/sell btc in the user wallet
   ToColdStorage: "to_cold_storage",

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -124,14 +124,14 @@ type AddColdStorageTxSendArgs = {
 type IntraledgerTxArgs = {
   senderWalletId: WalletId
   senderWalletCurrency: WalletCurrency
-  senderUsername: Username | null
+  senderUsername?: Username
   description: string
   sats?: Satoshis
   cents?: UsdCents
   recipientWalletId: WalletId
   recipientWalletCurrency: WalletCurrency
-  recipientUsername: Username | null
-  memoPayer: string | null
+  recipientUsername?: Username
+  memoPayer?: string
 }
 
 type AddIntraLedgerTxSendArgs = IntraledgerTxArgs & {
@@ -139,7 +139,7 @@ type AddIntraLedgerTxSendArgs = IntraledgerTxArgs & {
 }
 
 type SendIntraledgerTxArgs = IntraledgerTxArgs & {
-  recipientUsername: Username | null
+  recipientUsername?: Username
   shareMemoWithPayee: boolean
   metadata:
     | AddLnIntraledgerSendLedgerMetadata

--- a/src/domain/shared/calculator.ts
+++ b/src/domain/shared/calculator.ts
@@ -18,3 +18,26 @@ export const AmountCalculator = () => {
     add,
   }
 }
+
+export const AmountMathWrapper = <T extends WalletCurrency>(base: PaymentAmount<T>) => {
+  const add = (valueToAdd: PaymentAmount<T>) => {
+    return AmountMathWrapper(AmountCalculator().add(base, valueToAdd))
+  }
+
+  const sub = (valueToSub: PaymentAmount<T>) => {
+    return AmountMathWrapper(AmountCalculator().sub(base, valueToSub))
+  }
+
+  const lessThan = (valueCompared: PaymentAmount<T>) => {
+    return base.amount < valueCompared.amount
+  }
+
+  const value = base
+
+  return {
+    add,
+    sub,
+    lessThan,
+    value,
+  }
+}

--- a/src/domain/shared/calculator.ts
+++ b/src/domain/shared/calculator.ts
@@ -18,26 +18,3 @@ export const AmountCalculator = () => {
     add,
   }
 }
-
-export const AmountMathWrapper = <T extends WalletCurrency>(base: PaymentAmount<T>) => {
-  const add = (valueToAdd: PaymentAmount<T>) => {
-    return AmountMathWrapper(AmountCalculator().add(base, valueToAdd))
-  }
-
-  const sub = (valueToSub: PaymentAmount<T>) => {
-    return AmountMathWrapper(AmountCalculator().sub(base, valueToSub))
-  }
-
-  const lessThan = (valueCompared: PaymentAmount<T>) => {
-    return base.amount < valueCompared.amount
-  }
-
-  const value = base
-
-  return {
-    add,
-    sub,
-    lessThan,
-    value,
-  }
-}

--- a/src/domain/shared/index.types.d.ts
+++ b/src/domain/shared/index.types.d.ts
@@ -9,6 +9,10 @@ type PaymentAmount<T extends WalletCurrency> = {
   currency: T
   amount: bigint
 }
+type WalletDescriptor<T extends WalletCurrency> = {
+  id: WalletId
+  currency: T
+}
 
 type BtcPaymentAmount = PaymentAmount<"BTC">
 type UsdPaymentAmount = PaymentAmount<"USD">

--- a/src/domain/shared/primitives.ts
+++ b/src/domain/shared/primitives.ts
@@ -4,6 +4,25 @@ export const WalletCurrency = {
   Btc: "BTC",
 } as const
 
+export const FeeDirection = {
+  ToBank: "TO_BANK",
+  FromBank: "FROM_BANK",
+} as const
+
+export const BtcPaymentAmount = (sats: bigint): BtcPaymentAmount => {
+  return {
+    currency: WalletCurrency.Btc,
+    amount: sats,
+  }
+}
+
+export const UsdPaymentAmount = (cents: bigint): UsdPaymentAmount => {
+  return {
+    currency: WalletCurrency.Usd,
+    amount: cents,
+  }
+}
+
 export const paymentAmountFromSats = (sats: Satoshis): BtcPaymentAmount => {
   return {
     currency: WalletCurrency.Btc,

--- a/src/domain/shared/primitives.ts
+++ b/src/domain/shared/primitives.ts
@@ -4,10 +4,20 @@ export const WalletCurrency = {
   Btc: "BTC",
 } as const
 
-export const FeeDirection = {
-  ToBank: "TO_BANK",
-  FromBank: "FROM_BANK",
+export const ZERO_SATS = {
+  currency: WalletCurrency.Btc,
+  amount: 0n,
 } as const
+
+export const ZERO_CENTS = {
+  currency: WalletCurrency.Usd,
+  amount: 0n,
+}
+
+export const ZERO_FEE = {
+  usdProtocolFee: ZERO_CENTS,
+  btcProtocolFee: ZERO_SATS,
+}
 
 export const BtcPaymentAmount = (sats: bigint): BtcPaymentAmount => {
   return {

--- a/src/domain/shared/primitives.ts
+++ b/src/domain/shared/primitives.ts
@@ -19,6 +19,20 @@ export const ZERO_FEE = {
   btcProtocolFee: ZERO_SATS,
 }
 
+export const BtcWalletDescriptor = (walletId: WalletId) => {
+  return {
+    id: walletId,
+    currency: WalletCurrency.Btc,
+  } as WalletDescriptor<"BTC">
+}
+
+export const UsdWalletDescriptor = (walletId: WalletId) => {
+  return {
+    id: walletId,
+    currency: WalletCurrency.Usd,
+  } as WalletDescriptor<"USD">
+}
+
 export const BtcPaymentAmount = (sats: bigint): BtcPaymentAmount => {
   return {
     currency: WalletCurrency.Btc,

--- a/src/services/ledger/admin-legacy.ts
+++ b/src/services/ledger/admin-legacy.ts
@@ -107,7 +107,7 @@ export const addLndRoutingRevenue = async ({
   collectedOn: string // FIXME should be Date?
 }) => {
   const metadata = {
-    type: LedgerTransactionType.RoutingFee,
+    type: LedgerTransactionType.RoutingRevenue,
     currency: WalletCurrency.Btc,
     feesCollectedOn: collectedOn,
     pending: false,

--- a/src/services/ledger/domain/accounts.ts
+++ b/src/services/ledger/domain/accounts.ts
@@ -1,6 +1,21 @@
 // an accounting reminder:
 // https://en.wikipedia.org/wiki/Double-entry_bookkeeping
 
+import { WalletCurrency } from "@domain/shared"
+
 // assets:
 export const assetsMainAccount = "Assets"
-export const lndLedgerAccountId = `${assetsMainAccount}:Reserve:Lightning` // TODO: rename to Assets:Lnd
+export const lndLedgerAccountId =
+  `${assetsMainAccount}:Reserve:Lightning` as LedgerAccountId // TODO: rename to Assets:Lnd
+
+export const coldStorageAccountId = `${assetsMainAccount}:Reserve:Bitcoind`
+
+export const lndLedgerAccountDescriptor = {
+  id: lndLedgerAccountId,
+  currency: WalletCurrency.Btc,
+} as LedgerAccountDescriptor<"BTC">
+
+export const coldStorageAccountDescriptor = {
+  id: coldStorageAccountId,
+  currency: WalletCurrency.Btc,
+} as LedgerAccountDescriptor<"BTC">

--- a/src/services/ledger/domain/entry-builder.ts
+++ b/src/services/ledger/domain/entry-builder.ts
@@ -2,15 +2,6 @@ import { AmountCalculator, WalletCurrency } from "@domain/shared"
 
 import { coldStorageAccountDescriptor, lndLedgerAccountDescriptor } from "./accounts"
 
-export const ZERO_SATS = {
-  currency: WalletCurrency.Btc,
-  amount: 0n,
-} as const
-
-export const ZERO_CENTS = {
-  currency: WalletCurrency.Usd,
-  amount: 0n,
-}
 const calc = AmountCalculator()
 
 export const EntryBuilder = <M extends MediciEntry>({
@@ -161,24 +152,6 @@ const EntryBuilderDebit = <M extends MediciEntry>({
     debitAccount,
     debitLnd,
     debitColdStorage,
-  }
-}
-
-type EntryBuilderCreditState<M extends MediciEntry> = {
-  entry: M
-  metadata: TxMetadata
-  debitCurrency: WalletCurrency
-  amountWithOutFee: {
-    usdWithOutFee: UsdPaymentAmount
-    btcWithOutFee: BtcPaymentAmount
-  }
-  amountWithFee: {
-    usdWithFee: UsdPaymentAmount
-    btcWithFee: BtcPaymentAmount
-  }
-  staticAccountIds: {
-    dealerBtcAccountId: LedgerAccountId
-    dealerUsdAccountId: LedgerAccountId
   }
 }
 

--- a/src/services/ledger/domain/entry-builder.ts
+++ b/src/services/ledger/domain/entry-builder.ts
@@ -63,34 +63,8 @@ const EntryBuilderFee = <M extends MediciEntry>({
     })
   }
 
-  const withFeeFromBank = ({
-    btcProtocolFee,
-    usdProtocolFee,
-  }: {
-    btcProtocolFee: BtcPaymentAmount
-    usdProtocolFee: UsdPaymentAmount
-  }) => {
-    if (btcProtocolFee.amount > 0n) {
-      entry.debit(staticAccountIds.bankOwnerAccountId, Number(btcProtocolFee.amount), {
-        ...metadata,
-        currency: btcProtocolFee.currency,
-      })
-    }
-
-    const usdWithOutFee = calc.add(usdWithFee, usdProtocolFee)
-    const btcWithOutFee = calc.add(btcWithFee, btcProtocolFee)
-    return EntryBuilderDebit({
-      metadata,
-      entry,
-      amountWithFee: { usdWithFee, btcWithFee },
-      amountWithOutFee: { usdWithOutFee, btcWithOutFee },
-      staticAccountIds,
-    })
-  }
-
   return {
     withFee,
-    withFeeFromBank,
   }
 }
 

--- a/src/services/ledger/domain/errors.ts
+++ b/src/services/ledger/domain/errors.ts
@@ -1,0 +1,13 @@
+import { DomainError, ErrorLevel } from "@domain/shared"
+
+export class LedgerError extends DomainError {}
+
+export class LedgerServiceError extends LedgerError {}
+export class FeeDifferenceError extends LedgerError {}
+export class NoTransactionToSettleError extends LedgerServiceError {}
+export class UnknownLedgerError extends LedgerServiceError {
+  level = ErrorLevel.Critical
+}
+
+export class CouldNotFindTransactionError extends LedgerError {}
+export class CouldNotFindTransactionMetadataError extends CouldNotFindTransactionError {}

--- a/src/services/ledger/domain/index.ts
+++ b/src/services/ledger/domain/index.ts
@@ -4,3 +4,12 @@ export * from "./accounts"
 export const liabilitiesMainAccount = "Liabilities"
 export const toLedgerAccountId = (walletId: WalletId): LedgerAccountId =>
   `${liabilitiesMainAccount}:${walletId}` as LedgerAccountId
+
+export const toLedgerAccountDescriptor = <T extends WalletCurrency>(
+  walletDescriptor: WalletDescriptor<T>,
+): LedgerAccountDescriptor<T> => {
+  return {
+    id: toLedgerAccountId(walletDescriptor.id),
+    currency: walletDescriptor.currency,
+  } as LedgerAccountDescriptor<T>
+}

--- a/src/services/ledger/domain/index.ts
+++ b/src/services/ledger/domain/index.ts
@@ -1,3 +1,4 @@
+export * from "./legacy-entry-builder"
 export * from "./entry-builder"
 export * from "./accounts"
 

--- a/src/services/ledger/domain/index.types.d.ts
+++ b/src/services/ledger/domain/index.types.d.ts
@@ -78,16 +78,22 @@ type EntryBuilderDebit<M extends MediciEntry> = {
   debitColdStorage: () => EntryBuilderCredit<M>
 }
 
-type EntryBuilderCreditWithUsdDebit<M extends MediciEntry> = {
-  creditLnd: (amount: BtcPaymentAmount) => M
-  creditColdStorage: (amount: BtcPaymentAmount) => M
-  creditAccount: ({
-    accountId,
-    btcAmountForUsdDebit,
-  }: {
-    accountId: LedgerAccountId
-    btcAmountForUsdDebit?: BtcPaymentAmount
-  }) => M
+type EntryBuilderCreditState<M extends MediciEntry> = {
+  entry: M
+  metadata: TxMetadata
+  debitCurrency: WalletCurrency
+  amountWithOutFee: {
+    usdWithOutFee: UsdPaymentAmount
+    btcWithOutFee: BtcPaymentAmount
+  }
+  amountWithFee: {
+    usdWithFee: UsdPaymentAmount
+    btcWithFee: BtcPaymentAmount
+  }
+  staticAccountIds: {
+    dealerBtcAccountId: LedgerAccountId
+    dealerUsdAccountId: LedgerAccountId
+  }
 }
 
 type EntryBuilderCredit<M extends MediciEntry> = {
@@ -97,6 +103,61 @@ type EntryBuilderCredit<M extends MediciEntry> = {
     accountDescriptor: LedgerAccountDescriptor<C>,
   ) => M
 }
+
+type LegacyEntryBuilderConfig<M extends MediciEntry> = {
+  entry: M
+  staticAccountIds: StaticAccountIds
+  metadata: TxMetadata
+}
+
+type LegacyEntryBuilderDebitState<M extends MediciEntry> = {
+  entry: M
+  metadata: TxMetadata
+  fee: BtcPaymentAmount
+  staticAccountIds: StaticAccountIds
+}
+
+type LegacyEntryBuilderDebit<M extends MediciEntry> = {
+  debitAccount: <D extends WalletCurrency>({
+    accountId,
+    amount,
+    additionalMetadata,
+  }: {
+    accountId: LedgerAccountId
+    amount: PaymentAmount<D>
+    additionalMetadata?: TxMetadata
+  }) => LegacyEntryBuilderCredit<M, D>
+  debitLnd: (amount: BtcPaymentAmount) => LegacyEntryBuilderCreditWithBtcDebit<M>
+}
+
+type LegacyEntryBuilderCreditWithUsdDebit<M extends MediciEntry> = {
+  creditLnd: (amount: BtcPaymentAmount) => M
+  creditAccount: ({
+    accountId,
+    amount,
+  }: {
+    accountId: LedgerAccountId
+    amount?: BtcPaymentAmount
+  }) => M
+}
+
+type LegacyEntryBuilderCreditWithBtcDebit<M extends MediciEntry> = {
+  creditLnd: () => M
+  creditAccount: ({
+    accountId,
+    amount,
+  }: {
+    accountId: LedgerAccountId
+    amount?: UsdPaymentAmount
+  }) => M
+}
+
+type LegacyEntryBuilderCredit<
+  M extends MediciEntry,
+  D extends WalletCurrency,
+> = D extends "USD"
+  ? LegacyEntryBuilderCreditWithUsdDebit<M>
+  : LegacyEntryBuilderCreditWithBtcDebit<M>
 
 type BaseLedgerTransactionMetadata = {
   id: LedgerTransactionId

--- a/src/services/ledger/domain/index.types.d.ts
+++ b/src/services/ledger/domain/index.types.d.ts
@@ -43,13 +43,6 @@ type EntryBuilderFee<M extends MediciEntry> = {
     btcProtocolFee: BtcPaymentAmount
     usdProtocolFee: UsdPaymentAmount
   }) => EntryBuilderDebit<M>
-  withFeeFromBank: ({
-    btcProtocolFee,
-    usdProtocolFee,
-  }: {
-    btcProtocolFee: BtcPaymentAmount
-    usdProtocolFee: UsdPaymentAmount
-  }) => EntryBuilderDebit<M>
 }
 
 type EntryBuilderDebitState<M extends MediciEntry> = {

--- a/src/services/ledger/domain/index.types.d.ts
+++ b/src/services/ledger/domain/index.types.d.ts
@@ -1,6 +1,7 @@
 declare const ledgerAccountId: unique symbol
 type LedgerAccountId = string & { [ledgerAccountId]: never }
 
+// eslint-disable-next-line
 type TxMetadata = any
 
 type LedgerAccountDescriptor<T extends WalletCurrency> = {
@@ -53,9 +54,9 @@ type EntryBuilderDebitState<M extends MediciEntry> = {
     usdWithFee: UsdPaymentAmount
     btcWithFee: BtcPaymentAmount
   }
-  amountWithOutFee: {
-    usdWithOutFee: UsdPaymentAmount
-    btcWithOutFee: BtcPaymentAmount
+  fee: {
+    btcProtocolFee: BtcPaymentAmount
+    usdProtocolFee: UsdPaymentAmount
   }
 }
 
@@ -75,13 +76,13 @@ type EntryBuilderCreditState<M extends MediciEntry> = {
   entry: M
   metadata: TxMetadata
   debitCurrency: WalletCurrency
-  amountWithOutFee: {
-    usdWithOutFee: UsdPaymentAmount
-    btcWithOutFee: BtcPaymentAmount
-  }
   amountWithFee: {
     usdWithFee: UsdPaymentAmount
     btcWithFee: BtcPaymentAmount
+  }
+  fee: {
+    usdProtocolFee: UsdPaymentAmount
+    btcProtocolFee: BtcPaymentAmount
   }
   staticAccountIds: {
     dealerBtcAccountId: LedgerAccountId
@@ -121,6 +122,17 @@ type LegacyEntryBuilderDebit<M extends MediciEntry> = {
     additionalMetadata?: TxMetadata
   }) => LegacyEntryBuilderCredit<M, D>
   debitLnd: (amount: BtcPaymentAmount) => LegacyEntryBuilderCreditWithBtcDebit<M>
+}
+
+type LegacyEntryBuilderCreditState<M extends MediciEntry, D extends WalletCurrency> = {
+  entry: M
+  metadata: TxMetadata
+  fee: BtcPaymentAmount
+  debitAmount: PaymentAmount<D>
+  staticAccountIds: {
+    dealerBtcAccountId: LedgerAccountId
+    dealerUsdAccountId: LedgerAccountId
+  }
 }
 
 type LegacyEntryBuilderCreditWithUsdDebit<M extends MediciEntry> = {

--- a/src/services/ledger/domain/legacy-entry-builder.ts
+++ b/src/services/ledger/domain/legacy-entry-builder.ts
@@ -1,0 +1,258 @@
+import { AmountCalculator, WalletCurrency } from "@domain/shared"
+
+import { lndLedgerAccountId } from "./accounts"
+
+const ZERO_SATS = {
+  currency: WalletCurrency.Btc,
+  amount: 0n,
+} as const
+const calc = AmountCalculator()
+
+export const LegacyEntryBuilder = <M extends MediciEntry>({
+  staticAccountIds,
+  entry,
+  metadata,
+}: LegacyEntryBuilderConfig<M>) => {
+  const withFee = (fee: BtcPaymentAmount) => {
+    if (fee.amount > 0n) {
+      entry.credit(staticAccountIds.bankOwnerAccountId, Number(fee.amount), {
+        ...metadata,
+        currency: fee.currency,
+      })
+    }
+    return LegacyEntryBuilderDebit({ metadata, entry, fee, staticAccountIds })
+  }
+
+  const withoutFee = () => {
+    return withFee(ZERO_SATS)
+  }
+
+  return {
+    withFee,
+    withoutFee,
+  }
+}
+
+const LegacyEntryBuilderDebit = <M extends MediciEntry>({
+  entry,
+  metadata,
+  fee,
+  staticAccountIds,
+}: LegacyEntryBuilderDebitState<M>): LegacyEntryBuilderDebit<M> => {
+  const debitAccount = <T extends WalletCurrency>({
+    accountId,
+    amount,
+    additionalMetadata,
+  }: {
+    accountId: LedgerAccountId
+    amount: PaymentAmount<T>
+    additionalMetadata?: TxMetadata
+  }): LegacyEntryBuilderCredit<M, T> => {
+    const debitMetadata = additionalMetadata
+      ? { ...metadata, ...additionalMetadata }
+      : metadata
+    entry.debit(accountId, Number(amount.amount), {
+      ...debitMetadata,
+      currency: amount.currency,
+    })
+    if (amount.currency === WalletCurrency.Btc) {
+      return LegacyEntryBuilderCreditWithBtcDebit({
+        entry,
+        metadata,
+        fee,
+        debitAmount: amount as BtcPaymentAmount,
+        staticAccountIds,
+      }) as LegacyEntryBuilderCredit<M, T>
+    }
+
+    return LegacyEntryBuilderCreditWithUsdDebit({
+      entry,
+      metadata,
+      fee,
+      debitAmount: amount as UsdPaymentAmount,
+      staticAccountIds,
+    }) as LegacyEntryBuilderCredit<M, T>
+  }
+
+  const debitLnd = (
+    amount: BtcPaymentAmount,
+  ): LegacyEntryBuilderCreditWithBtcDebit<M> => {
+    entry.debit(lndLedgerAccountId, Number(amount.amount), {
+      ...metadata,
+      currency: amount.currency,
+    })
+    return LegacyEntryBuilderCreditWithBtcDebit({
+      entry,
+      metadata,
+      fee,
+      debitAmount: amount as BtcPaymentAmount,
+      staticAccountIds,
+    }) as LegacyEntryBuilderCreditWithBtcDebit<M>
+  }
+
+  return {
+    debitAccount,
+    debitLnd,
+  }
+}
+
+type LegacyEntryBuilderCreditState<M extends MediciEntry, D extends WalletCurrency> = {
+  entry: M
+  metadata: TxMetadata
+  fee: BtcPaymentAmount
+  debitAmount: PaymentAmount<D>
+  staticAccountIds: {
+    dealerBtcAccountId: LedgerAccountId
+    dealerUsdAccountId: LedgerAccountId
+  }
+}
+
+const LegacyEntryBuilderCreditWithUsdDebit = <M extends MediciEntry>({
+  entry,
+  metadata,
+  debitAmount,
+  staticAccountIds,
+  fee,
+}: LegacyEntryBuilderCreditState<M, "USD">): LegacyEntryBuilderCreditWithUsdDebit<M> => {
+  const creditLnd = (btcCreditAmount: BtcPaymentAmount) => {
+    withdrawUsdFromDealer({
+      entry,
+      metadata,
+      staticAccountIds,
+      btcAmount: btcCreditAmount,
+      usdAmount: debitAmount,
+    })
+    const creditAmount = calc.sub(btcCreditAmount, fee)
+    entry.credit(lndLedgerAccountId, Number(creditAmount.amount), {
+      ...metadata,
+      currency: btcCreditAmount.currency,
+    })
+    return entry
+  }
+  const creditAccount = ({
+    accountId,
+    amount,
+  }: {
+    accountId: LedgerAccountId
+    amount?: BtcPaymentAmount
+  }) => {
+    if (amount) {
+      withdrawUsdFromDealer({
+        entry,
+        metadata,
+        staticAccountIds,
+        btcAmount: amount,
+        usdAmount: debitAmount,
+      })
+    }
+    const creditAmount = amount ? calc.sub(amount, fee) : debitAmount
+    entry.credit(accountId, Number(creditAmount.amount), {
+      ...metadata,
+      currency: creditAmount.currency,
+    })
+    return entry
+  }
+  return {
+    creditLnd,
+    creditAccount,
+  }
+}
+
+const LegacyEntryBuilderCreditWithBtcDebit = <M extends MediciEntry>({
+  entry,
+  metadata,
+  fee,
+  debitAmount,
+  staticAccountIds,
+}: LegacyEntryBuilderCreditState<M, "BTC">): LegacyEntryBuilderCreditWithBtcDebit<M> => {
+  const creditLnd = () => {
+    const creditAmount = calc.sub(debitAmount, fee)
+    entry.credit(lndLedgerAccountId, Number(creditAmount.amount), {
+      ...metadata,
+      currency: creditAmount.currency,
+    })
+    return entry
+  }
+  const creditAccount = ({
+    accountId,
+    amount,
+  }: {
+    accountId: LedgerAccountId
+    amount?: UsdPaymentAmount
+  }) => {
+    if (amount) {
+      addUsdToDealer({
+        entry,
+        metadata,
+        staticAccountIds,
+        btcAmount: debitAmount,
+        usdAmount: amount,
+      })
+    }
+    const creditAmount = amount || calc.sub(debitAmount, fee)
+    entry.credit(accountId, Number(creditAmount.amount), {
+      ...metadata,
+      currency: creditAmount.currency,
+    })
+    return entry
+  }
+
+  return {
+    creditLnd,
+    creditAccount,
+  }
+}
+
+const addUsdToDealer = ({
+  staticAccountIds: { dealerBtcAccountId, dealerUsdAccountId },
+  entry,
+  btcAmount,
+  usdAmount,
+  metadata,
+}: {
+  staticAccountIds: {
+    dealerBtcAccountId: LedgerAccountId
+    dealerUsdAccountId: LedgerAccountId
+  }
+  entry: MediciEntry
+  btcAmount: BtcPaymentAmount
+  usdAmount: UsdPaymentAmount
+  metadata: TxMetadata
+}) => {
+  entry.credit(dealerBtcAccountId, Number(btcAmount.amount), {
+    ...metadata,
+    currency: btcAmount.currency,
+  })
+  entry.debit(dealerUsdAccountId, Number(usdAmount.amount), {
+    ...metadata,
+    currency: usdAmount.currency,
+  })
+  return entry
+}
+
+const withdrawUsdFromDealer = ({
+  staticAccountIds: { dealerBtcAccountId, dealerUsdAccountId },
+  entry,
+  btcAmount,
+  usdAmount,
+  metadata,
+}: {
+  staticAccountIds: {
+    dealerBtcAccountId: LedgerAccountId
+    dealerUsdAccountId: LedgerAccountId
+  }
+  entry: MediciEntry
+  btcAmount: BtcPaymentAmount
+  usdAmount: UsdPaymentAmount
+  metadata: TxMetadata
+}) => {
+  entry.debit(dealerBtcAccountId, Number(btcAmount.amount), {
+    ...metadata,
+    currency: btcAmount.currency,
+  })
+  entry.credit(dealerUsdAccountId, Number(usdAmount.amount), {
+    ...metadata,
+    currency: usdAmount.currency,
+  })
+  return entry
+}

--- a/src/services/ledger/domain/legacy-entry-builder.ts
+++ b/src/services/ledger/domain/legacy-entry-builder.ts
@@ -96,17 +96,6 @@ const LegacyEntryBuilderDebit = <M extends MediciEntry>({
   }
 }
 
-type LegacyEntryBuilderCreditState<M extends MediciEntry, D extends WalletCurrency> = {
-  entry: M
-  metadata: TxMetadata
-  fee: BtcPaymentAmount
-  debitAmount: PaymentAmount<D>
-  staticAccountIds: {
-    dealerBtcAccountId: LedgerAccountId
-    dealerUsdAccountId: LedgerAccountId
-  }
-}
-
 const LegacyEntryBuilderCreditWithUsdDebit = <M extends MediciEntry>({
   entry,
   metadata,

--- a/src/services/ledger/facade.ts
+++ b/src/services/ledger/facade.ts
@@ -1,0 +1,167 @@
+import { UnknownLedgerError } from "@domain/ledger"
+
+import { WalletCurrency } from "@domain/shared"
+
+import { MainBook } from "./books"
+import { EntryBuilder, toLedgerAccountDescriptor, toLedgerAccountId } from "./domain"
+import { persistAndReturnEntry } from "./helpers"
+import * as caching from "./caching"
+export * from "./tx-metadata"
+
+const ZERO_FEE = {
+  usdProtocolFee: {
+    currency: WalletCurrency.Usd,
+    amount: 0n,
+  },
+  btcProtocolFee: {
+    currency: WalletCurrency.Btc,
+    amount: 0n,
+  },
+} as const
+
+const staticAccountIds = async () => {
+  return {
+    bankOwnerAccountId: toLedgerAccountId(await caching.getBankOwnerWalletId()),
+    dealerBtcAccountId: toLedgerAccountId(await caching.getDealerBtcWalletId()),
+    dealerUsdAccountId: toLedgerAccountId(await caching.getDealerUsdWalletId()),
+  }
+}
+
+type RecordSendArgs<T extends WalletCurrency> = {
+  description: string
+  senderWalletDescriptor: WalletDescriptor<T>
+  amount: {
+    usdWithFee: UsdPaymentAmount
+    btcWithFee: BtcPaymentAmount
+  }
+  metadata: SendLedgerMetadata
+  fee?: {
+    usdProtocolFee: UsdPaymentAmount
+    btcProtocolFee: BtcPaymentAmount
+  }
+}
+
+type RecordReceiveArgs<T extends WalletCurrency> = {
+  description: string
+  receiverWalletDescriptor: WalletDescriptor<T>
+  amount: {
+    usdWithFee: UsdPaymentAmount
+    btcWithFee: BtcPaymentAmount
+  }
+  metadata: ReceiveLedgerMetadata
+  fee?: {
+    usdProtocolFee: UsdPaymentAmount
+    btcProtocolFee: BtcPaymentAmount
+  }
+}
+
+type RecordIntraledgerArgs<T extends WalletCurrency, V extends WalletCurrency> = {
+  description: string
+  senderWalletDescriptor: WalletDescriptor<T>
+  receiverWalletDescriptor: WalletDescriptor<V>
+  amount: {
+    usdWithFee: UsdPaymentAmount
+    btcWithFee: BtcPaymentAmount
+  }
+  metadata: IntraledgerLedgerMetadata
+  additionalDebitMetadata: any
+}
+
+export const recordSend = async <T extends WalletCurrency>({
+  description,
+  senderWalletDescriptor,
+  amount,
+  fee,
+  metadata,
+}: RecordSendArgs<T>) => {
+  const actualFee = fee || ZERO_FEE
+
+  let entry = MainBook.entry(description)
+  const builder = EntryBuilder({
+    staticAccountIds: await staticAccountIds(),
+    entry,
+    metadata,
+  })
+
+  entry = builder
+    .withTotalAmount(amount)
+    .withFee(actualFee)
+    .debitAccount({
+      accountDescriptor: toLedgerAccountDescriptor(senderWalletDescriptor),
+    })
+    .creditLnd()
+
+  return persistAndReturnEntry({ entry, hash: metadata.hash })
+}
+
+export const recordReceive = async <T extends WalletCurrency>({
+  description,
+  receiverWalletDescriptor,
+  amount,
+  fee,
+  metadata,
+}: RecordReceiveArgs<T>) => {
+  const actualFee = fee || ZERO_FEE
+
+  let entry = MainBook.entry(description)
+  const builder = EntryBuilder({
+    staticAccountIds: await staticAccountIds(),
+    entry,
+    metadata,
+  })
+
+  entry = builder
+    .withTotalAmount(amount)
+    .withFee(actualFee)
+    .debitLnd()
+    .creditAccount(toLedgerAccountDescriptor(receiverWalletDescriptor))
+
+  return persistAndReturnEntry({ entry, hash: metadata.hash })
+}
+
+export const getLedgerAccountBalanceForWalletId = async <T extends WalletCurrency>({
+  id: walletId,
+  currency: walletCurrency,
+}: WalletDescriptor<T>): Promise<PaymentAmount<T> | LedgerError> => {
+  try {
+    const { balance } = await MainBook.balance({
+      account: toLedgerAccountId(walletId),
+    })
+    return { amount: BigInt(balance), currency: walletCurrency }
+  } catch (err) {
+    return new UnknownLedgerError(err)
+  }
+}
+
+export const recordIntraledger = async <
+  T extends WalletCurrency,
+  V extends WalletCurrency,
+>({
+  description,
+  senderWalletDescriptor,
+  receiverWalletDescriptor,
+  amount,
+  metadata,
+  additionalDebitMetadata: additionalMetadata,
+}: RecordIntraledgerArgs<T, V>) => {
+  let entry = MainBook.entry(description)
+  const builder = EntryBuilder({
+    staticAccountIds: await staticAccountIds(),
+    entry,
+    metadata,
+  })
+
+  entry = builder
+    .withTotalAmount(amount)
+    .withFee(ZERO_FEE)
+    .debitAccount({
+      accountDescriptor: toLedgerAccountDescriptor(senderWalletDescriptor),
+      additionalMetadata,
+    })
+    .creditAccount(toLedgerAccountDescriptor(receiverWalletDescriptor))
+
+  return persistAndReturnEntry({
+    entry,
+    hash: "hash" in metadata ? metadata.hash : undefined,
+  })
+}

--- a/src/services/ledger/facade.ts
+++ b/src/services/ledger/facade.ts
@@ -16,53 +16,13 @@ const staticAccountIds = async () => {
   }
 }
 
-type RecordSendArgs<T extends WalletCurrency> = {
-  description: string
-  senderWalletDescriptor: WalletDescriptor<T>
-  amount: {
-    usdWithFee: UsdPaymentAmount
-    btcWithFee: BtcPaymentAmount
-  }
-  metadata: SendLedgerMetadata
-  fee?: {
-    usdProtocolFee: UsdPaymentAmount
-    btcProtocolFee: BtcPaymentAmount
-  }
-}
-
-type RecordReceiveArgs<T extends WalletCurrency> = {
-  description: string
-  receiverWalletDescriptor: WalletDescriptor<T>
-  amount: {
-    usdWithFee: UsdPaymentAmount
-    btcWithFee: BtcPaymentAmount
-  }
-  metadata: ReceiveLedgerMetadata
-  fee?: {
-    usdProtocolFee: UsdPaymentAmount
-    btcProtocolFee: BtcPaymentAmount
-  }
-}
-
-type RecordIntraledgerArgs<T extends WalletCurrency, V extends WalletCurrency> = {
-  description: string
-  senderWalletDescriptor: WalletDescriptor<T>
-  receiverWalletDescriptor: WalletDescriptor<V>
-  amount: {
-    usdWithFee: UsdPaymentAmount
-    btcWithFee: BtcPaymentAmount
-  }
-  metadata: IntraledgerLedgerMetadata
-  additionalDebitMetadata: TxMetadata
-}
-
-export const recordSend = async <T extends WalletCurrency>({
+export const recordSend = async ({
   description,
   senderWalletDescriptor,
   amount,
   fee,
   metadata,
-}: RecordSendArgs<T>) => {
+}: RecordSendArgs) => {
   const actualFee = fee || ZERO_FEE
 
   let entry = MainBook.entry(description)
@@ -83,13 +43,13 @@ export const recordSend = async <T extends WalletCurrency>({
   return persistAndReturnEntry({ entry, hash: metadata.hash })
 }
 
-export const recordReceive = async <T extends WalletCurrency>({
+export const recordReceive = async ({
   description,
   receiverWalletDescriptor,
   amount,
   fee,
   metadata,
-}: RecordReceiveArgs<T>) => {
+}: RecordReceiveArgs) => {
   const actualFee = fee || ZERO_FEE
 
   let entry = MainBook.entry(description)
@@ -122,17 +82,14 @@ export const getLedgerAccountBalanceForWalletId = async <T extends WalletCurrenc
   }
 }
 
-export const recordIntraledger = async <
-  T extends WalletCurrency,
-  V extends WalletCurrency,
->({
+export const recordIntraledger = async ({
   description,
   senderWalletDescriptor,
   receiverWalletDescriptor,
   amount,
   metadata,
   additionalDebitMetadata: additionalMetadata,
-}: RecordIntraledgerArgs<T, V>) => {
+}: RecordIntraledgerArgs) => {
   let entry = MainBook.entry(description)
   const builder = EntryBuilder({
     staticAccountIds: await staticAccountIds(),

--- a/src/services/ledger/facade.ts
+++ b/src/services/ledger/facade.ts
@@ -1,23 +1,12 @@
 import { UnknownLedgerError } from "@domain/ledger"
 
-import { WalletCurrency } from "@domain/shared"
+import { ZERO_FEE } from "@domain/shared"
 
 import { MainBook } from "./books"
-import { EntryBuilder, toLedgerAccountDescriptor, toLedgerAccountId } from "./domain"
+import { toLedgerAccountDescriptor, toLedgerAccountId, EntryBuilder } from "./domain"
 import { persistAndReturnEntry } from "./helpers"
 import * as caching from "./caching"
 export * from "./tx-metadata"
-
-const ZERO_FEE = {
-  usdProtocolFee: {
-    currency: WalletCurrency.Usd,
-    amount: 0n,
-  },
-  btcProtocolFee: {
-    currency: WalletCurrency.Btc,
-    amount: 0n,
-  },
-} as const
 
 const staticAccountIds = async () => {
   return {
@@ -64,7 +53,7 @@ type RecordIntraledgerArgs<T extends WalletCurrency, V extends WalletCurrency> =
     btcWithFee: BtcPaymentAmount
   }
   metadata: IntraledgerLedgerMetadata
-  additionalDebitMetadata: any
+  additionalDebitMetadata: TxMetadata
 }
 
 export const recordSend = async <T extends WalletCurrency>({

--- a/src/services/ledger/helpers.ts
+++ b/src/services/ledger/helpers.ts
@@ -1,0 +1,35 @@
+import { Entry } from "medici"
+
+import { UnknownLedgerError } from "./domain/errors"
+import { TransactionsMetadataRepository } from "./services"
+
+const txMetadataRepo = TransactionsMetadataRepository()
+
+export const persistAndReturnEntry = async ({
+  entry,
+  hash,
+}: {
+  entry: Entry
+  hash?: PaymentHash | OnChainTxHash
+}) => {
+  try {
+    const savedEntry = await entry.commit()
+    const journalEntry = translateToLedgerJournal(savedEntry)
+
+    const txsMetadataToPersist = journalEntry.transactionIds.map((id) => ({
+      id,
+      hash,
+    }))
+    txMetadataRepo.persistAll(txsMetadataToPersist)
+
+    return journalEntry
+  } catch (err) {
+    return new UnknownLedgerError(err)
+  }
+}
+
+export const translateToLedgerJournal = (savedEntry): LedgerJournal => ({
+  journalId: savedEntry._id.toString(),
+  voided: savedEntry.voided,
+  transactionIds: savedEntry._transactions.map((id) => id.toString()),
+})

--- a/src/services/ledger/index.types.d.ts
+++ b/src/services/ledger/index.types.d.ts
@@ -4,10 +4,10 @@ type TxnTypes = typeof import("./volume").TxnGroups[TxnGroup]
 type LedgerMetadata = {
   type: LedgerTransactionType
   pending: boolean
-  usd: DisplayCurrencyBaseAmount // to be renamed amountDisplayCurrency
 }
 
 type NonIntraledgerLedgerMetadata = LedgerMetadata & {
+  usd: DisplayCurrencyBaseAmount // to be renamed amountDisplayCurrency
   fee: Satoshis
   feeUsd: DisplayCurrencyBaseAmount // to be renamed feeDisplayCurrency
 }
@@ -36,29 +36,30 @@ type AddOnchainSendLedgerMetadata = NonIntraledgerLedgerMetadata & {
 type AddColdStorageLedgerMetadata = NonIntraledgerLedgerMetadata & {
   hash: OnChainTxHash
   payee_addresses: OnChainAddress[]
-  currency: WalletCurrency
+  currency?: WalletCurrency
 }
 
 type AddColdStorageReceiveLedgerMetadata = AddColdStorageLedgerMetadata
 
 type AddColdStorageSendLedgerMetadata = AddColdStorageLedgerMetadata
 
-type IntraledgerLedgerMetadata = LedgerMetadata & {
-  memoPayer: string | undefined
-  username: Username | undefined
+type IntraledgerBaseMetadata = LedgerMetadata & {
+  usd: DisplayCurrencyBaseAmount // to be renamed amountDisplayCurrency
+  memoPayer: string | undefined | null
+  username: Username | undefined | null
 }
 
-type AddLnIntraledgerSendLedgerMetadata = IntraledgerLedgerMetadata & {
+type AddLnIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata & {
   hash: PaymentHash
   pubkey: Pubkey
 }
 
-type AddOnChainIntraledgerSendLedgerMetadata = IntraledgerLedgerMetadata & {
+type AddOnChainIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata & {
   payee_addresses: OnChainAddress[]
   sendAll: boolean
 }
 
-type AddWalletIdIntraledgerSendLedgerMetadata = IntraledgerLedgerMetadata
+type AddWalletIdIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata
 
 type FeeReimbursementLedgerMetadata = {
   hash: PaymentHash
@@ -66,6 +67,14 @@ type FeeReimbursementLedgerMetadata = {
   pending: boolean
   usd: DisplayCurrencyBaseAmount
   related_journal: LedgerJournalId
+}
+
+type LnRoutingRevenueLedgerMetadata = LedgerMetadata & {
+  feesCollectedOn: string
+}
+
+type LnChannelOpenOrClosingFee = LedgerMetadata & {
+  txid: OnChainTxHash
 }
 
 type LoadLedgerParams = {
@@ -79,3 +88,10 @@ type ReceiveLedgerMetadata =
   | FeeReimbursementLedgerMetadata
   | LnReceiveLedgerMetadata
   | OnChainReceiveLedgerMetadata
+
+type IntraledgerLedgerMetadata =
+  | AddOnChainIntraledgerSendLedgerMetadata
+  | AddLnIntraledgerSendLedgerMetadata
+  | AddWalletIdIntraledgerSendLedgerMetadata
+
+type SendLedgerMetadata = AddOnchainSendLedgerMetadata | AddLnSendLedgerMetadata

--- a/src/services/ledger/index.types.d.ts
+++ b/src/services/ledger/index.types.d.ts
@@ -1,6 +1,46 @@
 type TxnGroup = keyof typeof import("./volume").TxnGroups
 type TxnTypes = typeof import("./volume").TxnGroups[TxnGroup]
 
+type RecordSendArgs = {
+  description: string
+  senderWalletDescriptor: WalletDescriptor<WalletCurrency>
+  amount: {
+    usdWithFee: UsdPaymentAmount
+    btcWithFee: BtcPaymentAmount
+  }
+  metadata: SendLedgerMetadata
+  fee?: {
+    usdProtocolFee: UsdPaymentAmount
+    btcProtocolFee: BtcPaymentAmount
+  }
+}
+
+type RecordReceiveArgs = {
+  description: string
+  receiverWalletDescriptor: WalletDescriptor<WalletCurrency>
+  amount: {
+    usdWithFee: UsdPaymentAmount
+    btcWithFee: BtcPaymentAmount
+  }
+  metadata: ReceiveLedgerMetadata
+  fee?: {
+    usdProtocolFee: UsdPaymentAmount
+    btcProtocolFee: BtcPaymentAmount
+  }
+}
+
+type RecordIntraledgerArgs = {
+  description: string
+  senderWalletDescriptor: WalletDescriptor<WalletCurrency>
+  receiverWalletDescriptor: WalletDescriptor<WalletCurrency>
+  amount: {
+    usdWithFee: UsdPaymentAmount
+    btcWithFee: BtcPaymentAmount
+  }
+  metadata: IntraledgerLedgerMetadata
+  additionalDebitMetadata: TxMetadata
+}
+
 type LedgerMetadata = {
   type: LedgerTransactionType
   pending: boolean
@@ -36,7 +76,7 @@ type AddOnchainSendLedgerMetadata = NonIntraledgerLedgerMetadata & {
 type AddColdStorageLedgerMetadata = NonIntraledgerLedgerMetadata & {
   hash: OnChainTxHash
   payee_addresses: OnChainAddress[]
-  currency?: WalletCurrency
+  currency: WalletCurrency
 }
 
 type AddColdStorageReceiveLedgerMetadata = AddColdStorageLedgerMetadata
@@ -45,8 +85,8 @@ type AddColdStorageSendLedgerMetadata = AddColdStorageLedgerMetadata
 
 type IntraledgerBaseMetadata = LedgerMetadata & {
   usd: DisplayCurrencyBaseAmount // to be renamed amountDisplayCurrency
-  memoPayer: string | undefined | null
-  username: Username | undefined | null
+  memoPayer?: string
+  username?: Username
 }
 
 type AddLnIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata & {

--- a/src/services/ledger/intraledger.ts
+++ b/src/services/ledger/intraledger.ts
@@ -229,7 +229,7 @@ const addIntraledgerTxTransfer = async ({
       })
       .creditAccount({
         accountId: recipientAccountId,
-        amount: paymentAmountFromSats(sats),
+        btcAmountForUsdDebit: paymentAmountFromSats(sats),
       })
   } else {
     // if (
@@ -251,7 +251,7 @@ const addIntraledgerTxTransfer = async ({
       })
       .creditAccount({
         accountId: recipientAccountId,
-        amount: paymentAmountFromCents(cents),
+        usdAmountForBtcDebit: paymentAmountFromCents(cents),
       })
   }
 

--- a/src/services/ledger/intraledger.ts
+++ b/src/services/ledger/intraledger.ts
@@ -162,7 +162,7 @@ const addIntraledgerTxTransfer = async ({
   const sharedMetadata = {
     ...metadata,
     username: senderUsername,
-    memoPayer: shareMemoWithPayee ? memoPayer : null,
+    memoPayer: shareMemoWithPayee ? memoPayer : undefined,
   }
 
   let entry = MainBook.entry(description)

--- a/src/services/ledger/intraledger.ts
+++ b/src/services/ledger/intraledger.ts
@@ -8,7 +8,7 @@ import {
 
 import { NotReachableError } from "@domain/errors"
 
-import { EntryBuilder, toLedgerAccountId } from "./domain"
+import { LegacyEntryBuilder, toLedgerAccountId } from "./domain"
 
 import { MainBook } from "./books"
 import * as caching from "./caching"
@@ -166,7 +166,7 @@ const addIntraledgerTxTransfer = async ({
   }
 
   let entry = MainBook.entry(description)
-  const builder = EntryBuilder({
+  const builder = LegacyEntryBuilder({
     staticAccountIds,
     entry,
     metadata: sharedMetadata,
@@ -229,7 +229,7 @@ const addIntraledgerTxTransfer = async ({
       })
       .creditAccount({
         accountId: recipientAccountId,
-        btcAmountForUsdDebit: paymentAmountFromSats(sats),
+        amount: paymentAmountFromSats(sats),
       })
   } else {
     // if (
@@ -251,7 +251,7 @@ const addIntraledgerTxTransfer = async ({
       })
       .creditAccount({
         accountId: recipientAccountId,
-        usdAmountForBtcDebit: paymentAmountFromCents(cents),
+        amount: paymentAmountFromCents(cents),
       })
   }
 

--- a/src/services/ledger/receive.ts
+++ b/src/services/ledger/receive.ts
@@ -10,7 +10,7 @@ import { LedgerError, UnknownLedgerError } from "@domain/ledger/errors"
 
 import { MainBook } from "./books"
 import * as caching from "./caching"
-import { EntryBuilder, toLedgerAccountId } from "./domain"
+import { LegacyEntryBuilder, toLedgerAccountId } from "./domain"
 
 import { TransactionsMetadataRepository } from "./services"
 
@@ -160,7 +160,7 @@ const addReceiptNoFee = async ({
     dealerUsdAccountId: toLedgerAccountId(await caching.getDealerUsdWalletId()),
   }
   let entry = MainBook.entry(description)
-  const builder = EntryBuilder({
+  const builder = LegacyEntryBuilder({
     staticAccountIds,
     entry,
     metadata: metaInput,
@@ -174,7 +174,7 @@ const addReceiptNoFee = async ({
     if (cents === undefined) return new NotReachableError("cents should be defined here")
     entry = builder.creditAccount({
       accountId,
-      usdAmountForBtcDebit: paymentAmountFromCents(cents),
+      amount: paymentAmountFromCents(cents),
     })
   }
   try {
@@ -222,7 +222,7 @@ const addReceiptFee = async ({
   }
 
   const entry = MainBook.entry(description)
-  const builder = EntryBuilder({
+  const builder = LegacyEntryBuilder({
     staticAccountIds,
     entry,
     metadata: metaInput,

--- a/src/services/ledger/receive.ts
+++ b/src/services/ledger/receive.ts
@@ -172,7 +172,10 @@ const addReceiptNoFee = async ({
     entry = builder.creditAccount({ accountId })
   } else {
     if (cents === undefined) return new NotReachableError("cents should be defined here")
-    entry = builder.creditAccount({ accountId, amount: paymentAmountFromCents(cents) })
+    entry = builder.creditAccount({
+      accountId,
+      usdAmountForBtcDebit: paymentAmountFromCents(cents),
+    })
   }
   try {
     const savedEntry = await entry.commit()

--- a/src/services/ledger/send.ts
+++ b/src/services/ledger/send.ts
@@ -12,7 +12,7 @@ import {
   WalletCurrency,
 } from "@domain/shared"
 
-import { EntryBuilder, toLedgerAccountId } from "./domain"
+import { LegacyEntryBuilder, toLedgerAccountId } from "./domain"
 
 import { MainBook, Transaction } from "./books"
 import * as caching from "./caching"
@@ -178,7 +178,7 @@ const addSendNoInternalFee = async ({
 
   const metadata = { ...metaInput, currency: walletCurrency }
   let entry = MainBook.entry(description)
-  const builder = EntryBuilder({
+  const builder = LegacyEntryBuilder({
     staticAccountIds,
     entry,
     metadata,
@@ -249,7 +249,7 @@ const addSendInternalFee = async ({
 
   try {
     const entry = MainBook.entry(description)
-    const builder = EntryBuilder({
+    const builder = LegacyEntryBuilder({
       staticAccountIds,
       entry,
       metadata: metaInput,

--- a/src/services/ledger/tx-metadata.ts
+++ b/src/services/ledger/tx-metadata.ts
@@ -3,15 +3,15 @@ import { LedgerTransactionType } from "@domain/ledger"
 export const LnSendLedgerMetadata = ({
   paymentHash,
   fee,
-  feeDisplayUsd,
-  amountDisplayUsd,
+  feeDisplayCurrency,
+  amountDisplayCurrency,
   pubkey,
   feeKnownInAdvance,
 }: {
   paymentHash: PaymentHash
   fee: BtcPaymentAmount
-  feeDisplayUsd: DisplayCurrencyBaseAmount
-  amountDisplayUsd: DisplayCurrencyBaseAmount
+  feeDisplayCurrency: DisplayCurrencyBaseAmount
+  amountDisplayCurrency: DisplayCurrencyBaseAmount
   pubkey: Pubkey
   feeKnownInAdvance: boolean
 }) => {
@@ -20,8 +20,8 @@ export const LnSendLedgerMetadata = ({
     pending: true,
     hash: paymentHash,
     fee: Number(fee.amount) as Satoshis,
-    feeUsd: feeDisplayUsd,
-    usd: amountDisplayUsd,
+    feeUsd: feeDisplayCurrency,
+    usd: amountDisplayCurrency,
     pubkey,
     feeKnownInAdvance,
   }
@@ -31,15 +31,15 @@ export const LnSendLedgerMetadata = ({
 export const OnChainSendLedgerMetadata = ({
   onChainTxHash,
   fee,
-  feeDisplayUsd,
-  amountDisplayUsd,
+  feeDisplayCurrency,
+  amountDisplayCurrency,
   payeeAddresses,
   sendAll,
 }: {
   onChainTxHash: OnChainTxHash
   fee: BtcPaymentAmount
-  feeDisplayUsd: DisplayCurrencyBaseAmount
-  amountDisplayUsd: DisplayCurrencyBaseAmount
+  feeDisplayCurrency: DisplayCurrencyBaseAmount
+  amountDisplayCurrency: DisplayCurrencyBaseAmount
   payeeAddresses: OnChainAddress[]
   sendAll: boolean
 }) => {
@@ -49,8 +49,8 @@ export const OnChainSendLedgerMetadata = ({
     hash: onChainTxHash,
     payee_addresses: payeeAddresses,
     fee: Number(fee.amount) as Satoshis,
-    feeUsd: feeDisplayUsd,
-    usd: amountDisplayUsd,
+    feeUsd: feeDisplayCurrency,
+    usd: amountDisplayCurrency,
     sendAll,
   }
 
@@ -60,14 +60,14 @@ export const OnChainSendLedgerMetadata = ({
 export const OnChainReceiveLedgerMetadata = ({
   onChainTxHash,
   fee,
-  feeDisplayUsd,
-  amountDisplayUsd,
+  feeDisplayCurrency,
+  amountDisplayCurrency,
   payeeAddresses,
 }: {
   onChainTxHash: OnChainTxHash
   fee: BtcPaymentAmount
-  feeDisplayUsd: DisplayCurrencyBaseAmount
-  amountDisplayUsd: DisplayCurrencyBaseAmount
+  feeDisplayCurrency: DisplayCurrencyBaseAmount
+  amountDisplayCurrency: DisplayCurrencyBaseAmount
   payeeAddresses: OnChainAddress[]
 }) => {
   const metadata: OnChainReceiveLedgerMetadata = {
@@ -75,8 +75,8 @@ export const OnChainReceiveLedgerMetadata = ({
     pending: false,
     hash: onChainTxHash,
     fee: Number(fee.amount) as Satoshis,
-    feeUsd: feeDisplayUsd,
-    usd: amountDisplayUsd,
+    feeUsd: feeDisplayCurrency,
+    usd: amountDisplayCurrency,
     payee_addresses: payeeAddresses,
   }
   return metadata
@@ -85,13 +85,13 @@ export const OnChainReceiveLedgerMetadata = ({
 export const LnReceiveLedgerMetadata = ({
   paymentHash,
   fee,
-  feeDisplayUsd,
-  amountDisplayUsd,
+  feeDisplayCurrency,
+  amountDisplayCurrency,
 }: {
   paymentHash: PaymentHash
   fee: BtcPaymentAmount
-  feeDisplayUsd: DisplayCurrencyBaseAmount
-  amountDisplayUsd: DisplayCurrencyBaseAmount
+  feeDisplayCurrency: DisplayCurrencyBaseAmount
+  amountDisplayCurrency: DisplayCurrencyBaseAmount
   pubkey: Pubkey
 }) => {
   const metadata: LnReceiveLedgerMetadata = {
@@ -99,8 +99,8 @@ export const LnReceiveLedgerMetadata = ({
     pending: false,
     hash: paymentHash,
     fee: Number(fee.amount) as Satoshis,
-    feeUsd: feeDisplayUsd,
-    usd: amountDisplayUsd,
+    feeUsd: feeDisplayCurrency,
+    usd: amountDisplayCurrency,
   }
   return metadata
 }
@@ -108,42 +108,42 @@ export const LnReceiveLedgerMetadata = ({
 export const LnFeeReimbursementReceiveLedgerMetadata = ({
   paymentHash,
   journalId,
-  amountDisplayUsd,
+  amountDisplayCurrency,
 }: {
   paymentHash: PaymentHash
   journalId: LedgerJournalId
-  amountDisplayUsd: DisplayCurrencyBaseAmount
+  amountDisplayCurrency: DisplayCurrencyBaseAmount
 }) => {
   const metadata: FeeReimbursementLedgerMetadata = {
     type: LedgerTransactionType.LnFeeReimbursement,
     hash: paymentHash,
     related_journal: journalId,
     pending: false,
-    usd: amountDisplayUsd,
+    usd: amountDisplayCurrency,
   }
   return metadata
 }
 
 export const OnChainIntraledgerLedgerMetadata = ({
-  amountDisplayUsd,
+  amountDisplayCurrency,
   payeeAddresses,
   sendAll,
   memoOfPayer,
   senderUsername,
   recipientUsername,
 }: {
-  amountDisplayUsd: DisplayCurrencyBaseAmount
+  amountDisplayCurrency: DisplayCurrencyBaseAmount
   payeeAddresses: OnChainAddress[]
   sendAll: boolean
-  memoOfPayer: string | null
-  senderUsername: Username | null
-  recipientUsername: Username | null
+  memoOfPayer?: string
+  senderUsername?: Username
+  recipientUsername?: Username
 }) => {
   const metadata: AddOnChainIntraledgerSendLedgerMetadata = {
     type: LedgerTransactionType.OnchainIntraLedger,
     pending: false,
-    usd: amountDisplayUsd,
-    memoPayer: null,
+    usd: amountDisplayCurrency,
+    memoPayer: undefined,
     username: senderUsername,
     payee_addresses: payeeAddresses,
     sendAll,
@@ -156,20 +156,20 @@ export const OnChainIntraledgerLedgerMetadata = ({
 }
 
 export const WalletIdIntraledgerLedgerMetadata = ({
-  amountDisplayUsd,
+  amountDisplayCurrency,
   memoOfPayer,
   senderUsername,
   recipientUsername,
 }: {
-  amountDisplayUsd: DisplayCurrencyBaseAmount
-  memoOfPayer: string | null
-  senderUsername: Username | null
-  recipientUsername: Username | null
+  amountDisplayCurrency: DisplayCurrencyBaseAmount
+  memoOfPayer?: string
+  senderUsername?: Username
+  recipientUsername?: Username
 }) => {
   const metadata: AddWalletIdIntraledgerSendLedgerMetadata = {
     type: LedgerTransactionType.IntraLedger,
     pending: false,
-    usd: amountDisplayUsd,
+    usd: amountDisplayCurrency,
     memoPayer: memoOfPayer,
     username: senderUsername,
   }
@@ -181,26 +181,25 @@ export const WalletIdIntraledgerLedgerMetadata = ({
 }
 
 export const LnIntraledgerLedgerMetadata = ({
-  amountDisplayUsd,
+  amountDisplayCurrency,
   memoOfPayer,
   senderUsername,
   recipientUsername,
   pubkey,
   paymentHash,
 }: {
-  amountDisplayUsd: DisplayCurrencyBaseAmount
-  payeeAddresses: OnChainAddress[]
-  memoOfPayer: string | null
-  senderUsername: Username | null
-  recipientUsername: Username | null
+  amountDisplayCurrency: DisplayCurrencyBaseAmount
+  memoOfPayer?: string
+  senderUsername?: Username
+  recipientUsername?: Username
   pubkey: Pubkey
   paymentHash: PaymentHash
 }) => {
   const metadata: AddLnIntraledgerSendLedgerMetadata = {
     type: LedgerTransactionType.LnIntraLedger,
     pending: false,
-    usd: amountDisplayUsd,
-    memoPayer: null,
+    usd: amountDisplayCurrency,
+    memoPayer: undefined,
     username: senderUsername,
     hash: paymentHash,
     pubkey,
@@ -244,14 +243,14 @@ export const LnRoutingRevenue = (collectedOn: Date) => {
 export const ColdStorageReceiveLedgerMetada = ({
   onChainTxHash,
   fee,
-  feeDisplayUsd,
-  amountDisplayUsd,
+  feeDisplayCurrency,
+  amountDisplayCurrency,
   payeeAddresses,
 }: {
   onChainTxHash: OnChainTxHash
   fee: BtcPaymentAmount
-  feeDisplayUsd: DisplayCurrencyBaseAmount
-  amountDisplayUsd: DisplayCurrencyBaseAmount
+  feeDisplayCurrency: DisplayCurrencyBaseAmount
+  amountDisplayCurrency: DisplayCurrencyBaseAmount
   payeeAddresses: OnChainAddress[]
 }) => {
   const metadata: AddColdStorageReceiveLedgerMetadata = {
@@ -260,8 +259,8 @@ export const ColdStorageReceiveLedgerMetada = ({
     hash: onChainTxHash,
     payee_addresses: payeeAddresses,
     fee: Number(fee.amount) as Satoshis,
-    feeUsd: feeDisplayUsd,
-    usd: amountDisplayUsd,
+    feeUsd: feeDisplayCurrency,
+    usd: amountDisplayCurrency,
   }
 
   return metadata
@@ -270,14 +269,14 @@ export const ColdStorageReceiveLedgerMetada = ({
 export const ColdStorageSendLedgerMetada = ({
   onChainTxHash,
   fee,
-  feeDisplayUsd,
-  amountDisplayUsd,
+  feeDisplayCurrency,
+  amountDisplayCurrency,
   payeeAddress,
 }: {
   onChainTxHash: OnChainTxHash
   fee: BtcPaymentAmount
-  feeDisplayUsd: DisplayCurrencyBaseAmount
-  amountDisplayUsd: DisplayCurrencyBaseAmount
+  feeDisplayCurrency: DisplayCurrencyBaseAmount
+  amountDisplayCurrency: DisplayCurrencyBaseAmount
   payeeAddress: OnChainAddress
 }) => {
   const metadata: AddColdStorageSendLedgerMetadata = {
@@ -286,8 +285,8 @@ export const ColdStorageSendLedgerMetada = ({
     hash: onChainTxHash,
     payee_addresses: [payeeAddress],
     fee: Number(fee.amount) as Satoshis,
-    feeUsd: feeDisplayUsd,
-    usd: amountDisplayUsd,
+    feeUsd: feeDisplayCurrency,
+    usd: amountDisplayCurrency,
   }
 
   return metadata

--- a/src/services/ledger/tx-metadata.ts
+++ b/src/services/ledger/tx-metadata.ts
@@ -246,15 +246,18 @@ export const ColdStorageReceiveLedgerMetada = ({
   feeDisplayCurrency,
   amountDisplayCurrency,
   payeeAddresses,
+  currency,
 }: {
   onChainTxHash: OnChainTxHash
   fee: BtcPaymentAmount
   feeDisplayCurrency: DisplayCurrencyBaseAmount
   amountDisplayCurrency: DisplayCurrencyBaseAmount
   payeeAddresses: OnChainAddress[]
+  currency: WalletCurrency
 }) => {
   const metadata: AddColdStorageReceiveLedgerMetadata = {
     type: LedgerTransactionType.ToColdStorage,
+    currency,
     pending: false,
     hash: onChainTxHash,
     payee_addresses: payeeAddresses,
@@ -272,15 +275,18 @@ export const ColdStorageSendLedgerMetada = ({
   feeDisplayCurrency,
   amountDisplayCurrency,
   payeeAddress,
+  currency,
 }: {
   onChainTxHash: OnChainTxHash
   fee: BtcPaymentAmount
   feeDisplayCurrency: DisplayCurrencyBaseAmount
   amountDisplayCurrency: DisplayCurrencyBaseAmount
   payeeAddress: OnChainAddress
+  currency: WalletCurrency
 }) => {
   const metadata: AddColdStorageSendLedgerMetadata = {
     type: LedgerTransactionType.ToHotWallet,
+    currency,
     pending: false,
     hash: onChainTxHash,
     payee_addresses: [payeeAddress],

--- a/src/services/ledger/tx-metadata.ts
+++ b/src/services/ledger/tx-metadata.ts
@@ -1,0 +1,294 @@
+import { LedgerTransactionType } from "@domain/ledger"
+
+export const LnSendLedgerMetadata = ({
+  paymentHash,
+  fee,
+  feeDisplayUsd,
+  amountDisplayUsd,
+  pubkey,
+  feeKnownInAdvance,
+}: {
+  paymentHash: PaymentHash
+  fee: BtcPaymentAmount
+  feeDisplayUsd: DisplayCurrencyBaseAmount
+  amountDisplayUsd: DisplayCurrencyBaseAmount
+  pubkey: Pubkey
+  feeKnownInAdvance: boolean
+}) => {
+  const metadata: AddLnSendLedgerMetadata = {
+    type: LedgerTransactionType.Payment,
+    pending: true,
+    hash: paymentHash,
+    fee: Number(fee.amount) as Satoshis,
+    feeUsd: feeDisplayUsd,
+    usd: amountDisplayUsd,
+    pubkey,
+    feeKnownInAdvance,
+  }
+  return metadata
+}
+
+export const OnChainSendLedgerMetadata = ({
+  onChainTxHash,
+  fee,
+  feeDisplayUsd,
+  amountDisplayUsd,
+  payeeAddresses,
+  sendAll,
+}: {
+  onChainTxHash: OnChainTxHash
+  fee: BtcPaymentAmount
+  feeDisplayUsd: DisplayCurrencyBaseAmount
+  amountDisplayUsd: DisplayCurrencyBaseAmount
+  payeeAddresses: OnChainAddress[]
+  sendAll: boolean
+}) => {
+  const metadata: AddOnchainSendLedgerMetadata = {
+    type: LedgerTransactionType.OnchainPayment,
+    pending: true,
+    hash: onChainTxHash,
+    payee_addresses: payeeAddresses,
+    fee: Number(fee.amount) as Satoshis,
+    feeUsd: feeDisplayUsd,
+    usd: amountDisplayUsd,
+    sendAll,
+  }
+
+  return metadata
+}
+
+export const OnChainReceiveLedgerMetadata = ({
+  onChainTxHash,
+  fee,
+  feeDisplayUsd,
+  amountDisplayUsd,
+  payeeAddresses,
+}: {
+  onChainTxHash: OnChainTxHash
+  fee: BtcPaymentAmount
+  feeDisplayUsd: DisplayCurrencyBaseAmount
+  amountDisplayUsd: DisplayCurrencyBaseAmount
+  payeeAddresses: OnChainAddress[]
+}) => {
+  const metadata: OnChainReceiveLedgerMetadata = {
+    type: LedgerTransactionType.OnchainReceipt,
+    pending: false,
+    hash: onChainTxHash,
+    fee: Number(fee.amount) as Satoshis,
+    feeUsd: feeDisplayUsd,
+    usd: amountDisplayUsd,
+    payee_addresses: payeeAddresses,
+  }
+  return metadata
+}
+
+export const LnReceiveLedgerMetadata = ({
+  paymentHash,
+  fee,
+  feeDisplayUsd,
+  amountDisplayUsd,
+}: {
+  paymentHash: PaymentHash
+  fee: BtcPaymentAmount
+  feeDisplayUsd: DisplayCurrencyBaseAmount
+  amountDisplayUsd: DisplayCurrencyBaseAmount
+  pubkey: Pubkey
+}) => {
+  const metadata: LnReceiveLedgerMetadata = {
+    type: LedgerTransactionType.Invoice,
+    pending: false,
+    hash: paymentHash,
+    fee: Number(fee.amount) as Satoshis,
+    feeUsd: feeDisplayUsd,
+    usd: amountDisplayUsd,
+  }
+  return metadata
+}
+
+export const LnFeeReimbursementReceiveLedgerMetadata = ({
+  paymentHash,
+  journalId,
+  amountDisplayUsd,
+}: {
+  paymentHash: PaymentHash
+  journalId: LedgerJournalId
+  amountDisplayUsd: DisplayCurrencyBaseAmount
+}) => {
+  const metadata: FeeReimbursementLedgerMetadata = {
+    type: LedgerTransactionType.LnFeeReimbursement,
+    hash: paymentHash,
+    related_journal: journalId,
+    pending: false,
+    usd: amountDisplayUsd,
+  }
+  return metadata
+}
+
+export const OnChainIntraledgerLedgerMetadata = ({
+  amountDisplayUsd,
+  payeeAddresses,
+  sendAll,
+  memoOfPayer,
+  senderUsername,
+  recipientUsername,
+}: {
+  amountDisplayUsd: DisplayCurrencyBaseAmount
+  payeeAddresses: OnChainAddress[]
+  sendAll: boolean
+  memoOfPayer: string | null
+  senderUsername: Username | null
+  recipientUsername: Username | null
+}) => {
+  const metadata: AddOnChainIntraledgerSendLedgerMetadata = {
+    type: LedgerTransactionType.OnchainIntraLedger,
+    pending: false,
+    usd: amountDisplayUsd,
+    memoPayer: null,
+    username: senderUsername,
+    payee_addresses: payeeAddresses,
+    sendAll,
+  }
+  const debitAccountAdditionalMetadata = {
+    memoPayer: memoOfPayer,
+    username: recipientUsername,
+  }
+  return { metadata, debitAccountAdditionalMetadata }
+}
+
+export const WalletIdIntraledgerLedgerMetadata = ({
+  amountDisplayUsd,
+  memoOfPayer,
+  senderUsername,
+  recipientUsername,
+}: {
+  amountDisplayUsd: DisplayCurrencyBaseAmount
+  memoOfPayer: string | null
+  senderUsername: Username | null
+  recipientUsername: Username | null
+}) => {
+  const metadata: AddWalletIdIntraledgerSendLedgerMetadata = {
+    type: LedgerTransactionType.IntraLedger,
+    pending: false,
+    usd: amountDisplayUsd,
+    memoPayer: memoOfPayer,
+    username: senderUsername,
+  }
+  const debitAccountAdditionalMetadata = {
+    username: recipientUsername,
+  }
+
+  return { metadata, debitAccountAdditionalMetadata }
+}
+
+export const LnIntraledgerLedgerMetadata = ({
+  amountDisplayUsd,
+  memoOfPayer,
+  senderUsername,
+  recipientUsername,
+  pubkey,
+  paymentHash,
+}: {
+  amountDisplayUsd: DisplayCurrencyBaseAmount
+  payeeAddresses: OnChainAddress[]
+  memoOfPayer: string | null
+  senderUsername: Username | null
+  recipientUsername: Username | null
+  pubkey: Pubkey
+  paymentHash: PaymentHash
+}) => {
+  const metadata: AddLnIntraledgerSendLedgerMetadata = {
+    type: LedgerTransactionType.LnIntraLedger,
+    pending: false,
+    usd: amountDisplayUsd,
+    memoPayer: null,
+    username: senderUsername,
+    hash: paymentHash,
+    pubkey,
+  }
+  const debitAccountAdditionalMetadata = {
+    memoPayer: memoOfPayer,
+    username: recipientUsername,
+  }
+  return { metadata, debitAccountAdditionalMetadata }
+}
+
+export const LnChannelOpenOrClosingFee = ({ txId }: { txId: OnChainTxHash }) => {
+  const metadata: LnChannelOpenOrClosingFee = {
+    type: LedgerTransactionType.Fee,
+    pending: false,
+    txid: txId,
+  }
+
+  return metadata
+}
+
+export const Escrow = () => {
+  const metadata: LedgerMetadata = {
+    type: LedgerTransactionType.Escrow,
+    pending: false,
+  }
+
+  return metadata
+}
+
+export const LnRoutingRevenue = (collectedOn: Date) => {
+  const metadata: LnRoutingRevenueLedgerMetadata = {
+    type: LedgerTransactionType.RoutingRevenue,
+    feesCollectedOn: collectedOn.toDateString(),
+    pending: false,
+  }
+
+  return metadata
+}
+
+export const ColdStorageReceiveLedgerMetada = ({
+  onChainTxHash,
+  fee,
+  feeDisplayUsd,
+  amountDisplayUsd,
+  payeeAddresses,
+}: {
+  onChainTxHash: OnChainTxHash
+  fee: BtcPaymentAmount
+  feeDisplayUsd: DisplayCurrencyBaseAmount
+  amountDisplayUsd: DisplayCurrencyBaseAmount
+  payeeAddresses: OnChainAddress[]
+}) => {
+  const metadata: AddColdStorageReceiveLedgerMetadata = {
+    type: LedgerTransactionType.ToColdStorage,
+    pending: false,
+    hash: onChainTxHash,
+    payee_addresses: payeeAddresses,
+    fee: Number(fee.amount) as Satoshis,
+    feeUsd: feeDisplayUsd,
+    usd: amountDisplayUsd,
+  }
+
+  return metadata
+}
+
+export const ColdStorageSendLedgerMetada = ({
+  onChainTxHash,
+  fee,
+  feeDisplayUsd,
+  amountDisplayUsd,
+  payeeAddress,
+}: {
+  onChainTxHash: OnChainTxHash
+  fee: BtcPaymentAmount
+  feeDisplayUsd: DisplayCurrencyBaseAmount
+  amountDisplayUsd: DisplayCurrencyBaseAmount
+  payeeAddress: OnChainAddress
+}) => {
+  const metadata: AddColdStorageSendLedgerMetadata = {
+    type: LedgerTransactionType.ToHotWallet,
+    pending: false,
+    hash: onChainTxHash,
+    payee_addresses: [payeeAddress],
+    fee: Number(fee.amount) as Satoshis,
+    feeUsd: feeDisplayUsd,
+    usd: amountDisplayUsd,
+  }
+
+  return metadata
+}

--- a/test/integration/services/ledger/facade.spec.ts
+++ b/test/integration/services/ledger/facade.spec.ts
@@ -1,0 +1,150 @@
+import crypto from "crypto"
+
+import { BtcWalletDescriptor, UsdWalletDescriptor, WalletCurrency } from "@domain/shared"
+import * as LedgerFacade from "@services/ledger/facade"
+
+describe("Facade", () => {
+  const receiveAmount = {
+    usdWithFee: { amount: 100n, currency: WalletCurrency.Usd },
+    btcWithFee: { amount: 200n, currency: WalletCurrency.Btc },
+  }
+  const sendAmount = {
+    usdWithFee: { amount: 20n, currency: WalletCurrency.Usd },
+    btcWithFee: { amount: 40n, currency: WalletCurrency.Btc },
+  }
+  const fee = {
+    usdProtocolFee: { amount: 10n, currency: WalletCurrency.Usd },
+    btcProtocolFee: { amount: 20n, currency: WalletCurrency.Btc },
+  }
+  const walletDescriptor1 = BtcWalletDescriptor(crypto.randomUUID() as WalletId)
+  const walletDescriptor2 = UsdWalletDescriptor(crypto.randomUUID() as WalletId)
+
+  describe("recordReceive", () => {
+    it("receives to btc wallet", async () => {
+      const metadata = LedgerFacade.LnReceiveLedgerMetadata({
+        paymentHash: crypto.randomUUID() as PaymentHash,
+        fee: fee.btcProtocolFee,
+        feeDisplayCurrency: Number(
+          fee.usdProtocolFee.amount,
+        ) as DisplayCurrencyBaseAmount,
+        amountDisplayCurrency: Number(
+          receiveAmount.usdWithFee.amount,
+        ) as DisplayCurrencyBaseAmount,
+        pubkey: crypto.randomUUID() as Pubkey,
+      })
+
+      await LedgerFacade.recordReceive({
+        description: "receives bitcoin",
+        amount: receiveAmount,
+        receiverWalletDescriptor: walletDescriptor1,
+        fee,
+        metadata,
+      })
+
+      const balance = await LedgerFacade.getLedgerAccountBalanceForWalletId(
+        walletDescriptor1,
+      )
+
+      if (balance instanceof Error) throw balance
+      expect(balance).toEqual(
+        expect.objectContaining({
+          amount: receiveAmount.btcWithFee.amount - fee.btcProtocolFee.amount,
+          currency: WalletCurrency.Btc,
+        }),
+      )
+    })
+  })
+
+  describe("recordSend", () => {
+    it("sends from btc wallet", async () => {
+      const startingBalance = await LedgerFacade.getLedgerAccountBalanceForWalletId(
+        walletDescriptor1,
+      )
+
+      if (startingBalance instanceof Error) throw startingBalance
+
+      const metadata = LedgerFacade.LnSendLedgerMetadata({
+        paymentHash: crypto.randomUUID() as PaymentHash,
+        fee: fee.btcProtocolFee,
+        feeDisplayCurrency: Number(
+          fee.usdProtocolFee.amount,
+        ) as DisplayCurrencyBaseAmount,
+        amountDisplayCurrency: Number(
+          receiveAmount.usdWithFee.amount,
+        ) as DisplayCurrencyBaseAmount,
+        pubkey: crypto.randomUUID() as Pubkey,
+        feeKnownInAdvance: true,
+      })
+
+      await LedgerFacade.recordSend({
+        description: "sends bitcoin",
+        amount: sendAmount,
+        senderWalletDescriptor: walletDescriptor1,
+        fee,
+        metadata,
+      })
+
+      const balance = await LedgerFacade.getLedgerAccountBalanceForWalletId(
+        walletDescriptor1,
+      )
+
+      if (balance instanceof Error) throw balance
+      expect(balance).toEqual(
+        expect.objectContaining({
+          amount: startingBalance.amount - sendAmount.btcWithFee.amount,
+          currency: WalletCurrency.Btc,
+        }),
+      )
+    })
+  })
+
+  describe("recordIntraledger", () => {
+    it("sends from btc wallet to usd wallet", async () => {
+      const startingBalanceSender = await LedgerFacade.getLedgerAccountBalanceForWalletId(
+        walletDescriptor1,
+      )
+
+      if (startingBalanceSender instanceof Error) throw startingBalanceSender
+
+      const { metadata, debitAccountAdditionalMetadata } =
+        LedgerFacade.LnIntraledgerLedgerMetadata({
+          paymentHash: crypto.randomUUID() as PaymentHash,
+          amountDisplayCurrency: Number(
+            receiveAmount.usdWithFee.amount,
+          ) as DisplayCurrencyBaseAmount,
+          pubkey: crypto.randomUUID() as Pubkey,
+        })
+
+      await LedgerFacade.recordIntraledger({
+        description: "sends bitcoin",
+        amount: sendAmount,
+        senderWalletDescriptor: walletDescriptor1,
+        receiverWalletDescriptor: walletDescriptor2,
+        metadata,
+        additionalDebitMetadata: debitAccountAdditionalMetadata,
+      })
+
+      const finishBalanceSender = await LedgerFacade.getLedgerAccountBalanceForWalletId(
+        walletDescriptor1,
+      )
+      if (finishBalanceSender instanceof Error) throw finishBalanceSender
+      const finishBalanceReceiver = await LedgerFacade.getLedgerAccountBalanceForWalletId(
+        walletDescriptor2,
+      )
+      if (finishBalanceReceiver instanceof Error) throw finishBalanceReceiver
+
+      expect(finishBalanceSender).toEqual(
+        expect.objectContaining({
+          amount: startingBalanceSender.amount - sendAmount.btcWithFee.amount,
+          currency: WalletCurrency.Btc,
+        }),
+      )
+      expect(finishBalanceReceiver).toEqual(
+        expect.objectContaining({
+          amount: sendAmount.usdWithFee.amount,
+          currency: WalletCurrency.Usd,
+        }),
+      )
+    })
+  })
+})

--- a/test/unit/services/ledger/domain/entry-builder.spec.ts
+++ b/test/unit/services/ledger/domain/entry-builder.spec.ts
@@ -1,4 +1,9 @@
-import { EntryBuilder, lndLedgerAccountId } from "@services/ledger/domain"
+import {
+  EntryBuilder,
+  lndLedgerAccountId,
+  ZERO_SATS,
+  ZERO_CENTS,
+} from "@services/ledger/domain"
 import { WalletCurrency, AmountCalculator } from "@domain/shared"
 
 class TestMediciEntry {
@@ -23,6 +28,30 @@ describe("EntryBuilder", () => {
     expect(entry.amount).toEqual(Number(amount.amount))
     expect(entry.metadata.currency).toEqual(amount.currency)
   }
+
+  const expectJournalToBeBalanced = (journal) => {
+    let usdCredits = 0
+    let btcCredits = 0
+    let usdDebits = 0
+    let btcDebits = 0
+
+    Object.values<any>(journal.debits).forEach((entry) =>
+      entry.metadata.currency === WalletCurrency.Usd
+        ? (usdDebits += entry.amount)
+        : (btcDebits += entry.amount),
+    )
+    Object.values<any>(journal.credits).forEach((entry) =>
+      entry.metadata.currency === WalletCurrency.Usd
+        ? (usdCredits += entry.amount)
+        : (btcCredits += entry.amount),
+    )
+
+    expect(usdCredits).toEqual(usdDebits)
+    expect(btcCredits).toEqual(btcDebits)
+    console.log(usdCredits)
+    console.log(btcCredits)
+  }
+
   const calc = AmountCalculator()
   const staticAccountIds = {
     bankOwnerAccountId: "bankOwnerAccountId" as LedgerAccountId,
@@ -30,7 +59,28 @@ describe("EntryBuilder", () => {
     dealerUsdAccountId: "dealerUsdAccountId" as LedgerAccountId,
   }
   const debitorAccountId = "debitorAccountId" as LedgerAccountId
+  const btcDebitorAccountDescriptor = {
+    id: debitorAccountId,
+    currency: WalletCurrency.Btc,
+  } as LedgerAccountDescriptor<"BTC">
+
+  const usdDebitorAccountDescriptor = {
+    id: debitorAccountId,
+    currency: WalletCurrency.Usd,
+  } as LedgerAccountDescriptor<"USD">
+
   const creditorAccountId = "creditorAccountId" as LedgerAccountId
+
+  const btcCreditorAccountDescriptor = {
+    id: creditorAccountId,
+    currency: WalletCurrency.Btc,
+  } as LedgerAccountDescriptor<"BTC">
+
+  const usdCreditorAccountDescriptor = {
+    id: creditorAccountId,
+    currency: WalletCurrency.Usd,
+  } as LedgerAccountDescriptor<"USD">
+
   const btcAmount = {
     currency: WalletCurrency.Btc,
     amount: 2000n,
@@ -39,10 +89,30 @@ describe("EntryBuilder", () => {
     currency: WalletCurrency.Usd,
     amount: 20n,
   }
+
+  const amount = {
+    btcWithFee: btcAmount,
+    usdWithFee: usdAmount,
+  }
   const btcFee = {
     currency: WalletCurrency.Btc,
-    amount: 111n,
+    amount: 110n,
   }
+  const usdFee = {
+    currency: WalletCurrency.Usd,
+    amount: 1n,
+  }
+
+  const protocolFee = {
+    usdProtocolFee: usdFee,
+    btcProtocolFee: btcFee,
+  }
+
+  const ZERO_FEE = {
+    usdProtocolFee: ZERO_CENTS,
+    btcProtocolFee: ZERO_SATS,
+  }
+
   const metadata = {
     currency: "BAD CURRENCY",
     some: "some",
@@ -59,13 +129,12 @@ describe("EntryBuilder", () => {
           metadata,
         })
         const result = builder
-          .withoutFee()
-          .debitAccount({
-            accountId: debitorAccountId,
-            amount: btcAmount,
-          })
+          .withTotalAmount(amount)
+          .withFee(ZERO_FEE)
+          .debitAccount({ accountDescriptor: btcDebitorAccountDescriptor })
           .creditLnd()
 
+        expectJournalToBeBalanced(result)
         expectEntryToEqual(result.credits[lndLedgerAccountId], btcAmount)
         expectEntryToEqual(result.debits[debitorAccountId], btcAmount)
         expect(result.debits[staticAccountIds.bankOwnerAccountId]).toBeUndefined()
@@ -79,13 +148,12 @@ describe("EntryBuilder", () => {
           metadata,
         })
         const result = builder
-          .withFee(btcFee)
-          .debitAccount({
-            accountId: debitorAccountId,
-            amount: btcAmount,
-          })
+          .withTotalAmount(amount)
+          .withFee(protocolFee)
+          .debitAccount({ accountDescriptor: btcDebitorAccountDescriptor })
           .creditLnd()
 
+        expectJournalToBeBalanced(result)
         expectEntryToEqual(result.credits[staticAccountIds.bankOwnerAccountId], btcFee)
         expectEntryToEqual(
           result.credits[lndLedgerAccountId],
@@ -104,10 +172,12 @@ describe("EntryBuilder", () => {
           metadata,
         })
         const result = builder
-          .withoutFee()
-          .debitLnd(btcAmount)
-          .creditAccount({ accountId: creditorAccountId })
+          .withTotalAmount(amount)
+          .withFee(ZERO_FEE)
+          .debitLnd()
+          .creditAccount(btcCreditorAccountDescriptor)
 
+        expectJournalToBeBalanced(result)
         expectEntryToEqual(result.debits[lndLedgerAccountId], btcAmount)
         expectEntryToEqual(result.credits[creditorAccountId], btcAmount)
       })
@@ -119,10 +189,13 @@ describe("EntryBuilder", () => {
           entry,
           metadata,
         })
-        const result = builder.withFee(btcFee).debitLnd(btcAmount).creditAccount({
-          accountId: creditorAccountId,
-        })
+        const result = builder
+          .withTotalAmount(amount)
+          .withFee(protocolFee)
+          .debitLnd()
+          .creditAccount(btcCreditorAccountDescriptor)
 
+        expectJournalToBeBalanced(result)
         expect(result.credits[staticAccountIds.bankOwnerAccountId].amount).toEqual(
           Number(btcFee.amount),
         )
@@ -142,13 +215,14 @@ describe("EntryBuilder", () => {
           metadata,
         })
         const result = builder
-          .withoutFee()
+          .withTotalAmount(amount)
+          .withFee(ZERO_FEE)
           .debitAccount({
-            accountId: debitorAccountId,
-            amount: usdAmount,
+            accountDescriptor: usdDebitorAccountDescriptor,
           })
-          .creditLnd(btcAmount)
+          .creditLnd()
 
+        expectJournalToBeBalanced(result)
         expectEntryToEqual(result.credits[lndLedgerAccountId], btcAmount)
         expectEntryToEqual(result.debits[debitorAccountId], usdAmount)
         expectEntryToEqual(result.debits[staticAccountIds.dealerBtcAccountId], btcAmount)
@@ -165,13 +239,14 @@ describe("EntryBuilder", () => {
           metadata,
         })
         const result = builder
-          .withFee(btcFee)
+          .withTotalAmount(amount)
+          .withFee(protocolFee)
           .debitAccount({
-            accountId: debitorAccountId,
-            amount: usdAmount,
+            accountDescriptor: usdDebitorAccountDescriptor,
           })
-          .creditLnd(btcAmount)
+          .creditLnd()
 
+        expectJournalToBeBalanced(result)
         expectEntryToEqual(
           result.credits[lndLedgerAccountId],
           calc.sub(btcAmount, btcFee),
@@ -193,10 +268,13 @@ describe("EntryBuilder", () => {
           entry,
           metadata,
         })
-        const result = builder.withoutFee().debitLnd(btcAmount).creditAccount({
-          accountId: creditorAccountId,
-          amount: usdAmount,
-        })
+        const result = builder
+          .withTotalAmount(amount)
+          .withFee(ZERO_FEE)
+          .debitLnd()
+          .creditAccount(usdCreditorAccountDescriptor)
+
+        expectJournalToBeBalanced(result)
         expectEntryToEqual(result.debits[lndLedgerAccountId], btcAmount)
         expectEntryToEqual(result.credits[creditorAccountId], usdAmount)
         expectEntryToEqual(result.credits[staticAccountIds.dealerBtcAccountId], btcAmount)
@@ -212,15 +290,24 @@ describe("EntryBuilder", () => {
           entry,
           metadata,
         })
-        const result = builder.withoutFee().debitLnd(btcAmount).creditAccount({
-          accountId: creditorAccountId,
-          amount: usdAmount,
-        })
+        const result = builder
+          .withTotalAmount(amount)
+          .withFee(protocolFee)
+          .debitLnd()
+          .creditAccount(usdCreditorAccountDescriptor)
+
+        expectJournalToBeBalanced(result)
         expectEntryToEqual(result.debits[lndLedgerAccountId], btcAmount)
-        expectEntryToEqual(result.credits[creditorAccountId], usdAmount)
-        expectEntryToEqual(result.credits[staticAccountIds.dealerBtcAccountId], btcAmount)
+        expectEntryToEqual(result.credits[creditorAccountId], calc.sub(usdAmount, usdFee))
+        expectEntryToEqual(
+          result.credits[staticAccountIds.dealerBtcAccountId],
+          calc.sub(btcAmount, btcFee),
+        )
         expect(result.debits[staticAccountIds.dealerBtcAccountId]).toBeUndefined()
-        expectEntryToEqual(result.debits[staticAccountIds.dealerUsdAccountId], usdAmount)
+        expectEntryToEqual(
+          result.debits[staticAccountIds.dealerUsdAccountId],
+          calc.sub(usdAmount, usdFee),
+        )
         expect(result.credits[staticAccountIds.dealerUsdAccountId]).toBeUndefined()
       })
     })
@@ -236,14 +323,12 @@ describe("EntryBuilder", () => {
           metadata,
         })
         const result = builder
-          .withoutFee()
+          .withTotalAmount(amount)
+          .withFee(ZERO_FEE)
           .debitAccount({
-            accountId: debitorAccountId,
-            amount: btcAmount,
+            accountDescriptor: btcDebitorAccountDescriptor,
           })
-          .creditAccount({
-            accountId: creditorAccountId,
-          })
+          .creditAccount(btcCreditorAccountDescriptor)
 
         expectEntryToEqual(result.credits[creditorAccountId], btcAmount)
         expectEntryToEqual(result.debits[debitorAccountId], btcAmount)
@@ -257,16 +342,14 @@ describe("EntryBuilder", () => {
           metadata,
         })
         const result = builder
-          .withoutFee()
+          .withTotalAmount(amount)
+          .withFee(ZERO_FEE)
           .debitAccount({
-            accountId: debitorAccountId,
-            amount: btcAmount,
+            accountDescriptor: btcDebitorAccountDescriptor,
           })
-          .creditAccount({
-            accountId: creditorAccountId,
-            amount: usdAmount,
-          })
-
+          .creditAccount(usdCreditorAccountDescriptor)
+        console.log("Btc to usd")
+        expectJournalToBeBalanced(result)
         expectEntryToEqual(result.credits[creditorAccountId], usdAmount)
         expectEntryToEqual(result.debits[debitorAccountId], btcAmount)
         expectEntryToEqual(result.credits[staticAccountIds.dealerBtcAccountId], btcAmount)
@@ -284,16 +367,13 @@ describe("EntryBuilder", () => {
           metadata,
         })
         const result = builder
-          .withoutFee()
+          .withTotalAmount(amount)
+          .withFee(ZERO_FEE)
           .debitAccount({
-            accountId: debitorAccountId,
-            amount: usdAmount,
+            accountDescriptor: usdDebitorAccountDescriptor,
           })
-          .creditAccount({
-            accountId: creditorAccountId,
-            amount: btcAmount,
-          })
-
+          .creditAccount(btcCreditorAccountDescriptor)
+        expectJournalToBeBalanced(result)
         expectEntryToEqual(result.credits[creditorAccountId], btcAmount)
         expectEntryToEqual(result.debits[debitorAccountId], usdAmount)
         expectEntryToEqual(result.debits[staticAccountIds.dealerBtcAccountId], btcAmount)
@@ -310,15 +390,13 @@ describe("EntryBuilder", () => {
           metadata,
         })
         const result = builder
-          .withoutFee()
+          .withTotalAmount(amount)
+          .withFee(ZERO_FEE)
           .debitAccount({
-            accountId: debitorAccountId,
-            amount: usdAmount,
+            accountDescriptor: usdDebitorAccountDescriptor,
           })
-          .creditAccount({
-            accountId: creditorAccountId,
-          })
-
+          .creditAccount(usdCreditorAccountDescriptor)
+        expectJournalToBeBalanced(result)
         expectEntryToEqual(result.credits[creditorAccountId], usdAmount)
         expectEntryToEqual(result.debits[debitorAccountId], usdAmount)
       })
@@ -334,17 +412,17 @@ describe("EntryBuilder", () => {
         metadata,
       })
       const result = builder
-        .withFee(btcFee)
+        .withTotalAmount(amount)
+        .withFee(ZERO_FEE)
         .debitAccount({
-          accountId: debitorAccountId,
-          amount: btcAmount,
+          accountDescriptor: btcDebitorAccountDescriptor,
           additionalMetadata: {
             more: "yes",
             muchMore: "muchMore",
           },
         })
         .creditLnd()
-
+      expectJournalToBeBalanced(result)
       expect(result.debits[debitorAccountId].metadata).toEqual(
         expect.objectContaining({
           some: "some",

--- a/test/unit/services/ledger/domain/entry-builder.spec.ts
+++ b/test/unit/services/ledger/domain/entry-builder.spec.ts
@@ -3,8 +3,8 @@ import { lndLedgerAccountId, EntryBuilder } from "@services/ledger/domain"
 import { WalletCurrency, AmountCalculator, ZERO_FEE } from "@domain/shared"
 
 class TestMediciEntry {
-  credits: any
-  debits: any
+  credits: any  // eslint-disable-line
+  debits: any // eslint-disable-line
 
   credit(accountPath, amount, metadata = null) {
     this.credits = this.credits || {}
@@ -31,11 +31,13 @@ describe("EntryBuilder", () => {
     let usdDebits = 0
     let btcDebits = 0
 
+    // eslint-disable-next-line
     Object.values<any>(journal.debits).forEach((entry) =>
       entry.metadata.currency === WalletCurrency.Usd
         ? (usdDebits += entry.amount)
         : (btcDebits += entry.amount),
     )
+    // eslint-disable-next-line
     Object.values<any>(journal.credits).forEach((entry) =>
       entry.metadata.currency === WalletCurrency.Usd
         ? (usdCredits += entry.amount)
@@ -44,8 +46,6 @@ describe("EntryBuilder", () => {
 
     expect(usdCredits).toEqual(usdDebits)
     expect(btcCredits).toEqual(btcDebits)
-    console.log(usdCredits)
-    console.log(btcCredits)
   }
 
   const calc = AmountCalculator()
@@ -339,7 +339,7 @@ describe("EntryBuilder", () => {
             accountDescriptor: btcDebitorAccountDescriptor,
           })
           .creditAccount(usdCreditorAccountDescriptor)
-        console.log("Btc to usd")
+
         expectJournalToBeBalanced(result)
         expectEntryToEqual(result.credits[creditorAccountId], usdAmount)
         expectEntryToEqual(result.debits[debitorAccountId], btcAmount)

--- a/test/unit/services/ledger/domain/legacy-entry-builder.spec.ts
+++ b/test/unit/services/ledger/domain/legacy-entry-builder.spec.ts
@@ -1,6 +1,5 @@
-import { lndLedgerAccountId, EntryBuilder } from "@services/ledger/domain"
-
-import { WalletCurrency, AmountCalculator, ZERO_FEE } from "@domain/shared"
+import { LegacyEntryBuilder, lndLedgerAccountId } from "@services/ledger/domain"
+import { WalletCurrency, AmountCalculator } from "@domain/shared"
 
 class TestMediciEntry {
   credits: any
@@ -19,35 +18,11 @@ class TestMediciEntry {
   }
 }
 
-describe("EntryBuilder", () => {
+describe("LegacyEntryBuilder", () => {
   const expectEntryToEqual = (entry, amount) => {
     expect(entry.amount).toEqual(Number(amount.amount))
     expect(entry.metadata.currency).toEqual(amount.currency)
   }
-
-  const expectJournalToBeBalanced = (journal) => {
-    let usdCredits = 0
-    let btcCredits = 0
-    let usdDebits = 0
-    let btcDebits = 0
-
-    Object.values<any>(journal.debits).forEach((entry) =>
-      entry.metadata.currency === WalletCurrency.Usd
-        ? (usdDebits += entry.amount)
-        : (btcDebits += entry.amount),
-    )
-    Object.values<any>(journal.credits).forEach((entry) =>
-      entry.metadata.currency === WalletCurrency.Usd
-        ? (usdCredits += entry.amount)
-        : (btcCredits += entry.amount),
-    )
-
-    expect(usdCredits).toEqual(usdDebits)
-    expect(btcCredits).toEqual(btcDebits)
-    console.log(usdCredits)
-    console.log(btcCredits)
-  }
-
   const calc = AmountCalculator()
   const staticAccountIds = {
     bankOwnerAccountId: "bankOwnerAccountId" as LedgerAccountId,
@@ -55,28 +30,7 @@ describe("EntryBuilder", () => {
     dealerUsdAccountId: "dealerUsdAccountId" as LedgerAccountId,
   }
   const debitorAccountId = "debitorAccountId" as LedgerAccountId
-  const btcDebitorAccountDescriptor = {
-    id: debitorAccountId,
-    currency: WalletCurrency.Btc,
-  } as LedgerAccountDescriptor<"BTC">
-
-  const usdDebitorAccountDescriptor = {
-    id: debitorAccountId,
-    currency: WalletCurrency.Usd,
-  } as LedgerAccountDescriptor<"USD">
-
   const creditorAccountId = "creditorAccountId" as LedgerAccountId
-
-  const btcCreditorAccountDescriptor = {
-    id: creditorAccountId,
-    currency: WalletCurrency.Btc,
-  } as LedgerAccountDescriptor<"BTC">
-
-  const usdCreditorAccountDescriptor = {
-    id: creditorAccountId,
-    currency: WalletCurrency.Usd,
-  } as LedgerAccountDescriptor<"USD">
-
   const btcAmount = {
     currency: WalletCurrency.Btc,
     amount: 2000n,
@@ -85,25 +39,10 @@ describe("EntryBuilder", () => {
     currency: WalletCurrency.Usd,
     amount: 20n,
   }
-
-  const amount = {
-    btcWithFee: btcAmount,
-    usdWithFee: usdAmount,
-  }
   const btcFee = {
     currency: WalletCurrency.Btc,
-    amount: 110n,
+    amount: 111n,
   }
-  const usdFee = {
-    currency: WalletCurrency.Usd,
-    amount: 1n,
-  }
-
-  const protocolFee = {
-    usdProtocolFee: usdFee,
-    btcProtocolFee: btcFee,
-  }
-
   const metadata = {
     currency: "BAD CURRENCY",
     some: "some",
@@ -114,18 +53,19 @@ describe("EntryBuilder", () => {
     describe("send", () => {
       it("without fee", () => {
         const entry = new TestMediciEntry()
-        const builder = EntryBuilder({
+        const builder = LegacyEntryBuilder({
           staticAccountIds,
           entry,
           metadata,
         })
         const result = builder
-          .withTotalAmount(amount)
-          .withFee(ZERO_FEE)
-          .debitAccount({ accountDescriptor: btcDebitorAccountDescriptor })
+          .withoutFee()
+          .debitAccount({
+            accountId: debitorAccountId,
+            amount: btcAmount,
+          })
           .creditLnd()
 
-        expectJournalToBeBalanced(result)
         expectEntryToEqual(result.credits[lndLedgerAccountId], btcAmount)
         expectEntryToEqual(result.debits[debitorAccountId], btcAmount)
         expect(result.debits[staticAccountIds.bankOwnerAccountId]).toBeUndefined()
@@ -133,18 +73,19 @@ describe("EntryBuilder", () => {
 
       it("with fee", () => {
         const entry = new TestMediciEntry()
-        const builder = EntryBuilder({
+        const builder = LegacyEntryBuilder({
           staticAccountIds,
           entry,
           metadata,
         })
         const result = builder
-          .withTotalAmount(amount)
-          .withFee(protocolFee)
-          .debitAccount({ accountDescriptor: btcDebitorAccountDescriptor })
+          .withFee(btcFee)
+          .debitAccount({
+            accountId: debitorAccountId,
+            amount: btcAmount,
+          })
           .creditLnd()
 
-        expectJournalToBeBalanced(result)
         expectEntryToEqual(result.credits[staticAccountIds.bankOwnerAccountId], btcFee)
         expectEntryToEqual(
           result.credits[lndLedgerAccountId],
@@ -157,36 +98,31 @@ describe("EntryBuilder", () => {
     describe("receive", () => {
       it("without fee", () => {
         const entry = new TestMediciEntry()
-        const builder = EntryBuilder({
+        const builder = LegacyEntryBuilder({
           staticAccountIds,
           entry,
           metadata,
         })
         const result = builder
-          .withTotalAmount(amount)
-          .withFee(ZERO_FEE)
-          .debitLnd()
-          .creditAccount(btcCreditorAccountDescriptor)
+          .withoutFee()
+          .debitLnd(btcAmount)
+          .creditAccount({ accountId: creditorAccountId })
 
-        expectJournalToBeBalanced(result)
         expectEntryToEqual(result.debits[lndLedgerAccountId], btcAmount)
         expectEntryToEqual(result.credits[creditorAccountId], btcAmount)
       })
 
       it("with fee", () => {
         const entry = new TestMediciEntry()
-        const builder = EntryBuilder({
+        const builder = LegacyEntryBuilder({
           staticAccountIds,
           entry,
           metadata,
         })
-        const result = builder
-          .withTotalAmount(amount)
-          .withFee(protocolFee)
-          .debitLnd()
-          .creditAccount(btcCreditorAccountDescriptor)
+        const result = builder.withFee(btcFee).debitLnd(btcAmount).creditAccount({
+          accountId: creditorAccountId,
+        })
 
-        expectJournalToBeBalanced(result)
         expect(result.credits[staticAccountIds.bankOwnerAccountId].amount).toEqual(
           Number(btcFee.amount),
         )
@@ -200,20 +136,19 @@ describe("EntryBuilder", () => {
     describe("send", () => {
       it("without fee", () => {
         const entry = new TestMediciEntry()
-        const builder = EntryBuilder({
+        const builder = LegacyEntryBuilder({
           staticAccountIds,
           entry,
           metadata,
         })
         const result = builder
-          .withTotalAmount(amount)
-          .withFee(ZERO_FEE)
+          .withoutFee()
           .debitAccount({
-            accountDescriptor: usdDebitorAccountDescriptor,
+            accountId: debitorAccountId,
+            amount: usdAmount,
           })
-          .creditLnd()
+          .creditLnd(btcAmount)
 
-        expectJournalToBeBalanced(result)
         expectEntryToEqual(result.credits[lndLedgerAccountId], btcAmount)
         expectEntryToEqual(result.debits[debitorAccountId], usdAmount)
         expectEntryToEqual(result.debits[staticAccountIds.dealerBtcAccountId], btcAmount)
@@ -224,20 +159,19 @@ describe("EntryBuilder", () => {
 
       it("with fee", () => {
         const entry = new TestMediciEntry()
-        const builder = EntryBuilder({
+        const builder = LegacyEntryBuilder({
           staticAccountIds,
           entry,
           metadata,
         })
         const result = builder
-          .withTotalAmount(amount)
-          .withFee(protocolFee)
+          .withFee(btcFee)
           .debitAccount({
-            accountDescriptor: usdDebitorAccountDescriptor,
+            accountId: debitorAccountId,
+            amount: usdAmount,
           })
-          .creditLnd()
+          .creditLnd(btcAmount)
 
-        expectJournalToBeBalanced(result)
         expectEntryToEqual(
           result.credits[lndLedgerAccountId],
           calc.sub(btcAmount, btcFee),
@@ -254,18 +188,15 @@ describe("EntryBuilder", () => {
     describe("receive", () => {
       it("without fee", () => {
         const entry = new TestMediciEntry()
-        const builder = EntryBuilder({
+        const builder = LegacyEntryBuilder({
           staticAccountIds,
           entry,
           metadata,
         })
-        const result = builder
-          .withTotalAmount(amount)
-          .withFee(ZERO_FEE)
-          .debitLnd()
-          .creditAccount(usdCreditorAccountDescriptor)
-
-        expectJournalToBeBalanced(result)
+        const result = builder.withoutFee().debitLnd(btcAmount).creditAccount({
+          accountId: creditorAccountId,
+          amount: usdAmount,
+        })
         expectEntryToEqual(result.debits[lndLedgerAccountId], btcAmount)
         expectEntryToEqual(result.credits[creditorAccountId], usdAmount)
         expectEntryToEqual(result.credits[staticAccountIds.dealerBtcAccountId], btcAmount)
@@ -276,29 +207,20 @@ describe("EntryBuilder", () => {
 
       it("with fee", () => {
         const entry = new TestMediciEntry()
-        const builder = EntryBuilder({
+        const builder = LegacyEntryBuilder({
           staticAccountIds,
           entry,
           metadata,
         })
-        const result = builder
-          .withTotalAmount(amount)
-          .withFee(protocolFee)
-          .debitLnd()
-          .creditAccount(usdCreditorAccountDescriptor)
-
-        expectJournalToBeBalanced(result)
+        const result = builder.withoutFee().debitLnd(btcAmount).creditAccount({
+          accountId: creditorAccountId,
+          amount: usdAmount,
+        })
         expectEntryToEqual(result.debits[lndLedgerAccountId], btcAmount)
-        expectEntryToEqual(result.credits[creditorAccountId], calc.sub(usdAmount, usdFee))
-        expectEntryToEqual(
-          result.credits[staticAccountIds.dealerBtcAccountId],
-          calc.sub(btcAmount, btcFee),
-        )
+        expectEntryToEqual(result.credits[creditorAccountId], usdAmount)
+        expectEntryToEqual(result.credits[staticAccountIds.dealerBtcAccountId], btcAmount)
         expect(result.debits[staticAccountIds.dealerBtcAccountId]).toBeUndefined()
-        expectEntryToEqual(
-          result.debits[staticAccountIds.dealerUsdAccountId],
-          calc.sub(usdAmount, usdFee),
-        )
+        expectEntryToEqual(result.debits[staticAccountIds.dealerUsdAccountId], usdAmount)
         expect(result.credits[staticAccountIds.dealerUsdAccountId]).toBeUndefined()
       })
     })
@@ -308,18 +230,20 @@ describe("EntryBuilder", () => {
     describe("from btc", () => {
       it("to btc", () => {
         const entry = new TestMediciEntry()
-        const builder = EntryBuilder({
+        const builder = LegacyEntryBuilder({
           staticAccountIds,
           entry,
           metadata,
         })
         const result = builder
-          .withTotalAmount(amount)
-          .withFee(ZERO_FEE)
+          .withoutFee()
           .debitAccount({
-            accountDescriptor: btcDebitorAccountDescriptor,
+            accountId: debitorAccountId,
+            amount: btcAmount,
           })
-          .creditAccount(btcCreditorAccountDescriptor)
+          .creditAccount({
+            accountId: creditorAccountId,
+          })
 
         expectEntryToEqual(result.credits[creditorAccountId], btcAmount)
         expectEntryToEqual(result.debits[debitorAccountId], btcAmount)
@@ -327,20 +251,22 @@ describe("EntryBuilder", () => {
 
       it("to usd", () => {
         const entry = new TestMediciEntry()
-        const builder = EntryBuilder({
+        const builder = LegacyEntryBuilder({
           staticAccountIds,
           entry,
           metadata,
         })
         const result = builder
-          .withTotalAmount(amount)
-          .withFee(ZERO_FEE)
+          .withoutFee()
           .debitAccount({
-            accountDescriptor: btcDebitorAccountDescriptor,
+            accountId: debitorAccountId,
+            amount: btcAmount,
           })
-          .creditAccount(usdCreditorAccountDescriptor)
-        console.log("Btc to usd")
-        expectJournalToBeBalanced(result)
+          .creditAccount({
+            accountId: creditorAccountId,
+            amount: usdAmount,
+          })
+
         expectEntryToEqual(result.credits[creditorAccountId], usdAmount)
         expectEntryToEqual(result.debits[debitorAccountId], btcAmount)
         expectEntryToEqual(result.credits[staticAccountIds.dealerBtcAccountId], btcAmount)
@@ -352,19 +278,22 @@ describe("EntryBuilder", () => {
     describe("from usd", () => {
       it("to btc", () => {
         const entry = new TestMediciEntry()
-        const builder = EntryBuilder({
+        const builder = LegacyEntryBuilder({
           staticAccountIds,
           entry,
           metadata,
         })
         const result = builder
-          .withTotalAmount(amount)
-          .withFee(ZERO_FEE)
+          .withoutFee()
           .debitAccount({
-            accountDescriptor: usdDebitorAccountDescriptor,
+            accountId: debitorAccountId,
+            amount: usdAmount,
           })
-          .creditAccount(btcCreditorAccountDescriptor)
-        expectJournalToBeBalanced(result)
+          .creditAccount({
+            accountId: creditorAccountId,
+            amount: btcAmount,
+          })
+
         expectEntryToEqual(result.credits[creditorAccountId], btcAmount)
         expectEntryToEqual(result.debits[debitorAccountId], usdAmount)
         expectEntryToEqual(result.debits[staticAccountIds.dealerBtcAccountId], btcAmount)
@@ -375,19 +304,21 @@ describe("EntryBuilder", () => {
 
       it("to usd", () => {
         const entry = new TestMediciEntry()
-        const builder = EntryBuilder({
+        const builder = LegacyEntryBuilder({
           staticAccountIds,
           entry,
           metadata,
         })
         const result = builder
-          .withTotalAmount(amount)
-          .withFee(ZERO_FEE)
+          .withoutFee()
           .debitAccount({
-            accountDescriptor: usdDebitorAccountDescriptor,
+            accountId: debitorAccountId,
+            amount: usdAmount,
           })
-          .creditAccount(usdCreditorAccountDescriptor)
-        expectJournalToBeBalanced(result)
+          .creditAccount({
+            accountId: creditorAccountId,
+          })
+
         expectEntryToEqual(result.credits[creditorAccountId], usdAmount)
         expectEntryToEqual(result.debits[debitorAccountId], usdAmount)
       })
@@ -397,23 +328,23 @@ describe("EntryBuilder", () => {
   describe("metadata", () => {
     it("debitor can take additional metadata", () => {
       const entry = new TestMediciEntry()
-      const builder = EntryBuilder({
+      const builder = LegacyEntryBuilder({
         staticAccountIds,
         entry,
         metadata,
       })
       const result = builder
-        .withTotalAmount(amount)
-        .withFee(ZERO_FEE)
+        .withFee(btcFee)
         .debitAccount({
-          accountDescriptor: btcDebitorAccountDescriptor,
+          accountId: debitorAccountId,
+          amount: btcAmount,
           additionalMetadata: {
             more: "yes",
             muchMore: "muchMore",
           },
         })
         .creditLnd()
-      expectJournalToBeBalanced(result)
+
       expect(result.debits[debitorAccountId].metadata).toEqual(
         expect.objectContaining({
           some: "some",

--- a/test/unit/services/ledger/domain/legacy-entry-builder.spec.ts
+++ b/test/unit/services/ledger/domain/legacy-entry-builder.spec.ts
@@ -2,8 +2,8 @@ import { LegacyEntryBuilder, lndLedgerAccountId } from "@services/ledger/domain"
 import { WalletCurrency, AmountCalculator } from "@domain/shared"
 
 class TestMediciEntry {
-  credits: any
-  debits: any
+  credits: any // eslint-disable-line
+  debits: any // eslint-disable-line
 
   credit(accountPath, amount, metadata = null) {
     this.credits = this.credits || {}

--- a/test/unit/services/ledger/domain/tx-metadata.spec.ts
+++ b/test/unit/services/ledger/domain/tx-metadata.spec.ts
@@ -1,0 +1,67 @@
+import { LedgerTransactionType } from "@domain/ledger"
+import {
+  LnIntraledgerLedgerMetadata,
+  OnChainIntraledgerLedgerMetadata,
+  WalletIdIntraledgerLedgerMetadata,
+} from "@services/ledger/tx-metadata"
+
+describe("Tx metadata", () => {
+  const senderUsername = "sender" as Username
+  const recipientUsername = "receiver" as Username
+  const memoOfPayer = "sample payer memo"
+  const pubkey = "pubkey" as Pubkey
+  const payeeAddresses: OnChainAddress[] = ["Address" as OnChainAddress]
+  const paymentHash = "paymenthash" as PaymentHash
+  const amountDisplayCurrency = 10 as DisplayCurrencyBaseAmount
+
+  describe("intraledger", () => {
+    it("onchain", () => {
+      const { metadata, debitAccountAdditionalMetadata } =
+        OnChainIntraledgerLedgerMetadata({
+          amountDisplayCurrency,
+          payeeAddresses,
+          sendAll: true,
+          memoOfPayer,
+          senderUsername,
+          recipientUsername,
+        })
+
+      expect(metadata.username).toEqual(senderUsername)
+      expect(debitAccountAdditionalMetadata.username).toEqual(recipientUsername)
+      expect(metadata.memoPayer).toBeUndefined()
+      expect(debitAccountAdditionalMetadata.memoPayer).toEqual(memoOfPayer)
+      expect(metadata.type).toEqual(LedgerTransactionType.OnchainIntraLedger)
+    })
+
+    it("ln", () => {
+      const { metadata, debitAccountAdditionalMetadata } = LnIntraledgerLedgerMetadata({
+        amountDisplayCurrency,
+        memoOfPayer,
+        senderUsername,
+        recipientUsername,
+        pubkey,
+        paymentHash,
+      })
+
+      expect(metadata.username).toEqual(senderUsername)
+      expect(debitAccountAdditionalMetadata.username).toEqual(recipientUsername)
+      expect(metadata.memoPayer).toBeUndefined()
+      expect(debitAccountAdditionalMetadata.memoPayer).toEqual(memoOfPayer)
+      expect(metadata.type).toEqual(LedgerTransactionType.LnIntraLedger)
+    })
+
+    it("wallet id", () => {
+      const { metadata, debitAccountAdditionalMetadata } =
+        WalletIdIntraledgerLedgerMetadata({
+          amountDisplayCurrency,
+          memoOfPayer,
+          senderUsername,
+          recipientUsername,
+        })
+
+      expect(metadata.username).toEqual(senderUsername)
+      expect(debitAccountAdditionalMetadata.username).toEqual(recipientUsername)
+      expect(metadata.memoPayer).toEqual(memoOfPayer)
+    })
+  })
+})

--- a/test/unit/services/ledger/domain/tx-metadata.spec.ts
+++ b/test/unit/services/ledger/domain/tx-metadata.spec.ts
@@ -26,11 +26,19 @@ describe("Tx metadata", () => {
           recipientUsername,
         })
 
-      expect(metadata.username).toEqual(senderUsername)
-      expect(debitAccountAdditionalMetadata.username).toEqual(recipientUsername)
-      expect(metadata.memoPayer).toBeUndefined()
-      expect(debitAccountAdditionalMetadata.memoPayer).toEqual(memoOfPayer)
-      expect(metadata.type).toEqual(LedgerTransactionType.OnchainIntraLedger)
+      expect(metadata).toEqual(
+        expect.objectContaining({
+          username: senderUsername,
+          memoPayer: undefined,
+          type: LedgerTransactionType.OnchainIntraLedger,
+        }),
+      )
+      expect(debitAccountAdditionalMetadata).toEqual(
+        expect.objectContaining({
+          username: recipientUsername,
+          memoPayer: memoOfPayer,
+        }),
+      )
     })
 
     it("ln", () => {
@@ -43,11 +51,19 @@ describe("Tx metadata", () => {
         paymentHash,
       })
 
-      expect(metadata.username).toEqual(senderUsername)
-      expect(debitAccountAdditionalMetadata.username).toEqual(recipientUsername)
-      expect(metadata.memoPayer).toBeUndefined()
-      expect(debitAccountAdditionalMetadata.memoPayer).toEqual(memoOfPayer)
-      expect(metadata.type).toEqual(LedgerTransactionType.LnIntraLedger)
+      expect(metadata).toEqual(
+        expect.objectContaining({
+          username: senderUsername,
+          memoPayer: undefined,
+          type: LedgerTransactionType.LnIntraLedger,
+        }),
+      )
+      expect(debitAccountAdditionalMetadata).toEqual(
+        expect.objectContaining({
+          username: recipientUsername,
+          memoPayer: memoOfPayer,
+        }),
+      )
     })
 
     it("wallet id", () => {
@@ -59,9 +75,18 @@ describe("Tx metadata", () => {
           recipientUsername,
         })
 
-      expect(metadata.username).toEqual(senderUsername)
-      expect(debitAccountAdditionalMetadata.username).toEqual(recipientUsername)
-      expect(metadata.memoPayer).toEqual(memoOfPayer)
+      expect(metadata).toEqual(
+        expect.objectContaining({
+          username: senderUsername,
+          memoPayer: memoOfPayer,
+          type: LedgerTransactionType.IntraLedger,
+        }),
+      )
+      expect(debitAccountAdditionalMetadata).toEqual(
+        expect.objectContaining({
+          username: recipientUsername,
+        }),
+      )
     })
   })
 })


### PR DESCRIPTION
Continues the work of PR #1170:
- add ledger facade
- rewrite ledger entry-builder to work with expected PaymentFlow updates