### PR TITLE
fix: correct amount for send-lightning balance check

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -73,6 +73,9 @@ test_accounts:
   phone: "+16505554335"
   code: "321321"
   username: "user15"
+- ref: "H"
+  phone: "+16505554336"
+  code: "321321"
 
 rateLimits:
   requestPhoneCodePerPhone:

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -66,6 +66,7 @@ export class AlreadyPaidError extends ValidationError {}
 export class SelfPaymentError extends ValidationError {}
 export class LessThanDustThresholdError extends ValidationError {}
 export class InsufficientBalanceError extends ValidationError {}
+export class InvalidCurrencyForWalletError extends ValidationError {}
 export class BalanceLessThanZeroError extends ValidationError {}
 export class InvalidTargetConfirmations extends ValidationError {}
 export class NoContactForUsernameError extends ValidationError {}

--- a/src/domain/payments/index.types.d.ts
+++ b/src/domain/payments/index.types.d.ts
@@ -43,7 +43,6 @@ type PaymentFlow<S extends WalletCurrency, R extends WalletCurrency> = PaymentFl
   R
 > & {
   protocolFeeInSenderWalletCurrency(): PaymentAmount<S>
-  paymentAmountInSenderWalletCurrency(): PaymentAmount<S>
   paymentAmounts(): { btc: BtcPaymentAmount; usd: UsdPaymentAmount }
   routeDetails(): {
     rawRoute?: RawRoute

--- a/src/domain/payments/index.types.d.ts
+++ b/src/domain/payments/index.types.d.ts
@@ -55,8 +55,9 @@ type PaymentFlow<S extends WalletCurrency, R extends WalletCurrency> = PaymentFl
     recipientPubkey: Pubkey | undefined
     recipientUsername: Username | undefined
   }
-  senderWalletDescriptor(): WalletDescriptor<WalletCurrency>
-  recipientWalletDescriptor(): WalletDescriptor<WalletCurrency> | undefined
+  senderWalletDescriptor(): WalletDescriptor<S>
+  recipientWalletDescriptor(): WalletDescriptor<R> | undefined
+  checkBalanceForSend(balanceAmount: PaymentAmount<S>): true | ValidationError
 }
 
 type LightningPaymentFlowBuilder<S extends WalletCurrency> = {

--- a/src/domain/payments/payment-flow.ts
+++ b/src/domain/payments/payment-flow.ts
@@ -13,12 +13,6 @@ export const PaymentFlow = <S extends WalletCurrency, R extends WalletCurrency>(
       : (state.usdProtocolFee as PaymentAmount<S>)
   }
 
-  const paymentAmountInSenderWalletCurrency = (): PaymentAmount<S> => {
-    return state.senderWalletCurrency === WalletCurrency.Btc
-      ? (state.btcPaymentAmount as PaymentAmount<S>)
-      : (state.usdPaymentAmount as PaymentAmount<S>)
-  }
-
   const paymentAmounts = (): { btc: BtcPaymentAmount; usd: UsdPaymentAmount } => ({
     btc: state.btcPaymentAmount,
     usd: state.usdPaymentAmount,
@@ -98,7 +92,6 @@ export const PaymentFlow = <S extends WalletCurrency, R extends WalletCurrency>(
   return {
     ...state,
     protocolFeeInSenderWalletCurrency,
-    paymentAmountInSenderWalletCurrency,
     paymentAmounts,
     routeDetails,
     recipientDetails,

--- a/src/domain/payments/payment-flow.ts
+++ b/src/domain/payments/payment-flow.ts
@@ -1,4 +1,5 @@
-import { ErrorLevel, WalletCurrency } from "@domain/shared"
+import { InsufficientBalanceError, InvalidCurrencyForWalletError } from "@domain/errors"
+import { AmountCalculator, ErrorLevel, WalletCurrency } from "@domain/shared"
 import { recordExceptionInCurrentSpan } from "@services/tracing"
 
 import { RouteValidator } from "./route-validator"
@@ -58,18 +59,41 @@ export const PaymentFlow = <S extends WalletCurrency, R extends WalletCurrency>(
     recipientUsername: state.recipientUsername,
   })
 
-  const senderWalletDescriptor = (): WalletDescriptor<WalletCurrency> => ({
+  const senderWalletDescriptor = (): WalletDescriptor<S> => ({
     id: state.senderWalletId,
     currency: state.senderWalletCurrency,
   })
 
-  const recipientWalletDescriptor = (): WalletDescriptor<WalletCurrency> | undefined =>
+  const recipientWalletDescriptor = (): WalletDescriptor<R> | undefined =>
     state.recipientWalletId && state.recipientWalletCurrency
       ? {
           id: state.recipientWalletId,
           currency: state.recipientWalletCurrency,
         }
       : undefined
+
+  const checkBalanceForSend = (
+    balanceAmount: PaymentAmount<S>,
+  ): true | ValidationError => {
+    if (state.senderWalletCurrency !== balanceAmount.currency)
+      return new InvalidCurrencyForWalletError()
+
+    const { amount, fee } =
+      balanceAmount.currency === WalletCurrency.Btc
+        ? { amount: state.btcPaymentAmount, fee: state.btcProtocolFee }
+        : { amount: state.usdPaymentAmount, fee: state.usdProtocolFee }
+    const totalSendAmount = AmountCalculator().add(amount, fee)
+
+    if (balanceAmount.amount < totalSendAmount.amount) {
+      const unitForMsg =
+        state.senderWalletCurrency === WalletCurrency.Btc ? "sats" : "cents"
+      return new InsufficientBalanceError(
+        `Payment amount '${totalSendAmount.amount}' ${unitForMsg} exceeds balance '${balanceAmount.amount}'`,
+      )
+    }
+
+    return true
+  }
 
   return {
     ...state,
@@ -80,5 +104,6 @@ export const PaymentFlow = <S extends WalletCurrency, R extends WalletCurrency>(
     recipientDetails,
     senderWalletDescriptor,
     recipientWalletDescriptor,
+    checkBalanceForSend,
   }
 }

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -371,6 +371,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "NonLnPaymentTransactionForPaymentFlowError":
     case "MissingPropsInTransactionForPaymentFlowError":
     case "InvalidZeroAmountPriceRatioInputError":
+    case "InvalidCurrencyForWalletError":
       message = `Unknown error occurred (code: ${error.name}${
         error.message ? ": " + error.message : ""
       })`

--- a/test/unit/payments/payment-flow.spec.ts
+++ b/test/unit/payments/payment-flow.spec.ts
@@ -1,0 +1,113 @@
+import { toSats } from "@domain/bitcoin"
+import { InsufficientBalanceError, InvalidCurrencyForWalletError } from "@domain/errors"
+import { toCents } from "@domain/fiat"
+import { PaymentFlow } from "@domain/payments"
+import { WalletCurrency } from "@domain/shared"
+import { PaymentInitiationMethod, SettlementMethod } from "@domain/wallets"
+
+describe("PaymentFlowFromLedgerTransaction", () => {
+  const satsAmount = toSats(20_000)
+  const centsAmount = toCents(1_000)
+  const satsFee = toSats(400)
+  const centsFee = toCents(20)
+  const timestamp = new Date()
+
+  const paymentFlowState: PaymentFlowState<WalletCurrency, WalletCurrency> = {
+    senderWalletId: "walletId" as WalletId,
+    settlementMethod: SettlementMethod.Lightning,
+    paymentInitiationMethod: PaymentInitiationMethod.Lightning,
+
+    paymentHash: "paymentHash" as PaymentHash,
+    descriptionFromInvoice: "",
+    createdAt: timestamp,
+    paymentSentAndPending: true,
+
+    btcPaymentAmount: {
+      amount: BigInt(satsAmount),
+      currency: WalletCurrency.Btc,
+    },
+    usdPaymentAmount: {
+      amount: BigInt(centsAmount),
+      currency: WalletCurrency.Usd,
+    },
+
+    inputAmount: undefined as unknown as bigint,
+    senderWalletCurrency: undefined as unknown as WalletCurrency,
+
+    btcProtocolFee: {
+      amount: BigInt(satsFee),
+      currency: WalletCurrency.Btc,
+    },
+    usdProtocolFee: {
+      amount: BigInt(centsFee),
+      currency: WalletCurrency.Usd,
+    },
+  }
+
+  const walletsToTest = [
+    {
+      name: "btc",
+      senderCurrency: WalletCurrency.Btc,
+      sendAmount: BigInt(satsAmount + satsFee),
+      inputAmount: BigInt(satsAmount),
+    },
+    {
+      name: "usd",
+      senderCurrency: WalletCurrency.Usd,
+      sendAmount: BigInt(centsAmount + centsFee),
+      inputAmount: BigInt(centsAmount),
+    },
+  ]
+  describe("checkBalanceForSend", () => {
+    for (const { name, senderCurrency, sendAmount, inputAmount } of walletsToTest) {
+      describe(`${name} sending wallet`, () => {
+        const paymentFlow = PaymentFlow({
+          ...paymentFlowState,
+          inputAmount,
+          senderWalletCurrency: senderCurrency,
+        })
+
+        it("passes for send amount under balance", () => {
+          const balanceForSend = {
+            amount: sendAmount + 1n,
+            currency: senderCurrency,
+          }
+          const check = paymentFlow.checkBalanceForSend(balanceForSend)
+          expect(check).not.toBeInstanceOf(Error)
+          expect(check).toBe(true)
+        })
+
+        it("passes for send amount equal to balance", () => {
+          const balanceForSend = {
+            amount: sendAmount,
+            currency: senderCurrency,
+          }
+          const check = paymentFlow.checkBalanceForSend(balanceForSend)
+          expect(check).not.toBeInstanceOf(Error)
+          expect(check).toBe(true)
+        })
+
+        it("fails for send amount above to balance", () => {
+          const balanceForSend = {
+            amount: sendAmount - 1n,
+            currency: senderCurrency,
+          }
+          const check = paymentFlow.checkBalanceForSend(balanceForSend)
+          expect(check).toBeInstanceOf(InsufficientBalanceError)
+        })
+
+        it("fails for wrong balance currency", () => {
+          const balanceForSend = {
+            amount: sendAmount + 1n,
+            currency:
+              senderCurrency === WalletCurrency.Btc
+                ? WalletCurrency.Usd
+                : WalletCurrency.Btc,
+          }
+          const check = paymentFlow.checkBalanceForSend(balanceForSend)
+          expect(check).toBeInstanceOf(InvalidCurrencyForWalletError)
+        })
+      })
+    }
+  })
+})


### PR DESCRIPTION
## Description

This PR corrects the comparison amount to include the fee as part of the check. It also moves this logic into a `PaymentFlow`  method and adds unit tests for it.