### PR TITLE
refactor: return max fee where possible when probe errors

### DIFF
--- a/src/domain/bitcoin/lightning/errors.ts
+++ b/src/domain/bitcoin/lightning/errors.ts
@@ -29,6 +29,10 @@ export class InvoiceExpiredOrBadPaymentHashError extends LightningServiceError {
 export class PaymentAttemptsTimedOutError extends LightningServiceError {}
 export class ProbeForRouteTimedOutError extends LightningServiceError {}
 export class PaymentInTransitionError extends LightningServiceError {}
+export class InvalidFeeProbeStateError extends LightningServiceError {
+  level = ErrorLevel.Critical
+}
+
 export class UnknownRouteNotFoundError extends LightningServiceError {
   level = ErrorLevel.Critical
 }

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -401,6 +401,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "BigIntFloatConversionError":
     case "UnknownBigIntConversionError":
     case "SafeWrapperError":
+    case "InvalidFeeProbeStateError":
       message = `Unknown error occurred (code: ${error.name}${
         error.message ? ": " + error.message : ""
       })`

--- a/src/graphql/root/mutation/ln-invoice-fee-probe.ts
+++ b/src/graphql/root/mutation/ln-invoice-fee-probe.ts
@@ -41,7 +41,7 @@ const LnInvoiceFeeProbeMutation = GT.Field({
       paymentRequest,
     })
 
-    if (feeSatAmount && error instanceof Error) {
+    if (feeSatAmount !== null && error instanceof Error) {
       return {
         errors: [{ message: mapError(error).message }],
         ...normalizePaymentAmount(feeSatAmount),

--- a/src/graphql/root/mutation/ln-invoice-fee-probe.ts
+++ b/src/graphql/root/mutation/ln-invoice-fee-probe.ts
@@ -1,3 +1,5 @@
+import { InvalidFeeProbeStateError } from "@domain/bitcoin/lightning"
+
 import { Payments } from "@app"
 
 import { GT } from "@graphql/index"
@@ -34,13 +36,28 @@ const LnInvoiceFeeProbeMutation = GT.Field({
     const btcWalletValidated = await validateIsBtcWalletForMutation(walletId)
     if (btcWalletValidated != true) return btcWalletValidated
 
-    const feeSatAmount = await Payments.getLightningFeeEstimation({
+    const { result: feeSatAmount, error } = await Payments.getLightningFeeEstimation({
       walletId,
       paymentRequest,
     })
-    if (feeSatAmount instanceof Error) {
-      const appErr = mapError(feeSatAmount)
-      return { errors: [{ message: appErr.message }] }
+
+    if (feeSatAmount && error instanceof Error) {
+      return {
+        errors: [{ message: mapError(error).message }],
+        ...normalizePaymentAmount(feeSatAmount),
+      }
+    }
+
+    if (error instanceof Error) {
+      return {
+        errors: [{ message: mapError(error).message }],
+      }
+    }
+
+    if (feeSatAmount === null) {
+      return {
+        errors: [{ message: mapError(new InvalidFeeProbeStateError()).message }],
+      }
     }
 
     return {

--- a/src/graphql/root/mutation/ln-noamount-invoice-fee-probe.ts
+++ b/src/graphql/root/mutation/ln-noamount-invoice-fee-probe.ts
@@ -1,3 +1,5 @@
+import { InvalidFeeProbeStateError } from "@domain/bitcoin/lightning"
+
 import { Payments } from "@app"
 
 import { GT } from "@graphql/index"
@@ -36,14 +38,30 @@ const LnNoAmountInvoiceFeeProbeMutation = GT.Field({
     const btcWalletValidated = await validateIsBtcWalletForMutation(walletId)
     if (btcWalletValidated != true) return btcWalletValidated
 
-    const feeSatAmount = await Payments.getNoAmountLightningFeeEstimation({
-      walletId,
-      amount,
-      paymentRequest,
-    })
-    if (feeSatAmount instanceof Error) {
-      const appErr = mapError(feeSatAmount)
-      return { errors: [{ message: appErr.message }] }
+    const { result: feeSatAmount, error } =
+      await Payments.getNoAmountLightningFeeEstimation({
+        walletId,
+        amount,
+        paymentRequest,
+      })
+
+    if (feeSatAmount && error instanceof Error) {
+      return {
+        errors: [{ message: mapError(error).message }],
+        ...normalizePaymentAmount(feeSatAmount),
+      }
+    }
+
+    if (error instanceof Error) {
+      return {
+        errors: [{ message: mapError(error).message }],
+      }
+    }
+
+    if (feeSatAmount === null) {
+      return {
+        errors: [{ message: mapError(new InvalidFeeProbeStateError()).message }],
+      }
     }
 
     return {

--- a/src/graphql/root/mutation/ln-noamount-invoice-fee-probe.ts
+++ b/src/graphql/root/mutation/ln-noamount-invoice-fee-probe.ts
@@ -45,7 +45,7 @@ const LnNoAmountInvoiceFeeProbeMutation = GT.Field({
         paymentRequest,
       })
 
-    if (feeSatAmount && error instanceof Error) {
+    if (feeSatAmount !== null && error instanceof Error) {
       return {
         errors: [{ message: mapError(error).message }],
         ...normalizePaymentAmount(feeSatAmount),

--- a/src/graphql/root/mutation/ln-noamount-usd-invoice-fee-probe.ts
+++ b/src/graphql/root/mutation/ln-noamount-usd-invoice-fee-probe.ts
@@ -1,3 +1,5 @@
+import { InvalidFeeProbeStateError } from "@domain/bitcoin/lightning"
+
 import { Payments } from "@app"
 
 import { GT } from "@graphql/index"
@@ -36,19 +38,35 @@ const LnNoAmountUsdInvoiceFeeProbeMutation = GT.Field({
     const usdWalletValidated = await validateIsUsdWalletForMutation(walletId)
     if (usdWalletValidated != true) return usdWalletValidated
 
-    const feeUsdAmount = await Payments.getNoAmountLightningFeeEstimation({
-      walletId,
-      amount,
-      paymentRequest,
-    })
-    if (feeUsdAmount instanceof Error) {
-      const appErr = mapError(feeUsdAmount)
-      return { errors: [{ message: appErr.message }] }
+    const { result: feeSatAmount, error } =
+      await Payments.getNoAmountLightningFeeEstimation({
+        walletId,
+        amount,
+        paymentRequest,
+      })
+
+    if (feeSatAmount && error instanceof Error) {
+      return {
+        errors: [{ message: mapError(error).message }],
+        ...normalizePaymentAmount(feeSatAmount),
+      }
+    }
+
+    if (error instanceof Error) {
+      return {
+        errors: [{ message: mapError(error).message }],
+      }
+    }
+
+    if (feeSatAmount === null) {
+      return {
+        errors: [{ message: mapError(new InvalidFeeProbeStateError()).message }],
+      }
     }
 
     return {
       errors: [],
-      ...normalizePaymentAmount(feeUsdAmount),
+      ...normalizePaymentAmount(feeSatAmount),
     }
   },
 })

--- a/src/graphql/root/mutation/ln-noamount-usd-invoice-fee-probe.ts
+++ b/src/graphql/root/mutation/ln-noamount-usd-invoice-fee-probe.ts
@@ -45,7 +45,7 @@ const LnNoAmountUsdInvoiceFeeProbeMutation = GT.Field({
         paymentRequest,
       })
 
-    if (feeSatAmount && error instanceof Error) {
+    if (feeSatAmount !== null && error instanceof Error) {
       return {
         errors: [{ message: mapError(error).message }],
         ...normalizePaymentAmount(feeSatAmount),

--- a/src/graphql/root/mutation/ln-usd-invoice-fee-probe.ts
+++ b/src/graphql/root/mutation/ln-usd-invoice-fee-probe.ts
@@ -1,3 +1,5 @@
+import { InvalidFeeProbeStateError } from "@domain/bitcoin/lightning"
+
 import { Payments } from "@app"
 
 import { GT } from "@graphql/index"
@@ -34,13 +36,28 @@ const LnUsdInvoiceFeeProbeMutation = GT.Field({
     const usdWalletValidated = await validateIsUsdWalletForMutation(walletId)
     if (usdWalletValidated != true) return usdWalletValidated
 
-    const feeSatAmount = await Payments.getLightningFeeEstimation({
+    const { result: feeSatAmount, error } = await Payments.getLightningFeeEstimation({
       walletId,
       paymentRequest,
     })
-    if (feeSatAmount instanceof Error) {
-      const appErr = mapError(feeSatAmount)
-      return { errors: [{ message: appErr.message }] }
+
+    if (feeSatAmount && error instanceof Error) {
+      return {
+        errors: [{ message: mapError(error).message }],
+        ...normalizePaymentAmount(feeSatAmount),
+      }
+    }
+
+    if (error instanceof Error) {
+      return {
+        errors: [{ message: mapError(error).message }],
+      }
+    }
+
+    if (feeSatAmount === null) {
+      return {
+        errors: [{ message: mapError(new InvalidFeeProbeStateError()).message }],
+      }
     }
 
     return {

--- a/src/graphql/root/mutation/ln-usd-invoice-fee-probe.ts
+++ b/src/graphql/root/mutation/ln-usd-invoice-fee-probe.ts
@@ -41,7 +41,7 @@ const LnUsdInvoiceFeeProbeMutation = GT.Field({
       paymentRequest,
     })
 
-    if (feeSatAmount && error instanceof Error) {
+    if (feeSatAmount !== null && error instanceof Error) {
       return {
         errors: [{ message: mapError(error).message }],
         ...normalizePaymentAmount(feeSatAmount),

--- a/test/e2e/servers/graphql-main-server/auth-requests.spec.ts
+++ b/test/e2e/servers/graphql-main-server/auth-requests.spec.ts
@@ -1,4 +1,4 @@
-import { toSats } from "@domain/bitcoin"
+import { FEECAP_PERCENT, toSats } from "@domain/bitcoin"
 import { toCents } from "@domain/fiat"
 import { WalletCurrency } from "@domain/shared"
 import { yamlConfig } from "@config"
@@ -339,16 +339,34 @@ describe("graphql", () => {
       expect(amount).toBe(0)
     })
 
-    it("returns an error if it is unable to find a route for payment", async () => {
+    it("returns an error & 1 sat fee if it is unable to find a route for 1 sat payment", async () => {
       const messageRegex = /^Unable to find a route for payment.$/
-      const unreachablePaymentRequest =
+      const unreachable1SatPaymentRequest =
         "lnbcrt10n1p39jatkpp5djwv295kunhe5e0e4whj3dcjzwy7cmcxk8cl2a4dquyrp3dqydesdqqcqzpuxqr23ssp56u5m680x7resnvcelmsngc64ljm7g5q9r26zw0qyq5fenuqlcfzq9qyyssqxv4kvltas2qshhmqnjctnqkjpdfzu89e428ga6yk9jsp8rf382f3t03ex4e6x3a4sxkl7ruj6lsfpkuu9u9ee5kgr5zdyj7x2nwdljgq74025p"
 
-      const input = { walletId, paymentRequest: unreachablePaymentRequest }
+      const input = { walletId, paymentRequest: unreachable1SatPaymentRequest }
       const result = await apolloClient.mutate({ mutation, variables: { input } })
       const { amount, errors } = result.data.lnInvoiceFeeProbe
       expect(errors).toHaveLength(1)
-      expect(amount).toBe(null)
+      expect(amount).toBe(1)
+      expect(errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ message: expect.stringMatching(messageRegex) }),
+        ]),
+      )
+    })
+
+    it("returns an error & expected sat fee if it is unable to find a route for 10k sat payment", async () => {
+      const messageRegex = /^Unable to find a route for payment.$/
+      const unreachable10kSatPaymentRequest =
+        "lnbc100u1p3fj2qlpp5gnp23luuectecrlqddwkh7n7flj6zrnna8eqm8h9ws4ecweucqzsdqqcqzpgxqyz5vqsp5gue9tr3djq08kw6286tzk948ys69pphyd6xmwyut0xyn6fqt2zfs9qyyssq043fsndfudcjt05m7pyeusgpdlegm8kcstc5xywc2zws35tmlpsxdyed8jg8vk4erdxpwwap8akc9vm769qw2zqq86u63mqpa22fu6cpqjuudj"
+      const expectedFee = 10_000 * FEECAP_PERCENT
+
+      const input = { walletId, paymentRequest: unreachable10kSatPaymentRequest }
+      const result = await apolloClient.mutate({ mutation, variables: { input } })
+      const { amount, errors } = result.data.lnInvoiceFeeProbe
+      expect(errors).toHaveLength(1)
+      expect(amount).toBe(expectedFee)
       expect(errors).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ message: expect.stringMatching(messageRegex) }),
@@ -372,7 +390,7 @@ describe("graphql", () => {
       expect(amount).toBe(0)
     })
 
-    it("returns an error if it is unable to find a route for payment", async () => {
+    it("returns an error & 1 sat fee if it is unable to find a route for 1 sat payment", async () => {
       const messageRegex = /^Unable to find a route for payment.$/
       const unreachablePaymentRequest =
         "lnbcrt1p39jaempp58sazckz8cce377ry7cle7k6rwafsjzkuqg022cp2vhxvccyss3csdqqcqzpuxqr23ssp509fhyjxf4utxetalmjett6xvwrm3g7datl6sted2w2m3qdnlq7ps9qyyssqg49tguulzccdtfdl07ltep8294d60tcryxl0tcau0uzwpre6mmxq7mc6737ffctl59fxv32a9g0ul63gx304862fuuwslnr2cd3ghuqq2rsxaz"
@@ -381,7 +399,31 @@ describe("graphql", () => {
       const result = await apolloClient.mutate({ mutation, variables: { input } })
       const { amount, errors } = result.data.lnNoAmountInvoiceFeeProbe
       expect(errors).toHaveLength(1)
-      expect(amount).toBe(null)
+      expect(amount).toBe(1)
+      expect(errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ message: expect.stringMatching(messageRegex) }),
+        ]),
+      )
+    })
+
+    it("returns an error & expected fee if it is unable to find a route for 10k sat payment", async () => {
+      const messageRegex = /^Unable to find a route for payment.$/
+      const unreachablePaymentRequest =
+        "lnbcrt1p39jaempp58sazckz8cce377ry7cle7k6rwafsjzkuqg022cp2vhxvccyss3csdqqcqzpuxqr23ssp509fhyjxf4utxetalmjett6xvwrm3g7datl6sted2w2m3qdnlq7ps9qyyssqg49tguulzccdtfdl07ltep8294d60tcryxl0tcau0uzwpre6mmxq7mc6737ffctl59fxv32a9g0ul63gx304862fuuwslnr2cd3ghuqq2rsxaz"
+
+      const paymentAmount = 10_000
+      const expectedFee = paymentAmount * FEECAP_PERCENT
+
+      const input = {
+        walletId,
+        amount: paymentAmount,
+        paymentRequest: unreachablePaymentRequest,
+      }
+      const result = await apolloClient.mutate({ mutation, variables: { input } })
+      const { amount, errors } = result.data.lnNoAmountInvoiceFeeProbe
+      expect(errors).toHaveLength(1)
+      expect(amount).toBe(expectedFee)
       expect(errors).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ message: expect.stringMatching(messageRegex) }),


### PR DESCRIPTION
## Description

This PR changes the feeProbe use-case method to return `PartialResult` objects to accommodate being able to return a max fee alongside an error if the probe fails.