### PR TITLE
refactor: round up usd send fees in payment flow builder

### DIFF
--- a/src/domain/payments/index.types.d.ts
+++ b/src/domain/payments/index.types.d.ts
@@ -2,6 +2,7 @@ type PriceRatio = {
   convertFromUsd(convert: UsdPaymentAmount): BtcPaymentAmount
   convertFromBtc(convert: BtcPaymentAmount): UsdPaymentAmount
   convertFromBtcToFloor(convert: BtcPaymentAmount): UsdPaymentAmount
+  convertFromBtcToCeil(convert: BtcPaymentAmount): UsdPaymentAmount
   usdPerSat(): DisplayCurrencyBasePerSat
 }
 

--- a/src/domain/payments/payment-flow-builder.ts
+++ b/src/domain/payments/payment-flow-builder.ts
@@ -442,7 +442,7 @@ const LPFBWithConversion = <S extends WalletCurrency, R extends WalletCurrency>(
 
     const btcProtocolFee = LnFees().feeFromRawRoute(rawRoute)
     if (btcProtocolFee instanceof Error) return btcProtocolFee
-    const usdProtocolFee = priceRatio.convertFromBtc(btcProtocolFee)
+    const usdProtocolFee = priceRatio.convertFromBtcToCeil(btcProtocolFee)
 
     return paymentFromState({
       ...state,

--- a/src/domain/payments/price-ratio.ts
+++ b/src/domain/payments/price-ratio.ts
@@ -52,10 +52,17 @@ export const PriceRatio = ({
       btc.amount,
     )
 
+  const convertFromBtcToCeil = (convert: BtcPaymentAmount): UsdPaymentAmount =>
+    calc.divCeil(
+      { amount: convert.amount * usd.amount, currency: WalletCurrency.Usd },
+      btc.amount,
+    )
+
   return {
     convertFromUsd,
     convertFromBtc,
     convertFromBtcToFloor,
+    convertFromBtcToCeil,
     usdPerSat: () =>
       (Number(usd.amount) / Number(btc.amount)) as DisplayCurrencyBasePerSat,
   }

--- a/src/domain/shared/calculator.ts
+++ b/src/domain/shared/calculator.ts
@@ -35,10 +35,23 @@ export const AmountCalculator = (): AmountCalculator => {
     return { amount: quotient, currency: a.currency }
   }
 
+  const divCeil = <T extends WalletCurrency>(
+    a: PaymentAmount<T>,
+    b: bigint,
+  ): PaymentAmount<T> => {
+    const quotient = a.amount / b
+
+    const mod = a.amount % b
+    return mod > 0n
+      ? { amount: quotient + 1n, currency: a.currency }
+      : { amount: quotient, currency: a.currency }
+  }
+
   return {
     sub,
     add,
     divRound,
     divFloor,
+    divCeil,
   }
 }

--- a/src/domain/shared/index.types.d.ts
+++ b/src/domain/shared/index.types.d.ts
@@ -40,4 +40,5 @@ type AmountCalculator = {
   ) => PaymentAmount<T>
   divRound: <T extends WalletCurrency>(a: PaymentAmount<T>, b: bigint) => PaymentAmount<T>
   divFloor: <T extends WalletCurrency>(a: PaymentAmount<T>, b: bigint) => PaymentAmount<T>
+  divCeil: <T extends WalletCurrency>(a: PaymentAmount<T>, b: bigint) => PaymentAmount<T>
 }

--- a/test/mocks/dealer-price/index.ts
+++ b/test/mocks/dealer-price/index.ts
@@ -4,8 +4,8 @@ import { CENTS_PER_USD, toCents, toCentsPerSatsRatio } from "@domain/fiat"
 import { toPriceRatio } from "@domain/payments"
 import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
 
-// simulated price at 20k btc/usd
-// or 50 sats per cents. 0.05 sat per cents
+// simulated price at 20k usd/btc
+// or 50 sats per cents. 0.02 sat per cents
 const baseRate = 20_000
 const baseRatio = baseRate / 1000
 const spreadImmediate = 0.04

--- a/test/unit/domain/payments/price-ratio.spec.ts
+++ b/test/unit/domain/payments/price-ratio.spec.ts
@@ -240,6 +240,64 @@ describe("PriceRatio", () => {
         })
       })
     })
