### PR TITLE
fix: update decode invoice to use safe tokens

### DIFF
--- a/src/domain/bitcoin/lightning/ln-invoice.ts
+++ b/src/domain/bitcoin/lightning/ln-invoice.ts
@@ -23,8 +23,8 @@ export const decodeInvoice = (
     return new LnInvoiceMissingPaymentSecretError()
   }
   const paymentSecret: PaymentIdentifyingSecret = decodedInvoice.payment
-  const amount: Satoshis | null = decodedInvoice.tokens
-    ? toSats(decodedInvoice.tokens)
+  const amount: Satoshis | null = decodedInvoice.safe_tokens
+    ? toSats(decodedInvoice.safe_tokens)
     : null
   const cltvDelta: number | null = decodedInvoice.cltv_delta
     ? decodedInvoice.cltv_delta
@@ -56,7 +56,7 @@ export const decodeInvoice = (
     description: decodedInvoice.description || "",
     paymentHash: decodedInvoice.id as PaymentHash,
     destination: decodedInvoice.destination as Pubkey,
-    milliSatsAmount: toMilliSatsFromNumber(decodedInvoice.mtokens || 0),
+    milliSatsAmount: toMilliSatsFromNumber(amount ? amount * 1000 : 0),
     features: (decodedInvoice.features || []) as LnInvoiceFeature[],
   }
 }

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -704,6 +704,22 @@ describe("UserWallet - Lightning Pay", () => {
         expect(finalBalance).toBe(initBalanceB - amountInvoice)
       })
 
+      it("pay msats invoice", async () => {
+        const milliSatsAmount = amountInvoice * 1000 + 1
+        const { request } = await createInvoice({
+          lnd: lndOutside1,
+          mtokens: milliSatsAmount + "",
+        })
+        const result = await fn({ account: accountB, walletId: walletIdB })({
+          invoice: request,
+        })
+        if (result instanceof Error) throw result
+        expect(result).toBe(PaymentSendStatus.Success)
+
+        const finalBalance = await getBalanceHelper(walletIdB)
+        expect(finalBalance).toBe(initBalanceB - Math.ceil(milliSatsAmount / 1000))
+      })
+
       it("fails when repaying invoice", async () => {
         const { request } = await createInvoice({
           lnd: lndOutside1,


### PR DESCRIPTION
Fix issue with msats invoices (probe and payment) updating decode invoice to use safe tokens

https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/sooTn7xzKfk/trace/tTvXGtnMP39?span=8418714adec94963