### PR TITLE
fix: correct amounts for fee_reimbursement txns in db

### DIFF
--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -699,8 +699,6 @@ const executePaymentViaLn = async ({
         journalId,
         actualFee: payResult.roundedUpFee,
         revealedPreImage: payResult.revealedPreImage,
-        amountDisplayCurrency: converter.fromUsdAmount(paymentFlow.usdPaymentAmount),
-        feeDisplayCurrency: converter.fromUsdAmount(paymentFlow.usdProtocolFee),
         logger,
       })
       if (reimbursed instanceof Error) return reimbursed

--- a/src/app/payments/update-pending-payments.ts
+++ b/src/app/payments/update-pending-payments.ts
@@ -181,8 +181,6 @@ const updatePendingPayment = async ({
           journalId: pendingPayment.journalId,
           actualFee: roundedUpFee,
           revealedPreImage,
-          amountDisplayCurrency: displayAmount,
-          feeDisplayCurrency: displayFee,
           logger,
         })
       } else if (status === PaymentStatus.Failed) {

--- a/src/app/wallets/reimburse-fee.ts
+++ b/src/app/wallets/reimburse-fee.ts
@@ -12,16 +12,12 @@ export const reimburseFee = async <S extends WalletCurrency, R extends WalletCur
   journalId,
   actualFee,
   revealedPreImage,
-  amountDisplayCurrency,
-  feeDisplayCurrency,
   logger,
 }: {
   paymentFlow: PaymentFlow<S, R>
   journalId: LedgerJournalId
   actualFee: Satoshis
   revealedPreImage?: RevealedPreImage
-  amountDisplayCurrency: DisplayCurrencyBaseAmount
-  feeDisplayCurrency: DisplayCurrencyBaseAmount
   logger: Logger
 }): Promise<true | ApplicationError> => {
   const actualFeeAmount = paymentAmountFromSats(actualFee)
@@ -52,13 +48,6 @@ export const reimburseFee = async <S extends WalletCurrency, R extends WalletCur
     return true
   }
 
-  const {
-    btcPaymentAmount: { amount: satsAmount },
-    usdPaymentAmount: { amount: centsAmount },
-    btcProtocolFee: { amount: satsFee },
-    usdProtocolFee: { amount: centsFee },
-  } = paymentFlow
-
   const displayCentsPerSat = priceRatio.usdPerSat()
   const converter = NewDisplayCurrencyConverter(displayCentsPerSat)
   const reimburseAmountDisplayCurrency = converter.fromUsdAmount(feeDifference.usd)
@@ -74,13 +63,13 @@ export const reimburseFee = async <S extends WalletCurrency, R extends WalletCur
 
     usd: (reimburseAmountDisplayCurrency / 100) as DisplayCurrencyBaseAmount,
 
-    satsAmount: toSats(satsAmount),
-    centsAmount: toCents(centsAmount),
-    satsFee: toSats(satsFee),
-    centsFee: toCents(centsFee),
+    satsAmount: toSats(feeDifference.btc.amount),
+    centsAmount: toCents(feeDifference.usd.amount),
+    satsFee: toSats(0),
+    centsFee: toCents(0),
 
-    displayAmount: amountDisplayCurrency,
-    displayFee: feeDisplayCurrency,
+    displayAmount: reimburseAmountDisplayCurrency,
+    displayFee: 0 as DisplayCurrencyBaseAmount,
     displayCurrency: DisplayCurrency.Usd,
   }
 

--- a/src/migrations/20220601191441-fix-reimburse-amounts.ts
+++ b/src/migrations/20220601191441-fix-reimburse-amounts.ts
@@ -1,0 +1,57 @@
+/* eslint @typescript-eslint/ban-ts-comment: "off" */
+// @ts-nocheck
+
+module.exports = {
+  async up(db) {
+    const collection = db.collection("medici_transactions")
+
+    // Fetch all reimbursement txns
+    let reimbursementTxnsCursor
+    try {
+      reimbursementTxnsCursor = collection.find({ type: "fee_reimbursement" })
+    } catch (error) {
+      console.log({ result: error }, "Couldn't find reimbursement txns")
+    }
+
+    const txns = []
+    for await (const txn of reimbursementTxnsCursor) {
+      txns.push(txn)
+    }
+
+    // Filter all hashes for reimbursement txns
+    const hashesSet = new Set(txns.map((txn) => txn.hash))
+    const hashes = Array.from(hashesSet.values())
+
+    // Update txns in db
+    for (const hash of hashes) {
+      const btcTxn = txns.find(
+        (txn) => txn.hash === hash && txn.currency === "BTC" && txn.debit === 0,
+      )
+      if (btcTxn === undefined) {
+        console.log(`Couldn't find usable reimbursements for ${hash}`)
+        continue
+      }
+
+      const update = {
+        satsAmount: btcTxn.credit,
+        centsAmount: Math.floor(btcTxn.usd * 100),
+        displayAmount: Math.floor(btcTxn.usd * 100),
+
+        satsFee: 0,
+        centsFee: 0,
+        displayFee: 0,
+      }
+
+      try {
+        const result = await collection.update(
+          { hash, type: "fee_reimbursement" },
+          [{ $set: update }],
+          { multi: true },
+        )
+        console.log({ result: result.result }, `edited reimbursements for ${hash}`)
+      } catch (error) {
+        console.log({ result: error }, `Couldn't update reimbursements for ${hash}`)
+      }
+    }
+  },
+}

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -505,14 +505,12 @@ describe("UserWallet - Lightning Pay", () => {
         feeUsd: 0,
         usd: feeCents / 100,
 
-        // FIXME: migrate db and fix code to make these pass
-
-        // satsAmount: feeSats,
-        // satsFee: 0,
-        // centsAmount: feeCents,
-        // centsFee: 0,
-        // displayAmount: feeCents,
-        // displayFee: 0,
+        satsAmount: feeSats,
+        satsFee: 0,
+        centsAmount: feeCents,
+        centsFee: 0,
+        displayAmount: feeCents,
+        displayFee: 0,
       }),
     )
 


### PR DESCRIPTION
## Description

This PR corrects the amounts properties being added to `fee_reimbursement` transactions. In the initial changeset, these properties were originally pointed at the original transaction's amount which is incorrect. This PR changes it so that the amounts correspond to the actual transaction they live on.

### Migration

This migration behaves the same for both pre-change and post-change txns in the db since it reads off existing properties (`debit` & `usd`) from the transaction and makes changes based on that. Also we are only writing the new amounts properties and are not reading from them as yet for any business logic or api returns so these changes should not need any other refactors in the codebase.