### PR TITLE
fix: badly calculated `usd` ln intraledger property

### DIFF
--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -515,13 +515,17 @@ const executePaymentViaIntraledger = async ({
 
       const journal = await LockService().extendLock({ logger, lock }, async () => {
         const lnIntraLedgerMetadata = LedgerFacade.LnIntraledgerLedgerMetadata({
+          paymentHash,
+          pubkey: recipientPubkey,
+          paymentFlow,
+
           amountDisplayCurrency: converter.fromUsdAmount(paymentFlow.usdPaymentAmount),
+          feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+          displayCurrency: DisplayCurrency.Usd,
 
           memoOfPayer: memo || undefined,
           senderUsername,
           recipientUsername,
-          pubkey: recipientPubkey,
-          paymentHash,
         })
         const { metadata, debitAccountAdditionalMetadata: additionalDebitMetadata } =
           lnIntraLedgerMetadata

--- a/src/services/ledger/index.types.d.ts
+++ b/src/services/ledger/index.types.d.ts
@@ -107,6 +107,12 @@ type AddLnIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata & {
   pubkey: Pubkey
 }
 
+type NewAddLnIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata &
+  LnSendAmountsMetadata & {
+    hash: PaymentHash
+    pubkey: Pubkey
+  }
+
 type AddOnChainIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata & {
   payee_addresses: OnChainAddress[]
   sendAll: boolean

--- a/src/services/ledger/tx-metadata.ts
+++ b/src/services/ledger/tx-metadata.ts
@@ -229,29 +229,55 @@ export const WalletIdIntraledgerLedgerMetadata = ({
   return { metadata, debitAccountAdditionalMetadata }
 }
 
-export const LnIntraledgerLedgerMetadata = ({
+export const LnIntraledgerLedgerMetadata = <
+  S extends WalletCurrency,
+  R extends WalletCurrency,
+>({
+  paymentHash,
+  pubkey,
+  paymentFlow,
+  feeDisplayCurrency,
   amountDisplayCurrency,
+  displayCurrency,
   memoOfPayer,
   senderUsername,
   recipientUsername,
-  pubkey,
-  paymentHash,
 }: {
+  paymentHash: PaymentHash
+  pubkey: Pubkey
+  paymentFlow: PaymentFlowState<S, R>
+  feeDisplayCurrency: DisplayCurrencyBaseAmount
   amountDisplayCurrency: DisplayCurrencyBaseAmount
+  displayCurrency: DisplayCurrency
   memoOfPayer?: string
   senderUsername?: Username
   recipientUsername?: Username
-  pubkey: Pubkey
-  paymentHash: PaymentHash
 }) => {
-  const metadata: AddLnIntraledgerSendLedgerMetadata = {
+  const {
+    btcPaymentAmount: { amount: satsAmount },
+    usdPaymentAmount: { amount: centsAmount },
+    btcProtocolFee: { amount: satsFee },
+    usdProtocolFee: { amount: centsFee },
+  } = paymentFlow
+
+  const metadata: NewAddLnIntraledgerSendLedgerMetadata = {
     type: LedgerTransactionType.LnIntraLedger,
     pending: false,
-    usd: amountDisplayCurrency,
     memoPayer: undefined,
     username: senderUsername,
     hash: paymentHash,
     pubkey,
+
+    usd: (amountDisplayCurrency / 100) as DisplayCurrencyBaseAmount,
+
+    satsFee: toSats(satsFee),
+    displayFee: feeDisplayCurrency,
+    displayAmount: amountDisplayCurrency,
+
+    displayCurrency,
+    centsAmount: toCents(centsAmount),
+    satsAmount: toSats(satsAmount),
+    centsFee: toCents(centsFee),
   }
   const debitAccountAdditionalMetadata = {
     memoPayer: memoOfPayer,

--- a/src/services/payment-flow/index.ts
+++ b/src/services/payment-flow/index.ts
@@ -6,6 +6,7 @@ import {
 } from "@domain/errors"
 import { PaymentFlow } from "@domain/payments"
 import { WalletCurrency } from "@domain/shared"
+import { elapsedSinceTimestamp } from "@utils"
 
 import { PaymentFlowState } from "./schema"
 
@@ -248,10 +249,7 @@ const isExpired = ({
   paymentFlow: PaymentFlow<WalletCurrency, WalletCurrency>
   expiryTimeInSeconds: Seconds
 }): boolean => {
-  const expiryTimeInMS = expiryTimeInSeconds * 1000
-
   if (paymentFlow.paymentSentAndPending) return false
 
-  const elapsedInMS = Date.now() - Number(paymentFlow.createdAt)
-  return elapsedInMS > expiryTimeInMS
+  return elapsedSinceTimestamp(paymentFlow.createdAt) > expiryTimeInSeconds
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -44,3 +44,7 @@ export const mapObj = <T, R>(
   }
   return mappedObj
 }
+
+export const elapsedSinceTimestamp = (date: Date): Seconds => {
+  return ((Date.now() - Number(date)) / 1000) as Seconds
+}

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -246,26 +246,28 @@ describe("UserWallet - Lightning Pay", () => {
       tx.settlementVia.type === PaymentInitiationMethod.IntraLedger &&
       tx.initiationVia.paymentHash === getHash(invoice)
 
-    let txResult = await Wallets.getTransactionsForWalletId({
+    const txResultB = await Wallets.getTransactionsForWalletId({
       walletId: walletIdB,
     })
-    if (txResult.error instanceof Error || txResult.result === null) {
-      throw txResult.error
+    if (txResultB.error instanceof Error || txResultB.result === null) {
+      throw txResultB.error
     }
-    const userBTxn = txResult.result
-    expect(userBTxn.filter(matchTx)[0].memo).toBe(memo)
-    expect(userBTxn.filter(matchTx)[0].settlementVia.type).toBe("intraledger")
-    // expect(userBTxn.filter(matchTx)[0].recipientUsername).toBe("lily")
+    const userBTxn = txResultB.result.filter(matchTx)[0]
+    expect(userBTxn.memo).toBe(memo)
+    expect(userBTxn.settlementDisplayCurrencyPerSat).toBe(0.0005)
+    expect(userBTxn.settlementVia.type).toBe("intraledger")
+    // expect(userBTxn.recipientUsername).toBe("lily")
 
-    txResult = await Wallets.getTransactionsForWalletId({
+    const txResultC = await Wallets.getTransactionsForWalletId({
       walletId: walletIdB,
     })
-    if (txResult.error instanceof Error || txResult.result === null) {
-      throw txResult.error
+    if (txResultC.error instanceof Error || txResultC.result === null) {
+      throw txResultC.error
     }
-    const userCTxn = txResult.result
-    expect(userCTxn.filter(matchTx)[0].memo).toBe(memo)
-    expect(userCTxn.filter(matchTx)[0].settlementVia.type).toBe("intraledger")
+    const userCTxn = txResultC.result.filter(matchTx)[0]
+    expect(userCTxn.memo).toBe(memo)
+    expect(userCTxn.settlementDisplayCurrencyPerSat).toBe(0.0005)
+    expect(userCTxn.settlementVia.type).toBe("intraledger")
   })
 
   it("sends to another Galoy user with two different memos", async () => {

--- a/test/integration/services/ledger/facade.spec.ts
+++ b/test/integration/services/ledger/facade.spec.ts
@@ -1,8 +1,15 @@
 import crypto from "crypto"
 
 import { getDisplayCurrencyConfig } from "@config"
-import { BtcWalletDescriptor, UsdWalletDescriptor, WalletCurrency } from "@domain/shared"
+import {
+  BtcWalletDescriptor,
+  UsdWalletDescriptor,
+  WalletCurrency,
+  ZERO_CENTS,
+  ZERO_SATS,
+} from "@domain/shared"
 import * as LedgerFacade from "@services/ledger/facade"
+import { DisplayCurrency } from "@domain/fiat"
 
 describe("Facade", () => {
   const receiveAmount = {
@@ -118,7 +125,15 @@ describe("Facade", () => {
           amountDisplayCurrency: Number(
             receiveAmount.usd.amount,
           ) as DisplayCurrencyBaseAmount,
+          feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+          displayCurrency: DisplayCurrency.Usd,
           pubkey: crypto.randomUUID() as Pubkey,
+          paymentFlow: {
+            btcPaymentAmount: receiveAmount.btc,
+            usdPaymentAmount: receiveAmount.usd,
+            btcProtocolFee: ZERO_SATS,
+            usdProtocolFee: ZERO_CENTS,
+          } as PaymentFlowState<WalletCurrency, WalletCurrency>,
         })
 
       await LedgerFacade.recordIntraledger({

--- a/test/unit/utils.spec.ts
+++ b/test/unit/utils.spec.ts
@@ -1,4 +1,5 @@
 import { btc2sat, sat2btc } from "@domain/bitcoin"
+import { elapsedSinceTimestamp } from "@utils"
 
 describe("utils.ts", () => {
   describe("btc2sat", () => {
@@ -18,6 +19,22 @@ describe("utils.ts", () => {
       expect(sat2btc(112356780)).toEqual(1.1235678)
       expect(sat2btc(-120000000)).toEqual(-1.2)
       expect(sat2btc(-112356780)).toEqual(-1.1235678)
+    })
+  })
+
+  describe("elapsedFromTimestamp", () => {
+    it("returns expected number of seconds for elapsed time", () => {
+      const timestamp = new Date()
+      const expectedElapsed = 20
+
+      const mockNowDate = new Date(timestamp)
+      mockNowDate.setSeconds(mockNowDate.getSeconds() + expectedElapsed)
+      jest
+        .spyOn(global.Date, "now")
+        .mockImplementationOnce(() => new Date(mockNowDate).valueOf())
+
+      const elapsed = elapsedSinceTimestamp(timestamp)
+      expect(elapsed).toBe(expectedElapsed)
     })
   })
 })


### PR DESCRIPTION
## Description

This PR:
- adds a new elapsedTime method + unit test
- fixes the metadata for the new Ln Intraledger logic