### PR TITLE
refactor: make redundant flow update method more specific

### DIFF
--- a/src/app/payments/update-pending-payments.ts
+++ b/src/app/payments/update-pending-payments.ts
@@ -135,15 +135,15 @@ const updatePendingPayment = async ({
       const inputAmount = inputAmountFromLedgerTransaction(pendingPayment)
       if (inputAmount instanceof Error) return inputAmount
 
+      const paymentFlowIndex: PaymentFlowStateIndex = {
+        paymentHash,
+        walletId,
+        inputAmount,
+      }
+
       let paymentFlow = await PaymentFlowStateRepository(
         defaultTimeToExpiryInSeconds,
-      ).updatePendingLightningPaymentFlow({
-        senderWalletId: walletId,
-        paymentHash,
-        inputAmount,
-
-        paymentSentAndPending: false,
-      })
+      ).markLightningPaymentFlowNotPending(paymentFlowIndex)
       if (paymentFlow instanceof Error) {
         paymentFlow = await reconstructPendingPaymentFlow(paymentHash)
         if (paymentFlow instanceof Error) return paymentFlow

--- a/src/domain/payments/index.types.d.ts
+++ b/src/domain/payments/index.types.d.ts
@@ -37,11 +37,9 @@ type PaymentFlowState<
   cachedRoute?: RawRoute
 }
 
-type PaymentFlowStatePendingUpdate = XorPaymentHashProperty & {
-  senderWalletId: WalletId
+type PaymentFlowStateIndex = XorPaymentHashProperty & {
+  walletId: WalletId
   inputAmount: bigint
-
-  paymentSentAndPending: boolean
 }
 
 type PaymentFlow<S extends WalletCurrency, R extends WalletCurrency> = PaymentFlowState<
@@ -152,20 +150,14 @@ interface IPaymentFlowRepository {
   persistNew<S extends WalletCurrency>(
     payment: PaymentFlow<S, WalletCurrency>,
   ): Promise<PaymentFlow<S, WalletCurrency> | RepositoryError>
-  findLightningPaymentFlow<S extends WalletCurrency, R extends WalletCurrency>({
-    walletId,
-    paymentHash,
-    intraLedgerHash,
-    inputAmount,
-  }: XorPaymentHashProperty & {
-    walletId: WalletId
-    inputAmount: bigint
-  }): Promise<PaymentFlow<S, R> | RepositoryError>
+  findLightningPaymentFlow<S extends WalletCurrency, R extends WalletCurrency>(
+    paymentFlowIndex: PaymentFlowStateIndex,
+  ): Promise<PaymentFlow<S, R> | RepositoryError>
   updateLightningPaymentFlow<S extends WalletCurrency>(
     paymentFlow: PaymentFlow<S, WalletCurrency>,
   ): Promise<true | RepositoryError>
-  updatePendingLightningPaymentFlow<S extends WalletCurrency>(
-    paymentFlowPendingUpdate: PaymentFlowStatePendingUpdate,
+  markLightningPaymentFlowNotPending<S extends WalletCurrency>(
+    paymentFlowIndex: PaymentFlowStateIndex,
   ): Promise<PaymentFlow<S, WalletCurrency> | RepositoryError>
   deleteExpiredLightningPaymentFlows(): Promise<number | RepositoryError>
 }

--- a/src/services/payment-flow/schema.types.d.ts
+++ b/src/services/payment-flow/schema.types.d.ts
@@ -30,12 +30,10 @@ type PaymentFlowStateRecordPartial = XOR<
   cachedRoute?: RawRoute
 }
 
-type PaymentFlowStateRecordPendingUpdate = XOR<
+type PaymentFlowStateRecordIndex = XOR<
   { paymentHash: string },
   { intraLedgerHash: string }
 > & {
   senderWalletId: string
   inputAmount: number
-
-  paymentSentAndPending: boolean
 }

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -44,6 +44,8 @@ import { add, toCents } from "@domain/fiat"
 
 import { ImbalanceCalculator } from "@domain/ledger/imbalance-calculator"
 
+import { PaymentFlowStateRepository } from "@services/payment-flow"
+
 import {
   cancelHodlInvoice,
   checkIsBalanced,
@@ -1061,6 +1063,13 @@ describe("UserWallet - Lightning Pay", () => {
       it("pay hodl invoice & ln payments repo updates", async () => {
         const { id, secret } = createInvoiceHash()
 
+        const paymentFlowRepo = PaymentFlowStateRepository(defaultTimeToExpiryInSeconds)
+        const paymentFlowIndex: PaymentFlowStateIndex = {
+          paymentHash: id as PaymentHash,
+          walletId: walletIdB,
+          inputAmount: BigInt(amountInvoice),
+        }
+
         const { request } = await createHodlInvoice({
           id,
           lnd: lndOutside1,
@@ -1105,6 +1114,12 @@ describe("UserWallet - Lightning Pay", () => {
         expect(lnPaymentOnPending.isCompleteRecord).toBeFalsy()
         expect(lnPaymentOnPending.createdAt).toBeInstanceOf(Date)
         expect(lnPaymentOnPending.status).toBeUndefined()
+
+        const paymentFlowPending = await paymentFlowRepo.findLightningPaymentFlow(
+          paymentFlowIndex,
+        )
+        if (paymentFlowPending instanceof Error) throw paymentFlowPending
+        expect(paymentFlowPending.paymentSentAndPending).toBeTruthy()
 
         const lndService = LndService()
         if (lndService instanceof Error) throw lndService
@@ -1174,6 +1189,12 @@ describe("UserWallet - Lightning Pay", () => {
         expect(lnPaymentOnSettled.paymentRequest).toBe(request)
         expect(lnPaymentOnSettled.sentFromPubkey).toBe(lnPaymentOnPay.sentFromPubkey)
         expect(lnPaymentOnSettled.isCompleteRecord).toBeTruthy()
+
+        const paymentFlowSettled = await paymentFlowRepo.findLightningPaymentFlow(
+          paymentFlowIndex,
+        )
+        if (paymentFlowSettled instanceof Error) throw paymentFlowSettled
+        expect(paymentFlowSettled.paymentSentAndPending).toBeFalsy()
 
         const finalBalance = await getBalanceHelper(walletIdB)
         expect(finalBalance).toBe(initBalanceB - amountInvoice)


### PR DESCRIPTION
## Description

Change the redundant update method to be purpose-specific 'mark not pending' method for `IPaymentFlowRepository` interface.