### PR TITLE
chore: make 'BtcWallet' naming consistent

### DIFF
--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -49,7 +49,7 @@ type AuthTokenPayload {
 """
 A wallet belonging to an account which contains a BTC balance and a list of transactions.
 """
-type BTCWallet implements Wallet {
+type BtcWallet implements Wallet {
   """
   A balance stored in BTC.
   """

--- a/src/graphql/types/object/btc-wallet.ts
+++ b/src/graphql/types/object/btc-wallet.ts
@@ -13,7 +13,7 @@ import WalletCurrency from "../scalar/wallet-currency"
 import { TransactionConnection } from "./transaction"
 
 const BtcWallet = GT.Object<Wallet>({
-  name: "BTCWallet",
+  name: "BtcWallet",
   description:
     "A wallet belonging to an account which contains a BTC balance and a list of transactions.",
   interfaces: () => [IWallet],


### PR DESCRIPTION
## Description

We usually camel-case these sorts of names and this is the only instance where it wasn't camel-cased.

_**Note:** would this be considered a breaking API change?_

![image](https://user-images.githubusercontent.com/17693119/171181909-dcf74c86-95e9-40ed-a537-50ba7199923a.png)
