### PR TITLE
fix: duplicate key is not a critical error

### DIFF
--- a/src/services/mongoose/users.ts
+++ b/src/services/mongoose/users.ts
@@ -5,6 +5,7 @@ import {
   CouldNotFindUserFromKratosIdError,
   CouldNotFindUserFromPhoneError,
   RepositoryError,
+  DuplicateError,
   UnknownRepositoryError,
 } from "@domain/errors"
 import { User } from "@services/mongoose/schema"
@@ -70,6 +71,9 @@ export const UsersRepository = (): IUsersRepository => {
       await user.save()
       return userFromRaw(user)
     } catch (err) {
+      if (err.message.contains("MongoError: E11000 duplicate key error collection")) {
+        return new DuplicateError(phone)
+      }
       return new UnknownRepositoryError(err)
     }
   }


### PR DESCRIPTION
We have had a few alerts because mongoDB has returned a duplicate key error on login. This is expected behaviour and shouldn't be treated as a critical error.