### PR TITLE
fix: return a valid error for empty paymentRequest

### DIFF
--- a/src/graphql/root/subscription/ln-invoice-payment-status.ts
+++ b/src/graphql/root/subscription/ln-invoice-payment-status.ts
@@ -32,10 +32,7 @@ const LnInvoicePaymentStatusSubscription = {
 
   subscribe: async (_, args) => {
     const { paymentRequest } = args.input
-
-    if (paymentRequest instanceof Error) {
-      return { errors: [{ message: paymentRequest.message }] }
-    }
+    if (paymentRequest instanceof Error) throw paymentRequest
 
     const paymentStatusChecker = await Lightning.PaymentStatusChecker({ paymentRequest })
 


### PR DESCRIPTION
Testing https://github.com/GaloyMoney/galoy/pull/1246 in staging found that we were getting an error without correct parsing
```
{
  "error": {
    "message": "Subscription field must return Async Iterable. Received: { errors: [[Object]] }."
  }
}
```

this change returns the proper error

```
{
  "errors": [
    {
      "message": "Invalid value for LnPaymentRequest",
      "locations": [{ "line": 2, "column": 3 }],
      "path": ["lnInvoicePaymentStatus"],
      "extensions": { "code": "INVALID_INPUT" }
    }
  ]
}
```

please notice that error handled in line 40 is different because this is an input validation error (should be handled in the same way than queries)