### PR TITLE
refactor: rename getDisplayCurrency to getDisplayCurrencyConfig

### DIFF
--- a/src/config/yaml.ts
+++ b/src/config/yaml.ts
@@ -81,7 +81,7 @@ i18n.configure({
 
 export const getI18nInstance = (): I18n => i18n
 
-export const getDisplayCurrency = (): DisplayCurrencyConfigSchema => ({
+export const getDisplayCurrencyConfig = (): DisplayCurrencyConfigSchema => ({
   code: yamlConfig.displayCurrency.code,
   symbol: yamlConfig.displayCurrency.symbol,
 })

--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -2,7 +2,7 @@ import {
   getLocale,
   SAT_USDCENT_PRICE,
   USER_PRICE_UPDATE_EVENT,
-  getDisplayCurrency,
+  getDisplayCurrencyConfig,
   getI18nInstance,
 } from "@config"
 import { toSats } from "@domain/bitcoin"
@@ -26,7 +26,7 @@ import { transactionBitcoinNotification, transactionUsdNotification } from "./pa
 
 const i18n = getI18nInstance()
 const defaultLocale = getLocale()
-const { symbol: fiatSymbol } = getDisplayCurrency()
+const { symbol: fiatSymbol } = getDisplayCurrencyConfig()
 
 export const NotificationsService = (logger: Logger): INotificationsService => {
   const sendOnChainNotification = async ({

--- a/src/services/notifications/payment.ts
+++ b/src/services/notifications/payment.ts
@@ -1,10 +1,10 @@
-import { getDisplayCurrency, getI18nInstance, getLocale } from "@config"
+import { getDisplayCurrencyConfig, getI18nInstance, getLocale } from "@config"
 
 import { sendNotification } from "./notification"
 
 const i18n = getI18nInstance()
 const defaultLocale = getLocale()
-const { symbol: fiatSymbol } = getDisplayCurrency()
+const { symbol: fiatSymbol } = getDisplayCurrencyConfig()
 
 export const getTitleBitcoin = ({
   type,

--- a/test/e2e/servers/trigger.spec.ts
+++ b/test/e2e/servers/trigger.spec.ts
@@ -1,5 +1,5 @@
 import { Prices, Wallets } from "@app"
-import { getDisplayCurrency, getLocale, ONCHAIN_MIN_CONFIRMATIONS } from "@config"
+import { getDisplayCurrencyConfig, getLocale, ONCHAIN_MIN_CONFIRMATIONS } from "@config"
 import { sat2btc, toSats } from "@domain/bitcoin"
 import { NotificationType } from "@domain/notifications"
 import { TxStatus } from "@domain/wallets"
@@ -46,7 +46,7 @@ let userRecordA: UserRecord
 let userRecordD: UserRecord
 
 const locale = getLocale()
-const { symbol: fiatSymbol } = getDisplayCurrency()
+const { symbol: fiatSymbol } = getDisplayCurrencyConfig()
 
 beforeAll(async () => {
   await initializeTestingState(defaultStateConfig())

--- a/test/integration/02-user-wallet/02-receive-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-onchain.spec.ts
@@ -6,7 +6,7 @@ import {
   getOnChainAddressCreateAttemptLimits,
   getAccountLimits,
   getLocale,
-  getDisplayCurrency,
+  getDisplayCurrencyConfig,
 } from "@config"
 import { sat2btc, toSats } from "@domain/bitcoin"
 import { NotificationType } from "@domain/notifications"
@@ -54,7 +54,7 @@ jest.mock("@services/notifications/notification")
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { sendNotification } = require("@services/notifications/notification")
 const locale = getLocale()
-const { symbol: fiatSymbol } = getDisplayCurrency()
+const { symbol: fiatSymbol } = getDisplayCurrencyConfig()
 
 beforeAll(async () => {
   await createMandatoryUsers()

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -7,7 +7,7 @@ import {
   getAccountLimits,
   MS_PER_DAY,
   getLocale,
-  getDisplayCurrency,
+  getDisplayCurrencyConfig,
 } from "@config"
 import { toSats, toTargetConfs } from "@domain/bitcoin"
 import { PaymentSendStatus } from "@domain/bitcoin/lightning"
@@ -83,7 +83,7 @@ let userIdA: UserId
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { sendNotification } = require("@services/notifications/notification")
 const locale = getLocale()
-const { symbol: fiatSymbol } = getDisplayCurrency()
+const { symbol: fiatSymbol } = getDisplayCurrencyConfig()
 
 beforeAll(async () => {
   await createMandatoryUsers()


### PR DESCRIPTION
### Description

Rename so as to not confuse with an external service call to get the display currency.