### PR TITLE
refactor: change 'Transaction' gql object amounts type/descriptions

### DIFF
--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -52,7 +52,7 @@ type BaseWalletTransaction = {
   readonly settlementAmount: Satoshis | UsdCents
   readonly settlementFee: Satoshis | UsdCents
   readonly settlementCurrency: WalletCurrency
-  readonly settlementDisplayCurrencyPerSat: number
+  readonly displayCurrencyPerSettlementCurrencyUnit: number
   readonly status: TxStatus
   readonly memo: string | null
   readonly createdAt: Date

--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -26,7 +26,7 @@ const filterPendingIncoming = (
               settlementAmount: sats,
               settlementFee: toSats(0),
               settlementCurrency: walletDetailsByWalletId[walletId].currency,
-              settlementDisplayCurrencyPerSat: displayCurrencyPerSat,
+              displayCurrencyPerSettlementCurrencyUnit: displayCurrencyPerSat,
               status: TxStatus.Pending,
               memo: null,
               createdAt: createdAt,
@@ -93,7 +93,7 @@ export const fromLedger = (
         settlementAmount,
         settlementFee,
         settlementCurrency: currency,
-        settlementDisplayCurrencyPerSat: displayCurrencyPerBaseUnitFromAmounts({
+        displayCurrencyPerSettlementCurrencyUnit: displayCurrencyPerBaseUnitFromAmounts({
           displayAmountAsNumber: usd,
           settlementAmountInBaseAsNumber: settlementAmount,
         }),

--- a/src/graphql/types/object/transaction.ts
+++ b/src/graphql/types/object/transaction.ts
@@ -46,12 +46,13 @@ const Transaction = GT.Object<WalletTransaction>({
     settlementPrice: {
       type: GT.NonNull(Price),
       resolve: (source) => {
-        const settlementDisplayCurrencyPerSatInCents =
-          source.settlementDisplayCurrencyPerSat * 100
+        const displayCurrencyPerSettlementCurrencyUnitInCents =
+          source.displayCurrencyPerSettlementCurrencyUnit * 100
         return {
-          formattedAmount: settlementDisplayCurrencyPerSatInCents.toString(),
+          formattedAmount: displayCurrencyPerSettlementCurrencyUnitInCents.toString(),
           base: Math.round(
-            settlementDisplayCurrencyPerSatInCents * 10 ** SAT_PRICE_PRECISION_OFFSET,
+            displayCurrencyPerSettlementCurrencyUnitInCents *
+              10 ** SAT_PRICE_PRECISION_OFFSET,
           ),
           offset: SAT_PRICE_PRECISION_OFFSET,
           currencyUnit: "USDCENT",

--- a/src/graphql/types/object/transaction.ts
+++ b/src/graphql/types/object/transaction.ts
@@ -7,12 +7,12 @@ import { SAT_PRICE_PRECISION_OFFSET } from "@config"
 
 import Memo from "../scalar/memo"
 
-import SatAmount from "../scalar/sat-amount"
 import InitiationVia from "../abstract/initiation-via"
 import SettlementVia from "../abstract/settlement-via"
 import Timestamp from "../scalar/timestamp"
 import TxDirection, { txDirectionValues } from "../scalar/tx-direction"
 import TxStatus from "../scalar/tx-status"
+import SignedAmount from "../scalar/signed-amount"
 import WalletCurrency from "../scalar/wallet-currency"
 
 import Price from "./price"
@@ -37,11 +37,11 @@ const Transaction = GT.Object<WalletTransaction>({
       description: "To which protocol the payment has settled on.",
     },
     settlementAmount: {
-      type: GT.NonNull(SatAmount),
-      description: "Amount of sats sent or received.",
+      type: GT.NonNull(SignedAmount),
+      description: "Amount of the settlement currency sent or received.",
     },
     settlementFee: {
-      type: GT.NonNull(SatAmount),
+      type: GT.NonNull(SignedAmount),
     },
     settlementPrice: {
       type: GT.NonNull(Price),
@@ -57,7 +57,7 @@ const Transaction = GT.Object<WalletTransaction>({
           currencyUnit: "USDCENT",
         }
       },
-      description: "Price in USDCENT/SATS at time of settlement.",
+      description: "Price in USDCENT/SETTLEMENTUNIT at time of settlement.",
     },
     settlementCurrency: {
       type: GT.NonNull(WalletCurrency),

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -292,7 +292,7 @@ describe("UserWallet - Lightning Pay", () => {
     }
     const userBTxn = txResultB.result.filter(matchTx)[0]
     expect(userBTxn.memo).toBe(memo)
-    expect(userBTxn.settlementDisplayCurrencyPerSat).toBe(0.0005)
+    expect(userBTxn.displayCurrencyPerSettlementCurrencyUnit).toBe(0.0005)
     expect(userBTxn.settlementVia.type).toBe("intraledger")
     // expect(userBTxn.recipientUsername).toBe("lily")
 
@@ -304,7 +304,7 @@ describe("UserWallet - Lightning Pay", () => {
     }
     const userCTxn = txResultC.result.filter(matchTx)[0]
     expect(userCTxn.memo).toBe(memo)
-    expect(userCTxn.settlementDisplayCurrencyPerSat).toBe(0.0005)
+    expect(userCTxn.displayCurrencyPerSettlementCurrencyUnit).toBe(0.0005)
     expect(userCTxn.settlementVia.type).toBe("intraledger")
   })
 

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -229,7 +229,7 @@ describe("UserWallet - onChainPay", () => {
       expect(settledTx.settlementFee).toBe(fee)
       expect(settledTx.settlementAmount).toBe(-amount - fee)
 
-      expect(settledTx.settlementDisplayCurrencyPerSat).toBeGreaterThan(0)
+      expect(settledTx.displayCurrencyPerSettlementCurrencyUnit).toBeGreaterThan(0)
 
       const finalBalance = await getBalanceHelper(walletIdA)
       expect(finalBalance).toBe(initialBalanceUserA - amount - fee)
@@ -335,7 +335,7 @@ describe("UserWallet - onChainPay", () => {
 
       expect(settledTx.settlementFee).toBe(fee)
       expect(settledTx.settlementAmount).toBe(-initialBalanceUserE)
-      expect(settledTx.settlementDisplayCurrencyPerSat).toBeGreaterThan(0)
+      expect(settledTx.displayCurrencyPerSettlementCurrencyUnit).toBeGreaterThan(0)
     }
 
     sub.removeAllListeners()
@@ -453,7 +453,7 @@ describe("UserWallet - onChainPay", () => {
 
       expect(settledTx.settlementFee).toBe(0)
       expect(settledTx.settlementAmount).toBe(-amount)
-      expect(settledTx.settlementDisplayCurrencyPerSat).toBeGreaterThan(0)
+      expect(settledTx.displayCurrencyPerSettlementCurrencyUnit).toBeGreaterThan(0)
 
       const finalBalance = await getBalanceHelper(walletIdA)
       expect(finalBalance).toBe(initialBalanceUserA - amount)
@@ -553,7 +553,7 @@ describe("UserWallet - onChainPay", () => {
 
       expect(settledTx.settlementFee).toBe(0)
       expect(settledTx.settlementAmount).toBe(-initialBalanceUserF)
-      expect(settledTx.settlementDisplayCurrencyPerSat).toBeGreaterThan(0)
+      expect(settledTx.displayCurrencyPerSettlementCurrencyUnit).toBeGreaterThan(0)
 
       const finalBalance = await getBalanceHelper(walletIdF)
       expect(finalBalance).toBe(0)

--- a/test/unit/domain/wallets/tx-history.spec.ts
+++ b/test/unit/domain/wallets/tx-history.spec.ts
@@ -105,10 +105,10 @@ describe("WalletTransactionHistory.fromLedger", () => {
     }): WalletTransaction[] => {
       const settlementFee =
         currency === WalletCurrency.Btc ? toSats(fee) : toCents(Math.floor(feeUsd * 100))
-      const settlementDisplayCurrencyPerSat = Math.abs(usd / settlementAmount)
+      const displayCurrencyPerSettlementCurrencyUnit = Math.abs(usd / settlementAmount)
 
       if (currency === WalletCurrency.Usd) {
-        expect(settlementDisplayCurrencyPerSat).toEqual(0.01)
+        expect(displayCurrencyPerSettlementCurrencyUnit).toEqual(0.01)
       }
 
       const currencyBaseWalletTxns = {
@@ -118,7 +118,7 @@ describe("WalletTransactionHistory.fromLedger", () => {
 
         settlementAmount,
         settlementFee,
-        settlementDisplayCurrencyPerSat,
+        displayCurrencyPerSettlementCurrencyUnit,
       }
 
       return [
@@ -307,7 +307,7 @@ describe("ConfirmedTransactionHistory.addPendingIncoming", () => {
         settlementAmount: toSats(25000),
         settlementFee: toSats(0),
         settlementCurrency: WalletCurrency.Btc,
-        settlementDisplayCurrencyPerSat: 1,
+        displayCurrencyPerSettlementCurrencyUnit: 1,
         status: TxStatus.Pending,
         createdAt: timestamp,
       },
@@ -326,7 +326,7 @@ describe("ConfirmedTransactionHistory.addPendingIncoming", () => {
         settlementCurrency: WalletCurrency.Btc,
         memo: null,
         settlementFee: toSats(0),
-        settlementDisplayCurrencyPerSat: 1,
+        displayCurrencyPerSettlementCurrencyUnit: 1,
 
         status: TxStatus.Pending,
         createdAt: timestamp,
@@ -379,7 +379,7 @@ describe("ConfirmedTransactionHistory.addPendingIncoming", () => {
         settlementAmount: toSats(25000),
         settlementFee: toSats(0),
         settlementCurrency: WalletCurrency.Btc,
-        settlementDisplayCurrencyPerSat: NaN,
+        displayCurrencyPerSettlementCurrencyUnit: NaN,
         status: TxStatus.Pending,
         createdAt: timestamp,
       },


### PR DESCRIPTION
## Description

`Transaction` objects now need to reference both `BTC` and `USD` settlement types.

This is a proposed change to the `Transaction` object to allow that. The `settlementAmount` property has been made generic since the currency information for the transaction is carried in the `settlementCurrency` property on the object (similar to how we encode this in the `PaymentAmount` type [in the domain](https://github.com/GaloyMoney/galoy/blob/16c76100cb7ed6241ae7a87982477346e460c175/src/domain/shared/index.types.d.ts#L12))

_**Tbd:** does this break the API?_