### PR TITLE
fix: invalid tracing context set as root in trigger

### DIFF
--- a/src/app/lightning/update-ln-payments.ts
+++ b/src/app/lightning/update-ln-payments.ts
@@ -60,15 +60,17 @@ const updateLnPaymentsByFunction = async ({
     const results = await asyncRunInSpan(
       "app.lightning.updateLnPaymentsPaginated",
       {
-        [SemanticAttributes.CODE_FUNCTION]: "updateLnPaymentsPaginated",
-        [SemanticAttributes.CODE_NAMESPACE]: "app.lightning",
-        [`${SemanticAttributes.CODE_FUNCTION}.params.cursor`]: String(after),
-        [`${SemanticAttributes.CODE_FUNCTION}.params.listPaymentsMethod`]: listFn.name,
-        [`${SemanticAttributes.CODE_FUNCTION}.params.pubkey`]: pubkey,
-        [`${SemanticAttributes.CODE_FUNCTION}.params.totalIncomplete`]:
-          incompleteLnPayments.length,
-        [`${SemanticAttributes.CODE_FUNCTION}.params.processedCount`]:
-          updatedProcessedHashes.length,
+        attributes: {
+          [SemanticAttributes.CODE_FUNCTION]: "updateLnPaymentsPaginated",
+          [SemanticAttributes.CODE_NAMESPACE]: "app.lightning",
+          [`${SemanticAttributes.CODE_FUNCTION}.params.cursor`]: String(after),
+          [`${SemanticAttributes.CODE_FUNCTION}.params.listPaymentsMethod`]: listFn.name,
+          [`${SemanticAttributes.CODE_FUNCTION}.params.pubkey`]: pubkey,
+          [`${SemanticAttributes.CODE_FUNCTION}.params.totalIncomplete`]:
+            incompleteLnPayments.length,
+          [`${SemanticAttributes.CODE_FUNCTION}.params.processedCount`]:
+            updatedProcessedHashes.length,
+        },
       },
       async () => {
         if (after === false) return new UnknownLightningServiceError()

--- a/src/app/payments/helpers.ts
+++ b/src/app/payments/helpers.ts
@@ -51,8 +51,10 @@ export const usdFromBtcMidPriceFn = async (
   asyncRunInSpan(
     "app.payments.usdFromBtcMidPriceFn",
     {
-      [SemanticAttributes.CODE_FUNCTION]: "usdFromBtcMidPriceFn",
-      [SemanticAttributes.CODE_NAMESPACE]: "app.payments",
+      attributes: {
+        [SemanticAttributes.CODE_FUNCTION]: "usdFromBtcMidPriceFn",
+        [SemanticAttributes.CODE_NAMESPACE]: "app.payments",
+      },
     },
     async () => {
       const midPriceRatio = await getMidPriceRatio()
@@ -85,8 +87,10 @@ export const btcFromUsdMidPriceFn = async (
   asyncRunInSpan(
     "app.payments.btcFromUsdMidPriceFn",
     {
-      [SemanticAttributes.CODE_FUNCTION]: "btcFromUsdMidPriceFn",
-      [SemanticAttributes.CODE_NAMESPACE]: "app.payments",
+      attributes: {
+        [SemanticAttributes.CODE_FUNCTION]: "btcFromUsdMidPriceFn",
+        [SemanticAttributes.CODE_NAMESPACE]: "app.payments",
+      },
     },
     async () => {
       const midPriceRatio = await getMidPriceRatio()

--- a/src/app/users/get-user.ts
+++ b/src/app/users/get-user.ts
@@ -42,8 +42,10 @@ const updateUserIPsInfo = async ({
   asyncRunInSpan(
     "app.users.updateUserIPsInfo",
     {
-      [SemanticAttributes.CODE_FUNCTION]: "updateUserIPsInfo",
-      [SemanticAttributes.CODE_NAMESPACE]: "app.users",
+      attributes: {
+        [SemanticAttributes.CODE_FUNCTION]: "updateUserIPsInfo",
+        [SemanticAttributes.CODE_NAMESPACE]: "app.users",
+      },
     },
     async () => {
       const ipConfig = getIpConfig()

--- a/src/debug/migrate-ln-payments-listpayments.ts
+++ b/src/debug/migrate-ln-payments-listpayments.ts
@@ -34,7 +34,11 @@ const indexRegex = /{"offset":(\d+),"limit":\d+}/
 const main = async () =>
   asyncRunInSpan(
     "debug.migrateLnPaymentsFromLnd",
-    { [SemanticAttributes.CODE_FUNCTION]: "debug.migrateLnPaymentsFromLnd" },
+    {
+      attributes: {
+        [SemanticAttributes.CODE_FUNCTION]: "debug.migrateLnPaymentsFromLnd",
+      },
+    },
     async (): Promise<true | ApplicationError> => {
       const lndService = LndService()
       if (lndService instanceof Error) return lndService
@@ -51,9 +55,11 @@ const main = async () =>
             count = await asyncRunInSpan(
               "debug.migrateLnPaymentsByFunction",
               {
-                [SemanticAttributes.CODE_FUNCTION]: "debug.migrateLnPaymentsByFunction",
-                "migrateLnPaymentsByFunction.iteration": `${listFn.name}:${count}`,
-                "migrateLnPaymentsByFunction.pubkey": pubkey,
+                attributes: {
+                  [SemanticAttributes.CODE_FUNCTION]: "debug.migrateLnPaymentsByFunction",
+                  "migrateLnPaymentsByFunction.iteration": `${listFn.name}:${count}`,
+                  "migrateLnPaymentsByFunction.pubkey": pubkey,
+                },
               },
               async () => {
                 if (count instanceof Error) return count

--- a/src/debug/migrate-ln-payments-trackpaymentsv2.ts
+++ b/src/debug/migrate-ln-payments-trackpaymentsv2.ts
@@ -44,10 +44,12 @@ const migrateLnPayment = async (
   asyncRunInSpan(
     "debug.migrateLnPayment",
     {
-      [SemanticAttributes.CODE_FUNCTION]: "migrateLnPayment",
-      [SemanticAttributes.CODE_NAMESPACE]: "debug",
-      "migrateLnPayment.paymentHash":
-        paymentHash instanceof Error ? paymentHash.name : paymentHash,
+      attributes: {
+        [SemanticAttributes.CODE_FUNCTION]: "migrateLnPayment",
+        [SemanticAttributes.CODE_NAMESPACE]: "debug",
+        "migrateLnPayment.paymentHash":
+          paymentHash instanceof Error ? paymentHash.name : paymentHash,
+      },
     },
     async (): Promise<true | LightningServiceError> => {
       if (paymentHash instanceof Error) return paymentHash

--- a/src/services/tracing.ts
+++ b/src/services/tracing.ts
@@ -229,10 +229,10 @@ const recordException = (span: Span, exception: Exception, level?: ErrorLevel) =
 
 export const asyncRunInSpan = <F extends () => ReturnType<F>>(
   spanName: string,
-  attributes: SpanAttributes,
+  options: SpanOptions,
   fn: F,
 ) => {
-  const ret = tracer.startActiveSpan(spanName, { attributes }, async (span) => {
+  const ret = tracer.startActiveSpan(spanName, options, async (span) => {
     try {
       const ret = await Promise.resolve(fn())
       if ((ret as unknown) instanceof Error) {


### PR DESCRIPTION
This is a proposed fix for [this issue](https://github.com/GaloyMoney/galoy/issues/1344).
It changes the attributes arguments to SpanOptions on the asyncRunInSpan function.
This means when we call it we can optionally set the span to be the root of the trace.
I have called in that way inside the trigger.ts for onchainBlockEventhandler as example.

The main change made:
https://github.com/GaloyMoney/galoy/blob/71f697ba18636b45ab4a6a9ae0a8d2b40a405e07/src/services/tracing.ts#L230-L239

How to set a span to be root with this:
https://github.com/GaloyMoney/galoy/blob/71f697ba18636b45ab4a6a9ae0a8d2b40a405e07/src/servers/trigger.ts#L177-L193

