### PR TITLE
fix: delete lnd payments async execution

### DIFF
--- a/src/servers/cron.ts
+++ b/src/servers/cron.ts
@@ -50,7 +50,7 @@ const main = async () => {
 
   const deleteLndPaymentsBefore2Months = async () => {
     const timestamp2Months = new Date(Date.now() - TWO_MONTHS_IN_MS)
-    const result = Lightning.deleteLnPaymentsBefore(timestamp2Months)
+    const result = await Lightning.deleteLnPaymentsBefore(timestamp2Months)
     if (result instanceof Error) throw result
   }
 
@@ -59,13 +59,13 @@ const main = async () => {
     updatePendingLightningInvoices,
     updatePendingLightningPayments,
     updateLnPaymentsCollection,
-    deleteExpiredInvoices,
-    deleteLndPaymentsBefore2Months,
-    deleteFailedPaymentsAttemptAllLnds,
     updateRoutingRevenues,
     updateOnChainReceipt,
     ...(cronConfig.rebalanceEnabled ? [rebalance] : []),
     deleteExpiredPaymentFlows,
+    deleteExpiredInvoices,
+    deleteLndPaymentsBefore2Months,
+    deleteFailedPaymentsAttemptAllLnds,
   ]
 
   for (const task of tasks) {


### PR DESCRIPTION
Fix async execution of `deleteLndPaymentsBefore2Months`. It was similar in how notifications work but in this case we need to wait to prevent the process from ending before the task completes.