### PR TITLE
fix: remove noisy events

### DIFF
--- a/src/services/ledger/volume.ts
+++ b/src/services/ledger/volume.ts
@@ -1,6 +1,6 @@
 import { LedgerTransactionType, toLiabilitiesWalletId } from "@domain/ledger"
 import { LedgerServiceError, UnknownLedgerError } from "@domain/ledger/errors"
-import { addAttributesToCurrentSpan, addEventToCurrentSpan } from "@services/tracing"
+import { addAttributesToCurrentSpan } from "@services/tracing"
 
 import { Transaction } from "./books"
 
@@ -55,7 +55,6 @@ const txVolumeSince = async ({
   }))
 
   try {
-    addEventToCurrentSpan("volume aggregation starts")
     const [result]: (TxBaseVolume & { _id: null })[] = await Transaction.aggregate([
       {
         $match: {
@@ -72,7 +71,6 @@ const txVolumeSince = async ({
         },
       },
     ])
-    addEventToCurrentSpan("volume aggregation ends")
 
     const outgoingBaseAmount = result?.outgoingBaseAmount ?? (0 as CurrencyBaseAmount)
     const incomingBaseAmount = result?.incomingBaseAmount ?? (0 as CurrencyBaseAmount)


### PR DESCRIPTION
These events make a lot of noise in the trace (eg https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/g6MxroZzscW/trace/Bm73uNu3nD1?span=b7b20f1ed4cce353) which makes it harder to visually identify the parts of the trace containing errors.
Also they don't add information as the query span (`monbodb.command`) already tells us how long the aggregation takes.