### PR TITLE
refactor: add friendly message for insufficient funds error

### DIFF
--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -17,6 +17,7 @@ import {
   UsernameError,
   RebalanceNeededError,
   DealerOfflineError,
+  InsufficientLiquidityError,
 } from "@graphql/error"
 import { baseLogger } from "@services/logger"
 
@@ -207,6 +208,10 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       message = "Unable to find a route for payment."
       return new RouteFindingError({ message, logger: baseLogger })
 
+    case "InsufficientOnChainFundsError":
+      message = "Funds temporarily offline. Will be restored shortly."
+      return new InsufficientLiquidityError({ message, logger: baseLogger })
+
     case "UnknownRouteNotFoundError":
       message = "Unknown error occurred when trying to find a route for payment."
       return new RouteFindingError({ message, logger: baseLogger })
@@ -324,7 +329,6 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "OnChainError":
     case "TransactionDecodeError":
     case "OnChainServiceError":
-    case "InsufficientOnChainFundsError":
     case "UnknownOnChainServiceError":
     case "CouldNotFindOnChainTransactionError":
     case "OnChainServiceUnavailableError":

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -209,7 +209,8 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       return new RouteFindingError({ message, logger: baseLogger })
 
     case "InsufficientOnChainFundsError":
-      message = "Funds temporarily offline. Will be restored shortly."
+      message =
+        "Onchain service temporarily unavailable. Withdraw via Lightning until service is restored."
       return new InsufficientLiquidityError({ message, logger: baseLogger })
 
     case "UnknownRouteNotFoundError":

--- a/src/graphql/error.ts
+++ b/src/graphql/error.ts
@@ -252,3 +252,14 @@ export class UsernameError extends CustomApolloError {
     })
   }
 }
+
+export class InsufficientLiquidityError extends CustomApolloError {
+  constructor(errData: CustomApolloErrorData) {
+    super({
+      message: "Temporary funds offline issue",
+      forwardToClient: true,
+      code: "LIQUIDITY_ERROR",
+      ...errData,
+    })
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a user-facing message for the error that pops up when all our onchain funds are swapped out and no funds are available in the hot wallet for sending by users (this is usually remedied by a looping out offchain funds back onchain).

We would like to communicate to the end-user in a concise way that:
- our liquidity is currently imbalanced
- it will be re-balanced again soon

We would like to avoid:
- signalling that we somehow don't have enough funds available to fulfill a user request
- implying that we somehow run a fractional reserve system (we don't)