### PR TITLE
refactor: omit zero amount txns from ledger entries

### DIFF
--- a/src/services/ledger/domain/entry-builder.ts
+++ b/src/services/ledger/domain/entry-builder.ts
@@ -192,7 +192,8 @@ const EntryBuilderCredit = <M extends MediciEntry>({
       ...metadata,
       currency: creditAmount.currency,
     })
-    return entryToReturn
+
+    return removeZeroAmountEntries(entryToReturn)
   }
 
   return {
@@ -253,5 +254,15 @@ const addUsdToBtcConversionToEntry = <M extends MediciEntry>({
     ...metadata,
     currency: usdAmount.currency,
   })
+  return entry
+}
+
+const removeZeroAmountEntries = <M extends MediciEntry>(entry: M): M => {
+  const updatedTransactions = entry.transactions.filter(
+    (txn) => !(txn.debit === 0 && txn.credit === 0),
+  )
+
+  entry.transactions = updatedTransactions
+
   return entry
 }

--- a/src/services/ledger/domain/index.types.d.ts
+++ b/src/services/ledger/domain/index.types.d.ts
@@ -20,6 +20,12 @@ interface MediciEntry {
     amount: number,
     extra?: TxMetadata,
   ) => MediciEntry
+  transactions: {
+    credit: number
+    debit: number
+    currency: WalletCurrency
+    accounts: LedgerAccountId
+  }[]
 }
 
 type StaticAccountIds = {

--- a/src/services/ledger/domain/legacy-entry-builder.ts
+++ b/src/services/ledger/domain/legacy-entry-builder.ts
@@ -116,7 +116,7 @@ const LegacyEntryBuilderCreditWithUsdDebit = <M extends MediciEntry>({
       ...metadata,
       currency: btcCreditAmount.currency,
     })
-    return entry
+    return removeZeroAmountEntries(entry)
   }
   const creditAccount = ({
     accountId,
@@ -139,7 +139,8 @@ const LegacyEntryBuilderCreditWithUsdDebit = <M extends MediciEntry>({
       ...metadata,
       currency: creditAmount.currency,
     })
-    return entry
+
+    return removeZeroAmountEntries(entry)
   }
   return {
     creditLnd,
@@ -243,5 +244,15 @@ const withdrawUsdFromDealer = ({
     ...metadata,
     currency: usdAmount.currency,
   })
+  return entry
+}
+
+const removeZeroAmountEntries = <M extends MediciEntry>(entry: M): M => {
+  const updatedTransactions = entry.transactions.filter(
+    (txn) => !(txn.debit === 0 && txn.credit === 0),
+  )
+
+  entry.transactions = updatedTransactions
+
   return entry
 }

--- a/test/unit/services/ledger/domain/entry-builder.spec.ts
+++ b/test/unit/services/ledger/domain/entry-builder.spec.ts
@@ -5,18 +5,58 @@ import { WalletCurrency, AmountCalculator, ZERO_BANK_FEE } from "@domain/shared"
 class TestMediciEntry {
   credits: any // eslint-disable-line
   debits: any // eslint-disable-line
+  transactions: any // eslint-disable-line
 
   credit(accountPath, amount, metadata = null) {
     this.credits = this.credits || {}
+    this.transactions = this.transactions || []
     this.credits[accountPath] = { amount, metadata }
+
+    const metadataObj = metadata === null ? {} : metadata
+    this.transactions.push({
+      debit: 0,
+      credit: amount,
+      accounts: accountPath,
+      ...metadataObj,
+    })
     return this
   }
 
   debit(accountPath, amount, metadata = null) {
     this.debits = this.debits || {}
+    this.transactions = this.transactions || []
     this.debits[accountPath] = { amount, metadata }
+
+    const metadataObj = metadata === null ? {} : metadata
+    this.transactions.push({
+      debit: amount,
+      credit: 0,
+      accounts: accountPath,
+      ...metadataObj,
+    })
     return this
   }
+}
+
+const reconstructEntryFromTransactions = (entry: TestMediciEntry): TestMediciEntry => {
+  const result = new TestMediciEntry()
+
+  for (const txn of entry.transactions) {
+    let accountPath, amount, metadata, credit, debit
+    if (txn.debit > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      ;({ debit: amount, credit, accounts: accountPath, ...metadata } = txn)
+      result.debit(accountPath, amount, metadata)
+    }
+
+    if (txn.credit > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      ;({ credit: amount, debit, accounts: accountPath, ...metadata } = txn)
+      result.credit(accountPath, amount, metadata)
+    }
+  }
+
+  return result
 }
 
 describe("EntryBuilder", () => {
@@ -305,11 +345,12 @@ describe("EntryBuilder", () => {
             metadata,
           })
 
-          const result = builder
+          const initialResult = builder
             .withTotalAmount(amount)
             .withBankFee(ZERO_BANK_FEE)
             .debitLnd()
             .creditAccount(usdCreditorAccountDescriptor)
+          const result = reconstructEntryFromTransactions(initialResult)
 
           expectJournalToBeBalanced(result)
           expectEntryToEqual(result.debits[lndLedgerAccountId], btcAmount)
@@ -319,7 +360,7 @@ describe("EntryBuilder", () => {
             btcAmount,
           )
           expect(result.debits[staticAccountIds.dealerBtcAccountId]).toBeUndefined()
-          expect(result.debits[staticAccountIds.dealerUsdAccountId].toBeUndefined())
+          expect(result.debits[staticAccountIds.dealerUsdAccountId]).toBeUndefined()
           expect(result.credits[staticAccountIds.dealerUsdAccountId]).toBeUndefined()
         })
       })

