### PR TITLE
refactor: separate transaction types to accommodate metadata

### DIFF
--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -61,6 +61,11 @@ type LedgerTransaction<S extends WalletCurrency> = {
   readonly txHash?: OnChainTxHash
 }
 
+type LedgerTransactionWithMetadata<S extends WalletCurrency> = {
+  hasMetadata: true
+} & LedgerTransaction<S> &
+  LedgerTransactionMetadata
+
 type ReceiveOnChainTxArgs = {
   walletId: WalletId
   walletCurrency: WalletCurrency

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -115,12 +115,7 @@ type AddPendingIncomingArgs = {
 
 type ConfirmedTransactionHistory = {
   readonly transactions: WalletTransaction[]
-  addPendingIncoming({
-    pendingIncoming,
-    addressesByWalletId,
-    walletDetailsByWalletId,
-    displayCurrencyPerSat,
-  }: AddPendingIncomingArgs): WalletTransactionHistoryWithPending
+  addPendingIncoming(args: AddPendingIncomingArgs): WalletTransactionHistoryWithPending
 }
 
 type WalletTransactionHistoryWithPending = {

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -38,7 +38,12 @@ type SettlementViaIntraledger = {
 
 type SettlementViaLn = {
   readonly type: "lightning"
-  revealedPreImage: RevealedPreImage | null
+  readonly revealedPreImage: undefined
+}
+
+type SettlementViaLnWithMetadata = {
+  readonly type: "lightning"
+  revealedPreImage: RevealedPreImage | undefined
 }
 
 type SettlementViaOnChain = {
@@ -93,18 +98,42 @@ type WalletLnSettledTransaction = BaseWalletTransaction & {
   readonly settlementVia: SettlementViaLn
 }
 
+type WalletLnSettledTransactionWithMetadata = BaseWalletTransaction & {
+  readonly initiationVia: InitiationViaLn
+  readonly settlementVia: SettlementViaLnWithMetadata
+}
+
+type IntraLedgerTransactionWithMetadata = { hasMetadata: true } & IntraLedgerTransaction
+
 type WalletOnChainTransaction =
   | WalletOnChainIntraledgerTransaction
   | WalletOnChainSettledTransaction
   | WalletLegacyOnChainIntraledgerTransaction
   | WalletLegacyOnChainSettledTransaction
 
+type WalletOnChainTransactionWithMetadata = { hasMetadata: true } & (
+  | WalletOnChainIntraledgerTransaction
+  | WalletOnChainSettledTransaction
+  | WalletLegacyOnChainIntraledgerTransaction
+  | WalletLegacyOnChainSettledTransaction
+)
+
 type WalletLnTransaction = WalletLnIntraledgerTransaction | WalletLnSettledTransaction
+
+type WalletLnTransactionWithMetadata = { hasMetadata: true } & (
+  | WalletLnIntraledgerTransaction
+  | WalletLnSettledTransactionWithMetadata
+)
 
 type WalletTransaction =
   | IntraLedgerTransaction
   | WalletOnChainTransaction
   | WalletLnTransaction
+
+type WalletTransactionWithMetadata =
+  | IntraLedgerTransactionWithMetadata
+  | WalletOnChainTransactionWithMetadata
+  | WalletLnTransactionWithMetadata
 
 type AddPendingIncomingArgs = {
   pendingIncoming: IncomingOnChainTransaction[]
@@ -118,8 +147,19 @@ type ConfirmedTransactionHistory = {
   addPendingIncoming(args: AddPendingIncomingArgs): WalletTransactionHistoryWithPending
 }
 
+type ConfirmedTransactionHistoryWithMetadata = {
+  readonly transactions: WalletTransactionWithMetadata[]
+  addPendingIncoming(
+    args: AddPendingIncomingArgs,
+  ): WalletTransactionHistoryWithPendingWithMetadata
+}
+
 type WalletTransactionHistoryWithPending = {
   readonly transactions: WalletTransaction[]
+}
+
+type WalletTransactionHistoryWithPendingWithMetadata = {
+  readonly transactions: WalletTransactionWithMetadata[]
 }
 
 type NewWalletInfo = {

--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -107,7 +107,7 @@ const translateLedgerTxnToWalletTxn = <S extends WalletCurrency>(
           counterPartyUsername: username as Username,
         },
       }
-      return walletTransaction
+      break
 
     case ExtendedLedgerTransactionType.OnchainIntraLedger:
       walletTransaction = {
@@ -122,7 +122,7 @@ const translateLedgerTxnToWalletTxn = <S extends WalletCurrency>(
           counterPartyUsername: username || null,
         },
       }
-      return walletTransaction
+      break
 
     case ExtendedLedgerTransactionType.OnchainPayment:
     case ExtendedLedgerTransactionType.OnchainReceipt:
@@ -137,7 +137,7 @@ const translateLedgerTxnToWalletTxn = <S extends WalletCurrency>(
           transactionHash: txHash as OnChainTxHash,
         },
       }
-      return walletTransaction
+      break
 
     case ExtendedLedgerTransactionType.LnIntraLedger:
       walletTransaction = {
@@ -153,7 +153,7 @@ const translateLedgerTxnToWalletTxn = <S extends WalletCurrency>(
           counterPartyUsername: username || null,
         },
       }
-      return walletTransaction
+      break
 
     case ExtendedLedgerTransactionType.Payment:
     case ExtendedLedgerTransactionType.Invoice:
@@ -169,22 +169,24 @@ const translateLedgerTxnToWalletTxn = <S extends WalletCurrency>(
           revealedPreImage: null,
         },
       }
-      return walletTransaction
+      break
+
+    default:
+      walletTransaction = {
+        ...baseTransaction,
+        initiationVia: {
+          type: PaymentInitiationMethod.IntraLedger,
+          counterPartyWalletId: recipientWalletId as WalletId,
+          counterPartyUsername: username as Username,
+        },
+        settlementVia: {
+          type: SettlementMethod.IntraLedger,
+          counterPartyWalletId: recipientWalletId as WalletId,
+          counterPartyUsername: username || null,
+        },
+      }
   }
 
-  walletTransaction = {
-    ...baseTransaction,
-    initiationVia: {
-      type: PaymentInitiationMethod.IntraLedger,
-      counterPartyWalletId: recipientWalletId as WalletId,
-      counterPartyUsername: username as Username,
-    },
-    settlementVia: {
-      type: SettlementMethod.IntraLedger,
-      counterPartyWalletId: recipientWalletId as WalletId,
-      counterPartyUsername: username || null,
-    },
-  }
   return walletTransaction
 }
 

--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -7,14 +7,14 @@ import { WalletCurrency } from "@domain/shared"
 import { PaymentInitiationMethod, SettlementMethod } from "./tx-methods"
 import { TxStatus } from "./tx-status"
 
-const filterPendingIncoming = (
-  pendingTransactions: IncomingOnChainTransaction[],
-  addressesByWalletId: { [key: WalletId]: OnChainAddress[] },
-  walletDetailsByWalletId: { [key: WalletId]: { currency: WalletCurrency } },
-  displayCurrencyPerSat: DisplayCurrencyPerSat,
-): WalletOnChainTransaction[] => {
+const filterPendingIncoming = ({
+  pendingIncoming,
+  addressesByWalletId,
+  walletDetailsByWalletId,
+  displayCurrencyPerSat,
+}: AddPendingIncomingArgs): WalletOnChainTransaction[] => {
   const walletTransactions: WalletOnChainTransaction[] = []
-  pendingTransactions.forEach(({ rawTx, createdAt }) => {
+  pendingIncoming.forEach(({ rawTx, createdAt }) => {
     rawTx.outs.forEach(({ sats, address }) => {
       if (address) {
         for (const walletIdString in addressesByWalletId) {
@@ -209,21 +209,8 @@ export const fromLedger = (
 
   return {
     transactions,
-    addPendingIncoming: ({
-      pendingIncoming,
-      addressesByWalletId,
-      walletDetailsByWalletId,
-      displayCurrencyPerSat,
-    }: AddPendingIncomingArgs): WalletTransactionHistoryWithPending => ({
-      transactions: [
-        ...filterPendingIncoming(
-          pendingIncoming,
-          addressesByWalletId,
-          walletDetailsByWalletId,
-          displayCurrencyPerSat,
-        ),
-        ...transactions,
-      ],
+    addPendingIncoming: (args) => ({
+      transactions: [...filterPendingIncoming(args), ...transactions],
     }),
   }
 }

--- a/test/unit/domain/wallets/tx-history.spec.ts
+++ b/test/unit/domain/wallets/tx-history.spec.ts
@@ -9,175 +9,175 @@ import { MEMO_SHARING_SATS_THRESHOLD } from "@config"
 import { WalletCurrency } from "@domain/shared"
 import { toCents } from "@domain/fiat"
 
-describe("WalletTransactionHistory.fromLedger", () => {
-  describe("translates ledger txs to wallet txs", () => {
-    const timestamp = new Date(Date.now())
-    const fee = toSats(2)
-    const feeUsd = 0.1
+describe("translates ledger txs to wallet txs", () => {
+  const timestamp = new Date(Date.now())
+  const fee = toSats(2)
+  const feeUsd = 0.1
 
-    const baseLedgerTransaction = {
-      id: "id" as LedgerTransactionId,
-      fee,
-      feeUsd,
-      pendingConfirmation: false,
-      journalId: "journalId" as LedgerJournalId,
-      timestamp,
-      feeKnownInAdvance: false,
+  const baseLedgerTransaction = {
+    id: "id" as LedgerTransactionId,
+    fee,
+    feeUsd,
+    pendingConfirmation: false,
+    journalId: "journalId" as LedgerJournalId,
+    timestamp,
+    feeKnownInAdvance: false,
+  }
+
+  const baseWalletTransaction = {
+    id: "id" as LedgerTransactionId,
+    status: TxStatus.Success,
+    createdAt: timestamp,
+  }
+
+  const ledgerTxnsInputs = ({
+    walletId,
+    settlementAmount,
+    usd,
+    currency,
+  }: {
+    walletId: WalletId
+    settlementAmount: Satoshis | UsdCents
+    usd: number
+    currency: WalletCurrency
+  }): LedgerTransaction<WalletCurrency>[] => {
+    const currencyBaseLedgerTxns = { ...baseLedgerTransaction, walletId, usd, currency }
+
+    return [
+      {
+        ...currencyBaseLedgerTxns,
+        type: LedgerTransactionType.Invoice,
+
+        debit: toSats(0),
+        credit: settlementAmount,
+
+        paymentHash: "paymentHash" as PaymentHash,
+        pubkey: "pubkey" as Pubkey,
+        memoFromPayer: "SomeMemo",
+      },
+      {
+        ...currencyBaseLedgerTxns,
+        recipientWalletId: "walletIdRecipient" as WalletId,
+        type: LedgerTransactionType.IntraLedger,
+
+        debit: toSats(0),
+        credit: settlementAmount,
+
+        paymentHash: "paymentHash" as PaymentHash,
+        pubkey: "pubkey" as Pubkey,
+        username: "username" as Username,
+      },
+      {
+        ...currencyBaseLedgerTxns,
+        recipientWalletId: "walletIdRecipient" as WalletId,
+        type: LedgerTransactionType.OnchainIntraLedger,
+
+        debit: toSats(0),
+        credit: settlementAmount,
+
+        address: "address" as OnChainAddress,
+        txHash: "txHash" as OnChainTxHash,
+      },
+      {
+        ...currencyBaseLedgerTxns,
+        type: LedgerTransactionType.OnchainReceipt,
+
+        debit: toSats(0),
+        credit: settlementAmount,
+
+        address: "address" as OnChainAddress,
+        txHash: "txHash" as OnChainTxHash,
+      },
+    ]
+  }
+
+  const expectedWalletTxns = ({
+    walletId,
+    settlementAmount,
+    usd,
+    currency,
+  }: {
+    walletId: WalletId
+    settlementAmount: Satoshis | UsdCents
+    usd: number
+    currency: WalletCurrency
+  }): WalletTransaction[] => {
+    const settlementFee =
+      currency === WalletCurrency.Btc ? toSats(fee) : toCents(Math.floor(feeUsd * 100))
+    const displayCurrencyPerSettlementCurrencyUnit = Math.abs(usd / settlementAmount)
+
+    if (currency === WalletCurrency.Usd) {
+      expect(displayCurrencyPerSettlementCurrencyUnit).toEqual(0.01)
     }
 
-    const baseWalletTransaction = {
-      id: "id" as LedgerTransactionId,
-      status: TxStatus.Success,
-      createdAt: timestamp,
-    }
-
-    const ledgerTxnsInputs = ({
+    const currencyBaseWalletTxns = {
+      ...baseWalletTransaction,
       walletId,
+      settlementCurrency: currency,
+
       settlementAmount,
-      usd,
-      currency,
-    }: {
-      walletId: WalletId
-      settlementAmount: Satoshis | UsdCents
-      usd: number
-      currency: WalletCurrency
-    }): LedgerTransaction<WalletCurrency>[] => {
-      const currencyBaseLedgerTxns = { ...baseLedgerTransaction, walletId, usd, currency }
+      settlementFee,
+      displayCurrencyPerSettlementCurrencyUnit,
+    }
 
-      return [
-        {
-          ...currencyBaseLedgerTxns,
-          type: LedgerTransactionType.Invoice,
-
-          debit: toSats(0),
-          credit: settlementAmount,
-
+    return [
+      {
+        ...currencyBaseWalletTxns,
+        initiationVia: {
+          type: PaymentInitiationMethod.Lightning,
           paymentHash: "paymentHash" as PaymentHash,
           pubkey: "pubkey" as Pubkey,
-          memoFromPayer: "SomeMemo",
         },
-        {
-          ...currencyBaseLedgerTxns,
-          recipientWalletId: "walletIdRecipient" as WalletId,
-          type: LedgerTransactionType.IntraLedger,
+        settlementVia: {
+          type: SettlementMethod.Lightning,
+          revealedPreImage: undefined,
+        },
+        memo: "SomeMemo",
+      },
 
-          debit: toSats(0),
-          credit: settlementAmount,
-
+      {
+        ...currencyBaseWalletTxns,
+        initiationVia: {
+          type: PaymentInitiationMethod.Lightning,
           paymentHash: "paymentHash" as PaymentHash,
           pubkey: "pubkey" as Pubkey,
-          username: "username" as Username,
         },
-        {
-          ...currencyBaseLedgerTxns,
-          recipientWalletId: "walletIdRecipient" as WalletId,
-          type: LedgerTransactionType.OnchainIntraLedger,
-
-          debit: toSats(0),
-          credit: settlementAmount,
-
+        settlementVia: {
+          type: SettlementMethod.IntraLedger,
+          counterPartyWalletId: "walletIdRecipient" as WalletId,
+          counterPartyUsername: "username" as Username,
+        },
+        memo: null,
+      },
+      {
+        ...currencyBaseWalletTxns,
+        initiationVia: {
+          type: PaymentInitiationMethod.OnChain,
           address: "address" as OnChainAddress,
-          txHash: "txHash" as OnChainTxHash,
         },
-        {
-          ...currencyBaseLedgerTxns,
-          type: LedgerTransactionType.OnchainReceipt,
-
-          debit: toSats(0),
-          credit: settlementAmount,
-
+        settlementVia: {
+          type: SettlementMethod.IntraLedger,
+          counterPartyWalletId: "walletIdRecipient" as WalletId,
+          counterPartyUsername: null,
+        },
+        memo: null,
+      },
+      {
+        ...currencyBaseWalletTxns,
+        initiationVia: {
+          type: PaymentInitiationMethod.OnChain,
           address: "address" as OnChainAddress,
-          txHash: "txHash" as OnChainTxHash,
         },
-      ]
-    }
-
-    const expectedWalletTxns = ({
-      walletId,
-      settlementAmount,
-      usd,
-      currency,
-    }: {
-      walletId: WalletId
-      settlementAmount: Satoshis | UsdCents
-      usd: number
-      currency: WalletCurrency
-    }): WalletTransaction[] => {
-      const settlementFee =
-        currency === WalletCurrency.Btc ? toSats(fee) : toCents(Math.floor(feeUsd * 100))
-      const displayCurrencyPerSettlementCurrencyUnit = Math.abs(usd / settlementAmount)
-
-      if (currency === WalletCurrency.Usd) {
-        expect(displayCurrencyPerSettlementCurrencyUnit).toEqual(0.01)
-      }
-
-      const currencyBaseWalletTxns = {
-        ...baseWalletTransaction,
-        walletId,
-        settlementCurrency: currency,
-
-        settlementAmount,
-        settlementFee,
-        displayCurrencyPerSettlementCurrencyUnit,
-      }
-
-      return [
-        {
-          ...currencyBaseWalletTxns,
-          initiationVia: {
-            type: PaymentInitiationMethod.Lightning,
-            paymentHash: "paymentHash" as PaymentHash,
-            pubkey: "pubkey" as Pubkey,
-          },
-          settlementVia: {
-            type: SettlementMethod.Lightning,
-            revealedPreImage: undefined,
-          },
-          memo: "SomeMemo",
+        settlementVia: {
+          type: SettlementMethod.OnChain,
+          transactionHash: "txHash" as OnChainTxHash,
         },
+        memo: null,
+      },
+    ]
+  }
 
-        {
-          ...currencyBaseWalletTxns,
-          initiationVia: {
-            type: PaymentInitiationMethod.Lightning,
-            paymentHash: "paymentHash" as PaymentHash,
-            pubkey: "pubkey" as Pubkey,
-          },
-          settlementVia: {
-            type: SettlementMethod.IntraLedger,
-            counterPartyWalletId: "walletIdRecipient" as WalletId,
-            counterPartyUsername: "username" as Username,
-          },
-          memo: null,
-        },
-        {
-          ...currencyBaseWalletTxns,
-          initiationVia: {
-            type: PaymentInitiationMethod.OnChain,
-            address: "address" as OnChainAddress,
-          },
-          settlementVia: {
-            type: SettlementMethod.IntraLedger,
-            counterPartyWalletId: "walletIdRecipient" as WalletId,
-            counterPartyUsername: null,
-          },
-          memo: null,
-        },
-        {
-          ...currencyBaseWalletTxns,
-          initiationVia: {
-            type: PaymentInitiationMethod.OnChain,
-            address: "address" as OnChainAddress,
-          },
-          settlementVia: {
-            type: SettlementMethod.OnChain,
-            transactionHash: "txHash" as OnChainTxHash,
-          },
-          memo: null,
-        },
-      ]
-    }
-
+  describe("WalletTransactionHistory.fromLedger", () => {
     it("translates btc ledger txs", () => {
       const currency = WalletCurrency.Btc
       const settlementAmount = toSats(100000)
@@ -216,6 +216,108 @@ describe("WalletTransactionHistory.fromLedger", () => {
 
       const expected = expectedWalletTxns(txnsArgs)
       expect(result.transactions).toEqual(expected)
+    })
+  })
+
+  describe("WalletTransactionHistory.fromLedgerWithMetadata", () => {
+    it("translates btc ledger txs", () => {
+      const currency = WalletCurrency.Btc
+      const settlementAmount = toSats(100000)
+      const usd = 20
+
+      const txnsArgs = {
+        walletId: crypto.randomUUID() as WalletId,
+        settlementAmount,
+        usd,
+        feeUsd,
+        currency,
+      }
+
+      const ledgerTxnsWithMetadata = ledgerTxnsInputs(txnsArgs).map(
+        <S extends WalletCurrency>(
+          txn: LedgerTransaction<S>,
+        ): LedgerTransactionWithMetadata<S> => ({
+          ...txn,
+          hasMetadata: true,
+        }),
+      )
+
+      // Add metadata to inputs
+      ledgerTxnsWithMetadata[0] = {
+        ...ledgerTxnsWithMetadata[0],
+        revealedPreImage: "revealedPreImage" as RevealedPreImage,
+      }
+
+      const result =
+        WalletTransactionHistory.fromLedgerWithMetadata(ledgerTxnsWithMetadata)
+
+      const expectedWithMetadata = expectedWalletTxns(txnsArgs).map(
+        (txn: WalletTransaction): WalletTransactionWithMetadata => ({
+          ...txn,
+          hasMetadata: true,
+        }),
+      )
+
+      // Add metadata to expected outputs
+      expectedWithMetadata[0] = {
+        ...expectedWithMetadata[0],
+        settlementVia: {
+          ...expectedWithMetadata[0].settlementVia,
+          revealedPreImage: "revealedPreImage" as RevealedPreImage,
+        },
+      } as WalletLnTransactionWithMetadata
+
+      expect(result.transactions).toEqual(expectedWithMetadata)
+    })
+
+    it("translates usd ledger txs", () => {
+      const currency = WalletCurrency.Usd
+      const settlementAmount = toCents(2000)
+      const usd = 20
+
+      const txnsArgs = {
+        walletId: crypto.randomUUID() as WalletId,
+        settlementAmount,
+        usd,
+        feeUsd,
+        currency,
+      }
+
+      const ledgerTxnsWithMetadata = ledgerTxnsInputs(txnsArgs).map(
+        <S extends WalletCurrency>(
+          txn: LedgerTransaction<S>,
+        ): LedgerTransactionWithMetadata<S> => ({
+          ...txn,
+          hasMetadata: true,
+        }),
+      )
+
+      // Add metadata to inputs
+      ledgerTxnsWithMetadata[0] = {
+        ...ledgerTxnsWithMetadata[0],
+        revealedPreImage: "revealedPreImage" as RevealedPreImage,
+      }
+
+      const result =
+        WalletTransactionHistory.fromLedgerWithMetadata(ledgerTxnsWithMetadata)
+
+      const expectedWithMetadata = expectedWalletTxns(txnsArgs).map(
+        (txn: WalletTransaction): WalletTransactionWithMetadata => ({
+          ...txn,
+          hasMetadata: true,
+        }),
+      )
+
+      // Add metadata to expected outputs
+      expectedWithMetadata[0] = {
+        ...expectedWithMetadata[0],
+        settlementVia: {
+          ...expectedWithMetadata[0].settlementVia,
+          revealedPreImage: "revealedPreImage" as RevealedPreImage,
+        },
+      } as WalletLnTransactionWithMetadata
+
+      expect(result.transactions).toEqual(expectedWithMetadata)
     })
   })
 })

--- a/test/unit/domain/wallets/tx-history.spec.ts
+++ b/test/unit/domain/wallets/tx-history.spec.ts
@@ -131,7 +131,7 @@ describe("WalletTransactionHistory.fromLedger", () => {
           },
           settlementVia: {
             type: SettlementMethod.Lightning,
-            revealedPreImage: null,
+            revealedPreImage: undefined,
           },
           memo: "SomeMemo",
         },


### PR DESCRIPTION
## Description

This PR separates `LedgerTransaction` and `WalletTransaction` types to have 2nd variants with metadata included.

The reason for this is we decided that there are cases where we wouldn't go to the 2nd `transaction_metadata` collection in our db for performance reasons and these types reflect the separate cases where we query that additional collection vs. when we do not.

These types will eventually move all the way to a new `TransactionWithMetatadata` object at the graphql level in a follow-up PR.

After this PR is merged, the changes will be incorporated into PR #1077 to help handle the new metadata changes there.