### PR TITLE
fix: ensure recipients of intraledger payments receive notifications via gql subscription

### DIFF
--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -226,7 +226,7 @@ export const NotificationsService = (logger: Logger): INotificationsService => {
         walletId: WalletId
         type: NotificationType
       }) => {
-        const wallet = await WalletsRepository().findById(senderWalletId)
+        const wallet = await WalletsRepository().findById(walletId)
         if (wallet instanceof Error) return wallet
 
         const account = await AccountsRepository().findById(wallet.accountId)


### PR DESCRIPTION
Prior to this commit, a bug in `notificationsService.intraLedgerPaid` resulted in the
`NotificationType.IntraLedgerPayment` being published to the sender twice. Now the
notification is published to the sender, and then the recipeint, correcting this
unintended behavior.

Resolves #934 and #1220.