### PR TITLE
feat: add new 'PaymentInTransition' lnd error handling

### DIFF
--- a/src/domain/bitcoin/lightning/errors.ts
+++ b/src/domain/bitcoin/lightning/errors.ts
@@ -28,6 +28,7 @@ export class InsufficientBalanceForRoutingError extends LightningServiceError {}
 export class InvoiceExpiredOrBadPaymentHashError extends LightningServiceError {}
 export class PaymentAttemptsTimedOutError extends LightningServiceError {}
 export class ProbeForRouteTimedOutError extends LightningServiceError {}
+export class PaymentInTransitionError extends LightningServiceError {}
 export class UnknownRouteNotFoundError extends LightningServiceError {
   level = ErrorLevel.Critical
 }

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -222,6 +222,10 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "UnknownLedgerError":
       return new DbError({ message, logger: baseLogger, level: "fatal" })
 
+    case "PaymentInTransitionError":
+      message = "Payment was sent and is still in transition."
+      return new LightningPaymentError({ message, logger: baseLogger })
+
     case "UnknownLightningServiceError":
       return new LightningPaymentError({ message, logger: baseLogger })
 

--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -17,6 +17,7 @@ import {
   InvoiceExpiredOrBadPaymentHashError,
   PaymentAttemptsTimedOutError,
   ProbeForRouteTimedOutError,
+  PaymentInTransitionError,
 } from "@domain/bitcoin/lightning"
 import lnService from "ln-service"
 import {
@@ -384,6 +385,8 @@ export const LndService = (
           return new InvoiceExpiredOrBadPaymentHashError(paymentHash)
         case KnownLndErrorDetails.PaymentAttemptsTimedOut:
           return new PaymentAttemptsTimedOutError()
+        case KnownLndErrorDetails.PaymentInTransition:
+          return new PaymentInTransitionError(paymentHash)
         default:
           return new UnknownLightningServiceError(JSON.stringify(err))
       }
@@ -458,6 +461,8 @@ export const LndService = (
           return new InvoiceExpiredOrBadPaymentHashError(decodedInvoice.paymentHash)
         case KnownLndErrorDetails.PaymentAttemptsTimedOut:
           return new PaymentAttemptsTimedOutError()
+        case KnownLndErrorDetails.PaymentInTransition:
+          return new PaymentInTransitionError(decodedInvoice.paymentHash)
         default:
           return new UnknownLightningServiceError(JSON.stringify(err))
       }
@@ -586,6 +591,7 @@ const KnownLndErrorDetails = {
   PaymentAttemptsTimedOut: "PaymentAttemptsTimedOut",
   ProbeForRouteTimedOut: "ProbeForRouteTimedOut",
   SentPaymentNotFound: "SentPaymentNotFound",
+  PaymentInTransition: "payment is in transition",
 } as const
 
 const translateLnPaymentLookup = (p): LnPaymentLookup => ({


### PR DESCRIPTION
## Description

Adds a new error type to handle lnd internal error when a payment is re-attempted and is still in transition.

Traces: [Link](https://ui.honeycomb.io/galoy/datasets/galoy-bbw?query=%7B%22start_time%22%3A1653504789%2C%22end_time%22%3A1653504872%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22code.function%22%2C%22error.name%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22COUNT%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22payment.request.hash%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22127500243a9de3d6bcc811f90bcc70cdfa7aab1bd6f52aa6cd1e8c9a5bcda50d%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22op%22%3A%22COUNT%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A1000%7D)

![image](https://user-images.githubusercontent.com/17693119/170491302-98b4c710-3b0b-4930-932e-1067648c7dc6.png)

