### PR TITLE
chore: migrate new amount-related properties to old entries

### DIFF
--- a/src/migrations/20220427130214-add-sats-amount-prop-to-payments.ts
+++ b/src/migrations/20220427130214-add-sats-amount-prop-to-payments.ts
@@ -1,0 +1,68 @@
+module.exports = {
+  async up(db) {
+    const collection = db.collection("medici_transactions")
+    try {
+      const resultDebits = await collection.update(
+        { type: "payment", debit: { $gt: 0 } },
+        [{ $set: { satsAmount: { $subtract: ["$debit", "$fee"] } } }],
+        { multi: true },
+      )
+      console.log(
+        { result: resultDebits },
+        "added 'satsAmount' prop to debit medici_transactions",
+      )
+    } catch (error) {
+      console.log(
+        { result: error },
+        "Couldn't add 'satsAmount' prop to debit medici_transactions",
+      )
+    }
+
+    try {
+      const allTxns = await collection.aggregate([
+        {
+          $match: {
+            satsAmount: { $exists: true },
+          },
+        },
+        {
+          $group: {
+            _id: "$hash",
+            satsAmount: { $first: "$satsAmount" },
+          },
+        },
+      ])
+      for await (const { _id: hash, satsAmount } of allTxns) {
+        if (!hash) continue
+        const resultRest = await collection.update({ hash }, [{ $set: { satsAmount } }], {
+          multi: true,
+        })
+        const {
+          result: { n, nModified },
+        } = resultRest
+        console.log(
+          `added 'satsAmount' prop to ${nModified} of ${n}  transactions for hash: ${hash}`,
+        )
+      }
+    } catch (error) {
+      console.log(
+        { result: error },
+        "Couldn't add 'satsAmount' prop to rest of medici_transactions",
+      )
+    }
+  },
+
+  async down(db) {
+    try {
+      const result = await db
+        .collection("medici_transactions")
+        .update({}, { $unset: { satsAmount: "" } }, { multi: true })
+      console.log({ result }, "removed 'satsAmount' prop from medici_transactions")
+    } catch (error) {
+      console.log(
+        { result: error },
+        "Couldn't remove 'satsAmount' prop from medici_transactions",
+      )
+    }
+  },
+}

--- a/src/migrations/20220427130214-add-sats-amount-prop-to-payments.ts
+++ b/src/migrations/20220427130214-add-sats-amount-prop-to-payments.ts
@@ -1,3 +1,6 @@
+/* eslint @typescript-eslint/no-var-requires: "off" */
+const { getDisplayCurrencyConfig } = require("../../lib/config/yaml")
+
 module.exports = {
   async up(db) {
     const collection = db.collection("medici_transactions")
@@ -51,7 +54,7 @@ module.exports = {
                 centsFee,
                 displayAmount: centsAmount,
                 displayFee: centsFee,
-                displayCurrency: "USD",
+                displayCurrency: getDisplayCurrencyConfig()?.code || "USD",
               },
             },
           ],


### PR DESCRIPTION
**_Note:_** _Converted to draft until #1281 is merged_

## Description: Migration-only (code-change in #1281)

This PR migrates new amount-related properties to past Lightning send payments records.

### To test migration locally
- `git checkout` to `main` branch and run `TEST="01|02-a|02-r|02-s.*l" make reset-integration` to initialize pre-migrated database

- `git checkout` to this branch and edit `Ln 3` in `src/migrations/migrate-mongo-config.js`:
   ```ts
   const address = process.env.MONGODB_ADDRESS ?? "localhost:27017"
   ```

- check mongo pre-migration to make sure `satsAmount` property does not exist in `medici_transactions` collection

- run `node_modules/.bin/migrate-mongo up -f src/migrations/migrate-mongo-config.js`

- check mongo post-migration with `{$or: [{type: "payment"}, {type: "fee_reimbursement"}]}` query to make sure all records returned have a value set for `satsAmount`

## Open `TODO`s
- [x] ~Figure out how to import display currency from default.yaml into migration script (double-check how this actually gets executed in environments and what modules are available to import from) https://github.com/GaloyMoney/galoy/pull/1269#discussion_r861157959~ **Done: https://github.com/GaloyMoney/galoy/pull/1269/commits/7ca4849bfc2943903f0b33292a6707915cac9901**

- [x] ~`BigInt` <-> `Number` question https://github.com/GaloyMoney/galoy/pull/1269#discussion_r861147720~