--- a/test/unit/services/ledger/domain/legacy-entry-builder.spec.ts
+++ b/test/unit/services/ledger/domain/legacy-entry-builder.spec.ts
@@ -186,23 +186,64 @@ describe("LegacyEntryBuilder", () => {
     })
 
     describe("receive", () => {
-      it("without fee", () => {
-        const entry = new TestMediciEntry()
-        const builder = LegacyEntryBuilder({
-          staticAccountIds,
-          entry,
-          metadata,
+      describe("without fee", () => {
+        it("handles txn with btc amount & usd amount", () => {
+          const entry = new TestMediciEntry()
+          const builder = LegacyEntryBuilder({
+            staticAccountIds,
+            entry,
+            metadata,
+          })
+          const result = builder.withoutFee().debitLnd(btcAmount).creditAccount({
+            accountId: creditorAccountId,
+            amount: usdAmount,
+          })
+          expectEntryToEqual(result.debits[lndLedgerAccountId], btcAmount)
+          expectEntryToEqual(result.credits[creditorAccountId], usdAmount)
+          expectEntryToEqual(
+            result.credits[staticAccountIds.dealerBtcAccountId],
+            btcAmount,
+          )
+          expect(result.debits[staticAccountIds.dealerBtcAccountId]).toBeUndefined()
+          expectEntryToEqual(
+            result.debits[staticAccountIds.dealerUsdAccountId],
+            usdAmount,
+          )
+          expect(result.credits[staticAccountIds.dealerUsdAccountId]).toBeUndefined()
         })
-        const result = builder.withoutFee().debitLnd(btcAmount).creditAccount({
-          accountId: creditorAccountId,
-          amount: usdAmount,
+
+        // e.g. a `recordReceive' fee-reimbursement with low sats amount
+        it("handles txn with btc amount & zero usd amount", () => {
+          const btcAmount = {
+            currency: WalletCurrency.Btc,
+            amount: 18n,
+          }
+          const usdAmount = {
+            currency: WalletCurrency.Usd,
+            amount: 0n,
+          }
+
+          const entry = new TestMediciEntry()
+          const builder = LegacyEntryBuilder({
+            staticAccountIds,
+            entry,
+            metadata,
+          })
+          const result = builder.withoutFee().debitLnd(btcAmount).creditAccount({
+            accountId: creditorAccountId,
+            amount: usdAmount,
+          })
+
+          expectEntryToEqual(result.debits[lndLedgerAccountId], btcAmount)
+          expect(result.credits[creditorAccountId]).toBeUndefined()
+          expectEntryToEqual(
+            result.credits[staticAccountIds.dealerBtcAccountId],
+            btcAmount,
+          )
+          expect(result.debits[staticAccountIds.dealerBtcAccountId]).toBeUndefined()
+          expect(result.debits[staticAccountIds.dealerUsdAccountId]).toBeUndefined()
+          expect(result.credits[staticAccountIds.dealerUsdAccountId]).toBeUndefined()
         })
-        expectEntryToEqual(result.debits[lndLedgerAccountId], btcAmount)
-        expectEntryToEqual(result.credits[creditorAccountId], usdAmount)
-        expectEntryToEqual(result.credits[staticAccountIds.dealerBtcAccountId], btcAmount)
-        expect(result.debits[staticAccountIds.dealerBtcAccountId]).toBeUndefined()
-        expectEntryToEqual(result.debits[staticAccountIds.dealerUsdAccountId], usdAmount)
-        expect(result.credits[staticAccountIds.dealerUsdAccountId]).toBeUndefined()
       })
 
       it("with fee", () => {

--- a/test/unit/services/ledger/domain/legacy-entry-builder.spec.ts
+++ b/test/unit/services/ledger/domain/legacy-entry-builder.spec.ts
@@ -4,18 +4,58 @@ import { WalletCurrency, AmountCalculator } from "@domain/shared"
 class TestMediciEntry {
   credits: any // eslint-disable-line
   debits: any // eslint-disable-line
+  transactions: any // eslint-disable-line
 
   credit(accountPath, amount, metadata = null) {
     this.credits = this.credits || {}
+    this.transactions = this.transactions || []
     this.credits[accountPath] = { amount, metadata }
+
+    const metadataObj = metadata === null ? {} : metadata
+    this.transactions.push({
+      debit: 0,
+      credit: amount,
+      accounts: accountPath,
+      ...metadataObj,
+    })
     return this
   }
 
   debit(accountPath, amount, metadata = null) {
     this.debits = this.debits || {}
+    this.transactions = this.transactions || []
     this.debits[accountPath] = { amount, metadata }
+
+    const metadataObj = metadata === null ? {} : metadata
+    this.transactions.push({
+      debit: amount,
+      credit: 0,
+      accounts: accountPath,
+      ...metadataObj,
+    })
     return this
   }
+}
+
+const reconstructEntryFromTransactions = (entry: TestMediciEntry): TestMediciEntry => {
+  const result = new TestMediciEntry()
+
+  for (const txn of entry.transactions) {
+    let accountPath, amount, metadata, credit, debit
+    if (txn.debit > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      ;({ debit: amount, credit, accounts: accountPath, ...metadata } = txn)
+      result.debit(accountPath, amount, metadata)
+    }
+
+    if (txn.credit > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      ;({ credit: amount, debit, accounts: accountPath, ...metadata } = txn)
+      result.credit(accountPath, amount, metadata)
+    }
+  }
+
+  return result
 }
 
 describe("LegacyEntryBuilder", () => {
@@ -229,10 +269,11 @@ describe("LegacyEntryBuilder", () => {
             entry,
             metadata,
           })
-          const result = builder.withoutFee().debitLnd(btcAmount).creditAccount({
+          const initialResult = builder.withoutFee().debitLnd(btcAmount).creditAccount({
             accountId: creditorAccountId,
             amount: usdAmount,
           })
+          const result = reconstructEntryFromTransactions(initialResult)
 
           expectEntryToEqual(result.debits[lndLedgerAccountId], btcAmount)
           expect(result.credits[creditorAccountId]).toBeUndefined()


### PR DESCRIPTION
## Description

This PR is to exclude unnecessary zero-amount entries to the ledger when receiving transactions. This is to target txns for USD wallets where:
- low-sat-amount reimbursements which result in zero-amount usd ledger entries
- no-amount usd invoice receives where the sats received don't cross 1 cent and result in a zero-amount entry

In both cases, the user will now no longer see any transactions in their transactions list for these events.