### PR TITLE
Add nextcloud static channel backups

### DIFF
--- a/src/app/admin/backup.ts
+++ b/src/app/admin/backup.ts
@@ -3,24 +3,36 @@ import {
   DropboxAccessToken,
   GcsApplicationCredentials,
   LND_SCB_BACKUP_BUCKET_NAME,
+  Nextcloudurl,
+  Nextclouduser,
+  Nextcloudpassword
 } from "@config"
 import { Storage } from "@google-cloud/storage"
-import { Dropbox } from "dropbox"
+import axios, { Axios } from "axios";
 
 export const uploadBackup =
   (logger: Logger) =>
   async ({ backup, pubkey }) => {
     logger.debug({ backup }, "updating scb on dbx")
     const filename = `${BTC_NETWORK}_lnd_scb_${pubkey}_${Date.now()}`
+if(!DropboxAccessToken){
+  logger.debug("No Dropbox token defined - skipping scb backup")
+}else{
+  try {
+    await axios.post(`https://content.dropboxapi.com/2/files/upload`,backup,{
+      headers: { "Authorization" : `Bearer ${DropboxAccessToken}`,
+      "Content-Type" : `Application/octet-stream`,
+      "Dropbox-API-Arg" : `{"autorename":false,"mode":"add","mute":true,"path":"/${filename}","strict_conflict":false}`,} 
+      })
+    logger.info({ backup }, "scb backed up on dbx successfully")
+  } catch (error) {
+    logger.error({ error }, "scb backup to dbx failed")
+  }
+}
 
-    try {
-      const dbx = new Dropbox({ accessToken: DropboxAccessToken })
-      await dbx.filesUpload({ path: `/${filename}`, contents: backup })
-      logger.info({ backup }, "scb backed up on dbx successfully")
-    } catch (error) {
-      logger.error({ error }, "scb backup to dbx failed")
-    }
-
+if(!GcsApplicationCredentials){
+  logger.debug("No Google Cloud Application credentials defined - skipping scb backup")
+}else{
     logger.debug({ backup }, "updating scb on gcs")
     try {
       const storage = new Storage({
@@ -33,4 +45,22 @@ export const uploadBackup =
     } catch (error) {
       logger.error({ error }, "scb backup to gcs failed")
     }
+  }
+
+if (!(Nextcloudurl && Nextclouduser && Nextcloudpassword)){
+logger.debug("No Nextcloud credentials defined - skipping scb backup")
+}else{
+    logger.debug({ backup }, "updating scb on nextcloud")
+    try {
+      await axios.put(`${Nextcloudurl}/${filename}`,backup,{
+        auth: {
+            username: Nextclouduser,
+            password: Nextcloudpassword
+          }},);
+      logger.info({ backup }, "scb backed up on nextcloud successfully")
+    } catch (error) {
+      logger.error({ error }, "scb backup to nextcloud failed")
+    }
+  }
+
   }

--- a/src/config/process.ts
+++ b/src/config/process.ts
@@ -82,6 +82,14 @@ export const isRunningJest = typeof jest !== "undefined"
 
 export const DropboxAccessToken = process.env.DROPBOX_ACCESS_TOKEN
 export const GcsApplicationCredentials = process.env.GCS_APPLICATION_CREDENTIALS
+export const Nextcloudurl = process.env.NEXTCLOUD_URL
+export const Nextclouduser = process.env.NEXTCLOUD_USER
+export const Nextcloudpassword = process.env.NEXTCLOUD_PASSWORD
+
+if(!(DropboxAccessToken || GcsApplicationCredentials || (Nextcloudurl && Nextclouduser && Nextcloudpassword))) {
+  throw new ConfigError("missing credentials for static channel backup, please check environment variables")
+}
+
 
 export const getBitcoinCoreRPCConfig = () => {
   return {


### PR DESCRIPTION
This pull request adds a nextcloud destination for the static channel backups.
Another pull request for the charts will follow and link back. However this can be merged without changes to the helm charts.
Additionally it replaces the dropbox dependency with axios.
Since Nextcloud uses a Webdav interface where the filepath is inside the url the NEXTCLOUD_URL environment variable takes the whole url for example "https://myserver.com/remote.php/dav/files/myuser/backupfolder".
Please see the [official documentation here](https://docs.nextcloud.com/server/latest/developer_manual/client_apis/WebDAV/basic.html#uploading-files).

Inside of the process.ts I have added a check which results in an error if none of the environment variables for any destination are set.
In the backup.ts itself there's also checks which skip whichever method is not defined. I am unsure about my use of logger.debug there for output. I can remove it if you think it's too much logger output.