### PR TITLE
chore: remove unnecessary on-chain tx filter span

### DIFF
--- a/src/app/wallets/get-transactions-for-wallet.ts
+++ b/src/app/wallets/get-transactions-for-wallet.ts
@@ -9,7 +9,6 @@ import { LedgerService } from "@services/ledger"
 import { OnChainService } from "@services/lnd/onchain-service"
 import { baseLogger } from "@services/logger"
 import { WalletsRepository } from "@services/mongoose"
-import { wrapToRunInSpan } from "@services/tracing"
 
 // FIXME(nicolas): remove only used in tests
 export const getTransactionsForWalletId = async ({
@@ -66,10 +65,7 @@ export const getTransactionsForWallets = async (
     addresses,
   })
 
-  const pendingIncoming = wrapToRunInSpan({
-    namespace: `domain.bitcoin`,
-    fn: () => filter.apply(onChainTxs),
-  })()
+  const pendingIncoming = filter.apply(onChainTxs)
 
   let price = await getCurrentPrice()
   if (price instanceof Error) {


### PR DESCRIPTION
Clean unnecessary on-chain tx filter span. https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/GnhD3nav6zC/trace/eVvnLBXzAJ4?fields[]=name&fields[]=service.name&span=802d4c4bb3cade56 (the span does not provide parameteres nor return errors just true/false)

note: this run in get transaction (main query) so represent ~38363 events per day (only in bbw env)