### PR TITLE
fix: fee_reimbursement transactions 'usd' property value

### DIFF
--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -733,7 +733,6 @@ const executePaymentViaLn = async ({
           revealedPreImage: payResult.revealedPreImage,
           amountDisplayCurrency: converter.fromUsdAmount(paymentFlow.usdPaymentAmount),
           feeDisplayCurrency: converter.fromUsdAmount(paymentFlow.usdProtocolFee),
-          displayCurrency: WalletCurrency.Usd,
           logger,
         })
         if (reimbursed instanceof Error) return reimbursed

--- a/src/app/wallets/update-pending-payments.ts
+++ b/src/app/wallets/update-pending-payments.ts
@@ -190,7 +190,6 @@ const updatePendingPayment = async ({
           revealedPreImage,
           amountDisplayCurrency: displayAmount,
           feeDisplayCurrency: displayFee,
-          displayCurrency: WalletCurrency.Usd,
           logger,
         })
       } else if (status === PaymentStatus.Failed) {


### PR DESCRIPTION
## Description

The metadata amounts added to `fee_reimbursement` transactions reflected the original `payment` transaction's amounts but this won't work for the display purpose these will be used for.

This PR corrects the active `usd` property (which is already correct on `main`) to reflect the reimbursement amount instead of the original payment amount from the related `payment` transaction entry.

We will need a follow up PR to correct the following currently-unused properties for `fee_reimbursement` transactions:
```
{
    satsAmount: feeSats,
    satsFee: 0,
    centsAmount: feeCents,
    centsFee: 0,
    displayAmount: feeCents,
    displayFee: 0
}
```