### PR TITLE
test: add case for non-owned walletId passed to transactions mutation

### DIFF
--- a/test/e2e/servers/graphql-main-server/auth-requests.spec.ts
+++ b/test/e2e/servers/graphql-main-server/auth-requests.spec.ts
@@ -220,6 +220,29 @@ describe("graphql", () => {
         ]),
       )
     })
+
+    it("returns an error if non-owned walletId is included", async () => {
+      const expectedErrorMessage = "Invalid walletId for account."
+      const otherWalletId = await getDefaultWalletIdByTestUserRef("A")
+
+      const walletIdsCases = [
+        [otherWalletId, walletId],
+        [otherWalletId],
+        [walletId, otherWalletId],
+      ]
+
+      for (const walletIds of walletIdsCases) {
+        const { data, errors } = await apolloClient.query({
+          query: TRANSACTIONS_BY_WALLET_IDS,
+          variables: { walletIds },
+        })
+        expect(data.me.defaultAccount.transactions).toBeNull()
+        expect(errors).not.toBeUndefined()
+        if (errors == undefined) throw new Error("'errors' property missing")
+
+        expect(errors[0].message).toBe(expectedErrorMessage)
+      }
+    })
   })
 
   describe("lnNoAmountInvoiceCreate", () => {


### PR DESCRIPTION
## Description

Adds a missing test case for new `transactions` selection.