### PR TITLE
refactor: consolidate BigInt calls & add safe big int

### DIFF
--- a/src/app/payments/update-pending-payments.ts
+++ b/src/app/payments/update-pending-payments.ts
@@ -132,7 +132,8 @@ const updatePendingPayment = async ({
         return true
       }
 
-      const inputAmount = BigInt(inputAmountFromLedgerTransaction(pendingPayment))
+      const inputAmount = inputAmountFromLedgerTransaction(pendingPayment)
+      if (inputAmount instanceof Error) return inputAmount
 
       let paymentFlow = await PaymentFlowStateRepository(
         defaultTimeToExpiryInSeconds,

--- a/src/app/payments/update-pending-payments.ts
+++ b/src/app/payments/update-pending-payments.ts
@@ -1,21 +1,21 @@
 import { toSats } from "@domain/bitcoin"
 import { defaultTimeToExpiryInSeconds, PaymentStatus } from "@domain/bitcoin/lightning"
 import { InconsistentDataError } from "@domain/errors"
-import { LedgerService } from "@services/ledger"
-import { LndService } from "@services/lnd"
-import { LockService } from "@services/lock"
-import { runInParallel } from "@utils"
-
-import { Wallets } from "@app"
-import { WalletsRepository } from "@services/mongoose"
-
-import { PaymentFlowStateRepository } from "@services/payment-flow"
 import {
   CouldNotFindTransactionError,
   inputAmountFromLedgerTransaction,
   LedgerTransactionType,
   UnknownLedgerError,
 } from "@domain/ledger"
+
+import { LedgerService } from "@services/ledger"
+import { LndService } from "@services/lnd"
+import { LockService } from "@services/lock"
+import { WalletsRepository } from "@services/mongoose"
+import { PaymentFlowStateRepository } from "@services/payment-flow"
+
+import { Wallets } from "@app"
+import { runInParallel } from "@utils"
 
 import { PaymentFlowFromLedgerTransaction } from "./translations"
 
@@ -132,12 +132,14 @@ const updatePendingPayment = async ({
         return true
       }
 
+      const inputAmount = BigInt(inputAmountFromLedgerTransaction(pendingPayment))
+
       let paymentFlow = await PaymentFlowStateRepository(
         defaultTimeToExpiryInSeconds,
       ).updatePendingLightningPaymentFlow({
         senderWalletId: walletId,
         paymentHash,
-        inputAmount: BigInt(inputAmountFromLedgerTransaction(pendingPayment)),
+        inputAmount,
 
         paymentSentAndPending: false,
       })

--- a/src/domain/ledger/index.ts
+++ b/src/domain/ledger/index.ts
@@ -1,5 +1,6 @@
 import { InvalidLedgerTransactionId } from "@domain/errors"
 import { WalletCurrency } from "@domain/shared"
+import { safeBigInt } from "@domain/shared/safe"
 
 export * from "./errors"
 export * from "./activity-checker"
@@ -70,5 +71,5 @@ export const inputAmountFromLedgerTransaction = (
   txn: LedgerTransaction<WalletCurrency>,
 ) => {
   const fee = txn.currency == WalletCurrency.Usd ? txn.feeUsd : txn.fee
-  return txn.debit - fee
+  return safeBigInt(txn.debit - fee)
 }

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -273,7 +273,7 @@ interface ILedgerService {
 
   getWalletBalanceAmount<S extends WalletCurrency>(
     walletDescriptor: WalletDescriptor<S>,
-  ): Promise<PaymentAmount<WalletCurrency> | LedgerServiceError>
+  ): Promise<PaymentAmount<S> | LedgerServiceError>
 
   allPaymentVolumeSince: GetVolumeSinceFn
 

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -273,7 +273,7 @@ interface ILedgerService {
 
   getWalletBalanceAmount<S extends WalletCurrency>(
     walletDescriptor: WalletDescriptor<S>,
-  ): Promise<PaymentAmount<S> | LedgerServiceError>
+  ): Promise<PaymentAmount<WalletCurrency> | LedgerServiceError>
 
   allPaymentVolumeSince: GetVolumeSinceFn
 

--- a/src/domain/payments/index.ts
+++ b/src/domain/payments/index.ts
@@ -4,7 +4,9 @@ export * from "./payment-flow-builder"
 export * from "./price-ratio"
 export * from "./ln-fees"
 
-import { ValidationError, WalletCurrency } from "@domain/shared"
+import { toSats } from "@domain/bitcoin"
+import { toCents } from "@domain/fiat"
+import { paymentAmountFromCents, paymentAmountFromSats } from "@domain/shared"
 
 import { InvalidBtcPaymentAmountError, InvalidUsdPaymentAmountError } from "./errors"
 
@@ -18,10 +20,7 @@ export const checkedToBtcPaymentAmount = (
     return new InvalidBtcPaymentAmountError()
   }
   if (!(amount && amount > 0)) return new InvalidBtcPaymentAmountError()
-  return {
-    amount: BigInt(amount),
-    currency: WalletCurrency.Btc,
-  }
+  return paymentAmountFromSats(toSats(amount))
 }
 
 export const checkedToUsdPaymentAmount = (
@@ -34,8 +33,5 @@ export const checkedToUsdPaymentAmount = (
     return new InvalidUsdPaymentAmountError()
   }
   if (!(amount && amount > 0)) return new InvalidUsdPaymentAmountError()
-  return {
-    amount: BigInt(amount),
-    currency: WalletCurrency.Usd,
-  }
+  return paymentAmountFromCents(toCents(amount))
 }

--- a/src/domain/payments/index.types.d.ts
+++ b/src/domain/payments/index.types.d.ts
@@ -152,7 +152,7 @@ interface IPaymentFlowRepository {
   persistNew<S extends WalletCurrency>(
     payment: PaymentFlow<S, WalletCurrency>,
   ): Promise<PaymentFlow<S, WalletCurrency> | RepositoryError>
-  findLightningPaymentFlow<S extends WalletCurrency>({
+  findLightningPaymentFlow({
     walletId,
     paymentHash,
     intraLedgerHash,
@@ -160,7 +160,7 @@ interface IPaymentFlowRepository {
   }: XorPaymentHashProperty & {
     walletId: WalletId
     inputAmount: bigint
-  }): Promise<PaymentFlow<S, WalletCurrency> | RepositoryError>
+  }): Promise<PaymentFlow<WalletCurrency, WalletCurrency> | RepositoryError>
   updateLightningPaymentFlow<S extends WalletCurrency>(
     paymentFlow: PaymentFlow<S, WalletCurrency>,
   ): Promise<true | RepositoryError>

--- a/src/domain/payments/index.types.d.ts
+++ b/src/domain/payments/index.types.d.ts
@@ -152,7 +152,7 @@ interface IPaymentFlowRepository {
   persistNew<S extends WalletCurrency>(
     payment: PaymentFlow<S, WalletCurrency>,
   ): Promise<PaymentFlow<S, WalletCurrency> | RepositoryError>
-  findLightningPaymentFlow({
+  findLightningPaymentFlow<S extends WalletCurrency, R extends WalletCurrency>({
     walletId,
     paymentHash,
     intraLedgerHash,
@@ -160,7 +160,7 @@ interface IPaymentFlowRepository {
   }: XorPaymentHashProperty & {
     walletId: WalletId
     inputAmount: bigint
-  }): Promise<PaymentFlow<WalletCurrency, WalletCurrency> | RepositoryError>
+  }): Promise<PaymentFlow<S, R> | RepositoryError>
   updateLightningPaymentFlow<S extends WalletCurrency>(
     paymentFlow: PaymentFlow<S, WalletCurrency>,
   ): Promise<true | RepositoryError>

--- a/src/domain/payments/ln-fees.ts
+++ b/src/domain/payments/ln-fees.ts
@@ -1,4 +1,10 @@
-import { WalletCurrency, ZERO_SATS, ZERO_CENTS } from "@domain/shared"
+import { toSats } from "@domain/bitcoin"
+import {
+  WalletCurrency,
+  ZERO_SATS,
+  ZERO_CENTS,
+  paymentAmountFromSats,
+} from "@domain/shared"
 
 export const FEECAP_PERCENT = 2n
 
@@ -28,11 +34,9 @@ export const LnFees = (
     }
   }
 
-  const feeFromRawRoute = (rawRoute: RawRoute) => {
-    return {
-      amount: BigInt(Math.ceil(rawRoute.fee)),
-      currency: WalletCurrency.Btc,
-    }
+  const feeFromRawRoute = (rawRoute: RawRoute): BtcPaymentAmount => {
+    const amount = toSats(Math.ceil(rawRoute.fee))
+    return paymentAmountFromSats(amount)
   }
 
   return {

--- a/src/domain/payments/price-ratio.ts
+++ b/src/domain/payments/price-ratio.ts
@@ -1,4 +1,6 @@
-import { WalletCurrency } from "@domain/shared"
+import { toSats } from "@domain/bitcoin"
+import { toCents } from "@domain/fiat"
+import { paymentAmountFromCents, paymentAmountFromSats } from "@domain/shared"
 
 import { InvalidZeroAmountPriceRatioInputError } from "./errors"
 
@@ -16,21 +18,17 @@ export const PriceRatio = ({
   const convertFromUsd = (convert: UsdPaymentAmount): BtcPaymentAmount => {
     const amountAsNumber =
       (Number(convert.amount) * Number(btc.amount)) / Number(usd.amount)
-    const amount = BigInt(Math.round(amountAsNumber))
-    return {
-      amount: convert.amount === 0n ? 0n : amount === 0n ? 1n : amount,
-      currency: WalletCurrency.Btc,
-    }
+    const amount = Math.round(amountAsNumber)
+    const btcAmount = convert.amount === 0n ? 0n : amount === 0 ? 1n : amount
+    return paymentAmountFromSats(toSats(btcAmount))
   }
 
   const convertFromBtc = (convert: BtcPaymentAmount): UsdPaymentAmount => {
     const amountAsNumber =
       (Number(convert.amount) * Number(usd.amount)) / Number(btc.amount)
-    const amount = BigInt(Math.round(amountAsNumber))
-    return {
-      amount: convert.amount === 0n ? 0n : amount === 0n ? 1n : amount,
-      currency: WalletCurrency.Usd,
-    }
+    const amount = Math.round(amountAsNumber)
+    const usdAmount = convert.amount === 0n ? 0 : amount === 0 ? 1 : amount
+    return paymentAmountFromCents(toCents(usdAmount))
   }
 
   return {

--- a/src/domain/shared/errors.ts
+++ b/src/domain/shared/errors.ts
@@ -15,3 +15,12 @@ export class DomainError extends Error {
 }
 
 export class ValidationError extends DomainError {}
+
+export class SafeWrapperError extends DomainError {
+  level = ErrorLevel.Critical
+}
+export class BigIntConversionError extends SafeWrapperError {}
+export class BigIntFloatConversionError extends BigIntConversionError {}
+export class UnknownBigIntConversionError extends BigIntConversionError {
+  level = ErrorLevel.Critical
+}

--- a/src/domain/shared/index.types.d.ts
+++ b/src/domain/shared/index.types.d.ts
@@ -1,6 +1,7 @@
 type ErrorLevel =
   typeof import("./errors").ErrorLevel[keyof typeof import("./errors").ErrorLevel]
 type ValidationError = import("./errors").ValidationError
+type BigIntConversionError = import("./errors").BigIntConversionError
 
 type WalletCurrency =
   typeof import("./primitives").WalletCurrency[keyof typeof import("./primitives").WalletCurrency]

--- a/src/domain/shared/primitives.ts
+++ b/src/domain/shared/primitives.ts
@@ -1,3 +1,5 @@
+import { safeBigInt } from "./safe"
+
 // TODO: think how to differentiate physical from synthetic USD
 export const WalletCurrency = {
   Usd: "USD",
@@ -63,5 +65,21 @@ export const paymentAmountFromCents = (cents: UsdCents): UsdPaymentAmount => {
   return {
     currency: WalletCurrency.Usd,
     amount: BigInt(cents),
+  }
+}
+
+export const paymentAmountFromNumber = <T extends WalletCurrency>({
+  amount,
+  currency,
+}: {
+  amount: number
+  currency: T
+}): PaymentAmount<T> | ValidationError => {
+  const safeAmount = safeBigInt(amount)
+  if (safeAmount instanceof Error) return safeAmount
+
+  return {
+    amount: safeAmount,
+    currency,
   }
 }

--- a/src/domain/shared/safe.ts
+++ b/src/domain/shared/safe.ts
@@ -1,0 +1,12 @@
+import { BigIntFloatConversionError, UnknownBigIntConversionError } from "./errors"
+
+export const safeBigInt = (num: number) => {
+  try {
+    return BigInt(num)
+  } catch (err) {
+    if (err instanceof RangeError) {
+      return new BigIntFloatConversionError(`${num}`)
+    }
+    return new UnknownBigIntConversionError(err)
+  }
+}

--- a/src/domain/shared/safe.ts
+++ b/src/domain/shared/safe.ts
@@ -1,6 +1,6 @@
 import { BigIntFloatConversionError, UnknownBigIntConversionError } from "./errors"
 
-export const safeBigInt = (num: number) => {
+export const safeBigInt = (num: number): bigint | BigIntConversionError => {
   try {
     return BigInt(num)
   } catch (err) {

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -393,6 +393,10 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "PubSubError":
     case "PubSubServiceError":
     case "UnknownPubSubError":
+    case "BigIntConversionError":
+    case "BigIntFloatConversionError":
+    case "UnknownBigIntConversionError":
+    case "SafeWrapperError":
       message = `Unknown error occurred (code: ${error.name}${
         error.message ? ": " + error.message : ""
       })`

--- a/src/services/dealer-price/dealer-price.ts
+++ b/src/services/dealer-price/dealer-price.ts
@@ -4,7 +4,7 @@ import { getDealerPriceConfig } from "@config"
 
 import { credentials } from "@grpc/grpc-js"
 
-import { WalletCurrency } from "@domain/shared"
+import { paymentAmountFromCents, paymentAmountFromSats } from "@domain/shared"
 
 import {
   NoConnectionToDealerError,
@@ -268,10 +268,8 @@ export const NewDealerPriceService = (
           Number(btcAmount.amount),
         ),
       )
-      return {
-        amount: BigInt(response.getAmountInCents()),
-        currency: WalletCurrency.Usd,
-      }
+      const amount = response.getAmountInCents()
+      return paymentAmountFromCents(toCents(amount))
     } catch (error) {
       baseLogger.error({ error }, "GetCentsFromSatsForImmediateBuy unable to fetch price")
       return parseDealerErrors(error)
@@ -287,10 +285,8 @@ export const NewDealerPriceService = (
           Number(btcAmount.amount),
         ),
       )
-      return {
-        amount: BigInt(response.getAmountInCents()),
-        currency: WalletCurrency.Usd,
-      }
+      const amount = response.getAmountInCents()
+      return paymentAmountFromCents(toCents(amount))
     } catch (error) {
       baseLogger.error(
         { error },
@@ -309,10 +305,8 @@ export const NewDealerPriceService = (
           .setAmountInSatoshis(Number(btcAmount.amount))
           .setTimeInSeconds(timeToExpiryInSeconds),
       )
-      return {
-        amount: BigInt(response.getAmountInCents()),
-        currency: WalletCurrency.Usd,
-      }
+      const amount = response.getAmountInCents()
+      return paymentAmountFromCents(toCents(amount))
     } catch (error) {
       baseLogger.error({ error }, "GetCentsFromSatsForFutureBuy unable to fetch price")
       return parseDealerErrors(error)
@@ -328,10 +322,8 @@ export const NewDealerPriceService = (
           .setAmountInSatoshis(Number(btcAmount.amount))
           .setTimeInSeconds(timeToExpiryInSeconds),
       )
-      return {
-        amount: BigInt(response.getAmountInCents()),
-        currency: WalletCurrency.Usd,
-      }
+      const amount = response.getAmountInCents()
+      return paymentAmountFromCents(toCents(amount))
     } catch (error) {
       baseLogger.error({ error }, "GetCentsFromSatsForFutureSell unable to fetch price")
       return parseDealerErrors(error)
@@ -347,10 +339,8 @@ export const NewDealerPriceService = (
           Number(usdAmount.amount),
         ),
       )
-      return {
-        amount: BigInt(response.getAmountInSatoshis()),
-        currency: WalletCurrency.Btc,
-      }
+      const amount = response.getAmountInSatoshis()
+      return paymentAmountFromSats(toSats(amount))
     } catch (error) {
       baseLogger.error({ error }, "GetSatsFromCentsForImmediateBuy unable to fetch price")
       return parseDealerErrors(error)
@@ -366,10 +356,8 @@ export const NewDealerPriceService = (
           Number(usdAmount.amount),
         ),
       )
-      return {
-        amount: BigInt(response.getAmountInSatoshis()),
-        currency: WalletCurrency.Btc,
-      }
+      const amount = response.getAmountInSatoshis()
+      return paymentAmountFromSats(toSats(amount))
     } catch (error) {
       baseLogger.error(
         { error },
@@ -388,10 +376,8 @@ export const NewDealerPriceService = (
           .setAmountInCents(Number(usdAmount.amount))
           .setTimeInSeconds(timeToExpiryInSeconds),
       )
-      return {
-        amount: BigInt(response.getAmountInSatoshis()),
-        currency: WalletCurrency.Btc,
-      }
+      const amount = response.getAmountInSatoshis()
+      return paymentAmountFromSats(toSats(amount))
     } catch (error) {
       baseLogger.error({ error }, "GetSatsFromCentsForFutureBuy unable to fetch price")
       return parseDealerErrors(error)
@@ -407,10 +393,8 @@ export const NewDealerPriceService = (
           .setAmountInCents(Number(usdAmount.amount))
           .setTimeInSeconds(timeToExpiryInSeconds),
       )
-      return {
-        amount: BigInt(response.getAmountInSatoshis()),
-        currency: WalletCurrency.Btc,
-      }
+      const amount = response.getAmountInSatoshis()
+      return paymentAmountFromSats(toSats(amount))
     } catch (error) {
       baseLogger.error({ error }, "GetSatsFromCentsForFutureSell unable to fetch price")
       return parseDealerErrors(error)

--- a/src/services/ledger/facade.ts
+++ b/src/services/ledger/facade.ts
@@ -1,14 +1,10 @@
 import { NoTransactionToSettleError, UnknownLedgerError } from "@domain/ledger"
-import { toCents } from "@domain/fiat"
-import { toSats } from "@domain/bitcoin"
 import {
   ZERO_BANK_FEE,
   AmountCalculator,
   ZERO_CENTS,
   ZERO_SATS,
-  WalletCurrency,
-  paymentAmountFromSats,
-  paymentAmountFromCents,
+  paymentAmountFromNumber,
 } from "@domain/shared"
 
 import { MainBook, Transaction } from "./books"
@@ -96,15 +92,13 @@ export const recordReceive = async ({
 
 export const getLedgerAccountBalanceForWalletId = async <T extends WalletCurrency>({
   id: walletId,
-  currency: walletCurrency,
-}: WalletDescriptor<T>): Promise<PaymentAmount<WalletCurrency> | LedgerError> => {
+  currency,
+}: WalletDescriptor<T>): Promise<PaymentAmount<T> | LedgerError> => {
   try {
     const { balance } = await MainBook.balance({
       account: toLedgerAccountId(walletId),
     })
-    return walletCurrency === WalletCurrency.Btc
-      ? paymentAmountFromSats(toSats(balance))
-      : paymentAmountFromCents(toCents(balance))
+    return paymentAmountFromNumber({ amount: balance, currency })
   } catch (err) {
     return new UnknownLedgerError(err)
   }

--- a/src/services/ledger/volume.ts
+++ b/src/services/ledger/volume.ts
@@ -1,5 +1,12 @@
+import { toSats } from "@domain/bitcoin"
+import { toCents } from "@domain/fiat"
 import { LedgerTransactionType, toLiabilitiesWalletId } from "@domain/ledger"
 import { LedgerServiceError, UnknownLedgerError } from "@domain/ledger/errors"
+import {
+  paymentAmountFromCents,
+  paymentAmountFromSats,
+  WalletCurrency,
+} from "@domain/shared"
 import { addAttributesToCurrentSpan } from "@services/tracing"
 
 import { Transaction } from "./books"
@@ -46,14 +53,14 @@ const volumeAmountFn =
     if (volume instanceof Error) return volume
 
     return {
-      outgoingBaseAmount: {
-        amount: BigInt(volume.outgoingBaseAmount),
-        currency: walletCurrency,
-      },
-      incomingBaseAmount: {
-        amount: BigInt(volume.incomingBaseAmount),
-        currency: walletCurrency,
-      },
+      outgoingBaseAmount:
+        walletCurrency === WalletCurrency.Btc
+          ? paymentAmountFromSats(toSats(volume.outgoingBaseAmount))
+          : paymentAmountFromCents(toCents(volume.outgoingBaseAmount)),
+      incomingBaseAmount:
+        walletCurrency === WalletCurrency.Btc
+          ? paymentAmountFromSats(toSats(volume.incomingBaseAmount))
+          : paymentAmountFromCents(toCents(volume.incomingBaseAmount)),
     }
   }
 

--- a/src/services/payment-flow/index.ts
+++ b/src/services/payment-flow/index.ts
@@ -13,6 +13,7 @@ import {
   paymentAmountFromSats,
   WalletCurrency,
 } from "@domain/shared"
+import { safeBigInt } from "@domain/shared/safe"
 import { elapsedSinceTimestamp } from "@utils"
 
 import { PaymentFlowState } from "./schema"
@@ -192,7 +193,8 @@ export const PaymentFlowStateRepository = (
 const paymentFlowFromRaw = <S extends WalletCurrency, R extends WalletCurrency>(
   paymentFlowState: PaymentFlowStateRecord,
 ): PaymentFlow<S, R> | ValidationError => {
-  const inputAmount = BigInt(paymentFlowState.inputAmount)
+  const inputAmount = safeBigInt(paymentFlowState.inputAmount)
+  if (inputAmount instanceof Error) return inputAmount
 
   const { paymentHash, intraLedgerHash } = paymentFlowState
   const hash = paymentHash


### PR DESCRIPTION
## Description

This PR does 2 things, which can be treated separately (via commits) depending on which changes we find appropriate
- moves most calls to `BigInt` into single calling functions
- adds a `safeBigInt` wrapper and swaps it into some places where `BigInt` is called

### Notes
- I had to remove some of the generic type signatures from certain functions because I couldn't get around a Typescript error with them (see commit https://github.com/GaloyMoney/galoy/pull/1304/commits/8354197459f3c13c189399a14f79921230aca3f7). 

  **The Typescript error is scoped out [here](https://www.typescriptlang.org/play#code/PTAEGUFEBUFUAUBQiAuBPADgU1AdQIYA2hWKAwgK4BOVWAdgMZqgC8oARAELRnugA+HWOAAi7ANyIGAezoBnFHiIly1Wo2ZsA3olB7QnFAwBcHbrwA0u-bDkATU+2FjEAX1D45oGfJTJ02ErEpCJYcgxUAJYYKNJUADwioFgAHij0dl4Ewao09EwAfKygOvqgkQ6gClF0AObWegxq+WimIm7+mDjw+GgAtvQoAIJ90hR0KPHQyWkZWcqklHkaRdoNHqPjKKZ0FH0ARlhU603LTKbQHahdBkY9-YMjYxPF9wMTT1vxXDzsBdeBWx2N6PTYvNggj5gyZOUR-ZA+BSgDC9d7DaEAMSo0j64HwKC8bAAFHJ8XIdntDlQAJSmQwMSHo56KFhFUqgWgoah0EonZoaUzZFRLdRMAB09KsZXw0NMpIJUtAriuiMUKIeUOZWJxZEGhNAJLJFIOR1poCBjM+4LZ1k53N5ZVOotaQWF-PFQMVehlzLlZMVyuVyBAoBEkAAsgB5BGyJE+rbFAAMMd8oAAXkdpFaUNq+qFwlEYnEenI5GFilMZuk6JlXYt3WgCkSAO6VIUhMIRaKxBLQApmy3QqarG1lO1UHlaDbMizeBumVtip0tJUq2OKDPY7O5-NdotUDH4SKEfWV1LV2vt3LOputwULFC7ws94cD1Gg5nD1ij-TjnmL5cNFYFg2CvEUWglIx1jKAB+ZF301LZczxAkiXjCZqWg-RTHVNFt2xPpdQmOQ0OhTDlSAA) for visibility/troubleshooting**

- I did a separate PR to change the remaining significant places where `BigInt` was still being used. It was a much bigger changeset so I separated it into a different branch (PR diff here https://github.com/GaloyMoney/galoy/compare/add-safe-big-int...add-safe-big-int-2)