### PR TITLE
fix: add double spending restriction for a pending payment

### DIFF
--- a/src/domain/payments/errors.ts
+++ b/src/domain/payments/errors.ts
@@ -6,6 +6,7 @@ export class InvalidZeroAmountPriceRatioInputError extends ValidationError {}
 export class ZeroAmountForUsdRecipientError extends ValidationError {}
 export class LnPaymentRequestNonZeroAmountRequiredError extends ValidationError {}
 export class LnPaymentRequestZeroAmountRequiredError extends ValidationError {}
+export class LnPaymentRequestInTransitError extends ValidationError {}
 export class LnHashPresentInIntraLedgerFlowError extends ValidationError {}
 export class IntraLedgerHashPresentInLnFlowError extends ValidationError {}
 export class NonLnPaymentTransactionForPaymentFlowError extends ValidationError {

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -104,6 +104,10 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       message = "Invoice is missing its 'payment secret' value"
       return new InvoiceDecodeError({ message, logger: baseLogger })
 
+    case "LnPaymentRequestInTransitError":
+      message = "There is a pending payment for this invoice"
+      return new ValidationInternalError({ message, logger: baseLogger })
+
     case "SatoshiAmountRequiredError":
       message = "An amount is required to complete payment"
       return new ValidationInternalError({ message, logger: baseLogger })


### PR DESCRIPTION
Fix issue reported here https://galoymoney-workspace.slack.com/archives/C025NSXHME3/p1655319587559629

- User sends a payment but it is hold (returns pending)
- User didn't notice the pending payment and try to do a second payment to the same invoice
- Payment fail but only 1 tx is voided (this fix does not include trigger update but avoids the double spending)