### PR TITLE
chore: delete redis config code from legacy dev setup

### DIFF
--- a/src/services/redis/index.ts
+++ b/src/services/redis/index.ts
@@ -4,8 +4,7 @@ import RedisCache from "ioredis-cache"
 
 import { baseLogger } from "@services/logger"
 
-let connectionObj = {},
-  natMap = {}
+let connectionObj = {}
 
 if (process.env.LOCAL === "docker-compose") {
   connectionObj = {
@@ -15,17 +14,6 @@ if (process.env.LOCAL === "docker-compose") {
     password: process.env.REDIS_PASSWORD,
   }
 } else {
-  if (process.env.LOCAL === "true") {
-    const REDIS_0_INTERNAL_IP = `${process.env.REDIS_0_INTERNAL_IP}:6379`
-
-    natMap = {
-      [REDIS_0_INTERNAL_IP]: {
-        host: process.env.REDIS_0_DNS,
-        port: process.env.REDIS_0_PORT,
-      },
-    }
-  }
-
   connectionObj = {
     sentinelPassword: process.env.REDIS_PASSWORD,
     sentinels: [
@@ -44,7 +32,6 @@ if (process.env.LOCAL === "docker-compose") {
     ],
     name: process.env.REDIS_MASTER_NAME ?? "mymaster",
     password: process.env.REDIS_PASSWORD,
-    natMap,
   }
 }
 


### PR DESCRIPTION
I believe this code was part of the old local-k8s dev environment and is no longer used.