### PR TITLE
fix: round down USD amounts when reimbursing fees

### DIFF
--- a/src/domain/ledger/fee-reimbursement.ts
+++ b/src/domain/ledger/fee-reimbursement.ts
@@ -22,7 +22,8 @@ export const FeeReimbursement = ({
       currency: WalletCurrency.Btc,
     }
 
-    const feeDifferenceUsdAmount = priceRatio.convertFromBtc(feeDifferenceBtcAmount)
+    const feeDifferenceUsdAmount =
+      priceRatio.convertFromBtcToFloor(feeDifferenceBtcAmount)
 
     return { btc: feeDifferenceBtcAmount, usd: feeDifferenceUsdAmount }
   }

--- a/src/domain/ledger/fee-reimbursement.ts
+++ b/src/domain/ledger/fee-reimbursement.ts
@@ -23,7 +23,9 @@ export const FeeReimbursement = ({
     }
 
     const feeDifferenceUsdAmount =
-      priceRatio.convertFromBtcToFloor(feeDifferenceBtcAmount)
+      actualFee.amount === 0n
+        ? priceRatio.convertFromBtc(feeDifferenceBtcAmount)
+        : priceRatio.convertFromBtcToFloor(feeDifferenceBtcAmount)
 
     return { btc: feeDifferenceBtcAmount, usd: feeDifferenceUsdAmount }
   }

--- a/src/domain/payments/index.types.d.ts
+++ b/src/domain/payments/index.types.d.ts
@@ -1,6 +1,7 @@
 type PriceRatio = {
   convertFromUsd(convert: UsdPaymentAmount): BtcPaymentAmount
   convertFromBtc(convert: BtcPaymentAmount): UsdPaymentAmount
+  convertFromBtcToFloor(convert: BtcPaymentAmount): UsdPaymentAmount
   usdPerSat(): DisplayCurrencyBasePerSat
 }
 

--- a/src/domain/payments/price-ratio.ts
+++ b/src/domain/payments/price-ratio.ts
@@ -46,9 +46,16 @@ export const PriceRatio = ({
     return { amount: amount.amount || 1n, currency }
   }
 
+  const convertFromBtcToFloor = (convert: BtcPaymentAmount): UsdPaymentAmount =>
+    calc.divFloor(
+      { amount: convert.amount * usd.amount, currency: WalletCurrency.Usd },
+      btc.amount,
+    )
+
   return {
     convertFromUsd,
     convertFromBtc,
+    convertFromBtcToFloor,
     usdPerSat: () =>
       (Number(usd.amount) / Number(btc.amount)) as DisplayCurrencyBasePerSat,
   }

--- a/src/domain/payments/price-ratio.ts
+++ b/src/domain/payments/price-ratio.ts
@@ -23,7 +23,10 @@ export const PriceRatio = ({
       return { amount: 0n, currency }
     }
 
-    const amount = calc.div({ amount: convert.amount * btc.amount, currency }, usd.amount)
+    const amount = calc.divRound(
+      { amount: convert.amount * btc.amount, currency },
+      usd.amount,
+    )
 
     return { amount: amount.amount || 1n, currency }
   }
@@ -35,7 +38,10 @@ export const PriceRatio = ({
       return { amount: 0n, currency }
     }
 
-    const amount = calc.div({ amount: convert.amount * usd.amount, currency }, btc.amount)
+    const amount = calc.divRound(
+      { amount: convert.amount * usd.amount, currency },
+      btc.amount,
+    )
 
     return { amount: amount.amount || 1n, currency }
   }

--- a/src/domain/shared/calculator.ts
+++ b/src/domain/shared/calculator.ts
@@ -26,9 +26,19 @@ export const AmountCalculator = (): AmountCalculator => {
       : { amount: quotient, currency: a.currency }
   }
 
+  const divFloor = <T extends WalletCurrency>(
+    a: PaymentAmount<T>,
+    b: bigint,
+  ): PaymentAmount<T> => {
+    const quotient = a.amount / b
+
+    return { amount: quotient, currency: a.currency }
+  }
+
   return {
     sub,
     add,
     divRound,
+    divFloor,
   }
 }

--- a/src/domain/shared/calculator.ts
+++ b/src/domain/shared/calculator.ts
@@ -13,7 +13,7 @@ export const AmountCalculator = (): AmountCalculator => {
     }
   }
 
