### PR TITLE
feat: add metadata to ledger txns

### DIFF
--- a/src/app/payments/update-pending-payments.ts
+++ b/src/app/payments/update-pending-payments.ts
@@ -210,7 +210,7 @@ const reconstructPendingPaymentFlow = async <
 >(
   paymentHash: PaymentHash,
 ): Promise<PaymentFlow<S, R> | ApplicationError> => {
-  const ledgerTxns = await LedgerService().getTransactionsByHash(paymentHash)
+  const ledgerTxns = await LedgerService().getTransactionsByHash<S>(paymentHash)
   if (ledgerTxns instanceof Error) return ledgerTxns
 
   const payment = ledgerTxns.find(
@@ -218,7 +218,7 @@ const reconstructPendingPaymentFlow = async <
       tx.pendingConfirmation === true &&
       tx.type === LedgerTransactionType.Payment &&
       tx.debit > 0,
-  ) as LedgerTransaction<S> | undefined
+  )
   if (!payment) return new CouldNotFindTransactionError()
 
   return PaymentFlowFromLedgerTransaction(payment)

--- a/src/app/wallets/get-transaction-by-id.ts
+++ b/src/app/wallets/get-transaction-by-id.ts
@@ -4,7 +4,7 @@ import { checkedToLedgerTransactionId } from "@domain/ledger"
 
 export const getTransactionById = async (
   id: string,
-): Promise<WalletTransaction | ApplicationError> => {
+): Promise<WalletTransactionWithMetadata | ApplicationError> => {
   const ledger = LedgerService()
 
   const ledgerTxId = checkedToLedgerTransactionId(id)
@@ -13,5 +13,6 @@ export const getTransactionById = async (
   const ledgerTransaction = await ledger.getTransactionById(ledgerTxId)
   if (ledgerTransaction instanceof Error) return ledgerTransaction
 
-  return WalletTransactionHistory.fromLedger([ledgerTransaction]).transactions[0]
+  return WalletTransactionHistory.fromLedgerWithMetadata([ledgerTransaction])
+    .transactions[0]
 }

--- a/src/app/wallets/get-transactions-by-hash.ts
+++ b/src/app/wallets/get-transactions-by-hash.ts
@@ -3,9 +3,9 @@ import { WalletTransactionHistory } from "@domain/wallets"
 
 export const getTransactionsByHash = async (
   hash: PaymentHash | OnChainTxHash,
-): Promise<WalletTransaction[] | ApplicationError> => {
+): Promise<WalletTransactionWithMetadata[] | ApplicationError> => {
   const ledger = LedgerService()
   const ledgerTransactions = await ledger.getTransactionsByHash(hash)
   if (ledgerTransactions instanceof Error) return ledgerTransactions
-  return WalletTransactionHistory.fromLedger(ledgerTransactions).transactions
+  return WalletTransactionHistory.fromLedgerWithMetadata(ledgerTransactions).transactions
 }

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -66,6 +66,7 @@ export class InvalidKratosUserId extends ValidationError {}
 export class InvalidEmailAddress extends ValidationError {}
 export class InvalidWalletId extends ValidationError {}
 export class InvalidLedgerTransactionId extends ValidationError {}
+export class InvalidLedgerTransaction extends ValidationError {}
 export class AlreadyPaidError extends ValidationError {}
 export class SelfPaymentError extends ValidationError {}
 export class LessThanDustThresholdError extends ValidationError {}
@@ -99,3 +100,5 @@ export class TwoFALimitsExceededError extends LimitsExceededError {}
 
 export class LnRouteValidationError extends ValidationError {}
 export class BadAmountForRouteError extends LnRouteValidationError {}
+
+export class NotAuthorizedForTransactionError extends AuthorizationError {}

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -245,13 +245,13 @@ interface ILedgerService {
       | LnLedgerTransactionMetadataUpdate,
   ): Promise<true | LedgerServiceError>
 
-  getTransactionById(
+  getTransactionById<S extends WalletCurrency>(
     id: LedgerTransactionId,
-  ): Promise<LedgerTransaction<WalletCurrency> | LedgerServiceError>
+  ): Promise<LedgerTransactionWithMetadata<S> | LedgerServiceError>
 
-  getTransactionsByHash(
+  getTransactionsByHash<S extends WalletCurrency>(
     paymentHash: PaymentHash | OnChainTxHash,
-  ): Promise<LedgerTransaction<WalletCurrency>[] | LedgerServiceError>
+  ): Promise<LedgerTransactionWithMetadata<S>[] | LedgerServiceError>
 
   getTransactionsByWalletId(
     walletId: WalletId,

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -24,8 +24,8 @@ type LedgerTransaction<S extends WalletCurrency> = {
   readonly id: LedgerTransactionId
   readonly walletId: WalletId | undefined // FIXME create a subclass so that this field is always set for liabilities wallets
   readonly type: LedgerTransactionType
-  readonly debit: S extends "BTC" ? Satoshis : UsdCents
-  readonly credit: S extends "BTC" ? Satoshis : UsdCents
+  readonly debit: Satoshis | UsdCents
+  readonly credit: Satoshis | UsdCents
   readonly fee: Satoshis
   readonly currency: S
   readonly timestamp: Date

--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -202,15 +202,15 @@ const translateLedgerTxnToWalletTxnWithMetadata = <S extends WalletCurrency>(
   if ("revealedPreImage" in txn) {
     if (walletTxnWithMetadata.settlementVia.type !== SettlementMethod.Lightning) {
       // TODO: return invalid-state error here and remove cast to 'WalletLnTransactionWithMetadata' just below
+    } else {
+      walletTxnWithMetadata = {
+        ...walletTxnWithMetadata,
+        settlementVia: {
+          ...walletTxnWithMetadata.settlementVia,
+          revealedPreImage: txn.revealedPreImage,
+        },
+      } as WalletLnTransactionWithMetadata
     }
-
-    walletTxnWithMetadata = {
-      ...walletTxnWithMetadata,
-      settlementVia: {
-        ...walletTxnWithMetadata.settlementVia,
-        revealedPreImage: txn.revealedPreImage,
-      },
-    } as WalletLnTransactionWithMetadata
   }
 
   return walletTxnWithMetadata

--- a/src/graphql/admin/root/query/transaction-by-id.ts
+++ b/src/graphql/admin/root/query/transaction-by-id.ts
@@ -1,10 +1,10 @@
 import { GT } from "@graphql/index"
 
 import { Wallets } from "@app"
-import Transaction from "@graphql/types/object/transaction"
+import TransactionWithMetadata from "@graphql/types/object/transaction-with-metadata"
 
 const TransactionByIdQuery = GT.Field({
-  type: Transaction,
+  type: TransactionWithMetadata,
   args: {
     id: { type: GT.NonNullID },
   },

--- a/src/graphql/admin/root/query/transactions-by-hash.ts
+++ b/src/graphql/admin/root/query/transactions-by-hash.ts
@@ -1,11 +1,11 @@
 import { GT } from "@graphql/index"
 
 import { Wallets } from "@app"
-import Transaction from "@graphql/types/object/transaction"
 import PaymentHash from "@graphql/types/scalar/payment-hash"
+import TransactionWithMetadata from "@graphql/types/object/transaction-with-metadata"
 
 const TransactionsByHashQuery = GT.Field({
-  type: GT.List(Transaction),
+  type: GT.List(TransactionWithMetadata),
   args: {
     hash: { type: GT.NonNull(PaymentHash) },
   },

--- a/src/graphql/admin/schema.graphql
+++ b/src/graphql/admin/schema.graphql
@@ -49,7 +49,7 @@ input AccountsAddUsdWalletInput {
 }
 
 """
-An authentication code valid for a single use
+An JWT-formatted authentication token
 """
 scalar AuthToken
 
@@ -302,8 +302,8 @@ type Query {
   allLevels: [AccountLevel!]!
   lightningInvoice(hash: PaymentHash!): LightningInvoice!
   lightningPayment(hash: PaymentHash!): LightningPayment!
-  transactionById(id: ID!): Transaction
-  transactionsByHash(hash: PaymentHash!): [Transaction]
+  transactionById(id: ID!): TransactionWithMetadata
+  transactionsByHash(hash: PaymentHash!): [TransactionWithMetadata]
 }
 
 """
@@ -326,17 +326,41 @@ type SettlementViaIntraLedger {
   counterPartyWalletId: WalletId
 }
 
+type SettlementViaIntraLedgerWithMetadata {
+  """
+  Settlement destination: Could be null if the payee does not have a username
+  """
+  counterPartyUsername: Username
+  counterPartyWalletId: WalletId
+}
+
 type SettlementViaLn {
   paymentSecret: LnPaymentSecret
     @deprecated(
-      reason: "Shifting property to 'preImage' to improve granularity of the LnPaymentSecret type"
+      reason: "Moving this property over to the TransactionWithMetadata object type."
     )
+  preImage: LnPaymentPreImage
+    @deprecated(
+      reason: "Moving this property over to the TransactionWithMetadata object type."
+    )
+}
+
+type SettlementViaLnWithMetadata {
   preImage: LnPaymentPreImage
 }
 
 type SettlementViaOnChain {
   transactionHash: OnChainTxHash!
 }
+
+type SettlementViaOnChainWithMetadata {
+  transactionHash: OnChainTxHash!
+}
+
+union SettlementViaWithMetadata =
+    SettlementViaIntraLedgerWithMetadata
+  | SettlementViaLnWithMetadata
+  | SettlementViaOnChainWithMetadata
 
 """
 An amount (of a currency) that can be negative (e.g. in a transaction)
@@ -427,6 +451,47 @@ type TransactionEdge {
   The item at the end of the edge
   """
   node: Transaction!
+}
+
+"""
+Give details about an individual transaction.
+Galoy have a smart routing system which is automatically
+settling intraledger when both the payer and payee use the same wallet
+therefore it's possible the transactions is being initiated onchain
+or with lightning but settled intraledger.
+"""
+type TransactionWithMetadata {
+  createdAt: Timestamp!
+  direction: TxDirection!
+  id: ID!
+
+  """
+  From which protocol the payment has been initiated.
+  """
+  initiationVia: InitiationVia!
+  memo: Memo
+
+  """
+  Amount of the settlement currency sent or received.
+  """
+  settlementAmount: SignedAmount!
+
+  """
+  Wallet currency for transaction.
+  """
+  settlementCurrency: WalletCurrency!
+  settlementFee: SignedAmount!
+
+  """
+  Price in USDCENT/SETTLEMENTUNIT at time of settlement.
+  """
+  settlementPrice: Price!
+
+  """
+  To which protocol the payment has settled on.
+  """
+  settlementVia: SettlementViaWithMetadata!
+  status: TxStatus!
 }
 
 enum TxDirection {

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -18,6 +18,7 @@ import {
   RebalanceNeededError,
   DealerOfflineError,
   InsufficientLiquidityError,
+  NotAuthorizedError,
 } from "@graphql/error"
 import { baseLogger } from "@services/logger"
 
@@ -272,6 +273,10 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       message = "Invalid walletId for account."
       return new ValidationInternalError({ message, logger: baseLogger })
 
+    case "NotAuthorizedForTransactionError":
+      message = "Invalid transaction id for account."
+      return new NotAuthorizedError({ message, logger: baseLogger })
+
     // ----------
     // Unhandled below here
     // ----------
@@ -349,6 +354,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "CouldNotFindTransactionError":
     case "CouldNotFindTransactionMetadataError":
     case "InvalidLedgerTransactionId":
+    case "InvalidLedgerTransaction":
     case "CacheError":
     case "CacheNotAvailableError":
     case "CacheServiceError":

--- a/src/graphql/error.ts
+++ b/src/graphql/error.ts
@@ -92,6 +92,12 @@ export class NotFoundError extends CustomApolloError {
   }
 }
 
+export class NotAuthorizedError extends CustomApolloError {
+  constructor(errData: CustomApolloErrorData) {
+    super({ code: "NOT_AUTHORIZED", forwardToClient: true, ...errData })
+  }
+}
+
 export class NewAccountWithdrawalError extends CustomApolloError {
   constructor(errData: CustomApolloErrorData) {
     super({

--- a/src/graphql/main/queries.ts
+++ b/src/graphql/main/queries.ts
@@ -11,6 +11,7 @@ import QuizQuestionsQuery from "@graphql/root/query/quiz-questions"
 import BtcPriceListQuery from "@graphql/root/query/btc-price-list"
 import OnChainTxFeeQuery from "@graphql/root/query/on-chain-tx-fee-query"
 import BtcPriceQuery from "@graphql/root/query/btc-price"
+import TransactionByIdQuery from "@graphql/root/query/transaction-by-id"
 
 import {
   addAttributesToCurrentSpanAndPropagate,
@@ -30,6 +31,7 @@ const fields = {
   btcPrice: BtcPriceQuery,
   btcPriceList: BtcPriceListQuery,
   onChainTxFee: OnChainTxFeeQuery,
+  transactionById: TransactionByIdQuery,
 }
 
 const addTracing = (fields) => {

--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -829,6 +829,7 @@ type Query {
     walletId: WalletId!
   ): OnChainTxFee!
   quizQuestions: [QuizQuestion]
+  transactionById(id: ID!): TransactionWithMetadata
   userDefaultWalletId(username: Username!): WalletId!
     @deprecated(reason: "will be migrated to AccountDefaultWalletId")
   usernameAvailable(username: Username!): Boolean
@@ -867,6 +868,14 @@ type SettlementViaIntraLedger {
   counterPartyWalletId: WalletId
 }
 
+type SettlementViaIntraLedgerWithMetadata {
+  """
+  Settlement destination: Could be null if the payee does not have a username
+  """
+  counterPartyUsername: Username
+  counterPartyWalletId: WalletId
+}
+
 type SettlementViaLn {
   paymentSecret: LnPaymentSecret
     @deprecated(
@@ -878,9 +887,22 @@ type SettlementViaLn {
     )
 }
 
+type SettlementViaLnWithMetadata {
+  preImage: LnPaymentPreImage
+}
+
 type SettlementViaOnChain {
   transactionHash: OnChainTxHash!
 }
+
+type SettlementViaOnChainWithMetadata {
+  transactionHash: OnChainTxHash!
+}
+
+union SettlementViaWithMetadata =
+    SettlementViaIntraLedgerWithMetadata
+  | SettlementViaLnWithMetadata
+  | SettlementViaOnChainWithMetadata
 
 """
 An amount (of a currency) that can be negative (e.g. in a transaction)
@@ -979,6 +1001,47 @@ type TransactionEdge {
   The item at the end of the edge
   """
   node: Transaction!
+}
+
+"""
+Give details about an individual transaction.
+Galoy have a smart routing system which is automatically
+settling intraledger when both the payer and payee use the same wallet
+therefore it's possible the transactions is being initiated onchain
+or with lightning but settled intraledger.
+"""
+type TransactionWithMetadata {
+  createdAt: Timestamp!
+  direction: TxDirection!
+  id: ID!
+
+  """
+  From which protocol the payment has been initiated.
+  """
+  initiationVia: InitiationVia!
+  memo: Memo
+
+  """
+  Amount of the settlement currency sent or received.
+  """
+  settlementAmount: SignedAmount!
+
+  """
+  Wallet currency for transaction.
+  """
+  settlementCurrency: WalletCurrency!
+  settlementFee: SignedAmount!
+
+  """
+  Price in USDCENT/SETTLEMENTUNIT at time of settlement.
+  """
+  settlementPrice: Price!
+
+  """
+  To which protocol the payment has settled on.
+  """
+  settlementVia: SettlementViaWithMetadata!
+  status: TxStatus!
 }
 
 input TwoFADeleteInput {

--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -37,7 +37,7 @@ type AccountUpdateDefaultWalletIdPayload {
 }
 
 """
-An authentication code valid for a single use
+An JWT-formatted authentication token
 """
 scalar AuthToken
 
@@ -870,9 +870,12 @@ type SettlementViaIntraLedger {
 type SettlementViaLn {
   paymentSecret: LnPaymentSecret
     @deprecated(
-      reason: "Shifting property to 'preImage' to improve granularity of the LnPaymentSecret type"
+      reason: "Moving this property over to the TransactionWithMetadata object type."
     )
   preImage: LnPaymentPreImage
+    @deprecated(
+      reason: "Moving this property over to the TransactionWithMetadata object type."
+    )
 }
 
 type SettlementViaOnChain {

--- a/src/graphql/root/query/transaction-by-id.ts
+++ b/src/graphql/root/query/transaction-by-id.ts
@@ -1,0 +1,40 @@
+import { GT } from "@graphql/index"
+
+import { Wallets } from "@app"
+import TransactionWithMetadata from "@graphql/types/object/transaction-with-metadata"
+import { WalletsRepository } from "@services/mongoose"
+import {
+  InvalidLedgerTransaction,
+  NotAuthorizedForTransactionError,
+} from "@domain/errors"
+import { mapError } from "@graphql/error-map"
+
+const TransactionByIdQuery = GT.Field({
+  type: TransactionWithMetadata,
+  args: {
+    id: { type: GT.NonNullID },
+  },
+  resolve: async (_, args, { domainAccount }: { domainAccount: Account }) => {
+    const { id } = args
+
+    if (id instanceof Error) throw id
+
+    const wallets = await WalletsRepository().listByAccountId(domainAccount.id)
+    if (wallets instanceof Error) throw mapError(wallets)
+    const walletIds = wallets.map((wallet) => wallet.id)
+
+    const ledgerTx = await Wallets.getTransactionById(id)
+    if (ledgerTx instanceof Error) throw mapError(ledgerTx)
+
+    if (ledgerTx.walletId === undefined) {
+      throw mapError(new InvalidLedgerTransaction())
+    }
+    if (!walletIds.includes(ledgerTx.walletId)) {
+      throw mapError(new NotAuthorizedForTransactionError())
+    }
+
+    return ledgerTx
+  },
+})
+
+export default TransactionByIdQuery

--- a/src/graphql/types/abstract/settlement-via-with-metadata.ts
+++ b/src/graphql/types/abstract/settlement-via-with-metadata.ts
@@ -8,10 +8,9 @@ import WalletId from "../scalar/wallet-id"
 import Username from "../scalar/username"
 import OnChainTxHash from "../scalar/onchain-tx-hash"
 import LnPaymentPreImage from "../scalar/ln-payment-preimage"
-import LnPaymentSecret from "../scalar/ln-payment-secret"
 
-const SettlementViaIntraLedger = GT.Object({
-  name: "SettlementViaIntraLedger",
+const SettlementViaIntraLedgerWithMetadata = GT.Object({
+  name: "SettlementViaIntraLedgerWithMetadata",
   isTypeOf: (source) => source.type === SettlementMethod.IntraLedger,
   fields: () => ({
     counterPartyWalletId: {
@@ -26,27 +25,20 @@ const SettlementViaIntraLedger = GT.Object({
   }),
 })
 
-const SettlementViaLn = GT.Object({
-  name: "SettlementViaLn",
-  isTypeOf: (source: SettlementViaLn) => source.type === SettlementMethod.Lightning,
+const SettlementViaLnWithMetadata = GT.Object({
+  name: "SettlementViaLnWithMetadata",
+  isTypeOf: (source: SettlementViaLnWithMetadata) =>
+    source.type === SettlementMethod.Lightning,
   fields: () => ({
-    paymentSecret: {
-      type: LnPaymentSecret,
-      resolve: () => undefined,
-      deprecationReason:
-        "Moving this property over to the TransactionWithMetadata object type.",
-    },
     preImage: {
       type: LnPaymentPreImage,
-      resolve: () => undefined,
-      deprecationReason:
-        "Moving this property over to the TransactionWithMetadata object type.",
+      resolve: (source: SettlementViaLnWithMetadata) => source.revealedPreImage,
     },
   }),
 })
 
-const SettlementViaOnChain = GT.Object({
-  name: "SettlementViaOnChain",
+const SettlementViaOnChainWithMetadata = GT.Object({
+  name: "SettlementViaOnChainWithMetadata",
   isTypeOf: (source) => source.type === SettlementMethod.OnChain,
   fields: () => ({
     transactionHash: {
@@ -55,9 +47,13 @@ const SettlementViaOnChain = GT.Object({
   }),
 })
 
-const SettlementVia = GT.Union({
-  name: "SettlementVia",
-  types: () => [SettlementViaIntraLedger, SettlementViaLn, SettlementViaOnChain],
+const SettlementViaWithMetadata = GT.Union({
+  name: "SettlementViaWithMetadata",
+  types: () => [
+    SettlementViaIntraLedgerWithMetadata,
+    SettlementViaLnWithMetadata,
+    SettlementViaOnChainWithMetadata,
+  ],
 })
 
-export default SettlementVia
+export default SettlementViaWithMetadata

--- a/src/graphql/types/object/business-account.ts
+++ b/src/graphql/types/object/business-account.ts
@@ -70,7 +70,7 @@ const BusinessAccount = GT.Object({
         if (walletIds === undefined) {
           const wallets = await WalletsRepository().listByAccountId(source.id)
           if (wallets instanceof Error) {
-            return { errors: [{ message: walletIds.message }] }
+            return { errors: [{ message: wallets.message }] }
           }
           walletIds = wallets.map((wallet) => wallet.id)
         }

--- a/src/graphql/types/object/consumer-account.ts
+++ b/src/graphql/types/object/consumer-account.ts
@@ -71,7 +71,7 @@ const ConsumerAccount = GT.Object({
         if (walletIds === undefined) {
           const wallets = await WalletsRepository().listByAccountId(source.id)
           if (wallets instanceof Error) {
-            return { errors: [{ message: walletIds.message }] }
+            return { errors: [{ message: wallets.message }] }
           }
           walletIds = wallets.map((wallet) => wallet.id)
         }

--- a/src/graphql/types/object/transaction-with-metadata.ts
+++ b/src/graphql/types/object/transaction-with-metadata.ts
@@ -1,0 +1,83 @@
+import dedent from "dedent"
+
+import { GT } from "@graphql/index"
+
+import { SAT_PRICE_PRECISION_OFFSET } from "@config"
+
+import Memo from "../scalar/memo"
+
+import InitiationVia from "../abstract/initiation-via"
+import SettlementViaWithMetadata from "../abstract/settlement-via-with-metadata"
+import Timestamp from "../scalar/timestamp"
+import TxDirection, { txDirectionValues } from "../scalar/tx-direction"
+import TxStatus from "../scalar/tx-status"
+import SignedAmount from "../scalar/signed-amount"
+import WalletCurrency from "../scalar/wallet-currency"
+
+import Price from "./price"
+
+const TransactionWithMetadata = GT.Object<WalletTransactionWithMetadata>({
+  name: "TransactionWithMetadata",
+  description: dedent`Give details about an individual transaction.
+  Galoy have a smart routing system which is automatically
+  settling intraledger when both the payer and payee use the same wallet
+  therefore it's possible the transactions is being initiated onchain
+  or with lightning but settled intraledger.`,
+  fields: () => ({
+    id: {
+      type: GT.NonNullID,
+    },
+    initiationVia: {
+      type: GT.NonNull(InitiationVia),
+      description: "From which protocol the payment has been initiated.",
+    },
+    settlementVia: {
+      type: GT.NonNull(SettlementViaWithMetadata),
+      description: "To which protocol the payment has settled on.",
+    },
+    settlementAmount: {
+      type: GT.NonNull(SignedAmount),
+      description: "Amount of the settlement currency sent or received.",
+    },
+    settlementFee: {
+      type: GT.NonNull(SignedAmount),
+    },
+    settlementPrice: {
+      type: GT.NonNull(Price),
+      resolve: (source) => {
+        const displayCurrencyPerSettlementCurrencyUnitInCents =
+          source.displayCurrencyPerSettlementCurrencyUnit * 100
+        return {
+          formattedAmount: displayCurrencyPerSettlementCurrencyUnitInCents.toString(),
+          base: Math.round(
+            displayCurrencyPerSettlementCurrencyUnitInCents *
+              10 ** SAT_PRICE_PRECISION_OFFSET,
+          ),
+          offset: SAT_PRICE_PRECISION_OFFSET,
+          currencyUnit: "USDCENT",
+        }
+      },
+      description: "Price in USDCENT/SETTLEMENTUNIT at time of settlement.",
+    },
+    settlementCurrency: {
+      type: GT.NonNull(WalletCurrency),
+      description: "Wallet currency for transaction.",
+    },
+    direction: {
+      type: GT.NonNull(TxDirection),
+      resolve: (source) =>
+        source.settlementAmount > 0 ? txDirectionValues.RECEIVE : txDirectionValues.SEND,
+    },
+    status: {
+      type: GT.NonNull(TxStatus),
+    },
+    memo: {
+      type: Memo,
+    },
+    createdAt: {
+      type: GT.NonNull(Timestamp),
+    },
+  }),
+})
+
+export default TransactionWithMetadata

--- a/src/servers/graphql-main-server.ts
+++ b/src/servers/graphql-main-server.ts
@@ -23,6 +23,7 @@ export async function startApolloServerForCoreSchema() {
       Query: {
         me: isAuthenticated,
         onChainTxFee: isAuthenticated,
+        transactionById: isAuthenticated,
       },
       Mutation: {
         twoFAGenerate: isAuthenticated,

--- a/src/services/ledger/index.ts
+++ b/src/services/ledger/index.ts
@@ -375,9 +375,9 @@ export const LedgerService = (): ILedgerService => {
   })
 }
 
-export const translateToLedgerTx = (
+export const translateToLedgerTx = <S extends WalletCurrency>(
   tx: ILedgerTransaction,
-): LedgerTransaction<WalletCurrency> => ({
+): LedgerTransaction<S> => ({
   id: tx.id as LedgerTransactionId,
   walletId: toWalletId(tx.accounts as LiabilitiesWalletId),
   type: tx.type as LedgerTransactionType,
@@ -386,7 +386,7 @@ export const translateToLedgerTx = (
   fee: toSats(tx.fee),
   usd: tx.usd || 0,
   feeUsd: tx.feeUsd || 0,
-  currency: tx.currency as WalletCurrency,
+  currency: tx.currency as S,
   timestamp: tx.timestamp,
   pendingConfirmation: tx.pending,
   journalId: tx._journal.toString() as LedgerJournalId,


### PR DESCRIPTION
## Description

This PR adds metadata to ledger transactions via a 2nd call to the metadata collection for ledger methods that reference transactions specifically by `id` or `paymentHash`. It does not do the additional metadata collection lookup for ledger methods that list all transaction for a given user.

To support this, an additional `transactionById` gql query was added so that an api user can fetch the full transactions list normally and then drill down into the details of a given transaction using this additional query.

**This PR supersedes PR #1077** 