### PR TITLE
feat: add signet support

### DIFF
--- a/src/config/process.ts
+++ b/src/config/process.ts
@@ -17,7 +17,7 @@ if (!jwtSecret) {
 export const JWT_SECRET = jwtSecret
 
 const btcNetwork = process.env.NETWORK
-const networks = ["mainnet", "testnet", "regtest"]
+const networks = ["mainnet", "testnet", "signet", "regtest"]
 if (!!btcNetwork && !networks.includes(btcNetwork)) {
   throw new ConfigError(`missing or invalid NETWORK: ${btcNetwork}`)
 }

--- a/src/domain/bitcoin/index.ts
+++ b/src/domain/bitcoin/index.ts
@@ -56,6 +56,7 @@ export const isSha256Hash = (value: string): boolean => !!value.match(/^[a-f0-9]
 export const BtcNetwork = {
   mainnet: "mainnet",
   testnet: "testnet",
+  signet: "signet",
   regtest: "regtest",
 } as const
 

--- a/src/domain/bitcoin/onchain/index.ts
+++ b/src/domain/bitcoin/onchain/index.ts
@@ -15,6 +15,7 @@ export const checkedToOnChainAddress = ({
   const regexes = {
     mainnet: [/^[13]{1}[a-km-zA-HJ-NP-Z1-9]{26,34}$/, /^bc1[a-z0-9]{39,59}$/i],
     testnet: [/^[mn2]{1}[a-km-zA-HJ-NP-Z1-9]{26,34}$/, /^tb1[a-z0-9]{39,59}$/i],
+    signet: [/^[mn2]{1}[a-km-zA-HJ-NP-Z1-9]{26,34}$/, /^tb1[a-z0-9]{39,59}$/i],
     regtest: [/^bcrt1[a-z0-9]{39,59}$/i],
   }
 

--- a/src/graphql/docs/galoy-dev.postman_environment.json
+++ b/src/graphql/docs/galoy-dev.postman_environment.json
@@ -58,6 +58,21 @@
 			"enabled": true
 		},
 		{
+			"key": "signet-p2pkh-address",
+			"value": "mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt",
+			"enabled": true
+		},
+		{
+			"key": "signet-p2sh-address",
+			"value": "2NGYHfoNUterKvuLVyVU5npmJPKmBwtoMzu",
+			"enabled": true
+		},
+		{
+			"key": "signet-segwitV0-address",
+			"value": "tb1ql7w62elx9ucw4pj5lgw4l028hmuw80sndtntxt",
+			"enabled": true
+		},
+		{
 			"key": "twoFASecret",
 			"value": "",
 			"type": "any",

--- a/src/graphql/docs/galoy-staging.postman_environment.json
+++ b/src/graphql/docs/galoy-staging.postman_environment.json
@@ -70,6 +70,21 @@
 			"enabled": true
 		},
 		{
+			"key": "signet-p2pkh-address",
+			"value": "mv4rnyY3Su5gjcDNzbMLKBQkBicCtHUtFB",
+			"enabled": true
+		},
+		{
+			"key": "signet-p2sh-address",
+			"value": "2NGYHfoNUterKvuLVyVU5npmJPKmBwtoMzu",
+			"enabled": true
+		},
+		{
+			"key": "signet-segwitV0-address",
+			"value": "tb1q796740jaeyppwsdfte5jqgay5yqvyvksmuxk6g",
+			"enabled": true
+		},
+		{
 			"key": "twoFASecret",
 			"value": "",
 			"type": "any",

--- a/test/unit/domain/bitcoin/onchain/checked-to-on-chain-address.spec.ts
+++ b/test/unit/domain/bitcoin/onchain/checked-to-on-chain-address.spec.ts
@@ -16,6 +16,24 @@ const addresses = [
     network: "testnet",
     address: "tb1p84x2taadgovgnlpnxt9f39gm7r68gwtvllxqe5w2n5ru00s9aquslzggwq",
   },
+  { network: "testnet", address: "mipcBbFg9gLiKh81Kj8taadgoZiY1ZJRfn" },
+  { network: "testnet", address: "tb1qw508d6qejxtdg4y5r3aadgory0c5xw7kxpjzsx" },
+  {
+    network: "testnet",
+    address: "tb1p84x2taadgovgnlpnxt9f39gm7r68gwtvllxqe5w2n5ru00s9aquslzggwq",
+  },
+  { network: "signet", address: "mipcBbFg9gLiKh81Kj8taadgoZiY1ZJRfn" },
+  { network: "signet", address: "tb1qw508d6qejxtdg4y5r3aadgory0c5xw7kxpjzsx" },
+  {
+    network: "signet",
+    address: "tb1p84x2taadgovgnlpnxt9f39gm7r68gwtvllxqe5w2n5ru00s9aquslzggwq",
+  },
+  { network: "signet", address: "mipcBbFg9gLiKh81Kj8taadgoZiY1ZJRfn" },
+  { network: "signet", address: "tb1qw508d6qejxtdg4y5r3aadgory0c5xw7kxpjzsx" },
+  {
+    network: "signet",
+    address: "tb1p84x2taadgovgnlpnxt9f39gm7r68gwtvllxqe5w2n5ru00s9aquslzggwq",
+  },
   { network: "regtest", address: "bcrt1q6z64a43mjgkcq0ul2zaqusq3spghrlau9slefp" },
   {
     network: "regtest",
@@ -36,9 +54,14 @@ describe("checkedToOnChainAddress", () => {
   test.each(addresses)(
     "$address is invalid for other networks",
     ({ network, address }) => {
-      let networksToCheck: Array<BtcNetwork> = [BtcNetwork.testnet, BtcNetwork.regtest]
+      let networksToCheck: Array<BtcNetwork> = [
+        BtcNetwork.testnet,
+        BtcNetwork.signet,
+        BtcNetwork.regtest,
+      ]
       if (network === "testnet")
         networksToCheck = [BtcNetwork.mainnet, BtcNetwork.regtest]
+      if (network === "signet") networksToCheck = [BtcNetwork.mainnet, BtcNetwork.regtest]
       if (network === "regtest")
         networksToCheck = [BtcNetwork.mainnet, BtcNetwork.testnet]
 


### PR DESCRIPTION
Introducing signet support for the api related to: https://github.com/GaloyMoney/charts/issues/1123

The changes are fairly straightforward as the address format is the same as on testnet. Simply reused the same addresses for signet for the checks.

See for example the same address being used on both signet end testnet displayed by a for of the Blockstream Esplora block explorer:

Signet:
https://explorer.bc-2.jp/address/tb1ql7w62elx9ucw4pj5lgw4l028hmuw80sndtntxt

Testnet: 
https://blockstream.info/testnet/address/tb1ql7w62elx9ucw4pj5lgw4l028hmuw80sndtntxt