### PR TITLE
feat: add timeout to route probe

### DIFF
--- a/src/domain/bitcoin/lightning/errors.ts
+++ b/src/domain/bitcoin/lightning/errors.ts
@@ -28,6 +28,7 @@ export class InsufficientBalanceForRoutingError extends LightningServiceError {}
 export class InvoiceExpiredOrBadPaymentHashError extends LightningServiceError {}
 export class PaymentAttemptsTimedOutError extends LightningServiceError {}
 export class ProbeForRouteTimedOutError extends LightningServiceError {}
+export class ProbeForRouteTimedOutFromApplicationError extends LightningServiceError {}
 export class PaymentInTransitionError extends LightningServiceError {}
 export class InvalidFeeProbeStateError extends LightningServiceError {
   level = ErrorLevel.Critical

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -209,6 +209,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       return new RouteFindingError({ message, logger: baseLogger })
 
     case "ProbeForRouteTimedOutError":
+    case "ProbeForRouteTimedOutFromApplicationError":
       message = "Unable to find a route for payment."
       return new RouteFindingError({ message, logger: baseLogger })
 


### PR DESCRIPTION
## Description

This is to add a timeout to fee probes to allow getting back the "max fee" at the api level after the fixed max time (currently 45s).