### PR TITLE
fix: handle null/undefined entry description for medici 5

### DIFF
--- a/src/services/ledger/domain/entry-builder.ts
+++ b/src/services/ledger/domain/entry-builder.ts
@@ -9,6 +9,10 @@ export const EntryBuilder = <M extends MediciEntry>({
   entry,
   metadata,
 }: EntryBuilderConfig<M>) => {
+  if (entry.journal.memo === "undefined" || entry.journal.memo === "null") {
+    entry.journal.memo = ""
+  }
+
   const withTotalAmount = ({
     usdWithFees,
     btcWithFees,


### PR DESCRIPTION
## Description

This is one proposed fix for the issue where we see `"undefined"` string values for `memo` field in transactions instead of `undefined` object.

### Root cause

Medici 5 entry constructor handles the description argument different now:
- medici 5: `book.entry(undefined)` results in an entry with `{ memo: "undefined" }`
- medici 4: `book.entry(undefined)` results in an entry with `{ memo: undefined }`

### Proposed fix here
Inside the EntryBuilder, convert any `"undefined"` or `"null"` memo strings to an empty string (`""`) to enforce the falsiness we need.

### Alternative fix
Convert `undefined`/`false` inputs to the book.entry constructor throughout our application code so that an empty string always finally gets to the `book.entry` constructor. Also add a check in the entry builder constructor for `"undefined"`/`"null"` strings as the entry memo and then return an error if the check fails (entry builder does not have same error handling implemented that the payment flow builder has as yet).