### PR TITLE
why does this compile

### DIFF
--- a/src/app/payments/send-intraledger.ts
+++ b/src/app/payments/send-intraledger.ts
@@ -61,7 +61,7 @@ export const intraledgerPaymentSendWalletId = async ({
   })
   const builderWithInvoice = paymentBuilder.withoutInvoice({
     uncheckedAmount,
-    description: memo || "",
+    description: memo,
   })
 
   const builderWithSenderWallet = builderWithInvoice.withSenderWallet(senderWallet)

--- a/src/domain/payments/index.types.d.ts
+++ b/src/domain/payments/index.types.d.ts
@@ -82,7 +82,7 @@ type LightningPaymentFlowBuilder<S extends WalletCurrency> = {
     description,
   }: {
     uncheckedAmount: number
-    description: string | null
+    description: string
   }): LPFBWithInvoice<S> | LPFBWithError
 }
 

--- a/src/domain/payments/index.types.d.ts
+++ b/src/domain/payments/index.types.d.ts
@@ -82,7 +82,7 @@ type LightningPaymentFlowBuilder<S extends WalletCurrency> = {
     description,
   }: {
     uncheckedAmount: number
-    description: string
+    description: string | null
   }): LPFBWithInvoice<S> | LPFBWithError
 }
 

--- a/src/domain/payments/payment-flow-builder.ts
+++ b/src/domain/payments/payment-flow-builder.ts
@@ -41,7 +41,7 @@ export const LightningPaymentFlowBuilder = <S extends WalletCurrency>(
     }
   }
 
-  const withInvoice = (invoice: LnInvoice): LPFBWithInvoice<S> | LPFBWithError => {
+  const withInvoice: LightningPaymentFlowBuilder<S>["withInvoice"] = (invoice) => {
     if (invoice.paymentAmount === null) {
       return LPFBWithError(
         new InvalidLightningPaymentFlowBuilderStateError(
@@ -60,13 +60,10 @@ export const LightningPaymentFlowBuilder = <S extends WalletCurrency>(
     })
   }
 
-  const withNoAmountInvoice = ({
+  const withNoAmountInvoice: LightningPaymentFlowBuilder<S>["withNoAmountInvoice"] = ({
     invoice,
     uncheckedAmount,
-  }: {
-    invoice: LnInvoice
-    uncheckedAmount: number
-  }): LPFBWithInvoice<S> | LPFBWithError => {
+  }) => {
     return LPFBWithInvoice({
       ...config,
       ...settlementMethodFromDestination(invoice.destination),
@@ -77,10 +74,10 @@ export const LightningPaymentFlowBuilder = <S extends WalletCurrency>(
     })
   }
 
-  const withoutInvoice = ({
+  const withoutInvoice: LightningPaymentFlowBuilder<S>["withoutInvoice"] = ({
     uncheckedAmount,
     description,
-  }): LPFBWithInvoice<S> | LPFBWithError => {
+  }) => {
     return LPFBWithInvoice({
       ...config,
       ...settlementMethodFromDestination(undefined),

--- a/src/domain/payments/payment-flow-builder.ts
+++ b/src/domain/payments/payment-flow-builder.ts
@@ -80,9 +80,6 @@ export const LightningPaymentFlowBuilder = <S extends WalletCurrency>(
   const withoutInvoice = ({
     uncheckedAmount,
     description,
-  }: {
-    uncheckedAmount: number
-    description: string
   }): LPFBWithInvoice<S> | LPFBWithError => {
     return LPFBWithInvoice({
       ...config,
@@ -90,6 +87,8 @@ export const LightningPaymentFlowBuilder = <S extends WalletCurrency>(
       paymentInitiationMethod: PaymentInitiationMethod.IntraLedger,
       intraLedgerHash: generateIntraLedgerHash(),
       uncheckedAmount,
+      // @Samer why does this compile? description can be null
+      // descriptionFromInvoice: string
       descriptionFromInvoice: description,
     })
   }


### PR DESCRIPTION
`make check-code` fails without the type definitions in the method
```
(130) $ make check-code
yarn tsc-check-noimplicitany
yarn run v1.22.18
$ tsc --noEmit -p tsconfig.no-implicit-any.json --skipLibCheck
src/domain/payments/payment-flow-builder.ts:81:5 - error TS7031: Binding element 'uncheckedAmount' implicitly has an 'any' type.

81     uncheckedAmount,
       ~~~~~~~~~~~~~~~

src/domain/payments/payment-flow-builder.ts:82:5 - error TS7031: Binding element 'description' implicitly has an 'any' type.

82     description,
       ~~~~~~~~~~~


Found 2 errors in the same file, starting at: src/domain/payments/payment-flow-builder.ts:81

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
make: *** [check-implicit] Error 2
```