### PR TITLE
feat: add graphql endpoints to fetch all wallet id's and wallet

### DIFF
--- a/src/app/wallets/index.ts
+++ b/src/app/wallets/index.ts
@@ -23,3 +23,8 @@ export const listWalletsByAccountId = async (
 ): Promise<Wallet[] | RepositoryError> => {
   return WalletsRepository().listByAccountId(accountId)
 }
+
+export const getAllWalletIds = async (): Promise<WalletId[] | RepositoryError> => {
+  const walletIds = await WalletsRepository().listAllWalletIds()
+  return walletIds
+}

--- a/src/app/wallets/index.ts
+++ b/src/app/wallets/index.ts
@@ -24,7 +24,8 @@ export const listWalletsByAccountId = async (
   return WalletsRepository().listByAccountId(accountId)
 }
 
-export const getAllWalletIds = async (): Promise<WalletId[] | RepositoryError> => {
-  const walletIds = await WalletsRepository().listAllWalletIds()
-  return walletIds
+export const getAllWalletIds = async (
+  walletCurrency: WalletCurrency,
+): Promise<WalletId[] | RepositoryError> => {
+  return WalletsRepository().listAllWalletIds(walletCurrency)
 }

--- a/src/app/wallets/index.ts
+++ b/src/app/wallets/index.ts
@@ -24,8 +24,10 @@ export const listWalletsByAccountId = async (
   return WalletsRepository().listByAccountId(accountId)
 }
 
-export const getAllWalletIds = async (
+export const listWalletIds = async (
   walletCurrency: WalletCurrency,
 ): Promise<WalletId[] | RepositoryError> => {
-  return WalletsRepository().listAllWalletIds(walletCurrency)
+  const wallets = await WalletsRepository().listByWalletCurrency(walletCurrency)
+  if (wallets instanceof Error) return wallets
+  return wallets.map((wallet) => wallet.id)
 }

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -28,7 +28,7 @@ export class CouldNotFindWalletFromUsernameError extends CouldNotFindError {}
 export class CouldNotFindWalletFromUsernameAndCurrencyError extends CouldNotFindError {}
 export class CouldNotFindWalletFromOnChainAddressError extends CouldNotFindError {}
 export class CouldNotFindWalletFromOnChainAddressesError extends CouldNotFindError {}
-export class CouldNotListWalletIdError extends CouldNotFindError {}
+export class CouldNotListWalletsFromWalletCurrencyError extends CouldNotFindError {}
 export class CouldNotFindLnPaymentFromHashError extends CouldNotFindError {}
 export class NoTransactionToUpdateError extends CouldNotFindError {}
 export class CouldNotFindLightningPaymentFlowError extends CouldNotFindError {}

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -28,6 +28,7 @@ export class CouldNotFindWalletFromUsernameError extends CouldNotFindError {}
 export class CouldNotFindWalletFromUsernameAndCurrencyError extends CouldNotFindError {}
 export class CouldNotFindWalletFromOnChainAddressError extends CouldNotFindError {}
 export class CouldNotFindWalletFromOnChainAddressesError extends CouldNotFindError {}
+export class CouldNotListWalletIdError extends CouldNotFindError {}
 export class CouldNotFindLnPaymentFromHashError extends CouldNotFindError {}
 export class NoTransactionToUpdateError extends CouldNotFindError {}
 export class CouldNotFindLightningPaymentFlowError extends CouldNotFindError {}

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -186,7 +186,7 @@ interface IWalletsRepository {
 
   findByAddress(address: OnChainAddress): Promise<Wallet | RepositoryError>
   listByAddresses(addresses: OnChainAddress[]): Promise<Wallet[] | RepositoryError>
-  listAllWalletIds(): Promise<WalletId[] | RepositoryError>
+  listAllWalletIds(walletCurrency: WalletCurrency): Promise<WalletId[] | RepositoryError>
 }
 
 type onChainDepositFeeArgs = {

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -186,6 +186,7 @@ interface IWalletsRepository {
 
   findByAddress(address: OnChainAddress): Promise<Wallet | RepositoryError>
   listByAddresses(addresses: OnChainAddress[]): Promise<Wallet[] | RepositoryError>
+  listAllWalletIds(): Promise<WalletId[] | RepositoryError>
 }
 
 type onChainDepositFeeArgs = {

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -186,7 +186,9 @@ interface IWalletsRepository {
 
   findByAddress(address: OnChainAddress): Promise<Wallet | RepositoryError>
   listByAddresses(addresses: OnChainAddress[]): Promise<Wallet[] | RepositoryError>
-  listAllWalletIds(walletCurrency: WalletCurrency): Promise<WalletId[] | RepositoryError>
+  listByWalletCurrency(
+    walletCurrency: WalletCurrency,
+  ): Promise<Wallet[] | RepositoryError>
 }
 
 type onChainDepositFeeArgs = {

--- a/src/graphql/admin/queries.ts
+++ b/src/graphql/admin/queries.ts
@@ -7,6 +7,8 @@ import TransactionByIdQuery from "./root/query/transaction-by-id"
 import TransactionsByHashQuery from "./root/query/transactions-by-hash"
 import AccountDetailsByUserPhoneQuery from "./root/query/account-details-by-phone"
 import AccountDetailsByUsernameQuery from "./root/query/account-details-by-username"
+import AllWalletIdsQuery from "./root/query/all-walletids"
+import WalletQuery from "./root/query/wallet"
 
 const QueryType = GT.Object({
   name: "Query",
@@ -18,6 +20,8 @@ const QueryType = GT.Object({
     transactionsByHash: TransactionsByHashQuery,
     lightningInvoice: LightningInvoiceQuery,
     lightningPayment: LightningPaymentQuery,
+    allWalletIds: AllWalletIdsQuery,
+    wallet: WalletQuery,
   }),
 })
 

--- a/src/graphql/admin/queries.ts
+++ b/src/graphql/admin/queries.ts
@@ -7,7 +7,7 @@ import TransactionByIdQuery from "./root/query/transaction-by-id"
 import TransactionsByHashQuery from "./root/query/transactions-by-hash"
 import AccountDetailsByUserPhoneQuery from "./root/query/account-details-by-phone"
 import AccountDetailsByUsernameQuery from "./root/query/account-details-by-username"
-import AllWalletIdsQuery from "./root/query/all-walletids"
+import ListWalletIdsQuery from "./root/query/all-walletids"
 import WalletQuery from "./root/query/wallet"
 
 const QueryType = GT.Object({
@@ -20,7 +20,7 @@ const QueryType = GT.Object({
     transactionsByHash: TransactionsByHashQuery,
     lightningInvoice: LightningInvoiceQuery,
     lightningPayment: LightningPaymentQuery,
-    allWalletIds: AllWalletIdsQuery,
+    listWalletIds: ListWalletIdsQuery,
     wallet: WalletQuery,
   }),
 })

--- a/src/graphql/admin/root/query/all-walletids.ts
+++ b/src/graphql/admin/root/query/all-walletids.ts
@@ -1,12 +1,15 @@
 import { GT } from "@graphql/index"
 import { Wallets } from "@app"
+import WalletCurrency from "@graphql/types/scalar/wallet-currency"
 import WalletId from "@graphql/types/scalar/wallet-id"
 
 const AllWalletIdsQuery = GT.Field({
   type: GT.NonNullList(WalletId),
-  resolve: async () => {
-    const walletIds = await Wallets.getAllWalletIds()
-    return walletIds
+  args: {
+    walletCurrency: { type: GT.NonNull(WalletCurrency) },
+  },
+  resolve: async (_, { walletCurrency }) => {
+    return Wallets.getAllWalletIds(walletCurrency)
   },
 })
 

--- a/src/graphql/admin/root/query/all-walletids.ts
+++ b/src/graphql/admin/root/query/all-walletids.ts
@@ -3,14 +3,12 @@ import { Wallets } from "@app"
 import WalletCurrency from "@graphql/types/scalar/wallet-currency"
 import WalletId from "@graphql/types/scalar/wallet-id"
 
-const AllWalletIdsQuery = GT.Field({
+const ListWalletIdsQuery = GT.Field({
   type: GT.NonNullList(WalletId),
   args: {
     walletCurrency: { type: GT.NonNull(WalletCurrency) },
   },
-  resolve: async (_, { walletCurrency }) => {
-    return Wallets.getAllWalletIds(walletCurrency)
-  },
+  resolve: async (_, { walletCurrency }) => Wallets.listWalletIds(walletCurrency),
 })
 
-export default AllWalletIdsQuery
+export default ListWalletIdsQuery

--- a/src/graphql/admin/root/query/all-walletids.ts
+++ b/src/graphql/admin/root/query/all-walletids.ts
@@ -1,0 +1,13 @@
+import { GT } from "@graphql/index"
+import { Wallets } from "@app"
+import WalletId from "@graphql/types/scalar/wallet-id"
+
+const AllWalletIdsQuery = GT.Field({
+  type: GT.NonNullList(WalletId),
+  resolve: async () => {
+    const walletIds = await Wallets.getAllWalletIds()
+    return walletIds
+  },
+})
+
+export default AllWalletIdsQuery

--- a/src/graphql/admin/root/query/wallet.ts
+++ b/src/graphql/admin/root/query/wallet.ts
@@ -1,0 +1,17 @@
+import { Wallets } from "@app"
+import { GT } from "@graphql/index"
+import IWallet from "@graphql/types/abstract/wallet"
+import WalletId from "@graphql/types/scalar/wallet-id"
+
+const WalletQuery = GT.Field({
+  type: GT.NonNull(IWallet),
+  args: {
+    walletId: { type: GT.NonNull(WalletId) },
+  },
+  resolve: async (_, { walletId }) => {
+    const wallet = await Wallets.getWallet(walletId)
+    return wallet
+  },
+})
+
+export default WalletQuery

--- a/src/graphql/admin/root/query/wallet.ts
+++ b/src/graphql/admin/root/query/wallet.ts
@@ -9,8 +9,7 @@ const WalletQuery = GT.Field({
     walletId: { type: GT.NonNull(WalletId) },
   },
   resolve: async (_, { walletId }) => {
-    const wallet = await Wallets.getWallet(walletId)
-    return wallet
+    return Wallets.getWallet(walletId)
   },
 })
 

--- a/src/graphql/admin/root/query/wallet.ts
+++ b/src/graphql/admin/root/query/wallet.ts
@@ -8,9 +8,7 @@ const WalletQuery = GT.Field({
   args: {
     walletId: { type: GT.NonNull(WalletId) },
   },
-  resolve: async (_, { walletId }) => {
-    return Wallets.getWallet(walletId)
-  },
+  resolve: async (_, { walletId }) => Wallets.getWallet(walletId),
 })
 
 export default WalletQuery

--- a/src/graphql/admin/schema.graphql
+++ b/src/graphql/admin/schema.graphql
@@ -300,9 +300,9 @@ type Query {
   accountDetailsByUserPhone(phone: Phone!): Account!
   accountDetailsByUsername(username: Username!): Account!
   allLevels: [AccountLevel!]!
-  allWalletIds(walletCurrency: WalletCurrency!): [WalletId!]!
   lightningInvoice(hash: PaymentHash!): LightningInvoice!
   lightningPayment(hash: PaymentHash!): LightningPayment!
+  listWalletIds(walletCurrency: WalletCurrency!): [WalletId!]!
   transactionById(id: ID!): Transaction
   transactionsByHash(hash: PaymentHash!): [Transaction]
   wallet(walletId: WalletId!): Wallet!

--- a/src/graphql/admin/schema.graphql
+++ b/src/graphql/admin/schema.graphql
@@ -300,10 +300,12 @@ type Query {
   accountDetailsByUserPhone(phone: Phone!): Account!
   accountDetailsByUsername(username: Username!): Account!
   allLevels: [AccountLevel!]!
+  allWalletIds: [WalletId!]!
   lightningInvoice(hash: PaymentHash!): LightningInvoice!
   lightningPayment(hash: PaymentHash!): LightningPayment!
   transactionById(id: ID!): Transaction
   transactionsByHash(hash: PaymentHash!): [Transaction]
+  wallet(walletId: WalletId!): Wallet!
 }
 
 """

--- a/src/graphql/admin/schema.graphql
+++ b/src/graphql/admin/schema.graphql
@@ -300,7 +300,7 @@ type Query {
   accountDetailsByUserPhone(phone: Phone!): Account!
   accountDetailsByUsername(username: Username!): Account!
   allLevels: [AccountLevel!]!
-  allWalletIds: [WalletId!]!
+  allWalletIds(walletCurrency: WalletCurrency!): [WalletId!]!
   lightningInvoice(hash: PaymentHash!): LightningInvoice!
   lightningPayment(hash: PaymentHash!): LightningPayment!
   transactionById(id: ID!): Transaction

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -320,6 +320,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "CouldNotFindWalletFromUsernameAndCurrencyError":
     case "CouldNotFindWalletFromOnChainAddressError":
     case "CouldNotFindWalletFromOnChainAddressesError":
+    case "CouldNotListWalletIdError":
     case "CouldNotFindLnPaymentFromHashError":
     case "LockError":
     case "LockServiceError":

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -320,7 +320,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "CouldNotFindWalletFromUsernameAndCurrencyError":
     case "CouldNotFindWalletFromOnChainAddressError":
     case "CouldNotFindWalletFromOnChainAddressesError":
-    case "CouldNotListWalletIdError":
+    case "CouldNotListWalletsFromWalletCurrencyError":
     case "CouldNotFindLnPaymentFromHashError":
     case "LockError":
     case "LockServiceError":

--- a/src/servers/graphql-admin-server.ts
+++ b/src/servers/graphql-admin-server.ts
@@ -28,6 +28,8 @@ export async function startApolloServerForAdminSchema() {
         transactionsByHash: and(isAuthenticated, isEditor),
         lightningInvoice: and(isAuthenticated, isEditor),
         lightningPayment: and(isAuthenticated, isEditor),
+        wallet: and(isAuthenticated, isEditor),
+        allWalletIds: and(isAuthenticated, isEditor),
       },
       Mutation: {
         accountUpdateStatus: and(isAuthenticated, isEditor),

--- a/src/servers/graphql-admin-server.ts
+++ b/src/servers/graphql-admin-server.ts
@@ -29,7 +29,7 @@ export async function startApolloServerForAdminSchema() {
         lightningInvoice: and(isAuthenticated, isEditor),
         lightningPayment: and(isAuthenticated, isEditor),
         wallet: and(isAuthenticated, isEditor),
-        allWalletIds: and(isAuthenticated, isEditor),
+        listWalletIds: and(isAuthenticated, isEditor),
       },
       Mutation: {
         accountUpdateStatus: and(isAuthenticated, isEditor),

--- a/src/services/mongoose/wallets.ts
+++ b/src/services/mongoose/wallets.ts
@@ -3,7 +3,7 @@ import {
   CouldNotFindWalletFromOnChainAddressError,
   CouldNotFindWalletFromOnChainAddressesError,
   CouldNotListWalletsFromAccountIdError,
-  CouldNotListWalletIdError,
+  CouldNotListWalletsFromWalletCurrencyError,
   RepositoryError,
   UnknownRepositoryError,
 } from "@domain/errors"
@@ -103,16 +103,15 @@ export const WalletsRepository = (): IWalletsRepository => {
       return new UnknownRepositoryError(err)
     }
   }
-  const listAllWalletIds = async (
+  const listByWalletCurrency = async (
     walletCurrency: WalletCurrency,
-  ): Promise<WalletId[] | RepositoryError> => {
+  ): Promise<Wallet[] | RepositoryError> => {
     try {
-      const result: WalletRecord[] = await Wallet.find({ currency: walletCurrency })
+      const result = await Wallet.find({ currency: walletCurrency })
       if (!result) {
-        return new CouldNotListWalletIdError()
+        return new CouldNotListWalletsFromWalletCurrencyError()
       }
-      const walletIds = result.map(({ id }) => id as WalletId)
-      return walletIds
+      return result.map(resultToWallet)
     } catch (err) {
       return new UnknownRepositoryError(err)
     }
@@ -124,7 +123,7 @@ export const WalletsRepository = (): IWalletsRepository => {
     findByAddress,
     listByAddresses,
     persistNew,
-    listAllWalletIds,
+    listByWalletCurrency,
   }
 }
 

--- a/src/services/mongoose/wallets.ts
+++ b/src/services/mongoose/wallets.ts
@@ -3,6 +3,7 @@ import {
   CouldNotFindWalletFromOnChainAddressError,
   CouldNotFindWalletFromOnChainAddressesError,
   CouldNotListWalletsFromAccountIdError,
+  CouldNotListWalletIdError,
   RepositoryError,
   UnknownRepositoryError,
 } from "@domain/errors"
@@ -102,6 +103,18 @@ export const WalletsRepository = (): IWalletsRepository => {
       return new UnknownRepositoryError(err)
     }
   }
+  const listAllWalletIds = async (): Promise<WalletId[] | RepositoryError> => {
+    try {
+      const result: WalletRecord[] = await Wallet.find({})
+      if (!result || result.length === 0) {
+        return new CouldNotListWalletIdError()
+      }
+      const walletIds = result.map(({ id }) => id as WalletId)
+      return walletIds
+    } catch (err) {
+      return new UnknownRepositoryError(err)
+    }
+  }
 
   return {
     findById,
@@ -109,6 +122,7 @@ export const WalletsRepository = (): IWalletsRepository => {
     findByAddress,
     listByAddresses,
     persistNew,
+    listAllWalletIds,
   }
 }
 

--- a/src/services/mongoose/wallets.ts
+++ b/src/services/mongoose/wallets.ts
@@ -103,10 +103,12 @@ export const WalletsRepository = (): IWalletsRepository => {
       return new UnknownRepositoryError(err)
     }
   }
-  const listAllWalletIds = async (): Promise<WalletId[] | RepositoryError> => {
+  const listAllWalletIds = async (
+    walletCurrency: WalletCurrency,
+  ): Promise<WalletId[] | RepositoryError> => {
     try {
-      const result: WalletRecord[] = await Wallet.find({})
-      if (!result || result.length === 0) {
+      const result: WalletRecord[] = await Wallet.find({ currency: walletCurrency })
+      if (!result) {
         return new CouldNotListWalletIdError()
       }
       const walletIds = result.map(({ id }) => id as WalletId)

--- a/src/services/mongoose/wallets.ts
+++ b/src/services/mongoose/wallets.ts
@@ -103,6 +103,8 @@ export const WalletsRepository = (): IWalletsRepository => {
       return new UnknownRepositoryError(err)
     }
   }
+  // TODO: future performance improvement might be needed
+  // add pagination for instance which would have millions of wallets
   const listByWalletCurrency = async (
     walletCurrency: WalletCurrency,
   ): Promise<Wallet[] | RepositoryError> => {


### PR DESCRIPTION
This PR adds two new endpoints in the admin Graphql query. An `allWalletIds` query that returns a list of all the wallet id's and a `wallet` query that returns an individual wallet based on the `walletId` passed.