### PR TITLE
fix: disable mongoose auto index

### DIFF
--- a/src/servers/graphql-main-server.ts
+++ b/src/servers/graphql-main-server.ts
@@ -69,7 +69,7 @@ export async function startApolloServerForCoreSchema() {
 }
 
 if (require.main === module) {
-  setupMongoConnection(false)
+  setupMongoConnection(true)
     .then(async () => {
       activateLndHealthCheck()
       await startApolloServerForCoreSchema()

--- a/src/services/mongodb/index.ts
+++ b/src/services/mongodb/index.ts
@@ -63,6 +63,7 @@ const path = `mongodb://${user}:${password}@${address}/${db}`
 export const setupMongoConnection = async (syncIndexes = false) => {
   try {
     await mongoose.connect(path, {
+      autoIndex: false,
       useNewUrlParser: true,
       useUnifiedTopology: true,
       useCreateIndex: true,


### PR DESCRIPTION
from mongoose doc: 
https://mongoosejs.com/docs/guide.html#indexes

> When your application starts up, Mongoose automatically calls createIndex for each defined index in your schema. Mongoose will call createIndex for each index sequentially, and emit an 'index' event on the model when all the createIndex calls succeeded or when there was an error. While nice for development, it is recommended this behavior be disabled in production

I checked the behavior enabling debug `mongoose.set("debug", true)` and that was happening (so index creation is being executed in every pod restart, every time we send balance notifications, cron execution, ...) so `syncIndexes` were only executing twice the createIndex.

Finally I enabled sync indexes in graphql main server because previously was done by the old server but was not updated after its deprecation