### PR TITLE
chore: add delete-all-payments debug script for lnd-1

### DIFF
--- a/src/debug/delete-all-payments.ts
+++ b/src/debug/delete-all-payments.ts
@@ -1,0 +1,21 @@
+import { authenticatedLndGrpc, deletePayments } from "ln-service"
+
+// export LND1_TLS=$(kubectl exec lnd1-0 -n galoy-bbw-bitcoin  -- base64 /root/.lnd/tls.cert | tr -d '\n\r')
+// export LND1_MACAROON=$(kubectl exec lnd1-0 -n galoy-bbw-bitcoin -- base64 /root/.lnd/data/chain/bitcoin/mainnet/admin.macaroon | tr -d '\n\r')
+
+const fn = async () => {
+  try {
+    const { lnd } = authenticatedLndGrpc({
+      cert: process.env.LND1_TLS,
+      macaroon: process.env.LND1_MACAROON,
+      node: "localhost",
+      port: 10009,
+    })
+    console.log(await deletePayments({ lnd }))
+    console.log("completed")
+  } catch (err) {
+    console.log({ err })
+  }
+}
+
+fn()


### PR DESCRIPTION
## Description

This should clear all payments from our lnd-1 so that we can remove the current corrupt payments and have the lnd database back in a good state.