### PR TITLE
fix: round balances out of ledger

### DIFF
--- a/src/services/ledger/index.ts
+++ b/src/services/ledger/index.ts
@@ -224,7 +224,7 @@ export const LedgerService = (): ILedgerService => {
           })
         }
       }
-      return { amount: BigInt(balance), currency: walletDescriptor.currency }
+      return { amount: BigInt(Math.floor(balance)), currency: walletDescriptor.currency }
     } catch (err) {
       return new UnknownLedgerError(err)
     }


### PR DESCRIPTION
## Description

We are currently getting `RangeError` errors from BigInt conversion for USD wallets because transactions currently have  float debit/credit values in our db. This is to round those balance values before passing them forward to a `BigInt` call. This fix is temporary and will eventually be overtaken by:
1. `safeBigInt` in #1304
2. a migration in future to round transaction amounts at the source in our db