### PR TITLE
chore: replace bitcoin-core with bitcoin-core-ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "axios": "^0.27.2",
     "bip32": "^3.0.1",
     "bip66": "^1.1.5",
-    "bitcoin-core": "^3.0.0",
+    "bitcoin-core-ts": "^3.0.3",
     "bitcoinjs-lib": "^6.0.1",
     "cors": "^2.8.5",
     "csv-writer": "^1.6.0",

--- a/src/services/bitcoind/bitcoin-core.types.d.ts
+++ b/src/services/bitcoind/bitcoin-core.types.d.ts
@@ -1,1 +1,1 @@
-declare module "bitcoin-core"
+declare module "bitcoin-core-ts"

--- a/src/services/bitcoind/index.ts
+++ b/src/services/bitcoind/index.ts
@@ -1,6 +1,6 @@
 import { btc2sat } from "@domain/bitcoin"
 
-import Client from "bitcoin-core"
+import Client from "bitcoin-core-ts"
 import sumBy from "lodash.sumby"
 
 const connection_obj = {

--- a/src/services/cold-storage/index.ts
+++ b/src/services/cold-storage/index.ts
@@ -1,4 +1,4 @@
-import BitcoindClient from "bitcoin-core"
+import BitcoindClient from "bitcoin-core-ts"
 import { btc2sat, sat2btc } from "@domain/bitcoin"
 import { BTC_NETWORK, getBitcoinCoreRPCConfig, getColdStorageConfig } from "@config"
 import {

--- a/test/helpers/bitcoin-core.ts
+++ b/test/helpers/bitcoin-core.ts
@@ -1,4 +1,4 @@
-import BitcoindClient from "bitcoin-core"
+import BitcoindClient from "bitcoin-core-ts"
 import {
   addInvoiceForSelf,
   createOnChainAddress,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2285,7 +2285,7 @@
   dependencies:
     "@types/lodash" "*"
 
-"@types/lodash@*":
+"@types/lodash@*", "@types/lodash@^4.14.180":
   version "4.14.182"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
   integrity sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==
@@ -3305,11 +3305,12 @@ bip66@1.1.5, bip66@^1.1.5:
   dependencies:
     safe-buffer "^5.0.1"
 
-bitcoin-core@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/bitcoin-core/-/bitcoin-core-3.0.0.tgz#3ad59a16b6748d8b60937affae6c5f1df2db770d"
-  integrity sha512-fdh8V/5lxDXwbq6KUCd9PjbTDe1kPGFM1brSFByuzMb+VSArr1qF422qbAJvW0dLQSaRhVDb7WC+a602QM70FQ==
+bitcoin-core-ts@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/bitcoin-core-ts/-/bitcoin-core-ts-3.0.3.tgz#e22586b8349a2ad9efe40b758c6ffeed9171acfb"
+  integrity sha512-zVYy2n6m51vQHiipp0QmmH96nYsXxAE81Y+C8amdx0vkK9SLioaE/xFPG//g88iw5e8MMdkQLILpEEQUVdDD9w==
   dependencies:
+    "@types/lodash" "^4.14.180"
     "@uphold/request-logger" "^2.0.0"
     debugnyan "^1.0.0"
     json-bigint "^0.2.0"
@@ -4459,9 +4460,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.4.164:
-  version "1.4.169"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.169.tgz#d4b8cf9816566c7e9518128f1a97f39de9c7af9d"
-  integrity sha512-Yb7UFva1sLlAaRyCkgoFF3qWvwZacFDtsGKi44rZsk8vnhL0DMhsUdhI4Dz9CCJQfftncDMGSI3AYiDtg8mD/w==
+  version "1.4.170"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.170.tgz#0415fc489402e09bfbe1f0c99bbf4d73f31d48d4"
+  integrity sha512-rZ8PZLhK4ORPjFqLp9aqC4/S1j4qWFsPPz13xmWdrbBkU/LlxMcok+f+6f8YnQ57MiZwKtOaW15biZZsY5Igvw==
 
 emittery@^0.10.2:
   version "0.10.2"


### PR DESCRIPTION
replace unmaintained bitcoin-core with bitcoin-core-ts ([fork](https://github.com/sapio-lang/bitcoin-core-ts)) from https://github.com/sapio-lang.

- It supports signet https://github.com/sapio-lang/bitcoin-core-ts/blob/master/src/index.ts#L21
- They began to add TS support