### PR TITLE
refactor: round up all max usd fee calcs in payment flow

### DIFF
--- a/src/domain/payments/payment-flow-builder.ts
+++ b/src/domain/payments/payment-flow-builder.ts
@@ -265,7 +265,7 @@ const LPFBWithRecipientWallet = <S extends WalletCurrency, R extends WalletCurre
             })
             if (priceRatio instanceof Error) return priceRatio
 
-            const usdProtocolFee = priceRatio.convertFromBtc(btcProtocolFee)
+            const usdProtocolFee = priceRatio.convertFromBtcToCeil(btcProtocolFee)
             return {
               ...stateWithCreatedAt,
               btcPaymentAmount,
@@ -335,7 +335,7 @@ const LPFBWithRecipientWallet = <S extends WalletCurrency, R extends WalletCurre
           })
           if (priceRatio instanceof Error) return priceRatio
 
-          const usdProtocolFee = priceRatio.convertFromBtc(btcProtocolFee)
+          const usdProtocolFee = priceRatio.convertFromBtcToCeil(btcProtocolFee)
           return {
             ...stateWithCreatedAt,
             btcPaymentAmount,

--- a/test/unit/domain/ledger/fee-reimbursement.spec.ts
+++ b/test/unit/domain/ledger/fee-reimbursement.spec.ts
@@ -143,7 +143,7 @@ describe("FeeReimbursement", () => {
       const priceRatio = PriceRatio(paymentAmounts)
       if (priceRatio instanceof Error) throw priceRatio
 
-      const paymentFlowConvertFromBtc = priceRatio.convertFromBtc
+      const paymentFlowConvertFromBtc = priceRatio.convertFromBtcToCeil
 
       it("rounds down if fee normally rounds down to 'max fee - 1'", () => {
         // Construct max fees paid
@@ -183,7 +183,7 @@ describe("FeeReimbursement", () => {
       const priceRatio = PriceRatio(paymentAmounts)
       if (priceRatio instanceof Error) throw priceRatio
 
-      const paymentFlowConvertFromBtc = priceRatio.convertFromBtc
+      const paymentFlowConvertFromBtc = priceRatio.convertFromBtcToCeil
 
       it("rounds down to 'max fee - 1' if fee normally rounds up to max fee", () => {
         // Construct max fees paid


### PR DESCRIPTION
## Description

This PR is to round up the remaining places in the payment-flow-builder where usd fees are calculated from a max btc fee.

It also spills over into reimbursement fee calculations, where before this rounding up was happening we would still get instances where the full usd amount would be reimbursed even though a non-zero amount of sats fees were spent.