### PR TITLE
fix: handle 'CouldNotFindLnPaymentFromHashError' errors

### DIFF
--- a/src/app/lightning/delete-ln-payments.ts
+++ b/src/app/lightning/delete-ln-payments.ts
@@ -1,4 +1,5 @@
 import { UnknownLightningServiceError } from "@domain/bitcoin/lightning"
+import { CouldNotFindLnPaymentFromHashError } from "@domain/errors"
 import { LndService } from "@services/lnd"
 import { LnPaymentsRepository } from "@services/mongoose"
 import {
@@ -40,7 +41,22 @@ const checkAndDeletePaymentForHash = async ({
     },
     async () => {
       const lnPayment = await LnPaymentsRepository().findByPaymentHash(paymentHash)
-      if (lnPayment instanceof Error) return lnPayment
+      if (lnPayment instanceof Error) {
+        if (lnPayment instanceof CouldNotFindLnPaymentFromHashError) {
+          const lnd = LndService()
+          if (lnd instanceof Error) return lnd
+          const lnPaymentLookup = await lnd.lookupPayment({ pubkey, paymentHash })
+          if (lnPaymentLookup instanceof Error) return lnPaymentLookup
+
+          await LnPaymentsRepository().persistNew({
+            paymentHash,
+            paymentRequest:
+              "createdAt" in lnPaymentLookup ? lnPaymentLookup.paymentRequest : undefined,
+            sentFromPubkey: pubkey,
+          })
+        }
+        return lnPayment
+      }
 
       addAttributesToCurrentSpan({ isCompleteRecord: lnPayment.isCompleteRecord })
       if (!lnPayment.isCompleteRecord) return false

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -29,11 +29,13 @@ export class CouldNotFindWalletFromUsernameAndCurrencyError extends CouldNotFind
 export class CouldNotFindWalletFromOnChainAddressError extends CouldNotFindError {}
 export class CouldNotFindWalletFromOnChainAddressesError extends CouldNotFindError {}
 export class CouldNotListWalletsFromWalletCurrencyError extends CouldNotFindError {}
-export class CouldNotFindLnPaymentFromHashError extends CouldNotFindError {}
 export class NoTransactionToUpdateError extends CouldNotFindError {}
 export class CouldNotFindLightningPaymentFlowError extends CouldNotFindError {}
 export class CouldNotUpdateLightningPaymentFlowError extends CouldNotFindError {}
 export class NoExpiredLightningPaymentFlowsError extends CouldNotFindError {}
+export class CouldNotFindLnPaymentFromHashError extends CouldNotFindError {
+  level = ErrorLevel.Critical
+}
 
 export class CouldNotFindAccountFromUsernameError extends CouldNotFindError {}
 export class CouldNotFindAccountFromPhoneError extends CouldNotFindError {}


### PR DESCRIPTION
## Description

One of the payment deletions from lnd failed because the payment wasn't persisted in our `lnPayments` collection in staging. This should never happen, and looking through honeycomb it has never happened on bbw and has only happened for one hash on staging (see [trace](https://ui.honeycomb.io/galoy/datasets/galoy-staging/result/tkf74TrugwD/trace/bW2JwSc5wJs?fields[]=c_name&fields[]=c_service.name&span=7ff71de4869e39f4)).

Given how infrequently this happens I made two changes:
- add any missing hashes from deletion code to lnPayment as incomplete payments to be picked up by the usual update-incomplete code
- escalated that particular `CouldNotFindLnPaymentFromHashError` error to critical

### Update

It turns out that this can happen if we do operations directly on the node like loop-outs. We had paused this PR to confirm whether we should arbitrarily be adding payment missing in the `lnPayments` collection back to the collection from lnd.

We decided that once we can differentiate user-transactions from our own transactions, we will want to persist all payment data from our lnds across to the `lnPayments` collection.

## Conclusion

From [this trace](https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/HfzG2c6Swru) we observed the `deletePayments` skip 701 payments that were in lnd but not in `lnPayments` collection. On diving in from the data side, we were pretty cleanly able to determine that 667 were to Loop and 34 to Bolt, likely loop-out transactions.

By doing absence checks against the `medici_transactions` collection we likely will always be able to come to this conclusion, so based on this it should be fine to move ahead with this PR.