### PR TITLE
fix: unskip invoice.spec integration tests

### DIFF
--- a/src/app/payments/helpers.ts
+++ b/src/app/payments/helpers.ts
@@ -115,12 +115,12 @@ export const btcFromUsdMidPriceFn = async (
   )
 
 export const getCurrentPriceInCentsPerSat = async (): Promise<
-  CentsPerSatsRatio | PriceServiceError
+  PriceRatio | PriceServiceError
 > => {
   const price = await getCurrentPrice()
   if (price instanceof Error) return price
 
-  return (price * CENTS_PER_USD) as CentsPerSatsRatio
+  return toPriceRatio(price * CENTS_PER_USD)
 }
 
 export const getMidPriceRatio = async (): Promise<PriceRatio | PriceServiceError> => {
@@ -131,17 +131,11 @@ export const getMidPriceRatio = async (): Promise<PriceRatio | PriceServiceError
         error: priceRatio,
         level: ErrorLevel.Critical,
       })
-      const ratio = await getCurrentPriceInCentsPerSat()
-      if (ratio instanceof Error) return ratio
-
-      return toPriceRatio(ratio)
+      return getCurrentPriceInCentsPerSat()
     }
   }
 
-  const ratio = await getCurrentPriceInCentsPerSat()
-  if (ratio instanceof Error) return ratio
-
-  return toPriceRatio(ratio)
+  return getCurrentPriceInCentsPerSat()
 }
 
 export const constructPaymentFlowBuilder = async <

--- a/test/integration/app/wallets/invoice.spec.ts
+++ b/test/integration/app/wallets/invoice.spec.ts
@@ -139,9 +139,10 @@ describe("Wallet - addInvoice USD", () => {
   it("add a self generated USD invoice", async () => {
     const centsInput = 10000
 
-    const centsPerSat = await getCurrentPriceInCentsPerSat()
-    if (centsPerSat instanceof Error) return centsPerSat
-    const satsFallbackViaPriceService = (centsInput / centsPerSat) * 0.996 // 40 bps spread
+    const centsPerSatRatio = await getCurrentPriceInCentsPerSat()
+    if (centsPerSatRatio instanceof Error) return centsPerSatRatio
+    const satsFallbackViaPriceService =
+      (centsInput / centsPerSatRatio.usdPerSat()) * 0.996 // 40 bps spread
 
     const sats = await DealerPriceService().getSatsFromCentsForFutureBuy(
       toCents(centsInput),

--- a/test/integration/app/wallets/invoice.spec.ts
+++ b/test/integration/app/wallets/invoice.spec.ts
@@ -136,7 +136,7 @@ describe("Wallet - addInvoice BTC", () => {
 })
 
 describe("Wallet - addInvoice USD", () => {
-  it.only("add a self generated USD invoice", async () => {
+  it("add a self generated USD invoice", async () => {
     const centsInput = 10000
 
     const centsPerSat = await getCurrentPriceInCentsPerSat()


### PR DESCRIPTION
## Description

This PR:
- unskips `invoice.spec` integration tests
- does a small refactor to move `toPriceRatio` calls higher up in the stack