### PR TITLE
fix: uncheckedAmount check to handle '0' value

### DIFF
--- a/src/domain/payments/payment-flow-builder.ts
+++ b/src/domain/payments/payment-flow-builder.ts
@@ -103,7 +103,7 @@ const LPFBWithInvoice = <S extends WalletCurrency>(
 ): LPFBWithInvoice<S> | LPFBWithError => {
   const withSenderWallet = (senderWallet: WalletDescriptor<S>) => {
     const { id: senderWalletId, currency: senderWalletCurrency } = senderWallet
-    if (state.uncheckedAmount) {
+    if (state.uncheckedAmount !== undefined) {
       if (senderWalletCurrency === WalletCurrency.Btc) {
         const paymentAmount = checkedToBtcPaymentAmount(state.uncheckedAmount)
         if (paymentAmount instanceof ValidationError) {

--- a/test/unit/payments/payment-flow-builder.spec.ts
+++ b/test/unit/payments/payment-flow-builder.spec.ts
@@ -980,6 +980,25 @@ describe("LightningPaymentFlowBuilder", () => {
         expect(payment).toBeInstanceOf(ValidationError)
       })
     })
+    describe("zero-value uncheckedAmount", () => {
+      it("returns a ValidationError", async () => {
+        const payment = await LightningPaymentFlowBuilder({
+          localNodeIds: [],
+          usdFromBtcMidPriceFn,
+          btcFromUsdMidPriceFn,
+        })
+          .withNoAmountInvoice({ invoice: invoiceWithNoAmount, uncheckedAmount: 0 })
+          .withSenderWallet(senderBtcWallet)
+          .withoutRecipientWallet()
+          .withConversion({
+            usdFromBtc,
+            btcFromUsd,
+          })
+          .withoutRoute()
+
+        expect(payment).toBeInstanceOf(ValidationError)
+      })
+    })
     describe("no recipient wallet despite IntraLedger", () => {
       it("returns InvalidLightningPaymentFlowBuilderStateError", async () => {
         const payment = await LightningPaymentFlowBuilder({


### PR DESCRIPTION
## Description

Fix for the issue where we were able to get `"withSenderWallet impossible"` error with the following variables for `intraledgerUsdPaymentSend` mutation (see [trace](https://ui.honeycomb.io/galoy/datasets/galoy-hack/result/wNdPskAo26S/trace/G6Rb4PfWdcg?span=dc63a3d8226675fd))
```
{
    "input": {
        "walletId": "{{walletIdUsd}}",
        "amount": 0.0229,
        "recipientWalletId": "{{walletIdBtc}}"
    }
}

```