### PR TITLE
fix: payment ledger duplication

### DIFF
--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -60,6 +60,7 @@ export class InvalidEmailAddress extends ValidationError {}
 export class InvalidWalletId extends ValidationError {}
 export class InvalidLedgerTransactionId extends ValidationError {}
 export class AlreadyPaidError extends ValidationError {}
+export class LnPaymentAlreadyRecordedError extends ValidationError {}
 export class SelfPaymentError extends ValidationError {}
 export class LessThanDustThresholdError extends ValidationError {}
 export class InsufficientBalanceError extends ValidationError {}

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -51,6 +51,10 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       message = "Invoice is already paid"
       return new LightningPaymentError({ message, logger: baseLogger })
 
+    case "LnPaymentAlreadyRecordedError":
+      message = "Invoice is already processed"
+      return new LightningPaymentError({ message, logger: baseLogger })
+
     case "CouldNotFindWalletInvoiceError":
       message = `User tried to pay invoice with hash ${error.message}, but it does not exist`
       return new LightningPaymentError({ message, logger: baseLogger })

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -12,6 +12,7 @@ import {
 import {
   InsufficientBalanceError as DomainInsufficientBalanceError,
   LimitsExceededError,
+  LnPaymentAlreadyRecordedError,
   SelfPaymentError as DomainSelfPaymentError,
 } from "@domain/errors"
 import { ValidationError } from "@domain/shared"
@@ -721,8 +722,7 @@ describe("UserWallet - Lightning Pay", () => {
         const result = await fn({ account: accountB, walletId: walletIdB })({
           invoice: request,
         })
-        if (result instanceof Error) throw result
-        expect(result).toBe(PaymentSendStatus.AlreadyPaid)
+        expect(result).toBeInstanceOf(LnPaymentAlreadyRecordedError)
 
         const finalBalanceSats = await getBalanceHelper(walletIdB)
         expect(finalBalanceSats).toEqual(intermediateBalanceSats)


### PR DESCRIPTION
Fix issue reported here https://galoymoney-workspace.slack.com/archives/C025NSXHME3/p1649730208489969

Currently we register a duplicated payment in the ledger and then void the transaction.

This update validates if tx is recorded after wallet lock to avoid the double record in the ledger