### PR TITLE
fix: inconsistency between type definition and implementation

### DIFF
--- a/src/app/payments/send-intraledger.ts
+++ b/src/app/payments/send-intraledger.ts
@@ -61,7 +61,7 @@ export const intraledgerPaymentSendWalletId = async ({
   })
   const builderWithInvoice = paymentBuilder.withoutInvoice({
     uncheckedAmount,
-    description: memo,
+    description: memo || "",
   })
 
   const builderWithSenderWallet = builderWithInvoice.withSenderWallet(senderWallet)

--- a/src/domain/payments/index.types.d.ts
+++ b/src/domain/payments/index.types.d.ts
@@ -82,7 +82,7 @@ type LightningPaymentFlowBuilder<S extends WalletCurrency> = {
     description,
   }: {
     uncheckedAmount: number
-    description: string | null
+    description: string
   }): LPFBWithInvoice<S> | LPFBWithError
 }
 


### PR DESCRIPTION
For unknown reasons the typescript compiler didn't flag a difference
between type definition and implementation which allowed a `null` value
to be passed where none was assumed in the downstream code.