### PR TITLE
fix: send balance instrumentation

### DIFF
--- a/src/servers/daily-balance-notification.ts
+++ b/src/servers/daily-balance-notification.ts
@@ -1,4 +1,4 @@
-import { sendDefaultWalletBalanceToUsers } from "@app/accounts/send-default-wallet-balance-to-users"
+import { Accounts } from "@app"
 import { baseLogger } from "@services/logger"
 import { setupMongoConnection } from "@services/mongodb"
 
@@ -9,7 +9,7 @@ const main = async () => {
   // We're not using the Accounts.sendDefaultWalletBalanceToUsers() call pattern
   // because the root span becomes much too large. By calling the function directly
   // we bypass the wrapper.
-  await sendDefaultWalletBalanceToUsers(logger)
+  await Accounts.sendDefaultWalletBalanceToUsers(logger)
 
   await mongoose.connection.close()
 }


### PR DESCRIPTION
Use Accounts from app to use the wrapped version of sendDefaultWalletBalanceToUsers. this makes easier to trace the sending of balance notifications 