### PR TITLE
refactor: rename 'transactionsByWalletId' to 'transactions'

### DIFF
--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -2,7 +2,7 @@ interface Account {
   csvTransactions(walletIds: [WalletId!]!): String!
   defaultWalletId: WalletId!
   id: ID!
-  transactionsByWalletIds(
+  transactions(
     """
     Returns the items in the list that come after the specified cursor.
     """
@@ -129,7 +129,7 @@ type ConsumerAccount implements Account {
   """
   A list of all transactions associated with walletIds optionally passed.
   """
-  transactionsByWalletIds(
+  transactions(
     """
     Returns the items in the list that come after the specified cursor.
     """

--- a/src/graphql/types/abstract/account.ts
+++ b/src/graphql/types/abstract/account.ts
@@ -27,7 +27,7 @@ const IAccount = GT.Interface({
         },
       },
     },
-    transactionsByWalletIds: {
+    transactions: {
       type: TransactionConnection,
       args: {
         ...connectionArgs,

--- a/src/graphql/types/object/business-account.ts
+++ b/src/graphql/types/object/business-account.ts
@@ -51,7 +51,7 @@ const BusinessAccount = GT.Object({
         return Accounts.getCSVForAccount(source.id)
       },
     },
-    transactionsByWalletIds: {
+    transactions: {
       description:
         "A list of all transactions associated with walletIds optionally passed.",
       type: TransactionConnection,

--- a/src/graphql/types/object/consumer-account.ts
+++ b/src/graphql/types/object/consumer-account.ts
@@ -52,7 +52,7 @@ const ConsumerAccount = GT.Object({
         return Accounts.getCSVForAccount(source.id)
       },
     },
-    transactionsByWalletIds: {
+    transactions: {
       description:
         "A list of all transactions associated with walletIds optionally passed.",
       type: TransactionConnection,

--- a/test/e2e/servers/graphql-main-server/auth-requests.spec.ts
+++ b/test/e2e/servers/graphql-main-server/auth-requests.spec.ts
@@ -161,7 +161,7 @@ describe("graphql", () => {
         variables: { walletIds: wallets.map((wallet) => wallet.id), first: 5 },
       })
 
-      const { edges: txns } = data.me.defaultAccount.transactionsByWalletIds
+      const { edges: txns } = data.me.defaultAccount.transactions
       expect(txns).toBeTruthy()
       expect(txns).toEqual(
         expect.arrayContaining([
@@ -201,7 +201,7 @@ describe("graphql", () => {
         query: TRANSACTIONS_BY_WALLET_IDS,
       })
 
-      const { edges: txns } = data.me.defaultAccount.transactionsByWalletIds
+      const { edges: txns } = data.me.defaultAccount.transactions
       expect(txns).toBeTruthy()
       expect(txns).toEqual(
         expect.arrayContaining([

--- a/test/e2e/servers/graphql-main-server/queries/transactions-by-wallet-ids.gql
+++ b/test/e2e/servers/graphql-main-server/queries/transactions-by-wallet-ids.gql
@@ -1,8 +1,8 @@
-query transactionsByWalletIds($walletIds: [WalletId], $first: Int, $after: String) {
+query transactions($walletIds: [WalletId], $first: Int, $after: String) {
   me {
     defaultAccount {
       defaultWalletId
-      transactionsByWalletIds(walletIds: $walletIds, first: $first, after: $after) {
+      transactions(walletIds: $walletIds, first: $first, after: $after) {
         ...TransactionList
       }
     }


### PR DESCRIPTION
## Description

With the last commit (https://github.com/GaloyMoney/galoy/pull/1325/commits/bd00fbd45f351dafcf66d5156f2d43769adc5739) that allowed the walletIds to be optional, this query behaves more like a 'transaction for account' query with an optional walletIds filter.

Given this, a better naming for this selection could simply be 'transactions' under an Account.