### PR TITLE
feat: add new amounts properties to transaction persist layer

### DIFF
--- a/src/app/wallets/reimburse-fee.ts
+++ b/src/app/wallets/reimburse-fee.ts
@@ -18,6 +18,7 @@ export const reimburseFee = async ({
   actualFee,
   revealedPreImage,
   paymentAmount,
+  usdFee,
   logger,
 }: {
   walletId: WalletId
@@ -28,6 +29,7 @@ export const reimburseFee = async ({
   actualFee: Satoshis
   revealedPreImage?: RevealedPreImage
   paymentAmount: Satoshis
+  usdFee: DisplayCurrencyBaseAmount
   logger: Logger
 }): Promise<true | ApplicationError> => {
   let cents: UsdCents | undefined
@@ -71,13 +73,16 @@ export const reimburseFee = async ({
     walletCurrency,
     paymentHash,
     sats: feeDifference,
-    amountDisplayCurrency,
     journalId,
     cents,
     revealedPreImage,
     paymentFlow: {
       btcPaymentAmount: { amount: BigInt(paymentAmount), currency: WalletCurrency.Btc },
+      btcProtocolFee: { amount: BigInt(maxFee), currency: WalletCurrency.Btc },
     },
+    feeDisplayCurrency: usdFee,
+    amountDisplayCurrency,
+    displayCurrency: WalletCurrency.Usd,
   })
   if (result instanceof Error) return result
 

--- a/src/app/wallets/reimburse-fee.ts
+++ b/src/app/wallets/reimburse-fee.ts
@@ -17,6 +17,7 @@ export const reimburseFee = async ({
   maxFee,
   actualFee,
   revealedPreImage,
+  paymentAmount,
   logger,
 }: {
   walletId: WalletId
@@ -26,6 +27,7 @@ export const reimburseFee = async ({
   maxFee: Satoshis
   actualFee: Satoshis
   revealedPreImage?: RevealedPreImage
+  paymentAmount: Satoshis
   logger: Logger
 }): Promise<true | ApplicationError> => {
   let cents: UsdCents | undefined
@@ -73,6 +75,9 @@ export const reimburseFee = async ({
     journalId,
     cents,
     revealedPreImage,
+    paymentFlow: {
+      btcPaymentAmount: { amount: BigInt(paymentAmount), currency: WalletCurrency.Btc },
+    },
   })
   if (result instanceof Error) return result
 

--- a/src/app/wallets/reimburse-fee.ts
+++ b/src/app/wallets/reimburse-fee.ts
@@ -1,4 +1,5 @@
 import { getCurrentPrice } from "@app/prices"
+import { getDisplayCurrencyConfig } from "@config"
 import { DealerPriceServiceError } from "@domain/dealer-price"
 import {
   DisplayCurrencyConverter,
@@ -82,7 +83,7 @@ export const reimburseFee = async ({
     },
     feeDisplayCurrency: usdFee,
     amountDisplayCurrency,
-    displayCurrency: WalletCurrency.Usd,
+    displayCurrency: getDisplayCurrencyConfig().code,
   })
   if (result instanceof Error) return result
 

--- a/src/app/wallets/send-lightning.ts
+++ b/src/app/wallets/send-lightning.ts
@@ -736,6 +736,7 @@ const executePaymentViaLn = async ({
           actualFee: payResult.roundedUpFee,
           revealedPreImage: payResult.revealedPreImage,
           paymentAmount: toSats(sats - feeRouting),
+          usdFee: feeRoutingDisplayCurrency,
           logger,
         })
         if (reimbursed instanceof Error) return reimbursed

--- a/src/app/wallets/send-lightning.ts
+++ b/src/app/wallets/send-lightning.ts
@@ -735,6 +735,7 @@ const executePaymentViaLn = async ({
           maxFee: feeRouting,
           actualFee: payResult.roundedUpFee,
           revealedPreImage: payResult.revealedPreImage,
+          paymentAmount: toSats(sats - feeRouting),
           logger,
         })
         if (reimbursed instanceof Error) return reimbursed

--- a/src/app/wallets/update-pending-payments.ts
+++ b/src/app/wallets/update-pending-payments.ts
@@ -163,6 +163,7 @@ const updatePendingPayment = async ({
             (pendingPayment.debit > 0 ? pendingPayment.debit : pendingPayment.credit) -
               pendingPayment.fee,
           ),
+          usdFee: pendingPayment.feeUsd as DisplayCurrencyBaseAmount,
           logger,
         })
       } else if (status === PaymentStatus.Failed) {

--- a/src/app/wallets/update-pending-payments.ts
+++ b/src/app/wallets/update-pending-payments.ts
@@ -159,6 +159,10 @@ const updatePendingPayment = async ({
           maxFee: pendingPayment.fee,
           actualFee: roundedUpFee,
           revealedPreImage,
+          paymentAmount: toSats(
+            (pendingPayment.debit > 0 ? pendingPayment.debit : pendingPayment.credit) -
+              pendingPayment.fee,
+          ),
           logger,
         })
       } else if (status === PaymentStatus.Failed) {

--- a/src/config/yaml.ts
+++ b/src/config/yaml.ts
@@ -14,12 +14,7 @@ import { toCents } from "@domain/fiat"
 
 import { WithdrawalFeePriceMethod } from "@domain/wallets"
 
-import {
-  ConfigSchema,
-  configSchema,
-  DisplayCurrencyConfigSchema,
-  RewardsConfigSchema,
-} from "./schema"
+import { ConfigSchema, configSchema, RewardsConfigSchema } from "./schema"
 import { ConfigError } from "./error"
 
 const defaultContent = fs.readFileSync("./default.yaml", "utf8")
@@ -81,7 +76,10 @@ i18n.configure({
 
 export const getI18nInstance = (): I18n => i18n
 
-export const getDisplayCurrencyConfig = (): DisplayCurrencyConfigSchema => ({
+export const getDisplayCurrencyConfig = (): {
+  code: DisplayCurrency
+  symbol: string
+} => ({
   code: yamlConfig.displayCurrency.code,
   symbol: yamlConfig.displayCurrency.symbol,
 })

--- a/src/domain/bitcoin/index.ts
+++ b/src/domain/bitcoin/index.ts
@@ -14,8 +14,8 @@ export const sat2btc = (sat: number) => {
   return sat / SATS_PER_BTC
 }
 
-export const toSats = (amount: number): Satoshis => {
-  return amount as Satoshis
+export const toSats = (amount: number | bigint): Satoshis => {
+  return Number(amount) as Satoshis
 }
 
 export const toTargetConfs = (confs: number): TargetConfirmations => {

--- a/src/domain/fiat/index.ts
+++ b/src/domain/fiat/index.ts
@@ -4,8 +4,8 @@ import {
   NonIntegerError,
 } from "@domain/errors"
 
-export const toCents = (amount: number): UsdCents => {
-  return amount as UsdCents
+export const toCents = (amount: number | bigint): UsdCents => {
+  return Number(amount) as UsdCents
 }
 
 export const toCentsPerSatsRatio = (amount: number): CentsPerSatsRatio => {

--- a/src/domain/fiat/index.ts
+++ b/src/domain/fiat/index.ts
@@ -35,8 +35,3 @@ export const sub = <T extends number>(
   if (result < 0) return new InvalidNegativeAmountError()
   return result as T
 }
-
-export const DisplayCurrency = {
-  Usd: "USD",
-  Btc: "BTC",
-} as const

--- a/src/domain/fiat/index.ts
+++ b/src/domain/fiat/index.ts
@@ -35,3 +35,8 @@ export const sub = <T extends number>(
   if (result < 0) return new InvalidNegativeAmountError()
   return result as T
 }
+
+export const DisplayCurrency = {
+  Usd: "USD",
+  Btc: "BTC",
+} as const

--- a/src/domain/fiat/index.types.d.ts
+++ b/src/domain/fiat/index.types.d.ts
@@ -1,6 +1,8 @@
 type UsdCents = number & { readonly brand: unique symbol }
 type CentsPerSatsRatio = number & { readonly brand: unique symbol }
 type DisplayCurrencyBaseAmount = number & { readonly brand: unique symbol }
+type DisplayCurrency =
+  typeof import(".").DisplayCurrency[keyof typeof import(".").DisplayCurrency]
 
 // TODO: a better way to type it can be:
 // <T extends Satoshis | UsdCents> someFunction({amount}: {amount: T})

--- a/src/domain/fiat/index.types.d.ts
+++ b/src/domain/fiat/index.types.d.ts
@@ -1,8 +1,7 @@
 type UsdCents = number & { readonly brand: unique symbol }
 type CentsPerSatsRatio = number & { readonly brand: unique symbol }
 type DisplayCurrencyBaseAmount = number & { readonly brand: unique symbol }
-type DisplayCurrency =
-  typeof import(".").DisplayCurrency[keyof typeof import(".").DisplayCurrency]
+type DisplayCurrency = string & { readonly brand: unique symbol }
 
 // TODO: a better way to type it can be:
 // <T extends Satoshis | UsdCents> someFunction({amount}: {amount: T})

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -166,10 +166,12 @@ type AddLnFeeReeimbursementReceiveArgs = {
   paymentHash: PaymentHash
   sats: Satoshis
   cents?: UsdCents
-  amountDisplayCurrency: DisplayCurrencyBaseAmount
   journalId: LedgerJournalId
   revealedPreImage?: RevealedPreImage
-  paymentFlow: { btcPaymentAmount: BtcPaymentAmount }
+  paymentFlow: { btcPaymentAmount: BtcPaymentAmount; btcProtocolFee: BtcPaymentAmount }
+  feeDisplayCurrency: DisplayCurrencyBaseAmount
+  amountDisplayCurrency: DisplayCurrencyBaseAmount
+  displayCurrency: DisplayCurrency
 }
 
 type FeeReimbursement = {

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -169,6 +169,7 @@ type AddLnFeeReeimbursementReceiveArgs = {
   amountDisplayCurrency: DisplayCurrencyBaseAmount
   journalId: LedgerJournalId
   revealedPreImage?: RevealedPreImage
+  paymentFlow: { btcPaymentAmount: BtcPaymentAmount }
 }
 
 type FeeReimbursement = {

--- a/src/services/ledger/index.types.d.ts
+++ b/src/services/ledger/index.types.d.ts
@@ -63,6 +63,13 @@ type OnChainReceiveLedgerMetadata = NonIntraledgerLedgerMetadata & {
 
 type LnSendAmountsMetadata = {
   satsAmount: Satoshis
+  centsAmount: UsdCents
+  satsFee: Satoshis
+  centsFee: UsdCents
+
+  displayAmount: DisplayCurrencyBaseAmount
+  displayFee: DisplayCurrencyBaseAmount
+  displayCurrency: DisplayCurrency
 }
 
 type AddLnSendLedgerMetadata = NonIntraledgerLedgerMetadata &

--- a/src/services/ledger/index.types.d.ts
+++ b/src/services/ledger/index.types.d.ts
@@ -61,11 +61,16 @@ type OnChainReceiveLedgerMetadata = NonIntraledgerLedgerMetadata & {
   payee_addresses: OnChainAddress[]
 }
 
-type AddLnSendLedgerMetadata = NonIntraledgerLedgerMetadata & {
-  hash: PaymentHash
-  pubkey: Pubkey
-  feeKnownInAdvance: boolean
+type LnSendAmountsMetadata = {
+  satsAmount: Satoshis
 }
+
+type AddLnSendLedgerMetadata = NonIntraledgerLedgerMetadata &
+  LnSendAmountsMetadata & {
+    hash: PaymentHash
+    pubkey: Pubkey
+    feeKnownInAdvance: boolean
+  }
 
 type AddOnchainSendLedgerMetadata = NonIntraledgerLedgerMetadata & {
   hash: OnChainTxHash
@@ -101,7 +106,7 @@ type AddOnChainIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata & {
 
 type AddWalletIdIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata
 
-type FeeReimbursementLedgerMetadata = {
+type FeeReimbursementLedgerMetadata = LnSendAmountsMetadata & {
   hash: PaymentHash
   type: LedgerTransactionType
   pending: boolean

--- a/src/services/ledger/receive.ts
+++ b/src/services/ledger/receive.ts
@@ -4,6 +4,7 @@ import {
   WalletCurrency,
 } from "@domain/shared"
 import { NotImplementedError, NotReachableError } from "@domain/errors"
+import { toSats } from "@domain/bitcoin"
 
 import { LedgerTransactionType } from "@domain/ledger"
 import { LedgerError, UnknownLedgerError } from "@domain/ledger/errors"
@@ -114,6 +115,7 @@ export const receive = {
     sats,
     cents,
     revealedPreImage,
+    paymentFlow,
   }: AddLnFeeReeimbursementReceiveArgs): Promise<LedgerJournal | LedgerError> => {
     const metadata: FeeReimbursementLedgerMetadata = {
       type: LedgerTransactionType.LnFeeReimbursement,
@@ -121,6 +123,7 @@ export const receive = {
       related_journal: journalId,
       pending: false,
       usd: amountDisplayCurrency,
+      satsAmount: toSats(paymentFlow.btcPaymentAmount.amount),
     }
 
     const description = "fee reimbursement"

--- a/src/services/ledger/schema.ts
+++ b/src/services/ledger/schema.ts
@@ -84,7 +84,6 @@ const transactionSchema = new Schema({
   },
   displayCurrency: {
     type: String,
-    enum: ["USD", "BTC"],
   },
 
   // when transaction with on_us transaction, this is the other party username

--- a/src/services/ledger/schema.ts
+++ b/src/services/ledger/schema.ts
@@ -70,6 +70,25 @@ const transactionSchema = new Schema({
   },
 
   satsAmount: Number,
+  centsAmount: Number,
+  satsFee: {
+    type: Number,
+    default: 0,
+  },
+  centsFee: {
+    type: Number,
+    default: 0,
+  },
+
+  displayAmount: Number,
+  displayFee: {
+    type: Number,
+    default: 0,
+  },
+  displayCurrency: {
+    type: String,
+    enum: ["USD", "BTC"],
+  },
 
   // when transaction with on_us transaction, this is the other party username
   // TODO: refactor, define username as a type so that every property that should be an username can inherit from those parameters

--- a/src/services/ledger/schema.ts
+++ b/src/services/ledger/schema.ts
@@ -73,17 +73,14 @@ const transactionSchema = new Schema({
   centsAmount: Number,
   satsFee: {
     type: Number,
-    default: 0,
   },
   centsFee: {
     type: Number,
-    default: 0,
   },
 
   displayAmount: Number,
   displayFee: {
     type: Number,
-    default: 0,
   },
   displayCurrency: {
     type: String,

--- a/src/services/ledger/schema.ts
+++ b/src/services/ledger/schema.ts
@@ -69,6 +69,8 @@ const transactionSchema = new Schema({
     default: 0,
   },
 
+  satsAmount: Number,
+
   // when transaction with on_us transaction, this is the other party username
   // TODO: refactor, define username as a type so that every property that should be an username can inherit from those parameters
   username: {

--- a/src/services/ledger/send.ts
+++ b/src/services/ledger/send.ts
@@ -1,4 +1,5 @@
 import { toSats } from "@domain/bitcoin"
+import { toCents } from "@domain/fiat"
 import { LedgerTransactionType } from "@domain/ledger"
 import { NotImplementedError } from "@domain/errors"
 import {
@@ -38,16 +39,30 @@ export const send = {
     feeKnownInAdvance,
     cents,
   }: AddLnTxSendArgs): Promise<LedgerJournal | LedgerError> => {
+    const centsAmount = Math.round(
+      (amountDisplayCurrency - feeRoutingDisplayCurrency) * 100,
+    )
+    const centsFee = Math.round(feeRoutingDisplayCurrency * 100)
+
     const metadata: AddLnSendLedgerMetadata = {
       type: LedgerTransactionType.Payment,
       pending: true,
       hash: paymentHash,
+      pubkey,
+      feeKnownInAdvance,
+
       fee: feeRouting,
       feeUsd: feeRoutingDisplayCurrency,
       usd: amountDisplayCurrency,
-      pubkey,
-      feeKnownInAdvance,
+
+      satsFee: toSats(feeRouting),
+      displayFee: centsFee as DisplayCurrencyBaseAmount,
+      displayAmount: centsAmount as DisplayCurrencyBaseAmount,
+
+      displayCurrency: WalletCurrency.Usd,
+      centsAmount: toCents(centsAmount),
       satsAmount: toSats(sats - feeRouting),
+      centsFee: toCents(centsFee),
     }
     return addSendNoInternalFee({
       walletId,

--- a/src/services/ledger/send.ts
+++ b/src/services/ledger/send.ts
@@ -1,3 +1,5 @@
+import { getDisplayCurrencyConfig } from "@config"
+
 import { toSats } from "@domain/bitcoin"
 import { toCents } from "@domain/fiat"
 import { LedgerTransactionType } from "@domain/ledger"
@@ -59,7 +61,7 @@ export const send = {
       displayFee: centsFee as DisplayCurrencyBaseAmount,
       displayAmount: centsAmount as DisplayCurrencyBaseAmount,
 
-      displayCurrency: WalletCurrency.Usd,
+      displayCurrency: getDisplayCurrencyConfig().code,
       centsAmount: toCents(centsAmount),
       satsAmount: toSats(sats - feeRouting),
       centsFee: toCents(centsFee),

--- a/src/services/ledger/send.ts
+++ b/src/services/ledger/send.ts
@@ -1,3 +1,4 @@
+import { toSats } from "@domain/bitcoin"
 import { LedgerTransactionType } from "@domain/ledger"
 import { NotImplementedError } from "@domain/errors"
 import {
@@ -46,6 +47,7 @@ export const send = {
       usd: amountDisplayCurrency,
       pubkey,
       feeKnownInAdvance,
+      satsAmount: toSats(sats - feeRouting),
     }
     return addSendNoInternalFee({
       walletId,

--- a/src/services/ledger/tx-metadata.ts
+++ b/src/services/ledger/tx-metadata.ts
@@ -1,37 +1,52 @@
 import { toSats } from "@domain/bitcoin"
+import { toCents } from "@domain/fiat"
 import { LedgerTransactionType } from "@domain/ledger"
 
 export const LnSendLedgerMetadata = ({
   paymentHash,
   fee,
+  pubkey,
+  paymentFlow,
   feeDisplayCurrency,
   amountDisplayCurrency,
-  pubkey,
+  displayCurrency,
   feeKnownInAdvance,
-  paymentFlow,
 }: {
   paymentHash: PaymentHash
   fee: BtcPaymentAmount
+  pubkey: Pubkey
+  paymentFlow: { btcPaymentAmount: BtcPaymentAmount; btcProtocolFee: BtcPaymentAmount }
   feeDisplayCurrency: DisplayCurrencyBaseAmount
   amountDisplayCurrency: DisplayCurrencyBaseAmount
-  pubkey: Pubkey
+  displayCurrency: DisplayCurrency
   feeKnownInAdvance: boolean
-  paymentFlow: { btcPaymentAmount: BtcPaymentAmount }
 }) => {
   const {
     btcPaymentAmount: { amount: satsAmount },
+    btcProtocolFee: { amount: satsFee },
   } = paymentFlow
+  const centsAmount = Math.round(amountDisplayCurrency * 100)
+  const centsFee = Math.round(feeDisplayCurrency * 100)
 
   const metadata: AddLnSendLedgerMetadata = {
     type: LedgerTransactionType.Payment,
     pending: true,
     hash: paymentHash,
+    pubkey,
+    feeKnownInAdvance,
+
     fee: Number(fee.amount) as Satoshis,
     feeUsd: feeDisplayCurrency,
     usd: amountDisplayCurrency,
-    pubkey,
-    feeKnownInAdvance,
+
+    satsFee: toSats(satsFee),
+    displayFee: feeDisplayCurrency,
+    displayAmount: amountDisplayCurrency,
+
+    displayCurrency,
+    centsAmount: toCents(centsAmount),
     satsAmount: toSats(satsAmount),
+    centsFee: toCents(centsFee),
   }
   return metadata
 }

--- a/src/services/ledger/tx-metadata.ts
+++ b/src/services/ledger/tx-metadata.ts
@@ -25,7 +25,7 @@ export const LnSendLedgerMetadata = ({
     btcPaymentAmount: { amount: satsAmount },
     btcProtocolFee: { amount: satsFee },
   } = paymentFlow
-  const centsAmount = Math.round(amountDisplayCurrency * 100)
+  const centsAmount = Math.round((amountDisplayCurrency - feeDisplayCurrency) * 100)
   const centsFee = Math.round(feeDisplayCurrency * 100)
 
   const metadata: AddLnSendLedgerMetadata = {
@@ -129,27 +129,43 @@ export const LnReceiveLedgerMetadata = ({
 }
 
 export const LnFeeReimbursementReceiveLedgerMetadata = ({
+  paymentFlow,
   paymentHash,
   journalId,
+  feeDisplayCurrency,
   amountDisplayCurrency,
-  paymentFlow,
+  displayCurrency,
 }: {
+  paymentFlow: { btcPaymentAmount: BtcPaymentAmount; btcProtocolFee: BtcPaymentAmount }
   paymentHash: PaymentHash
   journalId: LedgerJournalId
+  feeDisplayCurrency: DisplayCurrencyBaseAmount
   amountDisplayCurrency: DisplayCurrencyBaseAmount
-  paymentFlow: { btcPaymentAmount: BtcPaymentAmount }
+  displayCurrency: DisplayCurrency
 }) => {
   const {
     btcPaymentAmount: { amount: satsAmount },
+    btcProtocolFee: { amount: satsFee },
   } = paymentFlow
+  const centsAmount = Math.round((amountDisplayCurrency - feeDisplayCurrency) * 100)
+  const centsFee = Math.round(feeDisplayCurrency * 100)
 
   const metadata: FeeReimbursementLedgerMetadata = {
     type: LedgerTransactionType.LnFeeReimbursement,
     hash: paymentHash,
     related_journal: journalId,
     pending: false,
+
     usd: amountDisplayCurrency,
+
+    satsFee: toSats(satsFee),
+    displayFee: feeDisplayCurrency,
+    displayAmount: amountDisplayCurrency,
+
+    displayCurrency,
+    centsAmount: toCents(centsAmount),
     satsAmount: toSats(satsAmount),
+    centsFee: toCents(centsFee),
   }
   return metadata
 }

--- a/src/services/ledger/tx-metadata.ts
+++ b/src/services/ledger/tx-metadata.ts
@@ -1,3 +1,4 @@
+import { toSats } from "@domain/bitcoin"
 import { LedgerTransactionType } from "@domain/ledger"
 
 export const LnSendLedgerMetadata = ({
@@ -7,6 +8,7 @@ export const LnSendLedgerMetadata = ({
   amountDisplayCurrency,
   pubkey,
   feeKnownInAdvance,
+  paymentFlow,
 }: {
   paymentHash: PaymentHash
   fee: BtcPaymentAmount
@@ -14,7 +16,12 @@ export const LnSendLedgerMetadata = ({
   amountDisplayCurrency: DisplayCurrencyBaseAmount
   pubkey: Pubkey
   feeKnownInAdvance: boolean
+  paymentFlow: { btcPaymentAmount: BtcPaymentAmount }
 }) => {
+  const {
+    btcPaymentAmount: { amount: satsAmount },
+  } = paymentFlow
+
   const metadata: AddLnSendLedgerMetadata = {
     type: LedgerTransactionType.Payment,
     pending: true,
@@ -24,6 +31,7 @@ export const LnSendLedgerMetadata = ({
     usd: amountDisplayCurrency,
     pubkey,
     feeKnownInAdvance,
+    satsAmount: toSats(satsAmount),
   }
   return metadata
 }
@@ -109,17 +117,24 @@ export const LnFeeReimbursementReceiveLedgerMetadata = ({
   paymentHash,
   journalId,
   amountDisplayCurrency,
+  paymentFlow,
 }: {
   paymentHash: PaymentHash
   journalId: LedgerJournalId
   amountDisplayCurrency: DisplayCurrencyBaseAmount
+  paymentFlow: { btcPaymentAmount: BtcPaymentAmount }
 }) => {
+  const {
+    btcPaymentAmount: { amount: satsAmount },
+  } = paymentFlow
+
   const metadata: FeeReimbursementLedgerMetadata = {
     type: LedgerTransactionType.LnFeeReimbursement,
     hash: paymentHash,
     related_journal: journalId,
     pending: false,
     usd: amountDisplayCurrency,
+    satsAmount: toSats(satsAmount),
   }
   return metadata
 }

--- a/test/integration/services/ledger/facade.spec.ts
+++ b/test/integration/services/ledger/facade.spec.ts
@@ -68,9 +68,10 @@ describe("Facade", () => {
         amountDisplayCurrency: Number(
           receiveAmount.usd.amount,
         ) as DisplayCurrencyBaseAmount,
+        displayCurrency: WalletCurrency.Usd,
         pubkey: crypto.randomUUID() as Pubkey,
         feeKnownInAdvance: true,
-        paymentFlow: { btcPaymentAmount: receiveAmount.btc },
+        paymentFlow: { btcPaymentAmount: receiveAmount.btc, btcProtocolFee: bankFee.btc },
       })
 
       await LedgerFacade.recordSend({

--- a/test/integration/services/ledger/facade.spec.ts
+++ b/test/integration/services/ledger/facade.spec.ts
@@ -70,6 +70,7 @@ describe("Facade", () => {
         ) as DisplayCurrencyBaseAmount,
         pubkey: crypto.randomUUID() as Pubkey,
         feeKnownInAdvance: true,
+        paymentFlow: { btcPaymentAmount: receiveAmount.btc },
       })
 
       await LedgerFacade.recordSend({

--- a/test/integration/services/ledger/facade.spec.ts
+++ b/test/integration/services/ledger/facade.spec.ts
@@ -1,5 +1,6 @@
 import crypto from "crypto"
 
+import { getDisplayCurrencyConfig } from "@config"
 import { BtcWalletDescriptor, UsdWalletDescriptor, WalletCurrency } from "@domain/shared"
 import * as LedgerFacade from "@services/ledger/facade"
 
@@ -68,7 +69,7 @@ describe("Facade", () => {
         amountDisplayCurrency: Number(
           receiveAmount.usd.amount,
         ) as DisplayCurrencyBaseAmount,
-        displayCurrency: WalletCurrency.Usd,
+        displayCurrency: getDisplayCurrencyConfig().code,
         pubkey: crypto.randomUUID() as Pubkey,
         feeKnownInAdvance: true,
         paymentFlow: { btcPaymentAmount: receiveAmount.btc, btcProtocolFee: bankFee.btc },


### PR DESCRIPTION
## Description: Code-change-only (migration in #1269)

This PR adds a new amount-related properties to Lightning send payments to support the in-review payments-refactor work in #1237.