### PR TITLE
feat: add nextcloud static channel backups

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "csv-writer": "^1.6.0",
     "dedent": "^0.7.0",
     "dotenv": "^16.0.0",
-    "dropbox": "^10.4.1",
     "express": "^4.17.2",
     "express-jwt": "^7.7.5",
     "firebase-admin": "^10.2.0",

--- a/src/app/admin/backup.ts
+++ b/src/app/admin/backup.ts
@@ -3,9 +3,20 @@ import {
   DropboxAccessToken,
   GcsApplicationCredentials,
   LND_SCB_BACKUP_BUCKET_NAME,
+  Nextcloudurl,
+  Nextclouduser,
+  Nextcloudpassword,
 } from "@config"
 import { Storage } from "@google-cloud/storage"
-import { Dropbox } from "dropbox"
+import axios from "axios"
+import {
+  asyncRunInSpan,
+  SemanticAttributes,
+  addAttributesToCurrentSpan,
+  addEventToCurrentSpan,
+  recordExceptionInCurrentSpan,
+} from "@services/tracing"
+import { ErrorLevel } from "@domain/shared"
 
 export const uploadBackup =
   (logger: Logger) =>
@@ -13,24 +24,108 @@ export const uploadBackup =
     logger.debug({ backup }, "updating scb on dbx")
     const filename = `${BTC_NETWORK}_lnd_scb_${pubkey}_${Date.now()}`
 