+
+    describe("rounds amounts to ceil", () => {
+      describe("converts from usd", () => {
+        it("Not Implemented Yet", async () => true)
+      })
+      describe("converts from btc", () => {
+        const product = 2n
+        const priceRatio = PriceRatio({
+          btc: { amount: 100_000_000n, currency: WalletCurrency.Btc },
+          usd: { amount: 5_000_000n, currency: WalletCurrency.Usd },
+        })
+        if (priceRatio instanceof Error) throw priceRatio
+
+        it("correctly rounds up when unrounded value is just below 0.5 less than target product", () => {
+          const usdPaymentAmount = priceRatio.convertFromBtcToCeil({
+            amount: 29n,
+            currency: WalletCurrency.Btc,
+          })
+          expect(usdPaymentAmount).toEqual({
+            amount: product,
+            currency: WalletCurrency.Usd,
+          })
+        })
+
+        it("correctly rounds up when unrounded value is just above 0.5 more than target product", () => {
+          const usdPaymentAmount = priceRatio.convertFromBtcToCeil({
+            amount: 51n,
+            currency: WalletCurrency.Btc,
+          })
+          expect(usdPaymentAmount).toEqual({
+            amount: product + 1n,
+            currency: WalletCurrency.Usd,
+          })
+        })
+
+        it("correctly rounds up when unrounded value is just above target product", () => {
+          const usdPaymentAmount = priceRatio.convertFromBtcToCeil({
+            amount: 41n,
+            currency: WalletCurrency.Btc,
+          })
+          expect(usdPaymentAmount).toEqual({
+            amount: product + 1n,
+            currency: WalletCurrency.Usd,
+          })
+        })
+
+        it("correctly rounds up when unrounded value is just below target product", () => {
+          const usdPaymentAmount = priceRatio.convertFromBtcToCeil({
+            amount: 39n,
+            currency: WalletCurrency.Btc,
+          })
+          expect(usdPaymentAmount).toEqual({
+            amount: product,
+            currency: WalletCurrency.Usd,
+          })
+        })
+      })
+    })
   })
 
   it("does not return zero usd amount for small ratios", () => {

--- a/test/unit/domain/shared/amount-calculator.spec.ts
+++ b/test/unit/domain/shared/amount-calculator.spec.ts
@@ -144,5 +144,49 @@ describe("AmountCalculator", () => {
         expect(result.currency).toBe(currency)
       })
     })
+
+    describe("by rounding to ceil", () => {
+      it("no rounding if remainder is 0", () => {
+        const result = calc.divCeil({ amount: pivot, currency }, divisor)
+        expect(result.amount).toEqual(quotient)
+        expect(result.currency).toBe(currency)
+      })
+
+      it("rounds up if remainder is just above pivot", () => {
+        const result = calc.divCeil({ amount: pivot + 1n, currency }, divisor)
+        expect(result.amount).toEqual(quotient + 1n)
+        expect(result.currency).toBe(currency)
+      })
+
+      it("rounds up if remainder is just below pivot", () => {
+        const result = calc.divCeil({ amount: pivot - 1n, currency }, divisor)
+        expect(result.amount).toEqual(quotient)
+        expect(result.currency).toBe(currency)
+      })
+
+      it("rounds up if remainder is just below half of the divisor", () => {
+        const result = calc.divCeil(
+          { amount: pivot + (divisorBound - 1n), currency },
+          divisor,
+        )
+        expect(result.amount).toEqual(quotient + 1n)
+        expect(result.currency).toBe(currency)
+      })
+
+      it("rounds up if remainder is half of the divisor", () => {
+        const result = calc.divCeil({ amount: pivot + divisorBound, currency }, divisor)
+        expect(result.amount).toEqual(quotient + 1n)
+        expect(result.currency).toBe(currency)
+      })
+
+      it("rounds up if remainder is just above half of the divisor", () => {
+        const result = calc.divCeil(
+          { amount: pivot + (divisorBound + 1n), currency },
+          divisor,
+        )
+        expect(result.amount).toEqual(quotient + 1n)
+        expect(result.currency).toBe(currency)
+      })
+    })
   })
 })