-  const div = <T extends WalletCurrency>(
+  const divRound = <T extends WalletCurrency>(
     a: PaymentAmount<T>,
     b: bigint,
   ): PaymentAmount<T> => {
@@ -29,6 +29,6 @@ export const AmountCalculator = (): AmountCalculator => {
   return {
     sub,
     add,
-    div,
+    divRound,
   }
 }

--- a/src/domain/shared/index.types.d.ts
+++ b/src/domain/shared/index.types.d.ts
@@ -38,5 +38,5 @@ type AmountCalculator = {
     a: PaymentAmount<T>,
     b: PaymentAmount<T>,
   ) => PaymentAmount<T>
-  div: <T extends WalletCurrency>(a: PaymentAmount<T>, b: bigint) => PaymentAmount<T>
+  divRound: <T extends WalletCurrency>(a: PaymentAmount<T>, b: bigint) => PaymentAmount<T>
 }

--- a/src/domain/shared/index.types.d.ts
+++ b/src/domain/shared/index.types.d.ts
@@ -39,4 +39,5 @@ type AmountCalculator = {
     b: PaymentAmount<T>,
   ) => PaymentAmount<T>
   divRound: <T extends WalletCurrency>(a: PaymentAmount<T>, b: bigint) => PaymentAmount<T>
+  divFloor: <T extends WalletCurrency>(a: PaymentAmount<T>, b: bigint) => PaymentAmount<T>
 }

--- a/test/unit/domain/ledger/fee-reimbursement.spec.ts
+++ b/test/unit/domain/ledger/fee-reimbursement.spec.ts
@@ -54,4 +54,70 @@ describe("FeeReimbursement", () => {
     const feeDifference = feeReimbursement.getReimbursement(actualFeeAmount)
     expect(feeDifference).toBeInstanceOf(FeeDifferenceError)
   })
+  it("returns rounded down amount for USD amounts", () => {
+    const prepaidFeeAmount = {
+      btc: { amount: 100n, currency: WalletCurrency.Btc },
+      usd: { amount: 5n, currency: WalletCurrency.Usd },
+    }
+
+    const priceRatio = PriceRatio(prepaidFeeAmount)
+    if (priceRatio instanceof Error) throw priceRatio
+
+    const feeReimbursement = FeeReimbursement({ prepaidFeeAmount, priceRatio })
+
+    const actualFeeAmount1 = { amount: 1n, currency: WalletCurrency.Btc }
+    const feeDifference1 = feeReimbursement.getReimbursement(actualFeeAmount1)
+    expect(feeDifference1).toStrictEqual({
+      btc: { amount: 99n, currency: "BTC" },
+      usd: { currency: "USD", amount: 4n },
+    })
+
+    const actualFeeAmount2 = { amount: 19n, currency: WalletCurrency.Btc }
+    const feeDifference2 = feeReimbursement.getReimbursement(actualFeeAmount2)
+    expect(feeDifference2).toStrictEqual({
+      btc: { amount: 81n, currency: "BTC" },
+      usd: { currency: "USD", amount: 4n },
+    })
+
+    const actualFeeAmount3 = { amount: 21n, currency: WalletCurrency.Btc }
+    const feeDifference3 = feeReimbursement.getReimbursement(actualFeeAmount3)
+    expect(feeDifference3).toStrictEqual({
+      btc: { amount: 79n, currency: "BTC" },
+      usd: { currency: "USD", amount: 3n },
+    })
+  })
+  it("returns exact amount for USD amounts when no remainder", () => {
+    const prepaidFeeAmount = {
+      btc: { amount: 100n, currency: WalletCurrency.Btc },
+      usd: { amount: 5n, currency: WalletCurrency.Usd },
+    }
+
+    const priceRatio = PriceRatio(prepaidFeeAmount)
+    if (priceRatio instanceof Error) throw priceRatio
+
+    const feeReimbursement = FeeReimbursement({ prepaidFeeAmount, priceRatio })
+
+    const actualFeeAmount = { amount: 20n, currency: WalletCurrency.Btc }
+    const feeDifference = feeReimbursement.getReimbursement(actualFeeAmount)
+    expect(feeDifference).toStrictEqual({
+      btc: { amount: 80n, currency: "BTC" },
+      usd: { currency: "USD", amount: 4n },
+    })
+  })
+  it("returns original amount for zero fee actual amount", () => {
+    const prepaidFeeAmount = {
+      btc: { amount: 100n, currency: WalletCurrency.Btc },
+      usd: { amount: 5n, currency: WalletCurrency.Usd },
+    }
+
+    const priceRatio = PriceRatio(prepaidFeeAmount)
+    if (priceRatio instanceof Error) throw priceRatio
+
+    const feeReimbursement = FeeReimbursement({ prepaidFeeAmount, priceRatio })
+    const actualFeeAmount = { amount: 0n, currency: WalletCurrency.Btc }
+    const feeDifference = feeReimbursement.getReimbursement(actualFeeAmount)
+
+    console.log(feeDifference)
+    expect(feeDifference).toStrictEqual(prepaidFeeAmount)
+  })
 })