-    try {
-      const dbx = new Dropbox({ accessToken: DropboxAccessToken })
-      await dbx.filesUpload({ path: `/${filename}`, contents: backup })
-      logger.info({ backup }, "scb backed up on dbx successfully")
-    } catch (error) {
-      logger.error({ error }, "scb backup to dbx failed")
+    if (
+      !(
+        DropboxAccessToken ||
+        GcsApplicationCredentials ||
+        (Nextcloudurl && Nextclouduser && Nextcloudpassword)
+      )
+    ) {
+      const err = new Error(
+        "Missing environment variable for LND static channel backup destination.",
+      )
+      logger.error(err)
+      recordExceptionInCurrentSpan({ error: err, level: ErrorLevel.Critical })
     }
 
-    logger.debug({ backup }, "updating scb on gcs")
-    try {
-      const storage = new Storage({
-        keyFilename: GcsApplicationCredentials,
-      })
-      const bucket = storage.bucket(LND_SCB_BACKUP_BUCKET_NAME)
-      const file = bucket.file(`${filename}`)
-      await file.save(backup)
-      logger.info({ backup }, "scb backed up on gcs successfully")
-    } catch (error) {
-      logger.error({ error }, "scb backup to gcs failed")
+    if (!DropboxAccessToken) {
+      addAttributesToCurrentSpan({ ["uploadBackup.destination.dropbox"]: "false" })
+    } else {
+      addAttributesToCurrentSpan({ ["uploadBackup.destination.dropbox"]: "true" })
+      asyncRunInSpan(
+        "app.admin.backup.uploadBackup.dropbox",
+        {
+          attributes: {
+            [SemanticAttributes.CODE_FUNCTION]: "uploadBackup.dropbox",
+            [SemanticAttributes.CODE_NAMESPACE]: "app.admin.backup",
+          },
+        },
+        async () => {
+          try {
+            await axios.post(`https://content.dropboxapi.com/2/files/upload`, backup, {
+              headers: {
+                "Authorization": `Bearer ${DropboxAccessToken}`,
+                "Content-Type": `Application/octet-stream`,
+                "Dropbox-API-Arg": `{"autorename":false,"mode":"add","mute":true,"path":"/${filename}","strict_conflict":false}`,
+              },
+            })
+            logger.info({ backup }, "Static channel backup to Dropbox successful.")
+            addEventToCurrentSpan("Static channel backup to Dropbox successful.")
+          } catch (error) {
+            logger.error({ error }, "Static channel backup to Dropbox failed.")
+            recordExceptionInCurrentSpan({ error: error, level: ErrorLevel.Warn })
+          }
+        },
+      )
+    }
+
+    if (!GcsApplicationCredentials) {
+      addAttributesToCurrentSpan({ ["uploadBackup.destination.googlecloud"]: "false" })
+    } else {
+      addAttributesToCurrentSpan({ ["uploadBackup.destination.googlecloud"]: "true" })
+      asyncRunInSpan(
+        "app.admin.backup.uploadBackup.googlecloud",
+        {
+          attributes: {
+            [SemanticAttributes.CODE_FUNCTION]: "uploadBackup.googlecloud",
+            [SemanticAttributes.CODE_NAMESPACE]: "app.admin.backup",
+          },
+        },
+        async () => {
+          try {
+            const storage = new Storage({
+              keyFilename: GcsApplicationCredentials,
+            })
+            const bucket = storage.bucket(LND_SCB_BACKUP_BUCKET_NAME)
+            const file = bucket.file(`${filename}`)
+            await file.save(backup)
+            logger.info({ backup }, "Static channel backup to GoogleCloud successful.")
+            addEventToCurrentSpan("Static channel backup to GoogleCloud successful.")
+          } catch (error) {
+            logger.error({ error }, "Static channel backup to GoogleCloud failed.")
+            recordExceptionInCurrentSpan({ error: error, level: ErrorLevel.Warn })
+          }
+        },
+      )
+    }
+
+    if (!(Nextcloudurl && Nextclouduser && Nextcloudpassword)) {
+      addAttributesToCurrentSpan({ ["uploadBackup.destination.nextcloud"]: "false" })
+    } else {
+      addAttributesToCurrentSpan({ ["uploadBackup.destination.nextcloud"]: "true" })
+      asyncRunInSpan(
+        "app.admin.backup.uploadBackup.nextcloud",
+        {
+          attributes: {
+            [SemanticAttributes.CODE_FUNCTION]: "uploadBackup.nextcloud",
+            [SemanticAttributes.CODE_NAMESPACE]: "app.admin.backup",
+          },
+        },
+        async () => {
+          try {
+            await axios.put(`${Nextcloudurl}/${filename}`, backup, {
+              auth: {
+                username: `${Nextclouduser}`,
+                password: `${Nextcloudpassword}`,
+              },
+            })
+            logger.info({ backup }, "Static channel backup to Nextcloud successful.")
+            addEventToCurrentSpan("Static channel backup to Nextcloud successful.")
+          } catch (error) {
+            logger.error({ error }, "Static channel backup to Nextcloud failed.")
+            recordExceptionInCurrentSpan({ error: error, level: ErrorLevel.Warn })
+          }
+        },
+      )
     }
   }

--- a/src/config/process.ts
+++ b/src/config/process.ts
@@ -82,6 +82,9 @@ export const isRunningJest = typeof jest !== "undefined"
 
 export const DropboxAccessToken = process.env.DROPBOX_ACCESS_TOKEN
 export const GcsApplicationCredentials = process.env.GCS_APPLICATION_CREDENTIALS
+export const Nextcloudurl = process.env.NEXTCLOUD_URL
+export const Nextclouduser = process.env.NEXTCLOUD_USER
+export const Nextcloudpassword = process.env.NEXTCLOUD_PASSWORD
 
 export const getBitcoinCoreRPCConfig = () => {
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4420,13 +4420,6 @@ double-ended-queue@^2.1.0-0:
   resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
   integrity sha512-+BNfZ+deCo8hMNpDqDnvT+c0XpJ5cUa6mqYq89bho2Ifze4URTqRkcwR399hWoTrTkbZ/XJYDgP6rc7pRgffEQ==
 
-dropbox@^10.4.1:
-  version "10.30.0"
-  resolved "https://registry.yarnpkg.com/dropbox/-/dropbox-10.30.0.tgz#6b2a5bdf3fac8475645ea2d6d19b86abb0a504d5"
-  integrity sha512-ah4mb4YoI7WwS0yXtDLKxbp9apXp5TfPksDuEvvgCYR1bpMmQKUFG9raNMLC2NsF4Dc/9Axxqj436ErPvg9HeQ==
-  dependencies:
-    node-fetch "^2.6.1"
-
 dtrace-provider@~0.8:
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.8.tgz#2996d5490c37e1347be263b423ed7b297fb0d97e"


### PR DESCRIPTION
This pull request adds a nextcloud destination for the static channel backups.
The corresponding pull request for the charts can be found [here](https://github.com/GaloyMoney/charts/pull/978). However this can be merged without changes to the helm charts. If the nextcloud environment variables are not set it will simply skip it.

Additionally it replaces the dropbox dependency with axios.

Since Nextcloud uses a Webdav interface where the filepath is contained inside the url. The NEXTCLOUD_URL environment variable thus takes the whole url for example `https://myserver.com/remote.php/dav/files/myuser/backupfolder`.
Please see the [official documentation here](https://docs.nextcloud.com/server/latest/developer_manual/client_apis/WebDAV/basic.html#uploading-files).

I have added a check in the backup routine which results in an error log entry if none of the environment variables for any destination are set. But it will not crash.
If any of the environment variables for either google cloud, dropbox or nextcloud are not set it will skip them and notify in the logs.