--- a/test/unit/domain/shared/amount-calculator.spec.ts
+++ b/test/unit/domain/shared/amount-calculator.spec.ts
@@ -57,136 +57,97 @@ describe("AmountCalculator", () => {
     const divisorBound = 50n
     const quotient = 2n
 
-    describe("by rounding normally", () => {
-      it("no rounding if remainder is 0", () => {
-        const result = calc.divRound({ amount: pivot, currency }, divisor)
-        expect(result.amount).toEqual(quotient)
-        expect(result.currency).toBe(currency)
-      })
+    const describeCases = [
+      {
+        type: "normal",
+        div: calc.divRound,
+        up: "up",
+        down: "down",
+      },
+      {
+        type: "floor",
+        div: calc.divFloor,
+        up: "down",
+        down: "down",
+      },
+      {
+        type: "ceil",
+        div: calc.divCeil,
+        up: "up",
+        down: "up",
+      },
+    ]
+    const itCases = ({ up, down }) => [
+      {
+        title: `no rounding if remainder is 0`,
+        amount: pivot,
+        result: {
+          normal: quotient,
+          floor: quotient,
+          ceil: quotient,
+        },
+      },
+      {
+        title: `rounds ${down} if remainder is just above pivot`,
+        amount: pivot + 1n,
+        result: {
+          normal: quotient,
+          floor: quotient,
+          ceil: quotient + 1n,
+        },
+      },
+      {
+        title: `rounds ${up} if remainder is just below pivot`,
+        amount: pivot - 1n,
+        result: {
+          normal: quotient,
+          floor: quotient - 1n,
+          ceil: quotient,
+        },
+      },
+      {
+        title: `rounds ${down} if remainder is just below half of the divisor`,
+        amount: pivot + (divisorBound - 1n),
+        result: {
+          normal: quotient,
+          floor: quotient,
+          ceil: quotient + 1n,
+        },
+      },
+      {
+        title: `rounds ${up} if remainder is just above half of the divisor`,
+        amount: pivot + (divisorBound + 1n),
+        result: {
+          normal: quotient + 1n,
+          floor: quotient,
+          ceil: quotient + 1n,
+        },
+      },
+      {
+        title: `rounds ${down} if remainder is half of the divisor`,
+        amount: pivot + divisorBound,
+        result: {
+          normal: quotient,
+          floor: quotient,
+          ceil: quotient + 1n,
+        },
+      },
+    ]
 
-      it("rounds down if remainder is just above pivot", () => {
-        const result = calc.divRound({ amount: pivot + 1n, currency }, divisor)
-        expect(result.amount).toEqual(quotient)
-        expect(result.currency).toBe(currency)
-      })
+    for (const describeGroup of describeCases) {
+      describe(`by rounding to ${describeGroup.type}`, () => {
+        const { up, down } = describeGroup
+        for (const testCase of itCases({ up, down })) {
+          const { title, amount } = testCase
+          const expectedResult = testCase.result[describeGroup.type]
 
-      it("rounds up if remainder is just below pivot", () => {
-        const result = calc.divRound({ amount: pivot - 1n, currency }, divisor)
-        expect(result.amount).toEqual(quotient)
-        expect(result.currency).toBe(currency)
+          it(title, () => {
+            const result = describeGroup.div({ amount, currency }, divisor)
+            expect(result.amount).toEqual(expectedResult)
+            expect(result.currency).toBe(currency)
+          })
+        }
       })
-
-      it("rounds down if remainder is just below half of the divisor", () => {
-        const result = calc.divRound(
-          { amount: pivot + (divisorBound - 1n), currency },
-          divisor,
-        )
-        expect(result.amount).toEqual(quotient)
-        expect(result.currency).toBe(currency)
-      })
-
-      it("rounds down if remainder is half of the divisor", () => {
-        const result = calc.divRound({ amount: pivot + divisorBound, currency }, divisor)
-        expect(result.amount).toEqual(quotient)
-        expect(result.currency).toBe(currency)
-      })
-
-      it("rounds up if remainder is just above half of the divisor", () => {
-        const result = calc.divRound(
-          { amount: pivot + (divisorBound + 1n), currency },
-          divisor,
-        )
-        expect(result.amount).toEqual(quotient + 1n)
-        expect(result.currency).toBe(currency)
-      })
-    })
-
-    describe("by rounding to floor", () => {
-      it("no rounding if remainder is 0", () => {
-        const result = calc.divFloor({ amount: pivot, currency }, divisor)
-        expect(result.amount).toEqual(quotient)
-        expect(result.currency).toBe(currency)
-      })
-
-      it("rounds down if remainder is just above pivot", () => {
-        const result = calc.divFloor({ amount: pivot + 1n, currency }, divisor)
-        expect(result.amount).toEqual(quotient)
-        expect(result.currency).toBe(currency)
-      })
-
-      it("rounds down if remainder is just below pivot", () => {
-        const result = calc.divFloor({ amount: pivot - 1n, currency }, divisor)
-        expect(result.amount).toEqual(quotient - 1n)
-        expect(result.currency).toBe(currency)
-      })
-
-      it("rounds down if remainder is just below half of the divisor", () => {
-        const result = calc.divFloor(
-          { amount: pivot + (divisorBound - 1n), currency },
-          divisor,
-        )
-        expect(result.amount).toEqual(quotient)
-        expect(result.currency).toBe(currency)
-      })
-
-      it("rounds down if remainder is half of the divisor", () => {
-        const result = calc.divFloor({ amount: pivot + divisorBound, currency }, divisor)
-        expect(result.amount).toEqual(quotient)
-        expect(result.currency).toBe(currency)
-      })
-
-      it("rounds down if remainder is just above half of the divisor", () => {
-        const result = calc.divFloor(
-          { amount: pivot + (divisorBound + 1n), currency },
-          divisor,
-        )
-        expect(result.amount).toEqual(quotient)
-        expect(result.currency).toBe(currency)
-      })
-    })
-
-    describe("by rounding to ceil", () => {
-      it("no rounding if remainder is 0", () => {
-        const result = calc.divCeil({ amount: pivot, currency }, divisor)
-        expect(result.amount).toEqual(quotient)
-        expect(result.currency).toBe(currency)
-      })
-
-      it("rounds up if remainder is just above pivot", () => {
-        const result = calc.divCeil({ amount: pivot + 1n, currency }, divisor)
-        expect(result.amount).toEqual(quotient + 1n)
-        expect(result.currency).toBe(currency)
-      })
-
-      it("rounds up if remainder is just below pivot", () => {
-        const result = calc.divCeil({ amount: pivot - 1n, currency }, divisor)
-        expect(result.amount).toEqual(quotient)
-        expect(result.currency).toBe(currency)
-      })
-
-      it("rounds up if remainder is just below half of the divisor", () => {
-        const result = calc.divCeil(
-          { amount: pivot + (divisorBound - 1n), currency },
-          divisor,
-        )
-        expect(result.amount).toEqual(quotient + 1n)
-        expect(result.currency).toBe(currency)
-      })
-
-      it("rounds up if remainder is half of the divisor", () => {
-        const result = calc.divCeil({ amount: pivot + divisorBound, currency }, divisor)
-        expect(result.amount).toEqual(quotient + 1n)
-        expect(result.currency).toBe(currency)
-      })
-
-      it("rounds up if remainder is just above half of the divisor", () => {
-        const result = calc.divCeil(
-          { amount: pivot + (divisorBound + 1n), currency },
-          divisor,
-        )
-        expect(result.amount).toEqual(quotient + 1n)
-        expect(result.currency).toBe(currency)
-      })
-    })
+    }
   })
 })


### PR DESCRIPTION
## Description

This PR is to round up the routing fees when converting to `usdProtocolFee` when building a payment flow.

The bulk of this PR was:
🛠️  refactoring the payment-flow-builder unit tests with more realistic ratios and appropriate amounts ([here](https://github.com/GaloyMoney/galoy/pull/1359/commits/0359f5b9f357af68af97a5a520cc9767aff1733a))
🛠️  to be able to isolate a failing test ([here](https://github.com/GaloyMoney/galoy/pull/1359/commits/489089e0ad4cb62d8af90ec50578ac746c6b47c0))
✅  to be able to fix with the changes to the fee calculations ([here](https://github.com/GaloyMoney/galoy/pull/1359/commits/90eff7cb32848f6e6eb3d3dbeef239c02efcb768))