### PR TITLE
ci: run audit step

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,14 @@
+name: "Audit"
+on:
+  pull_request:
+    branches: [ main ]
+jobs:
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+    - run: yarn install
+    - name: Run audit
+      run: yarn audit --level critical

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -11,4 +11,4 @@ jobs:
     - uses: actions/setup-node@v2
     - run: yarn install
     - name: Run audit
-      run: yarn audit --level critical
+      run: make audit

--- a/Makefile
+++ b/Makefile
@@ -94,3 +94,7 @@ check-code:
 create-tmp-env-ci:
 	. ./.envrc && \
 	envsubst < .env.ci > tmp.env.ci
+
+# 16 is exit code for critical https://classic.yarnpkg.com/lang/en/docs/cli/audit
+audit:
+	bash -c 'yarn audit --level critical; [[ $$? -ge 16 ]] && exit 1 || exit 0'

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -321,7 +321,6 @@ jobs:
       trigger: true
       passed:
       - check-code
-      - audit
       - test-unit
       - test-integration
       - test-e2e

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -53,6 +53,7 @@ groups:
   - test-e2e
   - test-unit
   - check-code
+  - audit
   - build-edge-image
   - build-debug-edge-image
   - build-migrate-edge-image
@@ -206,6 +207,23 @@ jobs:
         path: pipeline-tasks/ci/tasks/check-code.sh
   on_failure: #@ slack_failure_notification()
 
+- name: audit
+  serial: true
+  plan:
+  - in_parallel:
+    - { get: repo, trigger: true }
+    - { get: pipeline-tasks }
+  - task: audit
+    config:
+      platform: linux
+      image_resource: #@ task_image_config()
+      inputs:
+      - name: pipeline-tasks
+      - name: repo
+      run:
+        path: pipeline-tasks/ci/tasks/audit.sh
+  on_failure: #@ slack_failure_notification()
+
 - name: build-edge-image
   serial: true
   plan:
@@ -303,6 +321,7 @@ jobs:
       trigger: true
       passed:
       - check-code
+      - audit
       - test-unit
       - test-integration
       - test-e2e

--- a/ci/tasks/audit.sh
+++ b/ci/tasks/audit.sh
@@ -4,4 +4,4 @@ set -eu
 
 pushd repo
 
-yarn audit --level critical
+make audit

--- a/ci/tasks/audit.sh
+++ b/ci/tasks/audit.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eu
+
+pushd repo
+
+yarn audit --level critical


### PR DESCRIPTION
FYI, this will block the pipeline now because there are already 5 critical severity vulnerabilities which should be fixed asap:
https://ci.galoy.io/teams/dev/pipelines/galoy-app/jobs/audit/builds/2#L62309a8a:5