### PR TITLE
refactor: exporter server

### DIFF
--- a/src/app/cold-storage/get-balances.ts
+++ b/src/app/cold-storage/get-balances.ts
@@ -1,5 +1,19 @@
 import { ColdStorageService } from "@services/cold-storage"
 
+export const getBalance = async (
+  walletName: string,
+): Promise<ColdStorageBalance | ApplicationError> => {
+  const coldStorageService = await ColdStorageService()
+  if (coldStorageService instanceof Error) return coldStorageService
+  return coldStorageService.getBalance(walletName)
+}
+
+export const listWallets = async (): Promise<string[] | ApplicationError> => {
+  const coldStorageService = await ColdStorageService()
+  if (coldStorageService instanceof Error) return coldStorageService
+  return coldStorageService.listWallets()
+}
+
 export const getBalances = async (): Promise<ColdStorageBalance[] | ApplicationError> => {
   const coldStorageService = await ColdStorageService()
   if (coldStorageService instanceof Error) return coldStorageService

--- a/src/core/balance-sheet.ts
+++ b/src/core/balance-sheet.ts
@@ -17,6 +17,32 @@ export const getLedgerAccounts = async () => {
   return { assets, liabilities, lightning, bitcoin, bankOwnerBalance }
 }
 
+export const getAssetsLiabilitiesDifference = async () => {
+  const [assets, liabilities] = await Promise.all([
+    ledgerAdmin.getAssetsBalance(),
+    ledgerAdmin.getLiabilitiesBalance(),
+  ])
+
+  return assets + liabilities
+}
+
+export const getBookingVersusRealWorldAssets = async () => {
+  const [lightning, bitcoin, lndBalances, bitcoind] = await Promise.all([
+    ledgerAdmin.getLndBalance(),
+    ledgerAdmin.getBitcoindBalance(),
+    lndsBalances(),
+    getBitcoindBalance(),
+  ])
+
+  const { total: lnd } = lndBalances
+
+  return (
+    lnd + // physical assets
+    bitcoind + // physical assets
+    (lightning + bitcoin)
+  ) // value in accounting
+}
+
 export const balanceSheetIsBalanced = async () => {
   const { assets, liabilities, lightning, bitcoin, bankOwnerBalance } =
     await getLedgerAccounts()

--- a/src/domain/cold-storage/index.types.d.ts
+++ b/src/domain/cold-storage/index.types.d.ts
@@ -42,7 +42,9 @@ type GetColdStoragePsbtArgs = {
 }
 
 interface IColdStorageService {
+  listWallets(): Promise<string[] | ColdStorageServiceError>
   getBalances(): Promise<ColdStorageBalance[] | ColdStorageServiceError>
+  getBalance(walletName: string): Promise<ColdStorageBalance | ColdStorageServiceError>
   createPsbt({
     walletName,
     onChainAddress,

--- a/src/services/cache/index.ts
+++ b/src/services/cache/index.ts
@@ -3,6 +3,7 @@ import {
   LocalCacheUndefinedError,
   UnknownLocalCacheServiceError,
 } from "@domain/cache"
+import { wrapAsyncFunctionsToRunInSpan } from "@services/tracing"
 import NodeCache from "node-cache"
 
 const localCache = new NodeCache()
@@ -54,5 +55,8 @@ export const LocalCacheService = (): ILocalCacheService => {
     }
   }
 
-  return { set, get, getOrSet, clear }
+  return wrapAsyncFunctionsToRunInSpan({
+    namespace: "services.cache",
+    fns: { set, get, getOrSet, clear },
+  })
 }

--- a/src/services/tracing.ts
+++ b/src/services/tracing.ts
@@ -292,7 +292,7 @@ export const wrapToRunInSpan = <
   namespace: string
 }) => {
   return (...args: A): R => {
-    const functionName = fn.name || fnName || "unknown"
+    const functionName = fnName || fn.name || "unknown"
     const spanName = `${namespace}.${functionName}`
     const spanOptions = resolveFunctionSpanOptions({
       namespace,
@@ -334,7 +334,7 @@ export const wrapAsyncToRunInSpan = <
   namespace: string
 }) => {
   return (...args: A): Promise<PromiseReturnType<R>> => {
-    const functionName = fn.name || fnName || "unknown"
+    const functionName = fnName || fn.name || "unknown"
     const spanName = `${namespace}.${functionName}`
     const spanOptions = resolveFunctionSpanOptions({
       namespace,


### PR DESCRIPTION
- Refactor exporter server
  - gauge creation now use collect (parallelizes get metrics)
  - gauge creation now adds tracing wrapper by default
  - improves performance for AssetsLiabilitiesDifference and BookingVersusRealWorldAssets
  - Add cache to galoy wallets balance (use a race condition similar to payInvoice). Does not fix db issue with funder wallet but avoid data gaps in grafana for other metrics 
- Add tracing to cache service
- Fix issue assigning function name in tracing service

New tracing example (dev): https://ui.honeycomb.io/galoy/datasets/jp-dev/result/J1Q1XDR2gBD/trace/5EgXYXu97Du?span=61f3eaa054836caf

