### PR TITLE
chore: swap 'paymentAmountFromSats/Cents' to 'paymentAmountFromNumber'

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -13,6 +13,8 @@ dealer:
   usd:
     hedgingEnabled: false
 
+ratioPrecision: 1_000_000
+
 buildVersion:
   android:
     minBuildNumber: 182

--- a/src/app/payments/helpers.ts
+++ b/src/app/payments/helpers.ts
@@ -62,6 +62,7 @@ export const usdFromBtcMidPriceFn = async (
 
       const usdAmount = Math.ceil(Number(amount.amount) * midPriceRatio)
       const usdPaymentAmount = paymentAmountFromCents(toCents(usdAmount))
+      if (usdPaymentAmount instanceof Error) return usdPaymentAmount
 
       addAttributesToCurrentSpan({
         "usdFromBtcMidPriceFn.midPriceRatio": midPriceRatio,
@@ -98,6 +99,7 @@ export const btcFromUsdMidPriceFn = async (
 
       const btcAmount = Math.ceil(Number(amount.amount) / midPriceRatio)
       const btcPaymentAmount = paymentAmountFromSats(toSats(btcAmount))
+      if (btcPaymentAmount instanceof Error) return btcPaymentAmount
 
       addAttributesToCurrentSpan({
         "btcFromUsdMidPriceFn.midPriceRatio": midPriceRatio,
@@ -212,6 +214,7 @@ const recipientDetailsFromInvoice = async (invoice: LnInvoice) => {
   } = walletInvoice
   const usdPaymentAmount =
     cents !== undefined ? paymentAmountFromCents(toCents(cents)) : undefined
+  if (usdPaymentAmount instanceof Error) return usdPaymentAmount
 
   const recipientWallet = await WalletsRepository().findById(recipientWalletId)
   if (recipientWallet instanceof Error) return recipientWallet

--- a/src/app/payments/helpers.ts
+++ b/src/app/payments/helpers.ts
@@ -16,12 +16,10 @@ import {
   ErrorLevel,
   ExchangeCurrencyUnit,
   paymentAmountFromNumber,
-  paymentAmountFromSats,
   WalletCurrency,
 } from "@domain/shared"
 import { AlreadyPaidError } from "@domain/errors"
 import { CENTS_PER_USD } from "@domain/fiat"
-import { toSats } from "@domain/bitcoin"
 
 import { NewDealerPriceService } from "@services/dealer-price"
 import {
@@ -101,7 +99,10 @@ export const btcFromUsdMidPriceFn = async (
       if (midPriceRatio instanceof Error) return midPriceRatio
 
       const btcAmount = Math.ceil(Number(amount.amount) / midPriceRatio)
-      const btcPaymentAmount = paymentAmountFromSats(toSats(btcAmount))
+      const btcPaymentAmount = paymentAmountFromNumber({
+        amount: btcAmount,
+        currency: WalletCurrency.Btc,
+      })
       if (btcPaymentAmount instanceof Error) return btcPaymentAmount
 
       addAttributesToCurrentSpan({

--- a/src/app/payments/helpers.ts
+++ b/src/app/payments/helpers.ts
@@ -60,7 +60,6 @@ export const usdFromBtcMidPriceFn = async (
       if (midPriceRatio instanceof Error) return midPriceRatio
 
       const usdPaymentAmount = midPriceRatio.convertFromBtc(amount)
-      if (usdPaymentAmount instanceof Error) return usdPaymentAmount
 
       addAttributesToCurrentSpan({
         "usdFromBtcMidPriceFn.midPriceRatio": midPriceRatio.usdPerSat(),
@@ -96,7 +95,6 @@ export const btcFromUsdMidPriceFn = async (
       if (midPriceRatio instanceof Error) return midPriceRatio
 
       const btcPaymentAmount = midPriceRatio.convertFromUsd(amount)
-      if (btcPaymentAmount instanceof Error) return btcPaymentAmount
 
       addAttributesToCurrentSpan({
         "btcFromUsdMidPriceFn.midPriceRatio": midPriceRatio.usdPerSat(),

--- a/src/app/payments/helpers.ts
+++ b/src/app/payments/helpers.ts
@@ -15,12 +15,12 @@ import {
 import {
   ErrorLevel,
   ExchangeCurrencyUnit,
-  paymentAmountFromCents,
+  paymentAmountFromNumber,
   paymentAmountFromSats,
   WalletCurrency,
 } from "@domain/shared"
 import { AlreadyPaidError } from "@domain/errors"
-import { CENTS_PER_USD, toCents } from "@domain/fiat"
+import { CENTS_PER_USD } from "@domain/fiat"
 import { toSats } from "@domain/bitcoin"
 
 import { NewDealerPriceService } from "@services/dealer-price"
@@ -61,7 +61,10 @@ export const usdFromBtcMidPriceFn = async (
       if (midPriceRatio instanceof Error) return midPriceRatio
 
       const usdAmount = Math.ceil(Number(amount.amount) * midPriceRatio)
-      const usdPaymentAmount = paymentAmountFromCents(toCents(usdAmount))
+      const usdPaymentAmount = paymentAmountFromNumber({
+        amount: usdAmount,
+        currency: WalletCurrency.Usd,
+      })
       if (usdPaymentAmount instanceof Error) return usdPaymentAmount
 
       addAttributesToCurrentSpan({
@@ -213,7 +216,9 @@ const recipientDetailsFromInvoice = async (invoice: LnInvoice) => {
     cents,
   } = walletInvoice
   const usdPaymentAmount =
-    cents !== undefined ? paymentAmountFromCents(toCents(cents)) : undefined
+    cents !== undefined
+      ? paymentAmountFromNumber({ amount: cents, currency: WalletCurrency.Usd })
+      : undefined
   if (usdPaymentAmount instanceof Error) return usdPaymentAmount
 
   const recipientWallet = await WalletsRepository().findById(recipientWalletId)

--- a/src/app/payments/translations.ts
+++ b/src/app/payments/translations.ts
@@ -47,7 +47,16 @@ export const PaymentFlowFromLedgerTransaction = <
   }
 
   const btcPaymentAmount = paymentAmountFromSats(satsAmount)
+  if (btcPaymentAmount instanceof Error) return btcPaymentAmount
+
   const usdPaymentAmount = paymentAmountFromCents(centsAmount)
+  if (usdPaymentAmount instanceof Error) return usdPaymentAmount
+
+  const btcProtocolFee = paymentAmountFromSats(satsFee)
+  if (btcProtocolFee instanceof Error) return btcProtocolFee
+
+  const usdProtocolFee = paymentAmountFromCents(centsFee)
+  if (usdProtocolFee instanceof Error) return usdProtocolFee
 
   return PaymentFlow({
     senderWalletId,
@@ -67,7 +76,7 @@ export const PaymentFlowFromLedgerTransaction = <
         ? usdPaymentAmount.amount
         : btcPaymentAmount.amount,
 
-    btcProtocolFee: paymentAmountFromSats(satsFee),
-    usdProtocolFee: paymentAmountFromCents(centsFee),
+    btcProtocolFee,
+    usdProtocolFee,
   })
 }

--- a/src/app/payments/translations.ts
+++ b/src/app/payments/translations.ts
@@ -4,11 +4,7 @@ import {
   NonLnPaymentTransactionForPaymentFlowError,
   PaymentFlow,
 } from "@domain/payments"
-import {
-  paymentAmountFromCents,
-  paymentAmountFromSats,
-  WalletCurrency,
-} from "@domain/shared"
+import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
 import { PaymentInitiationMethod, SettlementMethod } from "@domain/wallets"
 
 export const PaymentFlowFromLedgerTransaction = <
@@ -46,16 +42,28 @@ export const PaymentFlowFromLedgerTransaction = <
     return new MissingPropsInTransactionForPaymentFlowError()
   }
 
-  const btcPaymentAmount = paymentAmountFromSats(satsAmount)
+  const btcPaymentAmount = paymentAmountFromNumber({
+    amount: satsAmount,
+    currency: WalletCurrency.Btc,
+  })
   if (btcPaymentAmount instanceof Error) return btcPaymentAmount
 
-  const usdPaymentAmount = paymentAmountFromCents(centsAmount)
+  const usdPaymentAmount = paymentAmountFromNumber({
+    amount: centsAmount,
+    currency: WalletCurrency.Usd,
+  })
   if (usdPaymentAmount instanceof Error) return usdPaymentAmount
 
-  const btcProtocolFee = paymentAmountFromSats(satsFee)
+  const btcProtocolFee = paymentAmountFromNumber({
+    amount: satsFee,
+    currency: WalletCurrency.Btc,
+  })
   if (btcProtocolFee instanceof Error) return btcProtocolFee
 
-  const usdProtocolFee = paymentAmountFromCents(centsFee)
+  const usdProtocolFee = paymentAmountFromNumber({
+    amount: centsFee,
+    currency: WalletCurrency.Usd,
+  })
   if (usdProtocolFee instanceof Error) return usdProtocolFee
 
   return PaymentFlow({

--- a/src/app/wallets/reimburse-fee.ts
+++ b/src/app/wallets/reimburse-fee.ts
@@ -3,7 +3,7 @@ import { DisplayCurrency, NewDisplayCurrencyConverter, toCents } from "@domain/f
 import { LedgerTransactionType } from "@domain/ledger"
 import { FeeReimbursement } from "@domain/ledger/fee-reimbursement"
 import { PriceRatio } from "@domain/payments"
-import { paymentAmountFromSats } from "@domain/shared"
+import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
 
 import * as LedgerFacade from "@services/ledger/facade"
 
@@ -20,7 +20,10 @@ export const reimburseFee = async <S extends WalletCurrency, R extends WalletCur
   revealedPreImage?: RevealedPreImage
   logger: Logger
 }): Promise<true | ApplicationError> => {
-  const actualFeeAmount = paymentAmountFromSats(actualFee)
+  const actualFeeAmount = paymentAmountFromNumber({
+    amount: actualFee,
+    currency: WalletCurrency.Btc,
+  })
   if (actualFeeAmount instanceof Error) return actualFeeAmount
 
   const maxFeeAmounts = {

--- a/src/app/wallets/reimburse-fee.ts
+++ b/src/app/wallets/reimburse-fee.ts
@@ -21,6 +21,7 @@ export const reimburseFee = async <S extends WalletCurrency, R extends WalletCur
   logger: Logger
 }): Promise<true | ApplicationError> => {
   const actualFeeAmount = paymentAmountFromSats(actualFee)
+  if (actualFeeAmount instanceof Error) return actualFeeAmount
 
   const maxFeeAmounts = {
     btc: paymentFlow.btcProtocolFee,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -132,6 +132,7 @@ export const configSchema = {
     displayCurrency: displayCurrencyConfigSchema,
     funder: { type: "string" },
     dealer: dealerConfigSchema,
+    ratioPrecision: { type: "number" },
     buildVersion: {
       type: "object",
       properties: {

--- a/src/config/schema.types.d.ts
+++ b/src/config/schema.types.d.ts
@@ -30,6 +30,7 @@ type YamlSchema = {
       hedgingEnabled: boolean
     }
   }
+  ratioPrecision: number
   buildVersion: {
     android: BuildNumberInput
     ios: BuildNumberInput

--- a/src/config/yaml.ts
+++ b/src/config/yaml.ts
@@ -45,6 +45,8 @@ if (!valid) {
 }
 export const yamlConfig = yamlConfigInit as YamlSchema
 
+export const RATIO_PRECISION: number = yamlConfig.ratioPrecision
+
 export const MEMO_SHARING_SATS_THRESHOLD = yamlConfig.spamLimits.memoSharingSatsThreshold
 
 // how many block are we looking back for getChainTransactions

--- a/src/domain/accounts/new-limits-checker.ts
+++ b/src/domain/accounts/new-limits-checker.ts
@@ -26,6 +26,7 @@ export const AccountLimitsChecker = ({
     if (volumeInUsdAmount instanceof Error) return volumeInUsdAmount
 
     const limit = paymentAmountFromCents(accountLimits.intraLedgerLimit)
+    if (limit instanceof Error) return limit
     addAttributesToCurrentSpan({
       "txVolume.outgoingInBase": `${volumeInUsdAmount.amount}`,
       "txVolume.threshold": `${limit.amount}`,
@@ -55,6 +56,7 @@ export const AccountLimitsChecker = ({
     if (volumeInUsdAmount instanceof Error) return volumeInUsdAmount
 
     const limit = paymentAmountFromCents(accountLimits.withdrawalLimit)
+    if (limit instanceof Error) return limit
     addAttributesToCurrentSpan({
       "txVolume.outgoingInBase": `${volumeInUsdAmount.amount}`,
       "txVolume.threshold": `${limit.amount}`,
@@ -97,6 +99,7 @@ export const TwoFALimitsChecker = ({
     if (volumeInUsdAmount instanceof Error) return volumeInUsdAmount
 
     const limit = paymentAmountFromCents(twoFALimits.threshold)
+    if (limit instanceof Error) return limit
     addAttributesToCurrentSpan({
       "txVolume.outgoingInBase": `${volumeInUsdAmount.amount}`,
       "txVolume.threshold": `${limit.amount}`,

--- a/src/domain/accounts/new-limits-checker.ts
+++ b/src/domain/accounts/new-limits-checker.ts
@@ -3,7 +3,7 @@ import {
   TwoFALimitsExceededError,
   WithdrawalLimitsExceededError,
 } from "@domain/errors"
-import { paymentAmountFromCents, WalletCurrency } from "@domain/shared"
+import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
 import { addAttributesToCurrentSpan } from "@services/tracing"
 
 export const AccountLimitsChecker = ({
@@ -25,7 +25,10 @@ export const AccountLimitsChecker = ({
         : (walletVolume.outgoingBaseAmount as UsdPaymentAmount)
     if (volumeInUsdAmount instanceof Error) return volumeInUsdAmount
 
-    const limit = paymentAmountFromCents(accountLimits.intraLedgerLimit)
+    const limit = paymentAmountFromNumber({
+      amount: accountLimits.intraLedgerLimit,
+      currency: WalletCurrency.Usd,
+    })
     if (limit instanceof Error) return limit
     addAttributesToCurrentSpan({
       "txVolume.outgoingInBase": `${volumeInUsdAmount.amount}`,
@@ -55,7 +58,10 @@ export const AccountLimitsChecker = ({
         : (walletVolume.outgoingBaseAmount as UsdPaymentAmount)
     if (volumeInUsdAmount instanceof Error) return volumeInUsdAmount
 
-    const limit = paymentAmountFromCents(accountLimits.withdrawalLimit)
+    const limit = paymentAmountFromNumber({
+      amount: accountLimits.withdrawalLimit,
+      currency: WalletCurrency.Usd,
+    })
     if (limit instanceof Error) return limit
     addAttributesToCurrentSpan({
       "txVolume.outgoingInBase": `${volumeInUsdAmount.amount}`,
@@ -98,7 +104,10 @@ export const TwoFALimitsChecker = ({
         : (walletVolume.outgoingBaseAmount as UsdPaymentAmount)
     if (volumeInUsdAmount instanceof Error) return volumeInUsdAmount
 
-    const limit = paymentAmountFromCents(twoFALimits.threshold)
+    const limit = paymentAmountFromNumber({
+      amount: twoFALimits.threshold,
+      currency: WalletCurrency.Usd,
+    })
     if (limit instanceof Error) return limit
     addAttributesToCurrentSpan({
       "txVolume.outgoingInBase": `${volumeInUsdAmount.amount}`,

--- a/src/domain/accounts/new-limits-checker.ts
+++ b/src/domain/accounts/new-limits-checker.ts
@@ -23,7 +23,6 @@ export const AccountLimitsChecker = ({
             walletVolume.outgoingBaseAmount as BtcPaymentAmount,
           )
         : (walletVolume.outgoingBaseAmount as UsdPaymentAmount)
-    if (volumeInUsdAmount instanceof Error) return volumeInUsdAmount
 
     const limit = paymentAmountFromNumber({
       amount: accountLimits.intraLedgerLimit,
@@ -56,7 +55,6 @@ export const AccountLimitsChecker = ({
             walletVolume.outgoingBaseAmount as BtcPaymentAmount,
           )
         : (walletVolume.outgoingBaseAmount as UsdPaymentAmount)
-    if (volumeInUsdAmount instanceof Error) return volumeInUsdAmount
 
     const limit = paymentAmountFromNumber({
       amount: accountLimits.withdrawalLimit,
@@ -102,7 +100,6 @@ export const TwoFALimitsChecker = ({
             walletVolume.outgoingBaseAmount as BtcPaymentAmount,
           )
         : (walletVolume.outgoingBaseAmount as UsdPaymentAmount)
-    if (volumeInUsdAmount instanceof Error) return volumeInUsdAmount
 
     const limit = paymentAmountFromNumber({
       amount: twoFALimits.threshold,

--- a/src/domain/bitcoin/lightning/ln-invoice.ts
+++ b/src/domain/bitcoin/lightning/ln-invoice.ts
@@ -24,17 +24,16 @@ export const decodeInvoice = (
     return new LnInvoiceMissingPaymentSecretError()
   }
   const paymentSecret: PaymentIdentifyingSecret = decodedInvoice.payment
-  const amount: Satoshis | null = decodedInvoice.safe_tokens
-    ? toSats(decodedInvoice.safe_tokens)
-    : null
-  const paymentAmount: BtcPaymentAmount | null = amount
-    ? paymentAmountFromSats(amount)
-    : null
   const cltvDelta: number | null = decodedInvoice.cltv_delta
     ? decodedInvoice.cltv_delta
     : null
   const expiresAt = new Date(decodedInvoice.expires_at)
   const isExpired = !!decodedInvoice.is_expired
+  const amount: Satoshis | null = decodedInvoice.safe_tokens
+    ? toSats(decodedInvoice.safe_tokens)
+    : null
+  const paymentAmount = amount ? paymentAmountFromSats(amount) : null
+  if (paymentAmount instanceof Error) return paymentAmount
 
   let routeHints: Hop[][] = []
   if (decodedInvoice.routes) {

--- a/src/domain/bitcoin/lightning/ln-invoice.ts
+++ b/src/domain/bitcoin/lightning/ln-invoice.ts
@@ -1,4 +1,4 @@
-import { paymentAmountFromSats } from "@domain/shared"
+import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
 import { toMilliSatsFromNumber, toSats } from "@domain/bitcoin"
 import { parsePaymentRequest } from "invoices"
 
@@ -32,7 +32,9 @@ export const decodeInvoice = (
   const amount: Satoshis | null = decodedInvoice.safe_tokens
     ? toSats(decodedInvoice.safe_tokens)
     : null
-  const paymentAmount = amount ? paymentAmountFromSats(amount) : null
+  const paymentAmount = amount
+    ? paymentAmountFromNumber({ amount, currency: WalletCurrency.Btc })
+    : null
   if (paymentAmount instanceof Error) return paymentAmount
 
   let routeHints: Hop[][] = []

--- a/src/domain/dealer-price/index.types.d.ts
+++ b/src/domain/dealer-price/index.types.d.ts
@@ -60,5 +60,5 @@ interface INewDealerPriceService {
     amount: UsdPaymentAmount,
   ): Promise<BtcPaymentAmount | DealerPriceServiceError>
 
-  getCentsPerSatsExchangeMidRate(): Promise<CentsPerSatsRatio | DealerPriceServiceError>
+  getCentsPerSatsExchangeMidRate(): Promise<PriceRatio | ValidationError>
 }

--- a/src/domain/ledger/fee-reimbursement.ts
+++ b/src/domain/ledger/fee-reimbursement.ts
@@ -23,6 +23,7 @@ export const FeeReimbursement = ({
     }
 
     const feeDifferenceUsdAmount = priceRatio.convertFromBtc(feeDifferenceBtcAmount)
+    if (feeDifferenceUsdAmount instanceof Error) return feeDifferenceUsdAmount
 
     return { btc: feeDifferenceBtcAmount, usd: feeDifferenceUsdAmount }
   }

--- a/src/domain/ledger/fee-reimbursement.ts
+++ b/src/domain/ledger/fee-reimbursement.ts
@@ -23,7 +23,6 @@ export const FeeReimbursement = ({
     }
 
     const feeDifferenceUsdAmount = priceRatio.convertFromBtc(feeDifferenceBtcAmount)
-    if (feeDifferenceUsdAmount instanceof Error) return feeDifferenceUsdAmount
 
     return { btc: feeDifferenceBtcAmount, usd: feeDifferenceUsdAmount }
   }

--- a/src/domain/payments/index.ts
+++ b/src/domain/payments/index.ts
@@ -4,9 +4,7 @@ export * from "./payment-flow-builder"
 export * from "./price-ratio"
 export * from "./ln-fees"
 
-import { toSats } from "@domain/bitcoin"
-import { toCents } from "@domain/fiat"
-import { paymentAmountFromCents, paymentAmountFromSats } from "@domain/shared"
+import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
 
 import { InvalidBtcPaymentAmountError, InvalidUsdPaymentAmountError } from "./errors"
 
@@ -20,7 +18,7 @@ export const checkedToBtcPaymentAmount = (
     return new InvalidBtcPaymentAmountError()
   }
   if (!(amount && amount > 0)) return new InvalidBtcPaymentAmountError()
-  return paymentAmountFromSats(toSats(amount))
+  return paymentAmountFromNumber({ amount, currency: WalletCurrency.Btc })
 }
 
 export const checkedToUsdPaymentAmount = (
@@ -33,5 +31,5 @@ export const checkedToUsdPaymentAmount = (
     return new InvalidUsdPaymentAmountError()
   }
   if (!(amount && amount > 0)) return new InvalidUsdPaymentAmountError()
-  return paymentAmountFromCents(toCents(amount))
+  return paymentAmountFromNumber({ amount, currency: WalletCurrency.Usd })
 }

--- a/src/domain/payments/index.types.d.ts
+++ b/src/domain/payments/index.types.d.ts
@@ -1,6 +1,6 @@
 type PriceRatio = {
-  convertFromUsd(convert: UsdPaymentAmount): BtcPaymentAmount
-  convertFromBtc(convert: BtcPaymentAmount): UsdPaymentAmount
+  convertFromUsd(convert: UsdPaymentAmount): BtcPaymentAmount | ValidationError
+  convertFromBtc(convert: BtcPaymentAmount): UsdPaymentAmount | ValidationError
   usdPerSat(): DisplayCurrencyBasePerSat
 }
 

--- a/src/domain/payments/index.types.d.ts
+++ b/src/domain/payments/index.types.d.ts
@@ -1,6 +1,6 @@
 type PriceRatio = {
-  convertFromUsd(convert: UsdPaymentAmount): BtcPaymentAmount | ValidationError
-  convertFromBtc(convert: BtcPaymentAmount): UsdPaymentAmount | ValidationError
+  convertFromUsd(convert: UsdPaymentAmount): BtcPaymentAmount
+  convertFromBtc(convert: BtcPaymentAmount): UsdPaymentAmount
   usdPerSat(): DisplayCurrencyBasePerSat
 }
 

--- a/src/domain/payments/ln-fees.ts
+++ b/src/domain/payments/ln-fees.ts
@@ -34,7 +34,7 @@ export const LnFees = (
     }
   }
 
-  const feeFromRawRoute = (rawRoute: RawRoute): BtcPaymentAmount => {
+  const feeFromRawRoute = (rawRoute: RawRoute): BtcPaymentAmount | ValidationError => {
     const amount = toSats(Math.ceil(rawRoute.fee))
     return paymentAmountFromSats(amount)
   }

--- a/src/domain/payments/ln-fees.ts
+++ b/src/domain/payments/ln-fees.ts
@@ -1,9 +1,8 @@
-import { toSats } from "@domain/bitcoin"
 import {
   WalletCurrency,
   ZERO_SATS,
   ZERO_CENTS,
-  paymentAmountFromSats,
+  paymentAmountFromNumber,
 } from "@domain/shared"
 
 export const FEECAP_PERCENT = 2n
@@ -35,8 +34,8 @@ export const LnFees = (
   }
 
   const feeFromRawRoute = (rawRoute: RawRoute): BtcPaymentAmount | ValidationError => {
-    const amount = toSats(Math.ceil(rawRoute.fee))
-    return paymentAmountFromSats(amount)
+    const amount = Math.ceil(rawRoute.fee)
+    return paymentAmountFromNumber({ amount, currency: WalletCurrency.Btc })
   }
 
   return {

--- a/src/domain/payments/payment-flow-builder.ts
+++ b/src/domain/payments/payment-flow-builder.ts
@@ -266,7 +266,6 @@ const LPFBWithRecipientWallet = <S extends WalletCurrency, R extends WalletCurre
             if (priceRatio instanceof Error) return priceRatio
 
             const usdProtocolFee = priceRatio.convertFromBtc(btcProtocolFee)
-            if (usdProtocolFee instanceof Error) return usdProtocolFee
             return {
               ...stateWithCreatedAt,
               btcPaymentAmount,
@@ -289,7 +288,6 @@ const LPFBWithRecipientWallet = <S extends WalletCurrency, R extends WalletCurre
             if (priceRatio instanceof Error) return priceRatio
 
             const btcProtocolFee = priceRatio.convertFromUsd(usdProtocolFee)
-            if (btcProtocolFee instanceof Error) return btcProtocolFee
             return {
               ...stateWithCreatedAt,
               btcPaymentAmount: convertedAmount,
@@ -338,7 +336,6 @@ const LPFBWithRecipientWallet = <S extends WalletCurrency, R extends WalletCurre
           if (priceRatio instanceof Error) return priceRatio
 
           const usdProtocolFee = priceRatio.convertFromBtc(btcProtocolFee)
-          if (usdProtocolFee instanceof Error) return usdProtocolFee
           return {
             ...stateWithCreatedAt,
             btcPaymentAmount,
@@ -363,7 +360,6 @@ const LPFBWithRecipientWallet = <S extends WalletCurrency, R extends WalletCurre
           if (priceRatio instanceof Error) return priceRatio
 
           const btcProtocolFee = priceRatio.convertFromUsd(usdProtocolFee)
-          if (btcProtocolFee instanceof Error) return btcProtocolFee
           return {
             ...stateWithCreatedAt,
             btcPaymentAmount: convertedAmount,

--- a/src/domain/payments/payment-flow-builder.ts
+++ b/src/domain/payments/payment-flow-builder.ts
@@ -266,6 +266,7 @@ const LPFBWithRecipientWallet = <S extends WalletCurrency, R extends WalletCurre
             if (priceRatio instanceof Error) return priceRatio
 
             const usdProtocolFee = priceRatio.convertFromBtc(btcProtocolFee)
+            if (usdProtocolFee instanceof Error) return usdProtocolFee
             return {
               ...stateWithCreatedAt,
               btcPaymentAmount,
@@ -288,6 +289,7 @@ const LPFBWithRecipientWallet = <S extends WalletCurrency, R extends WalletCurre
             if (priceRatio instanceof Error) return priceRatio
 
             const btcProtocolFee = priceRatio.convertFromUsd(usdProtocolFee)
+            if (btcProtocolFee instanceof Error) return btcProtocolFee
             return {
               ...stateWithCreatedAt,
               btcPaymentAmount: convertedAmount,
@@ -336,6 +338,7 @@ const LPFBWithRecipientWallet = <S extends WalletCurrency, R extends WalletCurre
           if (priceRatio instanceof Error) return priceRatio
 
           const usdProtocolFee = priceRatio.convertFromBtc(btcProtocolFee)
+          if (usdProtocolFee instanceof Error) return usdProtocolFee
           return {
             ...stateWithCreatedAt,
             btcPaymentAmount,
@@ -360,6 +363,7 @@ const LPFBWithRecipientWallet = <S extends WalletCurrency, R extends WalletCurre
           if (priceRatio instanceof Error) return priceRatio
 
           const btcProtocolFee = priceRatio.convertFromUsd(usdProtocolFee)
+          if (btcProtocolFee instanceof Error) return btcProtocolFee
           return {
             ...stateWithCreatedAt,
             btcPaymentAmount: convertedAmount,
@@ -441,6 +445,7 @@ const LPFBWithConversion = <S extends WalletCurrency, R extends WalletCurrency>(
     if (priceRatio instanceof Error) return priceRatio
 
     const btcProtocolFee = LnFees().feeFromRawRoute(rawRoute)
+    if (btcProtocolFee instanceof Error) return btcProtocolFee
     const usdProtocolFee = priceRatio.convertFromBtc(btcProtocolFee)
 
     return paymentFromState({

--- a/src/domain/payments/price-ratio.ts
+++ b/src/domain/payments/price-ratio.ts
@@ -15,7 +15,9 @@ export const PriceRatio = ({
     return new InvalidZeroAmountPriceRatioInputError()
   }
 
-  const convertFromUsd = (convert: UsdPaymentAmount): BtcPaymentAmount => {
+  const convertFromUsd = (
+    convert: UsdPaymentAmount,
+  ): BtcPaymentAmount | ValidationError => {
     const amountAsNumber =
       (Number(convert.amount) * Number(btc.amount)) / Number(usd.amount)
     const amount = Math.round(amountAsNumber)
@@ -23,7 +25,9 @@ export const PriceRatio = ({
     return paymentAmountFromSats(toSats(btcAmount))
   }
 
-  const convertFromBtc = (convert: BtcPaymentAmount): UsdPaymentAmount => {
+  const convertFromBtc = (
+    convert: BtcPaymentAmount,
+  ): UsdPaymentAmount | ValidationError => {
     const amountAsNumber =
       (Number(convert.amount) * Number(usd.amount)) / Number(btc.amount)
     const amount = Math.round(amountAsNumber)

--- a/src/domain/payments/price-ratio.ts
+++ b/src/domain/payments/price-ratio.ts
@@ -1,4 +1,4 @@
-import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
+import { WalletCurrency } from "@domain/shared"
 
 import { InvalidZeroAmountPriceRatioInputError } from "./errors"
 
@@ -17,26 +17,24 @@ export const PriceRatio = ({
     convert: UsdPaymentAmount,
   ): BtcPaymentAmount | ValidationError => {
     if (convert.amount === 0n) {
-      return paymentAmountFromNumber({ amount: 0, currency: WalletCurrency.Btc })
+      return { amount: 0n, currency: WalletCurrency.Btc }
     }
 
-    const amount = Math.round(
-      (Number(convert.amount) * Number(btc.amount)) / Number(usd.amount),
-    )
-    return paymentAmountFromNumber({ amount: amount || 1, currency: WalletCurrency.Btc })
+    const amount = (convert.amount * btc.amount) / usd.amount
+
+    return { amount: amount || 1n, currency: WalletCurrency.Btc }
   }
 
   const convertFromBtc = (
     convert: BtcPaymentAmount,
   ): UsdPaymentAmount | ValidationError => {
     if (convert.amount === 0n) {
-      return paymentAmountFromNumber({ amount: 0, currency: WalletCurrency.Usd })
+      return { amount: 0n, currency: WalletCurrency.Usd }
     }
 
-    const amount = Math.round(
-      (Number(convert.amount) * Number(usd.amount)) / Number(btc.amount),
-    )
-    return paymentAmountFromNumber({ amount: amount || 1, currency: WalletCurrency.Usd })
+    const amount = (convert.amount * usd.amount) / btc.amount
+
+    return { amount: amount || 1n, currency: WalletCurrency.Usd }
   }
 
   return {

--- a/src/domain/payments/price-ratio.ts
+++ b/src/domain/payments/price-ratio.ts
@@ -1,3 +1,4 @@
+import { RATIO_PRECISION } from "@config"
 import { AmountCalculator, WalletCurrency } from "@domain/shared"
 
 import { InvalidZeroAmountPriceRatioInputError } from "./errors"
@@ -48,7 +49,7 @@ export const PriceRatio = ({
 }
 
 export const toPriceRatio = (ratio: number): PriceRatio | ValidationError => {
-  const precision = 1_000_000
+  const precision = RATIO_PRECISION
 
   const usd: UsdPaymentAmount = {
     amount: BigInt(Math.floor(ratio * precision)),

--- a/src/domain/payments/price-ratio.ts
+++ b/src/domain/payments/price-ratio.ts
@@ -13,9 +13,7 @@ export const PriceRatio = ({
     return new InvalidZeroAmountPriceRatioInputError()
   }
 
-  const convertFromUsd = (
-    convert: UsdPaymentAmount,
-  ): BtcPaymentAmount | ValidationError => {
+  const convertFromUsd = (convert: UsdPaymentAmount): BtcPaymentAmount => {
     if (convert.amount === 0n) {
       return { amount: 0n, currency: WalletCurrency.Btc }
     }
@@ -25,9 +23,7 @@ export const PriceRatio = ({
     return { amount: amount || 1n, currency: WalletCurrency.Btc }
   }
 
-  const convertFromBtc = (
-    convert: BtcPaymentAmount,
-  ): UsdPaymentAmount | ValidationError => {
+  const convertFromBtc = (convert: BtcPaymentAmount): UsdPaymentAmount => {
     if (convert.amount === 0n) {
       return { amount: 0n, currency: WalletCurrency.Usd }
     }

--- a/src/domain/payments/price-ratio.ts
+++ b/src/domain/payments/price-ratio.ts
@@ -1,6 +1,4 @@
-import { toSats } from "@domain/bitcoin"
-import { toCents } from "@domain/fiat"
-import { paymentAmountFromCents, paymentAmountFromSats } from "@domain/shared"
+import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
 
 import { InvalidZeroAmountPriceRatioInputError } from "./errors"
 
@@ -18,21 +16,27 @@ export const PriceRatio = ({
   const convertFromUsd = (
     convert: UsdPaymentAmount,
   ): BtcPaymentAmount | ValidationError => {
-    const amountAsNumber =
-      (Number(convert.amount) * Number(btc.amount)) / Number(usd.amount)
-    const amount = Math.round(amountAsNumber)
-    const btcAmount = convert.amount === 0n ? 0n : amount === 0 ? 1n : amount
-    return paymentAmountFromSats(toSats(btcAmount))
+    if (convert.amount === 0n) {
+      return paymentAmountFromNumber({ amount: 0, currency: WalletCurrency.Btc })
+    }
+
+    const amount = Math.round(
+      (Number(convert.amount) * Number(btc.amount)) / Number(usd.amount),
+    )
+    return paymentAmountFromNumber({ amount: amount || 1, currency: WalletCurrency.Btc })
   }
 
   const convertFromBtc = (
     convert: BtcPaymentAmount,
   ): UsdPaymentAmount | ValidationError => {
-    const amountAsNumber =
-      (Number(convert.amount) * Number(usd.amount)) / Number(btc.amount)
-    const amount = Math.round(amountAsNumber)
-    const usdAmount = convert.amount === 0n ? 0 : amount === 0 ? 1 : amount
-    return paymentAmountFromCents(toCents(usdAmount))
+    if (convert.amount === 0n) {
+      return paymentAmountFromNumber({ amount: 0, currency: WalletCurrency.Usd })
+    }
+
+    const amount = Math.round(
+      (Number(convert.amount) * Number(usd.amount)) / Number(btc.amount),
+    )
+    return paymentAmountFromNumber({ amount: amount || 1, currency: WalletCurrency.Usd })
   }
 
   return {

--- a/src/domain/payments/price-ratio.ts
+++ b/src/domain/payments/price-ratio.ts
@@ -1,6 +1,8 @@
-import { WalletCurrency } from "@domain/shared"
+import { AmountCalculator, WalletCurrency } from "@domain/shared"
 
 import { InvalidZeroAmountPriceRatioInputError } from "./errors"
+
+const calc = AmountCalculator()
 
 export const PriceRatio = ({
   usd,
@@ -14,23 +16,33 @@ export const PriceRatio = ({
   }
 
   const convertFromUsd = (convert: UsdPaymentAmount): BtcPaymentAmount => {
+    const currency = WalletCurrency.Btc
+
     if (convert.amount === 0n) {
-      return { amount: 0n, currency: WalletCurrency.Btc }
+      return { amount: 0n, currency }
     }
 
-    const amount = (convert.amount * btc.amount) / usd.amount
+    const amount = calc.divide(
+      { amount: convert.amount * btc.amount, currency },
+      usd.amount,
+    )
 
-    return { amount: amount || 1n, currency: WalletCurrency.Btc }
+    return { amount: amount.amount || 1n, currency }
   }
 
   const convertFromBtc = (convert: BtcPaymentAmount): UsdPaymentAmount => {
+    const currency = WalletCurrency.Usd
+
     if (convert.amount === 0n) {
-      return { amount: 0n, currency: WalletCurrency.Usd }
+      return { amount: 0n, currency }
     }
 
-    const amount = (convert.amount * usd.amount) / btc.amount
+    const amount = calc.divide(
+      { amount: convert.amount * usd.amount, currency },
+      btc.amount,
+    )
 
-    return { amount: amount || 1n, currency: WalletCurrency.Usd }
+    return { amount: amount.amount || 1n, currency }
   }
 
   return {

--- a/src/domain/payments/price-ratio.ts
+++ b/src/domain/payments/price-ratio.ts
@@ -46,3 +46,19 @@ export const PriceRatio = ({
       (Number(usd.amount) / Number(btc.amount)) as DisplayCurrencyBasePerSat,
   }
 }
+
+export const toPriceRatio = (ratio: number): PriceRatio | ValidationError => {
+  const precision = 1_000_000
+
+  const usd: UsdPaymentAmount = {
+    amount: BigInt(Math.floor(ratio * precision)),
+    currency: WalletCurrency.Usd,
+  }
+
+  const btc: BtcPaymentAmount = {
+    amount: BigInt(precision),
+    currency: WalletCurrency.Btc,
+  }
+
+  return PriceRatio({ usd, btc })
+}

--- a/src/domain/payments/price-ratio.ts
+++ b/src/domain/payments/price-ratio.ts
@@ -22,10 +22,7 @@ export const PriceRatio = ({
       return { amount: 0n, currency }
     }
 
-    const amount = calc.divide(
-      { amount: convert.amount * btc.amount, currency },
-      usd.amount,
-    )
+    const amount = calc.div({ amount: convert.amount * btc.amount, currency }, usd.amount)
 
     return { amount: amount.amount || 1n, currency }
   }
@@ -37,10 +34,7 @@ export const PriceRatio = ({
       return { amount: 0n, currency }
     }
 
-    const amount = calc.divide(
-      { amount: convert.amount * usd.amount, currency },
-      btc.amount,
-    )
+    const amount = calc.div({ amount: convert.amount * usd.amount, currency }, btc.amount)
 
     return { amount: amount.amount || 1n, currency }
   }

--- a/src/domain/shared/calculator.ts
+++ b/src/domain/shared/calculator.ts
@@ -13,8 +13,22 @@ export const AmountCalculator = () => {
     }
   }
 
+  const divide = <T extends WalletCurrency>(
+    a: PaymentAmount<T>,
+    b: bigint,
+  ): PaymentAmount<T> => {
+    const quotient = a.amount / b
+
+    const roundDownBound = b / 2n
+    const mod = a.amount % b
+    return mod > roundDownBound
+      ? { amount: quotient + 1n, currency: a.currency }
+      : { amount: quotient, currency: a.currency }
+  }
+
   return {
     sub,
     add,
+    divide,
   }
 }

--- a/src/domain/shared/calculator.ts
+++ b/src/domain/shared/calculator.ts
@@ -1,4 +1,4 @@
-export const AmountCalculator = () => {
+export const AmountCalculator = (): AmountCalculator => {
   const add = <T extends WalletCurrency>(a: PaymentAmount<T>, b: PaymentAmount<T>) => {
     return {
       currency: a.currency,
@@ -13,7 +13,7 @@ export const AmountCalculator = () => {
     }
   }
 
-  const divide = <T extends WalletCurrency>(
+  const div = <T extends WalletCurrency>(
     a: PaymentAmount<T>,
     b: bigint,
   ): PaymentAmount<T> => {
@@ -29,6 +29,6 @@ export const AmountCalculator = () => {
   return {
     sub,
     add,
-    divide,
+    div,
   }
 }

--- a/src/domain/shared/index.types.d.ts
+++ b/src/domain/shared/index.types.d.ts
@@ -28,3 +28,15 @@ type BtcPaymentAmount = PaymentAmount<"BTC">
 type UsdPaymentAmount = PaymentAmount<"USD">
 
 type RequireField<T, K extends keyof T> = T & Required<Pick<T, K>>
+
+type AmountCalculator = {
+  add: <T extends WalletCurrency>(
+    a: PaymentAmount<T>,
+    b: PaymentAmount<T>,
+  ) => PaymentAmount<T>
+  sub: <T extends WalletCurrency>(
+    a: PaymentAmount<T>,
+    b: PaymentAmount<T>,
+  ) => PaymentAmount<T>
+  div: <T extends WalletCurrency>(a: PaymentAmount<T>, b: bigint) => PaymentAmount<T>
+}

--- a/src/domain/shared/primitives.ts
+++ b/src/domain/shared/primitives.ts
@@ -54,17 +54,27 @@ export const UsdPaymentAmount = (cents: bigint): UsdPaymentAmount => {
   }
 }
 
-export const paymentAmountFromSats = (sats: Satoshis): BtcPaymentAmount => {
+export const paymentAmountFromSats = (
+  sats: Satoshis,
+): BtcPaymentAmount | ValidationError => {
+  const amount = safeBigInt(sats)
+  if (amount instanceof Error) return amount
+
   return {
     currency: WalletCurrency.Btc,
-    amount: BigInt(sats),
+    amount,
   }
 }
 
-export const paymentAmountFromCents = (cents: UsdCents): UsdPaymentAmount => {
+export const paymentAmountFromCents = (
+  cents: UsdCents,
+): UsdPaymentAmount | ValidationError => {
+  const amount = safeBigInt(cents)
+  if (amount instanceof Error) return amount
+
   return {
     currency: WalletCurrency.Usd,
-    amount: BigInt(cents),
+    amount,
   }
 }
 

--- a/src/domain/shared/primitives.ts
+++ b/src/domain/shared/primitives.ts
@@ -54,30 +54,6 @@ export const UsdPaymentAmount = (cents: bigint): UsdPaymentAmount => {
   }
 }
 
-export const paymentAmountFromSats = (
-  sats: Satoshis,
-): BtcPaymentAmount | ValidationError => {
-  const amount = safeBigInt(sats)
-  if (amount instanceof Error) return amount
-
-  return {
-    currency: WalletCurrency.Btc,
-    amount,
-  }
-}
-
-export const paymentAmountFromCents = (
-  cents: UsdCents,
-): UsdPaymentAmount | ValidationError => {
-  const amount = safeBigInt(cents)
-  if (amount instanceof Error) return amount
-
-  return {
-    currency: WalletCurrency.Usd,
-    amount,
-  }
-}
-
 export const paymentAmountFromNumber = <T extends WalletCurrency>({
   amount,
   currency,

--- a/src/services/dealer-price/dealer-price.ts
+++ b/src/services/dealer-price/dealer-price.ts
@@ -4,7 +4,7 @@ import { getDealerPriceConfig } from "@config"
 
 import { credentials } from "@grpc/grpc-js"
 
-import { paymentAmountFromCents, paymentAmountFromSats } from "@domain/shared"
+import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
 
 import {
   NoConnectionToDealerError,
@@ -269,7 +269,7 @@ export const NewDealerPriceService = (
         ),
       )
       const amount = response.getAmountInCents()
-      return paymentAmountFromCents(toCents(amount))
+      return paymentAmountFromNumber({ amount, currency: WalletCurrency.Usd })
     } catch (error) {
       baseLogger.error({ error }, "GetCentsFromSatsForImmediateBuy unable to fetch price")
       return parseDealerErrors(error)
@@ -286,7 +286,7 @@ export const NewDealerPriceService = (
         ),
       )
       const amount = response.getAmountInCents()
-      return paymentAmountFromCents(toCents(amount))
+      return paymentAmountFromNumber({ amount, currency: WalletCurrency.Usd })
     } catch (error) {
       baseLogger.error(
         { error },
@@ -306,7 +306,7 @@ export const NewDealerPriceService = (
           .setTimeInSeconds(timeToExpiryInSeconds),
       )
       const amount = response.getAmountInCents()
-      return paymentAmountFromCents(toCents(amount))
+      return paymentAmountFromNumber({ amount, currency: WalletCurrency.Usd })
     } catch (error) {
       baseLogger.error({ error }, "GetCentsFromSatsForFutureBuy unable to fetch price")
       return parseDealerErrors(error)
@@ -323,7 +323,7 @@ export const NewDealerPriceService = (
           .setTimeInSeconds(timeToExpiryInSeconds),
       )
       const amount = response.getAmountInCents()
-      return paymentAmountFromCents(toCents(amount))
+      return paymentAmountFromNumber({ amount, currency: WalletCurrency.Usd })
     } catch (error) {
       baseLogger.error({ error }, "GetCentsFromSatsForFutureSell unable to fetch price")
       return parseDealerErrors(error)
@@ -340,7 +340,7 @@ export const NewDealerPriceService = (
         ),
       )
       const amount = response.getAmountInSatoshis()
-      return paymentAmountFromSats(toSats(amount))
+      return paymentAmountFromNumber({ amount, currency: WalletCurrency.Btc })
     } catch (error) {
       baseLogger.error({ error }, "GetSatsFromCentsForImmediateBuy unable to fetch price")
       return parseDealerErrors(error)
@@ -357,7 +357,7 @@ export const NewDealerPriceService = (
         ),
       )
       const amount = response.getAmountInSatoshis()
-      return paymentAmountFromSats(toSats(amount))
+      return paymentAmountFromNumber({ amount, currency: WalletCurrency.Btc })
     } catch (error) {
       baseLogger.error(
         { error },
@@ -377,7 +377,7 @@ export const NewDealerPriceService = (
           .setTimeInSeconds(timeToExpiryInSeconds),
       )
       const amount = response.getAmountInSatoshis()
-      return paymentAmountFromSats(toSats(amount))
+      return paymentAmountFromNumber({ amount, currency: WalletCurrency.Btc })
     } catch (error) {
       baseLogger.error({ error }, "GetSatsFromCentsForFutureBuy unable to fetch price")
       return parseDealerErrors(error)
@@ -394,7 +394,7 @@ export const NewDealerPriceService = (
           .setTimeInSeconds(timeToExpiryInSeconds),
       )
       const amount = response.getAmountInSatoshis()
-      return paymentAmountFromSats(toSats(amount))
+      return paymentAmountFromNumber({ amount, currency: WalletCurrency.Btc })
     } catch (error) {
       baseLogger.error({ error }, "GetSatsFromCentsForFutureSell unable to fetch price")
       return parseDealerErrors(error)

--- a/src/services/dealer-price/dealer-price.ts
+++ b/src/services/dealer-price/dealer-price.ts
@@ -15,6 +15,7 @@ import { toSats } from "@domain/bitcoin"
 import { defaultTimeToExpiryInSeconds } from "@domain/bitcoin/lightning"
 
 import { toCents, toCentsPerSatsRatio } from "@domain/fiat"
+import { toPriceRatio } from "@domain/payments"
 
 import { baseLogger } from "../logger"
 
@@ -402,13 +403,13 @@ export const NewDealerPriceService = (
   }
 
   const getCentsPerSatsExchangeMidRate = async function (): Promise<
-    CentsPerSatsRatio | DealerPriceServiceError
+    PriceRatio | ValidationError
   > {
     try {
       const response = await clientGetCentsPerSatsExchangeMidRate(
         new GetCentsPerSatsExchangeMidRateRequest(),
       )
-      return toCentsPerSatsRatio(response.getRatioInCentsPerSatoshis())
+      return toPriceRatio(response.getRatioInCentsPerSatoshis())
     } catch (error) {
       baseLogger.error({ error }, "GetCentsPerSatsExchangeMidRate unable to fetch price")
       return parseDealerErrors(error)

--- a/src/services/ledger/intraledger.ts
+++ b/src/services/ledger/intraledger.ts
@@ -179,10 +179,14 @@ const addIntraledgerTxTransfer = async ({
     if (sats === undefined) {
       return new NotReachableError("sats undefined implementation error")
     }
+
+    const satsAmount = paymentAmountFromSats(sats)
+    if (satsAmount instanceof Error) return satsAmount
+
     entry = builder
       .debitAccount({
         accountId: senderAccountId,
-        amount: paymentAmountFromSats(sats),
+        amount: satsAmount,
         additionalMetadata: {
           memoPayer,
           username: recipientUsername,
@@ -198,10 +202,14 @@ const addIntraledgerTxTransfer = async ({
     if (cents === undefined) {
       return new Error("cents undefined implementation error")
     }
+
+    const centsAmount = paymentAmountFromCents(cents)
+    if (centsAmount instanceof Error) return centsAmount
+
     entry = builder
       .debitAccount({
         accountId: senderAccountId,
-        amount: paymentAmountFromCents(cents),
+        amount: centsAmount,
         additionalMetadata: {
           memoPayer,
           username: recipientUsername,
@@ -218,10 +226,15 @@ const addIntraledgerTxTransfer = async ({
       return new Error("cents or sats undefined implementation error")
     }
 
+    const centsAmount = paymentAmountFromCents(cents)
+    if (centsAmount instanceof Error) return centsAmount
+    const satsAmount = paymentAmountFromSats(sats)
+    if (satsAmount instanceof Error) return satsAmount
+
     entry = builder
       .debitAccount({
         accountId: senderAccountId,
-        amount: paymentAmountFromCents(cents),
+        amount: centsAmount,
         additionalMetadata: {
           memoPayer,
           username: recipientUsername,
@@ -229,7 +242,7 @@ const addIntraledgerTxTransfer = async ({
       })
       .creditAccount({
         accountId: recipientAccountId,
-        amount: paymentAmountFromSats(sats),
+        amount: satsAmount,
       })
   } else {
     // if (
@@ -240,10 +253,15 @@ const addIntraledgerTxTransfer = async ({
       return new Error("cents or sats undefined implementation error")
     }
 
+    const centsAmount = paymentAmountFromCents(cents)
+    if (centsAmount instanceof Error) return centsAmount
+    const satsAmount = paymentAmountFromSats(sats)
+    if (satsAmount instanceof Error) return satsAmount
+
     entry = builder
       .debitAccount({
         accountId: senderAccountId,
-        amount: paymentAmountFromSats(sats),
+        amount: satsAmount,
         additionalMetadata: {
           memoPayer,
           username: recipientUsername,
@@ -251,7 +269,7 @@ const addIntraledgerTxTransfer = async ({
       })
       .creditAccount({
         accountId: recipientAccountId,
-        amount: paymentAmountFromCents(cents),
+        amount: centsAmount,
       })
   }
 

--- a/src/services/ledger/intraledger.ts
+++ b/src/services/ledger/intraledger.ts
@@ -1,10 +1,6 @@
 import { LedgerTransactionType } from "@domain/ledger"
 import { LedgerError, UnknownLedgerError } from "@domain/ledger/errors"
-import {
-  paymentAmountFromSats,
-  paymentAmountFromCents,
-  WalletCurrency,
-} from "@domain/shared"
+import { WalletCurrency, paymentAmountFromNumber } from "@domain/shared"
 
 import { NotReachableError } from "@domain/errors"
 
@@ -180,7 +176,10 @@ const addIntraledgerTxTransfer = async ({
       return new NotReachableError("sats undefined implementation error")
     }
 
-    const satsAmount = paymentAmountFromSats(sats)
+    const satsAmount = paymentAmountFromNumber({
+      amount: sats,
+      currency: WalletCurrency.Btc,
+    })
     if (satsAmount instanceof Error) return satsAmount
 
     entry = builder
@@ -203,7 +202,10 @@ const addIntraledgerTxTransfer = async ({
       return new Error("cents undefined implementation error")
     }
 
-    const centsAmount = paymentAmountFromCents(cents)
+    const centsAmount = paymentAmountFromNumber({
+      amount: cents,
+      currency: WalletCurrency.Usd,
+    })
     if (centsAmount instanceof Error) return centsAmount
 
     entry = builder
@@ -226,9 +228,15 @@ const addIntraledgerTxTransfer = async ({
       return new Error("cents or sats undefined implementation error")
     }
 
-    const centsAmount = paymentAmountFromCents(cents)
+    const centsAmount = paymentAmountFromNumber({
+      amount: cents,
+      currency: WalletCurrency.Usd,
+    })
     if (centsAmount instanceof Error) return centsAmount
-    const satsAmount = paymentAmountFromSats(sats)
+    const satsAmount = paymentAmountFromNumber({
+      amount: sats,
+      currency: WalletCurrency.Btc,
+    })
     if (satsAmount instanceof Error) return satsAmount
 
     entry = builder
@@ -253,9 +261,15 @@ const addIntraledgerTxTransfer = async ({
       return new Error("cents or sats undefined implementation error")
     }
 
-    const centsAmount = paymentAmountFromCents(cents)
+    const centsAmount = paymentAmountFromNumber({
+      amount: cents,
+      currency: WalletCurrency.Usd,
+    })
     if (centsAmount instanceof Error) return centsAmount
-    const satsAmount = paymentAmountFromSats(sats)
+    const satsAmount = paymentAmountFromNumber({
+      amount: sats,
+      currency: WalletCurrency.Btc,
+    })
     if (satsAmount instanceof Error) return satsAmount
 
     entry = builder

--- a/src/services/ledger/receive.ts
+++ b/src/services/ledger/receive.ts
@@ -1,8 +1,4 @@
-import {
-  paymentAmountFromSats,
-  paymentAmountFromCents,
-  WalletCurrency,
-} from "@domain/shared"
+import { WalletCurrency, paymentAmountFromNumber } from "@domain/shared"
 import { NotImplementedError, NotReachableError } from "@domain/errors"
 import { toSats } from "@domain/bitcoin"
 import { toCents } from "@domain/fiat"
@@ -186,7 +182,10 @@ const addReceiptNoFee = async ({
     dealerUsdAccountId: toLedgerAccountId(await caching.getDealerUsdWalletId()),
   }
 
-  const satsAmount = paymentAmountFromSats(sats)
+  const satsAmount = paymentAmountFromNumber({
+    amount: sats,
+    currency: WalletCurrency.Btc,
+  })
   if (satsAmount instanceof Error) return satsAmount
 
   let entry = MainBook.entry(description)
@@ -202,7 +201,10 @@ const addReceiptNoFee = async ({
     entry = builder.creditAccount({ accountId })
   } else {
     if (cents === undefined) return new NotReachableError("cents should be defined here")
-    const centsAmount = paymentAmountFromCents(cents)
+    const centsAmount = paymentAmountFromNumber({
+      amount: cents,
+      currency: WalletCurrency.Usd,
+    })
     if (centsAmount instanceof Error) return centsAmount
 
     entry = builder.creditAccount({
@@ -254,9 +256,15 @@ const addReceiptFee = async ({
     return new NotImplementedError("USD Intraledger")
   }
 
-  const feeSatsAmount = paymentAmountFromSats(fee)
+  const feeSatsAmount = paymentAmountFromNumber({
+    amount: fee,
+    currency: WalletCurrency.Btc,
+  })
   if (feeSatsAmount instanceof Error) return feeSatsAmount
-  const satsAmount = paymentAmountFromSats(sats)
+  const satsAmount = paymentAmountFromNumber({
+    amount: sats,
+    currency: WalletCurrency.Btc,
+  })
   if (satsAmount instanceof Error) return satsAmount
 
   const entry = MainBook.entry(description)

--- a/src/services/ledger/send.ts
+++ b/src/services/ledger/send.ts
@@ -150,24 +150,29 @@ const addSendNoInternalFee = async ({
     metadata,
   }).withoutFee()
 
+  const satsAmount = paymentAmountFromSats(sats)
+  if (satsAmount instanceof Error) return satsAmount
+
   if (walletCurrency === WalletCurrency.Btc) {
     entry = builder
       .debitAccount({
         accountId,
-        amount: paymentAmountFromSats(sats),
+        amount: satsAmount,
       })
       .creditLnd()
   }
 
   if (walletCurrency === WalletCurrency.Usd) {
     if (!cents) return new UnknownLedgerError("Cents are required")
+    const centsAmount = paymentAmountFromCents(cents)
+    if (centsAmount instanceof Error) return centsAmount
 
     entry = builder
       .debitAccount({
         accountId,
-        amount: paymentAmountFromCents(cents),
+        amount: centsAmount,
       })
-      .creditLnd(paymentAmountFromSats(sats))
+      .creditLnd(satsAmount)
   }
 
   try {
@@ -214,14 +219,19 @@ const addSendInternalFee = async ({
   }
 
   try {
+    const feeSatsAmount = paymentAmountFromSats(fee)
+    if (feeSatsAmount instanceof Error) return feeSatsAmount
+    const satsAmount = paymentAmountFromSats(sats)
+    if (satsAmount instanceof Error) return satsAmount
+
     const entry = MainBook.entry(description)
     const builder = LegacyEntryBuilder({
       staticAccountIds,
       entry,
       metadata: metaInput,
     })
-      .withFee(paymentAmountFromSats(fee))
-      .debitAccount({ accountId, amount: paymentAmountFromSats(sats) })
+      .withFee(feeSatsAmount)
+      .debitAccount({ accountId, amount: satsAmount })
       .creditLnd()
 
     const savedEntry = await builder.commit()

--- a/src/services/ledger/send.ts
+++ b/src/services/ledger/send.ts
@@ -5,11 +5,7 @@ import {
   NoTransactionToSettleError,
   UnknownLedgerError,
 } from "@domain/ledger/errors"
-import {
-  paymentAmountFromSats,
-  paymentAmountFromCents,
-  WalletCurrency,
-} from "@domain/shared"
+import { WalletCurrency, paymentAmountFromNumber } from "@domain/shared"
 
 import { LegacyEntryBuilder, toLedgerAccountId } from "./domain"
 
@@ -150,7 +146,10 @@ const addSendNoInternalFee = async ({
     metadata,
   }).withoutFee()
 
-  const satsAmount = paymentAmountFromSats(sats)
+  const satsAmount = paymentAmountFromNumber({
+    amount: sats,
+    currency: WalletCurrency.Btc,
+  })
   if (satsAmount instanceof Error) return satsAmount
 
   if (walletCurrency === WalletCurrency.Btc) {
@@ -164,7 +163,10 @@ const addSendNoInternalFee = async ({
 
   if (walletCurrency === WalletCurrency.Usd) {
     if (!cents) return new UnknownLedgerError("Cents are required")
-    const centsAmount = paymentAmountFromCents(cents)
+    const centsAmount = paymentAmountFromNumber({
+      amount: cents,
+      currency: WalletCurrency.Usd,
+    })
     if (centsAmount instanceof Error) return centsAmount
 
     entry = builder
@@ -219,9 +221,15 @@ const addSendInternalFee = async ({
   }
 
   try {
-    const feeSatsAmount = paymentAmountFromSats(fee)
+    const feeSatsAmount = paymentAmountFromNumber({
+      amount: fee,
+      currency: WalletCurrency.Btc,
+    })
     if (feeSatsAmount instanceof Error) return feeSatsAmount
-    const satsAmount = paymentAmountFromSats(sats)
+    const satsAmount = paymentAmountFromNumber({
+      amount: sats,
+      currency: WalletCurrency.Btc,
+    })
     if (satsAmount instanceof Error) return satsAmount
 
     const entry = MainBook.entry(description)

--- a/src/services/ledger/volume.ts
+++ b/src/services/ledger/volume.ts
@@ -52,16 +52,19 @@ const volumeAmountFn =
     const volume = await txVolumeSince({ walletId, timestamp, txnGroup })
     if (volume instanceof Error) return volume
 
-    return {
-      outgoingBaseAmount:
-        walletCurrency === WalletCurrency.Btc
-          ? paymentAmountFromSats(toSats(volume.outgoingBaseAmount))
-          : paymentAmountFromCents(toCents(volume.outgoingBaseAmount)),
-      incomingBaseAmount:
-        walletCurrency === WalletCurrency.Btc
-          ? paymentAmountFromSats(toSats(volume.incomingBaseAmount))
-          : paymentAmountFromCents(toCents(volume.incomingBaseAmount)),
-    }
+    const outgoingBaseAmount =
+      walletCurrency === WalletCurrency.Btc
+        ? paymentAmountFromSats(toSats(volume.outgoingBaseAmount))
+        : paymentAmountFromCents(toCents(volume.outgoingBaseAmount))
+    if (outgoingBaseAmount instanceof Error) return outgoingBaseAmount
+
+    const incomingBaseAmount =
+      walletCurrency === WalletCurrency.Btc
+        ? paymentAmountFromSats(toSats(volume.incomingBaseAmount))
+        : paymentAmountFromCents(toCents(volume.incomingBaseAmount))
+    if (incomingBaseAmount instanceof Error) return incomingBaseAmount
+
+    return { outgoingBaseAmount, incomingBaseAmount }
   }
 
 const txVolumeSince = async ({

--- a/src/services/ledger/volume.ts
+++ b/src/services/ledger/volume.ts
@@ -1,12 +1,6 @@
-import { toSats } from "@domain/bitcoin"
-import { toCents } from "@domain/fiat"
 import { LedgerTransactionType, toLiabilitiesWalletId } from "@domain/ledger"
 import { LedgerServiceError, UnknownLedgerError } from "@domain/ledger/errors"
-import {
-  paymentAmountFromCents,
-  paymentAmountFromSats,
-  WalletCurrency,
-} from "@domain/shared"
+import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
 import { addAttributesToCurrentSpan } from "@services/tracing"
 
 import { Transaction } from "./books"
@@ -52,16 +46,16 @@ const volumeAmountFn =
     const volume = await txVolumeSince({ walletId, timestamp, txnGroup })
     if (volume instanceof Error) return volume
 
-    const outgoingBaseAmount =
-      walletCurrency === WalletCurrency.Btc
-        ? paymentAmountFromSats(toSats(volume.outgoingBaseAmount))
-        : paymentAmountFromCents(toCents(volume.outgoingBaseAmount))
+    const outgoingBaseAmount = paymentAmountFromNumber({
+      amount: volume.outgoingBaseAmount,
+      currency: walletCurrency,
+    })
     if (outgoingBaseAmount instanceof Error) return outgoingBaseAmount
 
-    const incomingBaseAmount =
-      walletCurrency === WalletCurrency.Btc
-        ? paymentAmountFromSats(toSats(volume.incomingBaseAmount))
-        : paymentAmountFromCents(toCents(volume.incomingBaseAmount))
+    const incomingBaseAmount = paymentAmountFromNumber({
+      amount: volume.incomingBaseAmount,
+      currency: walletCurrency,
+    })
     if (incomingBaseAmount instanceof Error) return incomingBaseAmount
 
     return { outgoingBaseAmount, incomingBaseAmount }

--- a/src/services/payment-flow/index.ts
+++ b/src/services/payment-flow/index.ts
@@ -202,6 +202,22 @@ const paymentFlowFromRaw = <S extends WalletCurrency, R extends WalletCurrency>(
       )
   if (hash instanceof Error) return hash
 
+  const btcPaymentAmount = paymentAmountFromSats(
+    toSats(paymentFlowState.btcPaymentAmount),
+  )
+  if (btcPaymentAmount instanceof Error) return btcPaymentAmount
+
+  const usdPaymentAmount = paymentAmountFromCents(
+    toCents(paymentFlowState.usdPaymentAmount),
+  )
+  if (usdPaymentAmount instanceof Error) return usdPaymentAmount
+
+  const btcProtocolFee = paymentAmountFromSats(toSats(paymentFlowState.btcProtocolFee))
+  if (btcProtocolFee instanceof Error) return btcProtocolFee
+
+  const usdProtocolFee = paymentAmountFromCents(toCents(paymentFlowState.usdProtocolFee))
+  if (usdProtocolFee instanceof Error) return usdProtocolFee
+
   return PaymentFlow<S, R>({
     ...hash,
 
@@ -214,12 +230,12 @@ const paymentFlowFromRaw = <S extends WalletCurrency, R extends WalletCurrency>(
     createdAt: paymentFlowState.createdAt,
     paymentSentAndPending: paymentFlowState.paymentSentAndPending,
 
-    btcPaymentAmount: paymentAmountFromSats(toSats(paymentFlowState.btcPaymentAmount)),
-    usdPaymentAmount: paymentAmountFromCents(toCents(paymentFlowState.usdPaymentAmount)),
+    btcPaymentAmount,
+    usdPaymentAmount,
     inputAmount,
 
-    btcProtocolFee: paymentAmountFromSats(toSats(paymentFlowState.btcProtocolFee)),
-    usdProtocolFee: paymentAmountFromCents(toCents(paymentFlowState.usdProtocolFee)),
+    btcProtocolFee,
+    usdProtocolFee,
 
     recipientWalletId: (paymentFlowState.recipientWalletId as WalletId) || undefined,
     recipientWalletCurrency: (paymentFlowState.recipientWalletCurrency as R) || undefined,

--- a/src/services/payment-flow/index.ts
+++ b/src/services/payment-flow/index.ts
@@ -1,5 +1,3 @@
-import { toSats } from "@domain/bitcoin"
-import { toCents } from "@domain/fiat"
 import {
   CouldNotFindLightningPaymentFlowError,
   CouldNotUpdateLightningPaymentFlowError,
@@ -8,11 +6,7 @@ import {
   UnknownRepositoryError,
 } from "@domain/errors"
 import { InvalidLightningPaymentFlowStateError, PaymentFlow } from "@domain/payments"
-import {
-  paymentAmountFromCents,
-  paymentAmountFromSats,
-  WalletCurrency,
-} from "@domain/shared"
+import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
 import { safeBigInt } from "@domain/shared/safe"
 import { elapsedSinceTimestamp } from "@utils"
 
@@ -202,20 +196,28 @@ const paymentFlowFromRaw = <S extends WalletCurrency, R extends WalletCurrency>(
       )
   if (hash instanceof Error) return hash
 
-  const btcPaymentAmount = paymentAmountFromSats(
-    toSats(paymentFlowState.btcPaymentAmount),
-  )
+  const btcPaymentAmount = paymentAmountFromNumber({
+    amount: paymentFlowState.btcPaymentAmount,
+    currency: WalletCurrency.Btc,
+  })
   if (btcPaymentAmount instanceof Error) return btcPaymentAmount
 
-  const usdPaymentAmount = paymentAmountFromCents(
-    toCents(paymentFlowState.usdPaymentAmount),
-  )
+  const usdPaymentAmount = paymentAmountFromNumber({
+    amount: paymentFlowState.usdPaymentAmount,
+    currency: WalletCurrency.Usd,
+  })
   if (usdPaymentAmount instanceof Error) return usdPaymentAmount
 
-  const btcProtocolFee = paymentAmountFromSats(toSats(paymentFlowState.btcProtocolFee))
+  const btcProtocolFee = paymentAmountFromNumber({
+    amount: paymentFlowState.btcProtocolFee,
+    currency: WalletCurrency.Btc,
+  })
   if (btcProtocolFee instanceof Error) return btcProtocolFee
 
-  const usdProtocolFee = paymentAmountFromCents(toCents(paymentFlowState.usdProtocolFee))
+  const usdProtocolFee = paymentAmountFromNumber({
+    amount: paymentFlowState.usdProtocolFee,
+    currency: WalletCurrency.Usd,
+  })
   if (usdProtocolFee instanceof Error) return usdProtocolFee
 
   return PaymentFlow<S, R>({

--- a/test/helpers/wallet.ts
+++ b/test/helpers/wallet.ts
@@ -71,7 +71,6 @@ export const newGetRemainingTwoFALimit = async <T extends WalletCurrency>({
     walletVolume.outgoingBaseAmount.currency === WalletCurrency.Btc
       ? priceRatio.convertFromBtc(walletVolume.outgoingBaseAmount as BtcPaymentAmount)
       : (walletVolume.outgoingBaseAmount as UsdPaymentAmount)
-  if (usdOutgoingAmount instanceof Error) return usdOutgoingAmount
 
   const remainingLimitAmount = AmountCalculator().sub(twoFALimitAmount, usdOutgoingAmount)
   if (remainingLimitAmount instanceof Error) return remainingLimitAmount

--- a/test/helpers/wallet.ts
+++ b/test/helpers/wallet.ts
@@ -2,6 +2,12 @@ import { getBalanceForWallet } from "@app/wallets"
 import { getTwoFALimits, MS_PER_DAY } from "@config"
 import { toSats } from "@domain/bitcoin"
 import { sub, toCents } from "@domain/fiat"
+import {
+  AmountCalculator,
+  paymentAmountFromNumber,
+  WalletCurrency,
+  ZERO_CENTS,
+} from "@domain/shared"
 import { LedgerService } from "@services/ledger"
 import { baseLogger } from "@services/logger"
 
@@ -38,4 +44,37 @@ export const getRemainingTwoFALimit = async ({
   const remainingLimit = sub(twoFALimit, satsToCents(outgoing))
   if (remainingLimit instanceof Error) throw remainingLimit
   return remainingLimit > 0 ? remainingLimit : toCents(0)
+}
+
+export const newGetRemainingTwoFALimit = async <T extends WalletCurrency>({
+  walletDescriptor,
+  priceRatio,
+}: {
+  walletDescriptor: WalletDescriptor<T>
+  priceRatio: PriceRatio
+}): Promise<UsdPaymentAmount | ApplicationError> => {
+  const timestamp1DayAgo = new Date(Date.now() - MS_PER_DAY)
+  const walletVolume = await LedgerService().allPaymentVolumeAmountSince({
+    walletId: walletDescriptor.id,
+    walletCurrency: walletDescriptor.currency,
+    timestamp: timestamp1DayAgo,
+  })
+  if (walletVolume instanceof Error) return walletVolume
+
+  const twoFALimitAmount = paymentAmountFromNumber({
+    amount: getTwoFALimits().threshold,
+    currency: WalletCurrency.Usd,
+  })
+  if (twoFALimitAmount instanceof Error) return twoFALimitAmount
+
+  const usdOutgoingAmount: UsdPaymentAmount | ValidationError =
+    walletVolume.outgoingBaseAmount.currency === WalletCurrency.Btc
+      ? priceRatio.convertFromBtc(walletVolume.outgoingBaseAmount as BtcPaymentAmount)
+      : (walletVolume.outgoingBaseAmount as UsdPaymentAmount)
+  if (usdOutgoingAmount instanceof Error) return usdOutgoingAmount
+
+  const remainingLimitAmount = AmountCalculator().sub(twoFALimitAmount, usdOutgoingAmount)
+  if (remainingLimitAmount instanceof Error) return remainingLimitAmount
+
+  return remainingLimitAmount.amount > 0 ? remainingLimitAmount : ZERO_CENTS
 }

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -199,7 +199,6 @@ describe("UserWallet - Lightning Pay", () => {
     const midPriceRatio = await getMidPriceRatio()
     if (midPriceRatio instanceof Error) throw midPriceRatio
     const btcThresholdAmount = midPriceRatio.convertFromUsd(usdAmountAboveThreshold)
-    if (btcThresholdAmount instanceof Error) throw btcThresholdAmount
 
     const { request } = await createInvoice({
       lnd: lndOutside1,
@@ -229,7 +228,6 @@ describe("UserWallet - Lightning Pay", () => {
     const midPriceRatio = await getMidPriceRatio()
     if (midPriceRatio instanceof Error) throw midPriceRatio
     const btcThresholdAmount = midPriceRatio.convertFromUsd(usdAmountAboveThreshold)
-    if (btcThresholdAmount instanceof Error) throw btcThresholdAmount
 
     const lnInvoice = await Wallets.addInvoiceForSelf({
       walletId: walletIdA as WalletId,
@@ -574,7 +572,6 @@ describe("UserWallet - Lightning Pay", () => {
     })
     if (feeAmountSats instanceof Error) return feeAmountSats
     const feeAmountCents = priceRatio.convertFromBtc(feeAmountSats)
-    if (feeAmountCents instanceof Error) return feeAmountCents
     const feeCents = toCents(feeAmountCents.amount)
 
     const txnFeeReimburse = txns.find(
@@ -1391,7 +1388,6 @@ describe("UserWallet - Lightning Pay", () => {
         const btcAmountAboveThreshold = midPriceRatio.convertFromUsd(
           usdAmountAboveThreshold,
         )
-        if (btcAmountAboveThreshold instanceof Error) throw btcAmountAboveThreshold
 
         const { request } = await createInvoice({
           lnd: lndOutside1,

--- a/test/mocks/dealer-price/index.ts
+++ b/test/mocks/dealer-price/index.ts
@@ -71,17 +71,17 @@ export const NewDealerPriceService = (
 ): INewDealerPriceService => ({
   getCentsFromSatsForImmediateBuy: async (
     amount: BtcPaymentAmount,
-  ): Promise<UsdPaymentAmount> =>
+  ): Promise<UsdPaymentAmount | DealerPriceServiceError> =>
     paymentAmountFromCents(toCents(Math.floor(Number(amount.amount) / buyImmediate))),
   getCentsFromSatsForImmediateSell: async (
     amount: BtcPaymentAmount,
-  ): Promise<UsdPaymentAmount> =>
+  ): Promise<UsdPaymentAmount | DealerPriceServiceError> =>
     paymentAmountFromCents(
       toCents(Math.floor(Number(amount.amount) / sellUsdImmediateFromSats)),
     ),
   getCentsFromSatsForFutureBuy: async (
     amount: BtcPaymentAmount,
-  ): Promise<UsdPaymentAmount> =>
+  ): Promise<UsdPaymentAmount | DealerPriceServiceError> =>
     paymentAmountFromCents(
       toCents(
         (Math.floor(Number(amount.amount) * getBuyUsdQuoteFromSats) *
@@ -91,7 +91,7 @@ export const NewDealerPriceService = (
     ),
   getCentsFromSatsForFutureSell: async (
     amount: BtcPaymentAmount,
-  ): Promise<UsdPaymentAmount> =>
+  ): Promise<UsdPaymentAmount | DealerPriceServiceError> =>
     paymentAmountFromCents(
       toCents(
         (Math.floor(Number(amount.amount) * getSellUsdQuoteFromSats) *
@@ -102,17 +102,17 @@ export const NewDealerPriceService = (
 
   getSatsFromCentsForImmediateBuy: async (
     amount: UsdPaymentAmount,
-  ): Promise<BtcPaymentAmount> =>
+  ): Promise<BtcPaymentAmount | DealerPriceServiceError> =>
     paymentAmountFromSats(
       toSats(Math.floor(Number(amount.amount) * buyUsdImmediateFromCents)),
     ),
   getSatsFromCentsForImmediateSell: async (
     amount: UsdPaymentAmount,
-  ): Promise<BtcPaymentAmount> =>
+  ): Promise<BtcPaymentAmount | DealerPriceServiceError> =>
     paymentAmountFromSats(toSats(Math.floor(Number(amount.amount) * sellUsdImmediate))),
   getSatsFromCentsForFutureBuy: async (
     amount: UsdPaymentAmount,
-  ): Promise<BtcPaymentAmount> =>
+  ): Promise<BtcPaymentAmount | DealerPriceServiceError> =>
     paymentAmountFromSats(
       toSats(
         (Math.floor(Number(amount.amount) * getBuyUsdQuoteFromCents) *
@@ -122,7 +122,7 @@ export const NewDealerPriceService = (
     ),
   getSatsFromCentsForFutureSell: async (
     amount: UsdPaymentAmount,
-  ): Promise<BtcPaymentAmount> =>
+  ): Promise<BtcPaymentAmount | DealerPriceServiceError> =>
     paymentAmountFromSats(
       toSats(
         (Math.floor(Number(amount.amount) * getSellUsdQuoteFromCents) *

--- a/test/mocks/dealer-price/index.ts
+++ b/test/mocks/dealer-price/index.ts
@@ -1,7 +1,7 @@
 import { SATS_PER_BTC, toSats } from "@domain/bitcoin"
 import { defaultTimeToExpiryInSeconds } from "@domain/bitcoin/lightning"
 import { CENTS_PER_USD, toCents, toCentsPerSatsRatio } from "@domain/fiat"
-import { paymentAmountFromCents, paymentAmountFromSats } from "@domain/shared"
+import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
 
 // simulated price at 20k btc/usd
 // or 50 sats per cents. 0.05 sat per cents
@@ -71,65 +71,97 @@ export const NewDealerPriceService = (
 ): INewDealerPriceService => ({
   getCentsFromSatsForImmediateBuy: async (
     amount: BtcPaymentAmount,
-  ): Promise<UsdPaymentAmount | DealerPriceServiceError> =>
-    paymentAmountFromCents(toCents(Math.floor(Number(amount.amount) / buyImmediate))),
+  ): Promise<UsdPaymentAmount | DealerPriceServiceError> => {
+    const amountForPayment = Math.floor(Number(amount.amount) / buyImmediate)
+
+    return paymentAmountFromNumber({
+      amount: amountForPayment,
+      currency: WalletCurrency.Usd,
+    })
+  },
   getCentsFromSatsForImmediateSell: async (
     amount: BtcPaymentAmount,
-  ): Promise<UsdPaymentAmount | DealerPriceServiceError> =>
-    paymentAmountFromCents(
-      toCents(Math.floor(Number(amount.amount) / sellUsdImmediateFromSats)),
-    ),
+  ): Promise<UsdPaymentAmount | DealerPriceServiceError> => {
+    const amountForPayment = Math.floor(Number(amount.amount) / sellUsdImmediateFromSats)
+
+    return paymentAmountFromNumber({
+      amount: amountForPayment,
+      currency: WalletCurrency.Usd,
+    })
+  },
   getCentsFromSatsForFutureBuy: async (
     amount: BtcPaymentAmount,
-  ): Promise<UsdPaymentAmount | DealerPriceServiceError> =>
-    paymentAmountFromCents(
-      toCents(
-        (Math.floor(Number(amount.amount) * getBuyUsdQuoteFromSats) *
-          timeToExpiryInSeconds) /
-          timeToExpiryInSeconds,
-      ),
-    ),
+  ): Promise<UsdPaymentAmount | DealerPriceServiceError> => {
+    const amountForPayment =
+      (Math.floor(Number(amount.amount) * getBuyUsdQuoteFromSats) *
+        timeToExpiryInSeconds) /
+      timeToExpiryInSeconds
+
+    return paymentAmountFromNumber({
+      amount: amountForPayment,
+      currency: WalletCurrency.Usd,
+    })
+  },
   getCentsFromSatsForFutureSell: async (
     amount: BtcPaymentAmount,
-  ): Promise<UsdPaymentAmount | DealerPriceServiceError> =>
-    paymentAmountFromCents(
-      toCents(
-        (Math.floor(Number(amount.amount) * getSellUsdQuoteFromSats) *
-          timeToExpiryInSeconds) /
-          timeToExpiryInSeconds,
-      ),
-    ),
+  ): Promise<UsdPaymentAmount | DealerPriceServiceError> => {
+    const amountForPayment =
+      (Math.floor(Number(amount.amount) * getSellUsdQuoteFromSats) *
+        timeToExpiryInSeconds) /
+      timeToExpiryInSeconds
+
+    return paymentAmountFromNumber({
+      amount: amountForPayment,
+      currency: WalletCurrency.Usd,
+    })
+  },
 
   getSatsFromCentsForImmediateBuy: async (
     amount: UsdPaymentAmount,
-  ): Promise<BtcPaymentAmount | DealerPriceServiceError> =>
-    paymentAmountFromSats(
-      toSats(Math.floor(Number(amount.amount) * buyUsdImmediateFromCents)),
-    ),
+  ): Promise<BtcPaymentAmount | DealerPriceServiceError> => {
+    const amountForPayment = Math.floor(Number(amount.amount) * buyUsdImmediateFromCents)
+
+    return paymentAmountFromNumber({
+      amount: amountForPayment,
+      currency: WalletCurrency.Btc,
+    })
+  },
   getSatsFromCentsForImmediateSell: async (
     amount: UsdPaymentAmount,
-  ): Promise<BtcPaymentAmount | DealerPriceServiceError> =>
-    paymentAmountFromSats(toSats(Math.floor(Number(amount.amount) * sellUsdImmediate))),
+  ): Promise<BtcPaymentAmount | DealerPriceServiceError> => {
+    const amountForPayment = Math.floor(Number(amount.amount) * sellUsdImmediate)
+
+    return paymentAmountFromNumber({
+      amount: amountForPayment,
+      currency: WalletCurrency.Btc,
+    })
+  },
   getSatsFromCentsForFutureBuy: async (
     amount: UsdPaymentAmount,
-  ): Promise<BtcPaymentAmount | DealerPriceServiceError> =>
-    paymentAmountFromSats(
-      toSats(
-        (Math.floor(Number(amount.amount) * getBuyUsdQuoteFromCents) *
-          timeToExpiryInSeconds) /
-          timeToExpiryInSeconds,
-      ),
-    ),
+  ): Promise<BtcPaymentAmount | DealerPriceServiceError> => {
+    const amountForPayment =
+      (Math.floor(Number(amount.amount) * getBuyUsdQuoteFromCents) *
+        timeToExpiryInSeconds) /
+      timeToExpiryInSeconds
+
+    return paymentAmountFromNumber({
+      amount: amountForPayment,
+      currency: WalletCurrency.Btc,
+    })
+  },
   getSatsFromCentsForFutureSell: async (
     amount: UsdPaymentAmount,
-  ): Promise<BtcPaymentAmount | DealerPriceServiceError> =>
-    paymentAmountFromSats(
-      toSats(
-        (Math.floor(Number(amount.amount) * getSellUsdQuoteFromCents) *
-          timeToExpiryInSeconds) /
-          timeToExpiryInSeconds,
-      ),
-    ),
+  ): Promise<BtcPaymentAmount | DealerPriceServiceError> => {
+    const amountForPayment =
+      (Math.floor(Number(amount.amount) * getSellUsdQuoteFromCents) *
+        timeToExpiryInSeconds) /
+      timeToExpiryInSeconds
+
+    return paymentAmountFromNumber({
+      amount: amountForPayment,
+      currency: WalletCurrency.Btc,
+    })
+  },
   getCentsPerSatsExchangeMidRate: async (): Promise<CentsPerSatsRatio> =>
     toCentsPerSatsRatio((baseRate * CENTS_PER_USD) / SATS_PER_BTC),
 })

--- a/test/mocks/dealer-price/index.ts
+++ b/test/mocks/dealer-price/index.ts
@@ -1,6 +1,7 @@
 import { SATS_PER_BTC, toSats } from "@domain/bitcoin"
 import { defaultTimeToExpiryInSeconds } from "@domain/bitcoin/lightning"
 import { CENTS_PER_USD, toCents, toCentsPerSatsRatio } from "@domain/fiat"
+import { toPriceRatio } from "@domain/payments"
 import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
 
 // simulated price at 20k btc/usd
@@ -162,6 +163,6 @@ export const NewDealerPriceService = (
       currency: WalletCurrency.Btc,
     })
   },
-  getCentsPerSatsExchangeMidRate: async (): Promise<CentsPerSatsRatio> =>
-    toCentsPerSatsRatio((baseRate * CENTS_PER_USD) / SATS_PER_BTC),
+  getCentsPerSatsExchangeMidRate: async (): Promise<PriceRatio | ValidationError> =>
+    toPriceRatio((baseRate * CENTS_PER_USD) / SATS_PER_BTC),
 })

--- a/test/unit/domain/payments/price-ratio.spec.ts
+++ b/test/unit/domain/payments/price-ratio.spec.ts
@@ -45,87 +45,95 @@ describe("PriceRatio", () => {
     })
   })
 
-  it("rounds amounts", () => {
-    const priceRatioRoundDown = PriceRatio({
-      usd: {
-        amount: 4_100_000n,
-        currency: WalletCurrency.Usd,
-      },
-      btc: {
-        amount: 100_000_000n,
+  describe("rounds amounts", () => {
+    it("correctly rounds down when value is just below 0.5", () => {
+      const priceRatio = PriceRatio({
+        usd: {
+          amount: 4_100_000n,
+          currency: WalletCurrency.Usd,
+        },
+        btc: {
+          amount: 100_000_000n,
+          currency: WalletCurrency.Btc,
+        },
+      })
+      if (priceRatio instanceof Error) throw priceRatio
+
+      expect(
+        priceRatio.convertFromUsd({ amount: 1n, currency: WalletCurrency.Usd }),
+      ).toEqual({
+        amount: 24n,
         currency: WalletCurrency.Btc,
-      },
-    })
-    if (priceRatioRoundDown instanceof Error) throw priceRatioRoundDown
-
-    expect(
-      priceRatioRoundDown.convertFromUsd({ amount: 1n, currency: WalletCurrency.Usd }),
-    ).toEqual({
-      amount: 24n,
-      currency: WalletCurrency.Btc,
+      })
     })
 
-    const priceRatioRoundUp = PriceRatio({
-      usd: {
-        amount: 3_900_000n,
-        currency: WalletCurrency.Usd,
-      },
-      btc: {
-        amount: 100_000_000n,
+    it.skip("correctly rounds up when value is just above 0.5", () => {
+      const priceRatio = PriceRatio({
+        usd: {
+          amount: 3_900_000n,
+          currency: WalletCurrency.Usd,
+        },
+        btc: {
+          amount: 100_000_000n,
+          currency: WalletCurrency.Btc,
+        },
+      })
+      if (priceRatio instanceof Error) throw priceRatio
+
+      expect(
+        priceRatio.convertFromUsd({ amount: 1n, currency: WalletCurrency.Usd }),
+      ).toEqual({
+        amount: 26n,
         currency: WalletCurrency.Btc,
-      },
-    })
-    if (priceRatioRoundUp instanceof Error) throw priceRatioRoundUp
-
-    expect(
-      priceRatioRoundUp.convertFromUsd({ amount: 1n, currency: WalletCurrency.Usd }),
-    ).toEqual({
-      amount: 26n,
-      currency: WalletCurrency.Btc,
+      })
     })
 
-    const priceRatioRoundSameHigher = PriceRatio({
-      usd: {
-        amount: 4_000_100n,
-        currency: WalletCurrency.Usd,
-      },
-      btc: {
-        amount: 100_000_000n,
+    it("correctly rounds down when value is just above 1.0", () => {
+      const priceRatio = PriceRatio({
+        usd: {
+          amount: 3_999_900n,
+          currency: WalletCurrency.Usd,
+        },
+        btc: {
+          amount: 100_000_000n,
+          currency: WalletCurrency.Btc,
+        },
+      })
+      if (priceRatio instanceof Error) throw priceRatio
+
+      expect(
+        priceRatio.convertFromUsd({
+          amount: 1n,
+          currency: WalletCurrency.Usd,
+        }),
+      ).toEqual({
+        amount: 25n,
         currency: WalletCurrency.Btc,
-      },
-    })
-    if (priceRatioRoundSameHigher instanceof Error) throw priceRatioRoundSameHigher
-
-    expect(
-      priceRatioRoundSameHigher.convertFromUsd({
-        amount: 1n,
-        currency: WalletCurrency.Usd,
-      }),
-    ).toEqual({
-      amount: 25n,
-      currency: WalletCurrency.Btc,
+      })
     })
 
-    const priceRatioRoundSameLower = PriceRatio({
-      usd: {
-        amount: 3_999_900n,
-        currency: WalletCurrency.Usd,
-      },
-      btc: {
-        amount: 100_000_000n,
+    it.skip("correctly rounds up when value is just below 1.0", () => {
+      const priceRatio = PriceRatio({
+        usd: {
+          amount: 4_000_100n,
+          currency: WalletCurrency.Usd,
+        },
+        btc: {
+          amount: 100_000_000n,
+          currency: WalletCurrency.Btc,
+        },
+      })
+      if (priceRatio instanceof Error) throw priceRatio
+
+      expect(
+        priceRatio.convertFromUsd({
+          amount: 1n,
+          currency: WalletCurrency.Usd,
+        }),
+      ).toEqual({
+        amount: 25n,
         currency: WalletCurrency.Btc,
-      },
-    })
-    if (priceRatioRoundSameLower instanceof Error) throw priceRatioRoundSameLower
-
-    expect(
-      priceRatioRoundSameLower.convertFromUsd({
-        amount: 1n,
-        currency: WalletCurrency.Usd,
-      }),
-    ).toEqual({
-      amount: 25n,
-      currency: WalletCurrency.Btc,
+      })
     })
   })
 

--- a/test/unit/domain/payments/price-ratio.spec.ts
+++ b/test/unit/domain/payments/price-ratio.spec.ts
@@ -1,5 +1,9 @@
 import { WalletCurrency } from "@domain/shared"
-import { InvalidZeroAmountPriceRatioInputError, PriceRatio } from "@domain/payments"
+import {
+  InvalidZeroAmountPriceRatioInputError,
+  PriceRatio,
+  toPriceRatio,
+} from "@domain/payments"
 
 describe("PriceRatio", () => {
   const usdQuoteAmount = {
@@ -223,5 +227,17 @@ describe("PriceRatio", () => {
       },
     })
     expect(priceRatio).toBeInstanceOf(InvalidZeroAmountPriceRatioInputError)
+  })
+})
+
+describe("to PriceRatio from float ratio", () => {
+  it("converts a float ratio to PriceRatio object", async () => {
+    const ratio = 0.0005
+
+    const priceRatio = toPriceRatio(ratio)
+    expect(priceRatio).not.toBeInstanceOf(Error)
+    if (priceRatio instanceof Error) throw priceRatio
+
+    expect(priceRatio.usdPerSat()).toEqual(ratio)
   })
 })

--- a/test/unit/domain/payments/price-ratio.spec.ts
+++ b/test/unit/domain/payments/price-ratio.spec.ts
@@ -67,7 +67,7 @@ describe("PriceRatio", () => {
       })
     })
 
-    it.skip("correctly rounds up when value is just above 0.5", () => {
+    it("correctly rounds up when value is just above 0.5", () => {
       const priceRatio = PriceRatio({
         usd: {
           amount: 3_900_000n,
@@ -112,7 +112,7 @@ describe("PriceRatio", () => {
       })
     })
 
-    it.skip("correctly rounds up when value is just below 1.0", () => {
+    it("correctly rounds up when value is just below 1.0", () => {
       const priceRatio = PriceRatio({
         usd: {
           amount: 4_000_100n,

--- a/test/unit/domain/payments/price-ratio.spec.ts
+++ b/test/unit/domain/payments/price-ratio.spec.ts
@@ -46,58 +46,52 @@ describe("PriceRatio", () => {
   })
 
   describe("rounds amounts", () => {
-    it("correctly rounds down when value is just below 0.5", () => {
+    const btcPivot = { amount: 100_000_000n, currency: WalletCurrency.Btc }
+    const quotient = 25n
+
+    it("correctly rounds down when unrounded value is just below 0.5 less than target quotient", () => {
       const priceRatio = PriceRatio({
         usd: {
           amount: 4_100_000n,
           currency: WalletCurrency.Usd,
         },
-        btc: {
-          amount: 100_000_000n,
-          currency: WalletCurrency.Btc,
-        },
+        btc: btcPivot,
       })
       if (priceRatio instanceof Error) throw priceRatio
 
       expect(
         priceRatio.convertFromUsd({ amount: 1n, currency: WalletCurrency.Usd }),
       ).toEqual({
-        amount: 24n,
+        amount: quotient - 1n,
         currency: WalletCurrency.Btc,
       })
     })
 
-    it("correctly rounds up when value is just above 0.5", () => {
+    it("correctly rounds up when unrounded value is just above 0.5 more than target quotient", () => {
       const priceRatio = PriceRatio({
         usd: {
           amount: 3_900_000n,
           currency: WalletCurrency.Usd,
         },
-        btc: {
-          amount: 100_000_000n,
-          currency: WalletCurrency.Btc,
-        },
+        btc: btcPivot,
       })
       if (priceRatio instanceof Error) throw priceRatio
 
       expect(
         priceRatio.convertFromUsd({ amount: 1n, currency: WalletCurrency.Usd }),
       ).toEqual({
-        amount: 26n,
+        amount: quotient + 1n,
         currency: WalletCurrency.Btc,
       })
     })
 
-    it("correctly rounds down when value is just above 1.0", () => {
+    it("correctly rounds down when unrounded value is just above target quotient", () => {
       const priceRatio = PriceRatio({
         usd: {
           amount: 3_999_900n,
           currency: WalletCurrency.Usd,
         },
-        btc: {
-          amount: 100_000_000n,
-          currency: WalletCurrency.Btc,
-        },
+        btc: btcPivot,
       })
       if (priceRatio instanceof Error) throw priceRatio
 
@@ -107,21 +101,18 @@ describe("PriceRatio", () => {
           currency: WalletCurrency.Usd,
         }),
       ).toEqual({
-        amount: 25n,
+        amount: quotient,
         currency: WalletCurrency.Btc,
       })
     })
 
-    it("correctly rounds up when value is just below 1.0", () => {
+    it("correctly rounds up when unrounded value is just below target quotient", () => {
       const priceRatio = PriceRatio({
         usd: {
           amount: 4_000_100n,
           currency: WalletCurrency.Usd,
         },
-        btc: {
-          amount: 100_000_000n,
-          currency: WalletCurrency.Btc,
-        },
+        btc: btcPivot,
       })
       if (priceRatio instanceof Error) throw priceRatio
 

--- a/test/unit/domain/shared/amount-calculator.spec.ts
+++ b/test/unit/domain/shared/amount-calculator.spec.ts
@@ -1,0 +1,55 @@
+import { AmountCalculator, WalletCurrency } from "@domain/shared"
+
+describe("AmountCalculator", () => {
+  const calc = AmountCalculator()
+  describe("divides", () => {
+    const currency = WalletCurrency.Btc
+
+    const pivot = 200n
+    const divisor = 100n
+    const divisorBound = 50n
+    const quotient = 2n
+
+    it("no rounding if remainder is 0", () => {
+      const result = calc.divide({ amount: pivot, currency }, divisor)
+      expect(result.amount).toEqual(quotient)
+      expect(result.currency).toBe(currency)
+    })
+
+    it("rounds down if remainder is just above pivot", () => {
+      const result = calc.divide({ amount: pivot + 1n, currency }, divisor)
+      expect(result.amount).toEqual(quotient)
+      expect(result.currency).toBe(currency)
+    })
+
+    it("rounds up if remainder is just below pivot", () => {
+      const result = calc.divide({ amount: pivot - 1n, currency }, divisor)
+      expect(result.amount).toEqual(quotient)
+      expect(result.currency).toBe(currency)
+    })
+
+    it("rounds down if remainder is just below half of the divisor", () => {
+      const result = calc.divide(
+        { amount: pivot + (divisorBound - 1n), currency },
+        divisor,
+      )
+      expect(result.amount).toEqual(quotient)
+      expect(result.currency).toBe(currency)
+    })
+
+    it("rounds down if remainder is half of the divisor", () => {
+      const result = calc.divide({ amount: pivot + divisorBound, currency }, divisor)
+      expect(result.amount).toEqual(quotient)
+      expect(result.currency).toBe(currency)
+    })
+
+    it("rounds up if remainder is just above half of the divisor", () => {
+      const result = calc.divide(
+        { amount: pivot + (divisorBound + 1n), currency },
+        divisor,
+      )
+      expect(result.amount).toEqual(quotient + 1n)
+      expect(result.currency).toBe(currency)
+    })
+  })
+})

--- a/test/unit/domain/shared/amount-calculator.spec.ts
+++ b/test/unit/domain/shared/amount-calculator.spec.ts
@@ -2,6 +2,53 @@ import { AmountCalculator, WalletCurrency } from "@domain/shared"
 
 describe("AmountCalculator", () => {
   const calc = AmountCalculator()
+
+  describe("adds", () => {
+    const currency = WalletCurrency.Btc
+    const a = { amount: 200n, currency }
+    const b = { amount: 100n, currency }
+
+    it("adds two payment amounts", () => {
+      const res = calc.add(a, b)
+      expect(res).toStrictEqual({ amount: 300n, currency })
+    })
+
+    // TODO: implement
+    it.skip("fails with two payment amounts of mismatched currencies", () => {
+      const res1 = calc.add(a, { amount: 200n, currency: WalletCurrency.Usd })
+      expect(res1).toBeInstanceOf(Error)
+
+      const res2 = calc.add({ amount: 100n, currency: WalletCurrency.Usd }, b)
+      expect(res2).toBeInstanceOf(Error)
+    })
+  })
+
+  describe("subs", () => {
+    const currency = WalletCurrency.Btc
+    const a = { amount: 200n, currency }
+    const b = { amount: 100n, currency }
+
+    it("sub two payment amounts", () => {
+      const res = calc.sub(a, b)
+      expect(res).toStrictEqual({ amount: 100n, currency })
+    })
+
+    // TODO: implement
+    it.skip("fails with two payment amounts of mismatched currencies", () => {
+      const res1 = calc.sub(a, { amount: 200n, currency: WalletCurrency.Usd })
+      expect(res1).toBeInstanceOf(Error)
+
+      const res2 = calc.sub({ amount: 100n, currency: WalletCurrency.Usd }, b)
+      expect(res2).toBeInstanceOf(Error)
+    })
+
+    // TODO: implement
+    it.skip("fails with if 1st value is smaller than 2nd one", () => {
+      const res = calc.sub(b, a)
+      expect(res).toBeInstanceOf(Error)
+    })
+  })
+
   describe("divides", () => {
     const currency = WalletCurrency.Btc
 

--- a/test/unit/domain/shared/amount-calculator.spec.ts
+++ b/test/unit/domain/shared/amount-calculator.spec.ts
@@ -11,43 +11,37 @@ describe("AmountCalculator", () => {
     const quotient = 2n
 
     it("no rounding if remainder is 0", () => {
-      const result = calc.divide({ amount: pivot, currency }, divisor)
+      const result = calc.div({ amount: pivot, currency }, divisor)
       expect(result.amount).toEqual(quotient)
       expect(result.currency).toBe(currency)
     })
 
     it("rounds down if remainder is just above pivot", () => {
-      const result = calc.divide({ amount: pivot + 1n, currency }, divisor)
+      const result = calc.div({ amount: pivot + 1n, currency }, divisor)
       expect(result.amount).toEqual(quotient)
       expect(result.currency).toBe(currency)
     })
 
     it("rounds up if remainder is just below pivot", () => {
-      const result = calc.divide({ amount: pivot - 1n, currency }, divisor)
+      const result = calc.div({ amount: pivot - 1n, currency }, divisor)
       expect(result.amount).toEqual(quotient)
       expect(result.currency).toBe(currency)
     })
 
     it("rounds down if remainder is just below half of the divisor", () => {
-      const result = calc.divide(
-        { amount: pivot + (divisorBound - 1n), currency },
-        divisor,
-      )
+      const result = calc.div({ amount: pivot + (divisorBound - 1n), currency }, divisor)
       expect(result.amount).toEqual(quotient)
       expect(result.currency).toBe(currency)
     })
 
     it("rounds down if remainder is half of the divisor", () => {
-      const result = calc.divide({ amount: pivot + divisorBound, currency }, divisor)
+      const result = calc.div({ amount: pivot + divisorBound, currency }, divisor)
       expect(result.amount).toEqual(quotient)
       expect(result.currency).toBe(currency)
     })
 
     it("rounds up if remainder is just above half of the divisor", () => {
-      const result = calc.divide(
-        { amount: pivot + (divisorBound + 1n), currency },
-        divisor,
-      )
+      const result = calc.div({ amount: pivot + (divisorBound + 1n), currency }, divisor)
       expect(result.amount).toEqual(quotient + 1n)
       expect(result.currency).toBe(currency)
     })

--- a/test/unit/domain/wallet-invoices/wallet-invoice-factory.spec.ts
+++ b/test/unit/domain/wallet-invoices/wallet-invoice-factory.spec.ts
@@ -15,6 +15,9 @@ beforeAll(async () => {
 describe("wallet invoice factory methods", () => {
   it("translates a registered invoice to wallet invoice", () => {
     const amountInSats = toSats(42)
+    const paymentAmount = paymentAmountFromSats(amountInSats)
+    if (paymentAmount instanceof Error) throw paymentAmount
+
     const registeredInvoice: RegisteredInvoice = {
       invoice: {
         paymentHash: "paymentHash" as PaymentHash,
@@ -24,7 +27,7 @@ describe("wallet invoice factory methods", () => {
         cltvDelta: null,
         destination: "destination" as Pubkey,
         amount: amountInSats,
-        paymentAmount: paymentAmountFromSats(amountInSats),
+        paymentAmount,
         milliSatsAmount: toMilliSatsFromNumber(42000),
         description: "",
         features: [],
@@ -52,6 +55,9 @@ describe("wallet invoice factory methods", () => {
 
   it("translates a registered invoice to wallet invoice for a recipient", () => {
     const amountInSats = toSats(42)
+    const paymentAmount = paymentAmountFromSats(amountInSats)
+    if (paymentAmount instanceof Error) throw paymentAmount
+
     const registeredInvoice: RegisteredInvoice = {
       invoice: {
         paymentHash: "paymentHash" as PaymentHash,
@@ -61,7 +67,7 @@ describe("wallet invoice factory methods", () => {
         cltvDelta: null,
         destination: "destination" as Pubkey,
         amount: amountInSats,
-        paymentAmount: paymentAmountFromSats(amountInSats),
+        paymentAmount,
         milliSatsAmount: toMilliSatsFromNumber(42000),
         description: "",
         features: [],

--- a/test/unit/domain/wallet-invoices/wallet-invoice-factory.spec.ts
+++ b/test/unit/domain/wallet-invoices/wallet-invoice-factory.spec.ts
@@ -1,4 +1,4 @@
-import { paymentAmountFromSats, WalletCurrency } from "@domain/shared"
+import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
 import { MS_PER_DAY } from "@config"
 import { toMilliSatsFromNumber, toSats } from "@domain/bitcoin"
 import { toCents } from "@domain/fiat"
@@ -14,8 +14,11 @@ beforeAll(async () => {
 
 describe("wallet invoice factory methods", () => {
   it("translates a registered invoice to wallet invoice", () => {
-    const amountInSats = toSats(42)
-    const paymentAmount = paymentAmountFromSats(amountInSats)
+    const amountInSats = 42
+    const paymentAmount = paymentAmountFromNumber({
+      amount: amountInSats,
+      currency: WalletCurrency.Btc,
+    })
     if (paymentAmount instanceof Error) throw paymentAmount
 
     const registeredInvoice: RegisteredInvoice = {
@@ -26,7 +29,7 @@ describe("wallet invoice factory methods", () => {
         routeHints: [],
         cltvDelta: null,
         destination: "destination" as Pubkey,
-        amount: amountInSats,
+        amount: toSats(amountInSats),
         paymentAmount,
         milliSatsAmount: toMilliSatsFromNumber(42000),
         description: "",
@@ -54,8 +57,11 @@ describe("wallet invoice factory methods", () => {
   })
 
   it("translates a registered invoice to wallet invoice for a recipient", () => {
-    const amountInSats = toSats(42)
-    const paymentAmount = paymentAmountFromSats(amountInSats)
+    const amountInSats = 42
+    const paymentAmount = paymentAmountFromNumber({
+      amount: amountInSats,
+      currency: WalletCurrency.Btc,
+    })
     if (paymentAmount instanceof Error) throw paymentAmount
 
     const registeredInvoice: RegisteredInvoice = {
@@ -66,7 +72,7 @@ describe("wallet invoice factory methods", () => {
         routeHints: [],
         cltvDelta: null,
         destination: "destination" as Pubkey,
-        amount: amountInSats,
+        amount: toSats(amountInSats),
         paymentAmount,
         milliSatsAmount: toMilliSatsFromNumber(42000),
         description: "",

--- a/test/unit/payments/payment-flow-builder.spec.ts
+++ b/test/unit/payments/payment-flow-builder.spec.ts
@@ -149,6 +149,9 @@ describe("LightningPaymentFlowBuilder", () => {
           checkSenderWallet(payment)
 
           const btcProtocolFee = LnFees().feeFromRawRoute(rawRoute)
+          if (btcProtocolFee instanceof Error) return btcProtocolFee
+          expect(btcProtocolFee).not.toBeInstanceOf(Error)
+
           expect(payment).toEqual(
             expect.objectContaining({
               btcProtocolFee,


### PR DESCRIPTION
## Description

This refactor is to avoid us having to do compound calls like `paymentAmountFromSat(toSats(1))`