--- a/test/unit/domain/payments/price-ratio.spec.ts
+++ b/test/unit/domain/payments/price-ratio.spec.ts
@@ -182,6 +182,64 @@ describe("PriceRatio", () => {
         })
       })
     })
+
+    describe("rounds amounts to floor", () => {
+      describe("converts from usd", () => {
+        it("Not Implemented Yet", async () => true)
+      })
+      describe("converts from btc", () => {
+        const product = 2n
+        const priceRatio = PriceRatio({
+          btc: { amount: 100_000_000n, currency: WalletCurrency.Btc },
+          usd: { amount: 5_000_000n, currency: WalletCurrency.Usd },
+        })
+        if (priceRatio instanceof Error) throw priceRatio
+
+        it("correctly rounds down when unrounded value is just below 0.5 less than target product", () => {
+          const usdPaymentAmount = priceRatio.convertFromBtcToFloor({
+            amount: 29n,
+            currency: WalletCurrency.Btc,
+          })
+          expect(usdPaymentAmount).toEqual({
+            amount: product - 1n,
+            currency: WalletCurrency.Usd,
+          })
+        })
+
+        it("correctly rounds down when unrounded value is just above 0.5 more than target product", () => {
+          const usdPaymentAmount = priceRatio.convertFromBtcToFloor({
+            amount: 51n,
+            currency: WalletCurrency.Btc,
+          })
+          expect(usdPaymentAmount).toEqual({
+            amount: product,
+            currency: WalletCurrency.Usd,
+          })
+        })
+
+        it("correctly rounds down when unrounded value is just above target product", () => {
+          const usdPaymentAmount = priceRatio.convertFromBtcToFloor({
+            amount: 41n,
+            currency: WalletCurrency.Btc,
+          })
+          expect(usdPaymentAmount).toEqual({
+            amount: product,
+            currency: WalletCurrency.Usd,
+          })
+        })
+
+        it("correctly rounds down when unrounded value is just below target product", () => {
+          const usdPaymentAmount = priceRatio.convertFromBtcToFloor({
+            amount: 39n,
+            currency: WalletCurrency.Btc,
+          })
+          expect(usdPaymentAmount).toEqual({
+            amount: product - 1n,
+            currency: WalletCurrency.Usd,
+          })
+        })
+      })
+    })
   })
 
   it("does not return zero usd amount for small ratios", () => {

--- a/test/unit/domain/payments/price-ratio.spec.ts
+++ b/test/unit/domain/payments/price-ratio.spec.ts
@@ -46,84 +46,140 @@ describe("PriceRatio", () => {
   })
 
   describe("rounds amounts", () => {
-    const btcPivot = { amount: 100_000_000n, currency: WalletCurrency.Btc }
-    const quotient = 25n
+    describe("rounds amounts normally", () => {
+      describe("converts from usd", () => {
+        const btcPivot = { amount: 100_000_000n, currency: WalletCurrency.Btc }
+        const quotient = 25n
 
-    it("correctly rounds down when unrounded value is just below 0.5 less than target quotient", () => {
-      const priceRatio = PriceRatio({
-        usd: {
-          amount: 4_100_000n,
-          currency: WalletCurrency.Usd,
-        },
-        btc: btcPivot,
+        it("correctly rounds down when unrounded value is just below 0.5 less than target quotient", () => {
+          const priceRatio = PriceRatio({
+            usd: {
+              amount: 4_100_000n,
+              currency: WalletCurrency.Usd,
+            },
+            btc: btcPivot,
+          })
+          if (priceRatio instanceof Error) throw priceRatio
+
+          expect(
+            priceRatio.convertFromUsd({ amount: 1n, currency: WalletCurrency.Usd }),
+          ).toEqual({
+            amount: quotient - 1n,
+            currency: WalletCurrency.Btc,
+          })
+        })
+
+        it("correctly rounds up when unrounded value is just above 0.5 more than target quotient", () => {
+          const priceRatio = PriceRatio({
+            usd: {
+              amount: 3_900_000n,
+              currency: WalletCurrency.Usd,
+            },
+            btc: btcPivot,
+          })
+          if (priceRatio instanceof Error) throw priceRatio
+
+          expect(
+            priceRatio.convertFromUsd({ amount: 1n, currency: WalletCurrency.Usd }),
+          ).toEqual({
+            amount: quotient + 1n,
+            currency: WalletCurrency.Btc,
+          })
+        })
+
+        it("correctly rounds down when unrounded value is just above target quotient", () => {
+          const priceRatio = PriceRatio({
+            usd: {
+              amount: 3_999_900n,
+              currency: WalletCurrency.Usd,
+            },
+            btc: btcPivot,
+          })
+          if (priceRatio instanceof Error) throw priceRatio
+
+          expect(
+            priceRatio.convertFromUsd({
+              amount: 1n,
+              currency: WalletCurrency.Usd,
+            }),
+          ).toEqual({
+            amount: quotient,
+            currency: WalletCurrency.Btc,
+          })
+        })
+
+        it("correctly rounds up when unrounded value is just below target quotient", () => {
+          const priceRatio = PriceRatio({
+            usd: {
+              amount: 4_000_100n,
+              currency: WalletCurrency.Usd,
+            },
+            btc: btcPivot,
+          })
+          if (priceRatio instanceof Error) throw priceRatio
+
+          expect(
+            priceRatio.convertFromUsd({
+              amount: 1n,
+              currency: WalletCurrency.Usd,
+            }),
+          ).toEqual({
+            amount: quotient,
+            currency: WalletCurrency.Btc,
+          })
+        })
       })
-      if (priceRatio instanceof Error) throw priceRatio
+      describe("converts from btc", () => {
+        const product = 2n
+        const priceRatio = PriceRatio({
+          btc: { amount: 100_000_000n, currency: WalletCurrency.Btc },
+          usd: { amount: 5_000_000n, currency: WalletCurrency.Usd },
+        })
+        if (priceRatio instanceof Error) throw priceRatio
 
-      expect(
-        priceRatio.convertFromUsd({ amount: 1n, currency: WalletCurrency.Usd }),
-      ).toEqual({
-        amount: quotient - 1n,
-        currency: WalletCurrency.Btc,
-      })
-    })
+        it("correctly rounds down when unrounded value is just below 0.5 less than target product", () => {
+          const usdPaymentAmount = priceRatio.convertFromBtc({
+            amount: 29n,
+            currency: WalletCurrency.Btc,
+          })
+          expect(usdPaymentAmount).toEqual({
+            amount: product - 1n,
+            currency: WalletCurrency.Usd,
+          })
+        })
 
-    it("correctly rounds up when unrounded value is just above 0.5 more than target quotient", () => {
-      const priceRatio = PriceRatio({
-        usd: {
-          amount: 3_900_000n,
-          currency: WalletCurrency.Usd,
-        },
-        btc: btcPivot,
-      })
-      if (priceRatio instanceof Error) throw priceRatio
+        it("correctly rounds up when unrounded value is just above 0.5 more than target product", () => {
+          const usdPaymentAmount = priceRatio.convertFromBtc({
+            amount: 51n,
+            currency: WalletCurrency.Btc,
+          })
+          expect(usdPaymentAmount).toEqual({
+            amount: product + 1n,
+            currency: WalletCurrency.Usd,
+          })
+        })
 
-      expect(
-        priceRatio.convertFromUsd({ amount: 1n, currency: WalletCurrency.Usd }),
-      ).toEqual({
-        amount: quotient + 1n,
-        currency: WalletCurrency.Btc,
-      })
-    })
+        it("correctly rounds down when unrounded value is just above target product", () => {
+          const usdPaymentAmount = priceRatio.convertFromBtc({
+            amount: 41n,
+            currency: WalletCurrency.Btc,
+          })
+          expect(usdPaymentAmount).toEqual({
+            amount: product,
+            currency: WalletCurrency.Usd,
+          })
+        })
 
-    it("correctly rounds down when unrounded value is just above target quotient", () => {
-      const priceRatio = PriceRatio({
-        usd: {
-          amount: 3_999_900n,
-          currency: WalletCurrency.Usd,
-        },
-        btc: btcPivot,
-      })
-      if (priceRatio instanceof Error) throw priceRatio
-
-      expect(
-        priceRatio.convertFromUsd({
-          amount: 1n,
-          currency: WalletCurrency.Usd,
-        }),
-      ).toEqual({
-        amount: quotient,
-        currency: WalletCurrency.Btc,
-      })
-    })
-
-    it("correctly rounds up when unrounded value is just below target quotient", () => {
-      const priceRatio = PriceRatio({
-        usd: {
-          amount: 4_000_100n,
-          currency: WalletCurrency.Usd,
-        },
-        btc: btcPivot,
-      })
-      if (priceRatio instanceof Error) throw priceRatio
-
-      expect(
-        priceRatio.convertFromUsd({
-          amount: 1n,
-          currency: WalletCurrency.Usd,
-        }),
-      ).toEqual({
-        amount: 25n,
-        currency: WalletCurrency.Btc,
+        it("correctly rounds up when unrounded value is just below target product", () => {
+          const usdPaymentAmount = priceRatio.convertFromBtc({
+            amount: 39n,
+            currency: WalletCurrency.Btc,
+          })
+          expect(usdPaymentAmount).toEqual({
+            amount: product,
+            currency: WalletCurrency.Usd,
+          })
+        })
       })
     })
   })

--- a/test/unit/domain/shared/amount-calculator.spec.ts
+++ b/test/unit/domain/shared/amount-calculator.spec.ts
@@ -57,46 +57,92 @@ describe("AmountCalculator", () => {
     const divisorBound = 50n
     const quotient = 2n
 
-    it("no rounding if remainder is 0", () => {
-      const result = calc.divRound({ amount: pivot, currency }, divisor)
-      expect(result.amount).toEqual(quotient)
-      expect(result.currency).toBe(currency)
+    describe("by rounding normally", () => {
+      it("no rounding if remainder is 0", () => {
+        const result = calc.divRound({ amount: pivot, currency }, divisor)
+        expect(result.amount).toEqual(quotient)
+        expect(result.currency).toBe(currency)
+      })
+
+      it("rounds down if remainder is just above pivot", () => {
+        const result = calc.divRound({ amount: pivot + 1n, currency }, divisor)
+        expect(result.amount).toEqual(quotient)
+        expect(result.currency).toBe(currency)
+      })
+
+      it("rounds up if remainder is just below pivot", () => {
+        const result = calc.divRound({ amount: pivot - 1n, currency }, divisor)
+        expect(result.amount).toEqual(quotient)
+        expect(result.currency).toBe(currency)
+      })
+
+      it("rounds down if remainder is just below half of the divisor", () => {
+        const result = calc.divRound(
+          { amount: pivot + (divisorBound - 1n), currency },
+          divisor,
+        )
+        expect(result.amount).toEqual(quotient)
+        expect(result.currency).toBe(currency)
+      })
+
+      it("rounds down if remainder is half of the divisor", () => {
+        const result = calc.divRound({ amount: pivot + divisorBound, currency }, divisor)
+        expect(result.amount).toEqual(quotient)
+        expect(result.currency).toBe(currency)
+      })
+
+      it("rounds up if remainder is just above half of the divisor", () => {
+        const result = calc.divRound(
+          { amount: pivot + (divisorBound + 1n), currency },
+          divisor,
+        )
+        expect(result.amount).toEqual(quotient + 1n)
+        expect(result.currency).toBe(currency)
+      })
     })
 
-    it("rounds down if remainder is just above pivot", () => {
-      const result = calc.divRound({ amount: pivot + 1n, currency }, divisor)
-      expect(result.amount).toEqual(quotient)
-      expect(result.currency).toBe(currency)
-    })
+    describe("by rounding to floor", () => {
+      it("no rounding if remainder is 0", () => {
+        const result = calc.divFloor({ amount: pivot, currency }, divisor)
+        expect(result.amount).toEqual(quotient)
+        expect(result.currency).toBe(currency)
+      })
 
-    it("rounds up if remainder is just below pivot", () => {
-      const result = calc.divRound({ amount: pivot - 1n, currency }, divisor)
-      expect(result.amount).toEqual(quotient)
-      expect(result.currency).toBe(currency)
-    })
+      it("rounds down if remainder is just above pivot", () => {
+        const result = calc.divFloor({ amount: pivot + 1n, currency }, divisor)
+        expect(result.amount).toEqual(quotient)
+        expect(result.currency).toBe(currency)
+      })
 
-    it("rounds down if remainder is just below half of the divisor", () => {
-      const result = calc.divRound(
-        { amount: pivot + (divisorBound - 1n), currency },
-        divisor,
-      )
-      expect(result.amount).toEqual(quotient)
-      expect(result.currency).toBe(currency)
-    })
+      it("rounds down if remainder is just below pivot", () => {
+        const result = calc.divFloor({ amount: pivot - 1n, currency }, divisor)
+        expect(result.amount).toEqual(quotient - 1n)
+        expect(result.currency).toBe(currency)
+      })
 
-    it("rounds down if remainder is half of the divisor", () => {
-      const result = calc.divRound({ amount: pivot + divisorBound, currency }, divisor)
-      expect(result.amount).toEqual(quotient)
-      expect(result.currency).toBe(currency)
-    })
+      it("rounds down if remainder is just below half of the divisor", () => {
+        const result = calc.divFloor(
+          { amount: pivot + (divisorBound - 1n), currency },
+          divisor,
+        )
+        expect(result.amount).toEqual(quotient)
+        expect(result.currency).toBe(currency)
+      })
 
-    it("rounds up if remainder is just above half of the divisor", () => {
-      const result = calc.divRound(
-        { amount: pivot + (divisorBound + 1n), currency },
-        divisor,
-      )
-      expect(result.amount).toEqual(quotient + 1n)
-      expect(result.currency).toBe(currency)
+      it("rounds down if remainder is half of the divisor", () => {
+        const result = calc.divFloor({ amount: pivot + divisorBound, currency }, divisor)
+        expect(result.amount).toEqual(quotient)
+        expect(result.currency).toBe(currency)
+      })
+
+      it("rounds down if remainder is just above half of the divisor", () => {
+        const result = calc.divFloor(
+          { amount: pivot + (divisorBound + 1n), currency },
+          divisor,
+        )
+        expect(result.amount).toEqual(quotient)
+        expect(result.currency).toBe(currency)
+      })
     })
   })
 })

--- a/test/unit/domain/shared/amount-calculator.spec.ts
+++ b/test/unit/domain/shared/amount-calculator.spec.ts
@@ -58,37 +58,43 @@ describe("AmountCalculator", () => {
     const quotient = 2n
 
     it("no rounding if remainder is 0", () => {
-      const result = calc.div({ amount: pivot, currency }, divisor)
+      const result = calc.divRound({ amount: pivot, currency }, divisor)
       expect(result.amount).toEqual(quotient)
       expect(result.currency).toBe(currency)
     })
 
     it("rounds down if remainder is just above pivot", () => {
-      const result = calc.div({ amount: pivot + 1n, currency }, divisor)
+      const result = calc.divRound({ amount: pivot + 1n, currency }, divisor)
       expect(result.amount).toEqual(quotient)
       expect(result.currency).toBe(currency)
     })
 
     it("rounds up if remainder is just below pivot", () => {
-      const result = calc.div({ amount: pivot - 1n, currency }, divisor)
+      const result = calc.divRound({ amount: pivot - 1n, currency }, divisor)
       expect(result.amount).toEqual(quotient)
       expect(result.currency).toBe(currency)
     })
 
     it("rounds down if remainder is just below half of the divisor", () => {
-      const result = calc.div({ amount: pivot + (divisorBound - 1n), currency }, divisor)
+      const result = calc.divRound(
+        { amount: pivot + (divisorBound - 1n), currency },
+        divisor,
+      )
       expect(result.amount).toEqual(quotient)
       expect(result.currency).toBe(currency)
     })
 
     it("rounds down if remainder is half of the divisor", () => {
-      const result = calc.div({ amount: pivot + divisorBound, currency }, divisor)
+      const result = calc.divRound({ amount: pivot + divisorBound, currency }, divisor)
       expect(result.amount).toEqual(quotient)
       expect(result.currency).toBe(currency)
     })
 
     it("rounds up if remainder is just above half of the divisor", () => {
-      const result = calc.div({ amount: pivot + (divisorBound + 1n), currency }, divisor)
+      const result = calc.divRound(
+        { amount: pivot + (divisorBound + 1n), currency },
+        divisor,
+      )
       expect(result.amount).toEqual(quotient + 1n)
       expect(result.currency).toBe(currency)
     })


### PR DESCRIPTION
## Description

This PR ensures that for reimbursements if there is a non-zero sat fee we should always round down the usd amount that we reimburse.