### PR TITLE
feat: switch invoice generation to hodl invoices & external preimages

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -75,6 +75,7 @@ test_accounts:
 - ref: F
   phone: "+16505554333"
   code: "321321"
+  needUsdWallet: true
 - ref: "G"
   phone: "+16505554335"
   code: "321321"

--- a/src/app/wallets/get-balance-for-wallet.ts
+++ b/src/app/wallets/get-balance-for-wallet.ts
@@ -1,8 +1,6 @@
 import { LedgerService } from "@services/ledger"
 import { updatePendingPaymentsByWalletId } from "@app/payments"
 
-import { updatePendingInvoicesByWalletId } from "./update-pending-invoices"
-
 export const getBalanceForWallet = async ({
   walletId,
   logger,
@@ -10,16 +8,10 @@ export const getBalanceForWallet = async ({
   walletId: WalletId
   logger: Logger
 }): Promise<CurrencyBaseAmount | ApplicationError> => {
-  const [, updatePaymentsResult] = await Promise.all([
-    updatePendingInvoicesByWalletId({
-      walletId,
-      logger,
-    }),
-    updatePendingPaymentsByWalletId({
-      walletId,
-      logger,
-    }),
-  ])
+  const updatePaymentsResult = await updatePendingPaymentsByWalletId({
+    walletId,
+    logger,
+  })
   if (updatePaymentsResult instanceof Error) return updatePaymentsResult
 
   return LedgerService().getWalletBalance(walletId)

--- a/src/app/wallets/update-pending-invoices.ts
+++ b/src/app/wallets/update-pending-invoices.ts
@@ -12,55 +12,34 @@ import {
   WalletsRepository,
 } from "@services/mongoose"
 import { NotificationsService } from "@services/notifications"
-import { runInParallel } from "@utils"
+import { elapsedSinceTimestamp, runInParallel } from "@utils"
 import { WalletInvoiceReceiver } from "@domain/wallet-invoices/wallet-invoice-receiver"
 import * as LedgerFacade from "@services/ledger/facade"
 import { usdFromBtcMidPriceFn } from "@app/shared"
 
-export const updatePendingInvoices = async (logger: Logger): Promise<void> => {
+export const declineHeldInvoices = async (logger: Logger): Promise<void> => {
   const invoicesRepo = WalletInvoicesRepository()
 
-  const walletIdsWithPendingInvoices = invoicesRepo.listWalletIdsWithPendingInvoices()
+  const pendingInvoices = invoicesRepo.yieldPending()
 
-  if (walletIdsWithPendingInvoices instanceof Error) {
+  if (pendingInvoices instanceof Error) {
     logger.error(
-      { error: walletIdsWithPendingInvoices },
+      { error: pendingInvoices },
       "finish updating pending invoices with error",
     )
     return
   }
 
   await runInParallel({
-    iterator: walletIdsWithPendingInvoices,
+    iterator: pendingInvoices,
     logger,
-    processor: async (walletId: WalletId, index: number) => {
-      logger.trace(
-        "updating pending invoices for wallet %s in worker %d",
-        walletId,
-        index,
-      )
-      await updatePendingInvoicesByWalletId({ walletId, logger })
+    processor: async (walletInvoice: WalletInvoice, index: number) => {
+      logger.trace("updating pending invoices %s in worker %d", index)
+      await declineHeldInvoice({ walletInvoice, logger })
     },
   })
 
   logger.info("finish updating pending invoices")
-}
-
-export const updatePendingInvoicesByWalletId = async ({
-  walletId,
-  logger,
-}: {
-  walletId: WalletId
-  logger: Logger
-}) => {
-  const invoicesRepo = WalletInvoicesRepository()
-
-  const invoices = invoicesRepo.findPendingByWalletId(walletId)
-  if (invoices instanceof Error) return invoices
-
-  for await (const walletInvoice of invoices) {
-    await updatePendingInvoice({ walletInvoice, logger })
-  }
 }
 
 export const updatePendingInvoiceByPaymentHash = async ({
@@ -94,31 +73,7 @@ const updatePendingInvoice = async ({
 
   const walletInvoicesRepo = WalletInvoicesRepository()
 
-  const { pubkey, paymentHash, recipientWalletDescriptor } = walletInvoice
-
-  const lnInvoiceLookup = await lndService.lookupInvoice({ pubkey, paymentHash })
-  if (lnInvoiceLookup instanceof InvoiceNotFoundError) {
-    const isDeleted = await walletInvoicesRepo.deleteByPaymentHash(paymentHash)
-    if (isDeleted instanceof Error) {
-      logger.error(
-        { walletInvoice, error: isDeleted },
-        "impossible to delete WalletInvoice entry",
-      )
-      return isDeleted
-    }
-    return false
-  }
-  if (lnInvoiceLookup instanceof Error) return lnInvoiceLookup
-
-  if (!lnInvoiceLookup.isSettled) {
-    logger.debug({ invoice: lnInvoiceLookup }, "invoice has not been paid")
-    return false
-  }
-
-  const {
-    lnInvoice: { description },
-    roundedDownReceived,
-  } = lnInvoiceLookup
+  const { pubkey, paymentHash, secret, recipientWalletDescriptor } = walletInvoice
 
   const pendingInvoiceLogger = logger.child({
     hash: paymentHash,
@@ -129,9 +84,30 @@ const updatePendingInvoice = async ({
     onUs: false,
   })
 
+  const lnInvoiceLookup = await lndService.lookupInvoice({ pubkey, paymentHash })
+  if (lnInvoiceLookup instanceof InvoiceNotFoundError) {
+    const isDeleted = await walletInvoicesRepo.deleteByPaymentHash(paymentHash)
+    if (isDeleted instanceof Error) {
+      pendingInvoiceLogger.error("impossible to delete WalletInvoice entry")
+      return isDeleted
+    }
+    return false
+  }
+  if (lnInvoiceLookup instanceof Error) return lnInvoiceLookup
+
+  const {
+    lnInvoice: { description },
+    roundedDownReceived,
+  } = lnInvoiceLookup
+
   if (walletInvoice.paid) {
     pendingInvoiceLogger.info("invoice has already been processed")
     return true
+  }
+
+  if (!lnInvoiceLookup.isHeld) {
+    pendingInvoiceLogger.info("invoice has not been paid yet")
+    return false
   }
 
   const receivedBtc = paymentAmountFromNumber({
@@ -157,7 +133,7 @@ const updatePendingInvoice = async ({
       return false
     }
     if (invoiceToUpdate instanceof Error) return invoiceToUpdate
-    if (invoiceToUpdate.paid) {
+    if (walletInvoice.paid) {
       pendingInvoiceLogger.info("invoice has already been processed")
       return true
     }
@@ -165,13 +141,16 @@ const updatePendingInvoice = async ({
     const displayCurrencyPerSat = await getCurrentPrice()
     if (displayCurrencyPerSat instanceof Error) return displayCurrencyPerSat
 
+    const invoiceSettled = await lndService.settleInvoice({ pubkey, secret })
+    if (invoiceSettled instanceof Error) return invoiceSettled
+
+    const invoicePaid = await walletInvoicesRepo.markAsPaid(paymentHash)
+    if (invoicePaid instanceof Error) return invoicePaid
+
     // TODO: this should be a in a mongodb transaction session with the ledger transaction below
     // markAsPaid could be done after the transaction, but we should in that case not only look
     // for walletInvoicesRepo, but also in the ledger to make sure in case the process crash in this
     // loop that an eventual consistency doesn't lead to a double credit
-
-    const invoicePaid = await walletInvoicesRepo.markAsPaid(paymentHash)
-    if (invoicePaid instanceof Error) return invoicePaid
 
     const metadata = LedgerFacade.LnReceiveLedgerMetadata({
       paymentHash,
@@ -237,4 +216,65 @@ const updatePendingInvoice = async ({
 
     return true
   })
+}
+
+const declineHeldInvoice = async ({
+  walletInvoice,
+  logger,
+}: {
+  walletInvoice: WalletInvoice
+  logger: Logger
+}): Promise<boolean | ApplicationError> => {
+  const lndService = LndService()
+  if (lndService instanceof Error) return lndService
+
+  const walletInvoicesRepo = WalletInvoicesRepository()
+
+  const { pubkey, paymentHash } = walletInvoice
+
+  const lnInvoiceLookup = await lndService.lookupInvoice({ pubkey, paymentHash })
+
+  const pendingInvoiceLogger = logger.child({
+    hash: paymentHash,
+    lnInvoiceLookup,
+    walletInvoice,
+    topic: "payment",
+    protocol: "lightning",
+    transactionType: "receipt",
+    onUs: false,
+  })
+
+  if (lnInvoiceLookup instanceof InvoiceNotFoundError) {
+    const isDeleted = await walletInvoicesRepo.deleteByPaymentHash(paymentHash)
+    if (isDeleted instanceof Error) {
+      pendingInvoiceLogger.error("impossible to delete WalletInvoice entry")
+      return isDeleted
+    }
+    return false
+  }
+  if (lnInvoiceLookup instanceof Error) return lnInvoiceLookup
+
+  if (!lnInvoiceLookup.isHeld) {
+    pendingInvoiceLogger.info({ lnInvoiceLookup }, "invoice has not been paid yet")
+    return false
+  }
+
+  let heldForMsg = ""
+  if (lnInvoiceLookup.heldAt) {
+    heldForMsg = `for ${elapsedSinceTimestamp(lnInvoiceLookup.heldAt)}s `
+  }
+  pendingInvoiceLogger.error(
+    { lnInvoiceLookup },
+    `invoice has been held ${heldForMsg}and is now been cancelled`,
+  )
+
+  const invoiceSettled = await lndService.cancelInvoice({ pubkey, paymentHash })
+  if (invoiceSettled instanceof Error) return invoiceSettled
+
+  const isDeleted = await walletInvoicesRepo.deleteByPaymentHash(paymentHash)
+  if (isDeleted instanceof Error) {
+    pendingInvoiceLogger.error("impossible to delete WalletInvoice entry")
+  }
+
+  return true
 }

--- a/src/app/wallets/update-pending-invoices.ts
+++ b/src/app/wallets/update-pending-invoices.ts
@@ -112,7 +112,7 @@ const updatePendingInvoice = async ({
     return true
   }
 
-  if (!lnInvoiceLookup.isHeld) {
+  if (!lnInvoiceLookup.isHeld && !lnInvoiceLookup.isSettled) {
     pendingInvoiceLogger.info("invoice has not been paid yet")
     return false
   }
@@ -148,8 +148,10 @@ const updatePendingInvoice = async ({
     const displayCurrencyPerSat = await getCurrentPrice()
     if (displayCurrencyPerSat instanceof Error) return displayCurrencyPerSat
 
-    const invoiceSettled = await lndService.settleInvoice({ pubkey, secret })
-    if (invoiceSettled instanceof Error) return invoiceSettled
+    if (!lnInvoiceLookup.isSettled) {
+      const invoiceSettled = await lndService.settleInvoice({ pubkey, secret })
+      if (invoiceSettled instanceof Error) return invoiceSettled
+    }
 
     const invoicePaid = await walletInvoicesRepo.markAsPaid(paymentHash)
     if (invoicePaid instanceof Error) return invoicePaid

--- a/src/app/wallets/update-pending-invoices.ts
+++ b/src/app/wallets/update-pending-invoices.ts
@@ -263,6 +263,14 @@ export const declineHeldInvoice = async ({
   }
   if (lnInvoiceLookup instanceof Error) return lnInvoiceLookup
 
+  // FIXME: This is just to support transition to hodl invoices
+  // TODO: REMOVE THIS after hodl invoices has been deployed for 24 hours.
+  if (lnInvoiceLookup.isSettled) {
+    const walletInvoice = await WalletInvoicesRepository().findByPaymentHash(paymentHash)
+    if (walletInvoice instanceof Error) return walletInvoice
+    return updatePendingInvoice({ walletInvoice, logger })
+  }
+
   if (!lnInvoiceLookup.isHeld) {
     pendingInvoiceLogger.info({ lnInvoiceLookup }, "invoice has not been paid yet")
     return false

--- a/src/domain/bitcoin/lightning/errors.ts
+++ b/src/domain/bitcoin/lightning/errors.ts
@@ -13,6 +13,10 @@ export class CouldNotDecodeReturnedPaymentRequest extends LightningServiceError 
 export class UnknownLightningServiceError extends LightningServiceError {
   level = ErrorLevel.Critical
 }
+export class SecretDoesNotMatchAnyExistingHodlInvoiceError extends LightningServiceError {
+  level = ErrorLevel.Critical
+}
+
 export class InvoiceNotFoundError extends LightningServiceError {}
 export class LnPaymentPendingError extends LightningServiceError {}
 export class LnAlreadyPaidError extends LightningServiceError {}

--- a/src/domain/bitcoin/lightning/index.ts
+++ b/src/domain/bitcoin/lightning/index.ts
@@ -1,3 +1,5 @@
+import { createHash, randomBytes } from "crypto"
+
 import { InvalidPubKeyError } from "@domain/errors"
 
 export { decodeInvoice } from "./ln-invoice"
@@ -38,4 +40,15 @@ export const parseFinalHopsFromInvoice = (invoice: LnInvoice): Pubkey[] => {
     pubkeys.push(lastHop.nodePubkey)
   }
   return Array.from(new Set(pubkeys))
+}
+
+export const sha256 = (buffer: Buffer) =>
+  createHash("sha256").update(buffer).digest("hex")
+const randomSecret = () => randomBytes(32)
+
+export const getSecretAndPaymentHash = () => {
+  const secret = randomSecret()
+  const paymentHash = sha256(secret) as PaymentHash
+
+  return { secret: secret.toString("hex") as SecretPreImage, paymentHash }
 }

--- a/src/domain/bitcoin/lightning/index.types.d.ts
+++ b/src/domain/bitcoin/lightning/index.types.d.ts
@@ -50,6 +50,8 @@ type LnInvoiceLookup = {
   readonly createdAt: Date
   readonly confirmedAt: Date | undefined
   readonly isSettled: boolean
+  readonly isHeld: boolean
+  readonly heldAt: Date | undefined
   readonly roundedDownReceived: Satoshis
   readonly milliSatsReceived: MilliSatoshis
   readonly secretPreImage: SecretPreImage
@@ -109,6 +111,7 @@ type LnInvoice = {
 }
 
 type RegisterInvoiceArgs = {
+  paymentHash: PaymentHash
   description: string
   descriptionHash?: string
   sats: Satoshis
@@ -116,6 +119,7 @@ type RegisterInvoiceArgs = {
 }
 
 type NewRegisterInvoiceArgs = {
+  paymentHash: PaymentHash
   description: string
   descriptionHash?: string
   btcPaymentAmount: BtcPaymentAmount
@@ -217,6 +221,14 @@ interface ILightningService {
   }: {
     paymentHash: PaymentHash
     pubkey?: Pubkey
+  }): Promise<true | LightningServiceError>
+
+  settleInvoice({
+    pubkey,
+    secret,
+  }: {
+    pubkey: Pubkey
+    secret: SecretPreImage
   }): Promise<true | LightningServiceError>
 
   cancelInvoice({

--- a/src/domain/bitcoin/lightning/index.types.d.ts
+++ b/src/domain/bitcoin/lightning/index.types.d.ts
@@ -47,6 +47,7 @@ type LnInvoiceFeature = {
 }
 
 type LnInvoiceLookup = {
+  readonly paymentHash: PaymentHash
   readonly createdAt: Date
   readonly confirmedAt: Date | undefined
   readonly isSettled: boolean
@@ -214,6 +215,8 @@ interface ILightningService {
   ): Promise<ListLnPaymentsResult | LightningServiceError>
 
   listFailedPayments: ListLnPayments
+
+  listInvoices(lnd: AuthenticatedLnd): Promise<LnInvoiceLookup[] | LightningServiceError>
 
   deletePaymentByHash({
     paymentHash,

--- a/src/domain/wallet-invoices/errors.ts
+++ b/src/domain/wallet-invoices/errors.ts
@@ -1,0 +1,5 @@
+import { ValidationError, ErrorLevel } from "@domain/shared"
+
+export class InvalidWalletInvoiceBuilderStateError extends ValidationError {
+  level = ErrorLevel.Critical
+}

--- a/src/domain/wallet-invoices/index.types.d.ts
+++ b/src/domain/wallet-invoices/index.types.d.ts
@@ -68,6 +68,7 @@ type WIBWithAmount = {
 
 type WalletInvoice = {
   paymentHash: PaymentHash
+  secret: SecretPreImage
   selfGenerated: boolean
   pubkey: Pubkey
   usdAmount?: UsdPaymentAmount
@@ -108,11 +109,7 @@ interface IWalletInvoicesRepository {
     paymentHash: PaymentHash,
   ) => Promise<WalletInvoice | RepositoryError>
 
-  findPendingByWalletId: (
-    walletId: WalletId,
-  ) => AsyncGenerator<WalletInvoice> | RepositoryError
-
-  listWalletIdsWithPendingInvoices: () => AsyncGenerator<WalletId> | RepositoryError
+  yieldPending: () => AsyncGenerator<WalletInvoice> | RepositoryError
 
   deleteByPaymentHash: (paymentHash: PaymentHash) => Promise<boolean | RepositoryError>
 

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -416,6 +416,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "InvalidFeeProbeStateError":
     case "InvalidPubKeyError":
     case "SkipProbeForPubkeyError":
+    case "SecretDoesNotMatchAnyExistingHodlInvoiceError":
       message = `Unknown error occurred (code: ${error.name}${
         error.message ? ": " + error.message : ""
       })`

--- a/src/servers/cron.ts
+++ b/src/servers/cron.ts
@@ -26,7 +26,7 @@ const main = async () => {
     if (result instanceof Error) throw result
   }
 
-  const updatePendingLightningInvoices = () => Wallets.updatePendingInvoices(logger)
+  const updatePendingLightningInvoices = () => Wallets.declineHeldInvoices(logger)
 
   const updatePendingLightningPayments = () => Payments.updatePendingPayments(logger)
 

--- a/src/servers/cron.ts
+++ b/src/servers/cron.ts
@@ -26,7 +26,7 @@ const main = async () => {
     if (result instanceof Error) throw result
   }
 
-  const updatePendingLightningInvoices = () => Wallets.declineHeldInvoices(logger)
+  const updatePendingLightningInvoices = () => Wallets.handleHeldInvoices(logger)
 
   const updatePendingLightningPayments = () => Payments.updatePendingPayments(logger)
 

--- a/src/servers/trigger.ts
+++ b/src/servers/trigger.ts
@@ -181,7 +181,7 @@ export const onchainBlockEventHandler = async (height: number) => {
 export const invoiceUpdateEventHandler = async (invoice: GetInvoiceResult) => {
   logger.info({ invoice }, "invoiceUpdateEventHandler")
 
-  if (!invoice.is_confirmed) {
+  if (!invoice.is_held) {
     return
   }
 

--- a/src/servers/trigger.ts
+++ b/src/servers/trigger.ts
@@ -24,14 +24,14 @@ import { uploadBackup } from "@app/admin/backup"
 import { toSats } from "@domain/bitcoin"
 import { CacheKeys } from "@domain/cache"
 import { DisplayCurrency, DisplayCurrencyConverter } from "@domain/fiat"
-import { WalletCurrency } from "@domain/shared"
+import { ErrorLevel, WalletCurrency } from "@domain/shared"
 
 import { baseLogger } from "@services/logger"
 import { LedgerService } from "@services/ledger"
 import { RedisCacheService } from "@services/cache"
 import { onChannelUpdated } from "@services/lnd/utils"
 import { setupMongoConnection } from "@services/mongodb"
-import { wrapAsyncToRunInSpan } from "@services/tracing"
+import { recordExceptionInCurrentSpan, wrapAsyncToRunInSpan } from "@services/tracing"
 import { NotificationsService } from "@services/notifications"
 import { activateLndHealthCheck, lndStatusEvent } from "@services/lnd/health"
 import {
@@ -225,6 +225,11 @@ const listenerOnchain = (lnd: AuthenticatedLnd) => {
 
   subTransactions.on("error", (err) => {
     baseLogger.error({ err }, "error subTransactions")
+    recordExceptionInCurrentSpan({
+      error: err,
+      level: ErrorLevel.Warn,
+      attributes: { ["error.subscription"]: "subTransactions" },
+    })
   })
 
   const subBlocks = subscribeToBlocks({ lnd })
@@ -238,6 +243,11 @@ const listenerOnchain = (lnd: AuthenticatedLnd) => {
 
   subBlocks.on("error", (err) => {
     baseLogger.error({ err }, "error subBlocks")
+    recordExceptionInCurrentSpan({
+      error: err,
+      level: ErrorLevel.Warn,
+      attributes: { ["error.subscription"]: "subBlocks" },
+    })
   })
 }
 
@@ -266,6 +276,11 @@ const listenerHodlInvoice = ({
   )
   subInvoice.on("error", (err) => {
     baseLogger.info({ err }, "error subChannels")
+    recordExceptionInCurrentSpan({
+      error: err,
+      level: ErrorLevel.Warn,
+      attributes: { ["error.subscription"]: "subChannels" },
+    })
     subInvoice.removeAllListeners()
   })
 }
@@ -318,6 +333,11 @@ export const setupInvoiceSubscribe = ({
   )
   subInvoices.on("error", (err) => {
     baseLogger.info({ err }, "error subInvoices")
+    recordExceptionInCurrentSpan({
+      error: err,
+      level: ErrorLevel.Warn,
+      attributes: { ["error.subscription"]: "subInvoices" },
+    })
     subInvoices.removeAllListeners()
   })
 
@@ -338,6 +358,11 @@ const listenerOffchain = ({ lnd, pubkey }: { lnd: AuthenticatedLnd; pubkey: Pubk
   )
   subChannels.on("error", (err) => {
     baseLogger.info({ err }, "error subChannels")
+    recordExceptionInCurrentSpan({
+      error: err,
+      level: ErrorLevel.Warn,
+      attributes: { ["error.subscription"]: "subChannels" },
+    })
     subChannels.removeAllListeners()
   })
 
@@ -352,6 +377,11 @@ const listenerOffchain = ({ lnd, pubkey }: { lnd: AuthenticatedLnd; pubkey: Pubk
 
   subBackups.on("error", (err) => {
     baseLogger.info({ err }, "error subBackups")
+    recordExceptionInCurrentSpan({
+      error: err,
+      level: ErrorLevel.Warn,
+      attributes: { ["error.subscription"]: "subBackups" },
+    })
     subBackups.removeAllListeners()
   })
 }

--- a/src/servers/trigger.ts
+++ b/src/servers/trigger.ts
@@ -257,7 +257,7 @@ const listenerHodlInvoice = ({
   subInvoice.on(
     "invoice_updated",
     async (invoice: SubscribeToInvoiceInvoiceUpdatedEvent) => {
-      if (invoice.is_confirmed === true) {
+      if (invoice.is_confirmed || invoice.is_canceled) {
         subInvoice.removeAllListeners()
       } else {
         await invoiceUpdateHandler(invoice)

--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -694,7 +694,7 @@ const lookupPaymentByPubkeyAndHash = async ({
   }
 }
 
-const KnownLndErrorDetails = {
+export const KnownLndErrorDetails = {
   InsufficientBalance: "insufficient local balance",
   InvoiceNotFound: "unable to locate invoice",
   InvoiceAlreadyPaid: "invoice is already paid",

--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -1,6 +1,6 @@
 import {
   cancelHodlInvoice,
-  createInvoice,
+  createHodlInvoice,
   getChannelBalance,
   getClosedChannels,
   getFailedPayments,
@@ -17,6 +17,7 @@ import {
   payViaRoutes,
   PayViaRoutesResult,
   deletePayment,
+  settleHodlInvoice,
 } from "lightning"
 import lnService from "ln-service"
 
@@ -41,6 +42,7 @@ import {
   ProbeForRouteTimedOutError,
   ProbeForRouteTimedOutFromApplicationError,
   RouteNotFoundError,
+  SecretDoesNotMatchAnyExistingHodlInvoiceError,
   UnknownLightningServiceError,
   UnknownRouteNotFoundError,
 } from "@domain/bitcoin/lightning"
@@ -254,6 +256,7 @@ export const LndService = (): ILightningService | LightningServiceError => {
   }
 
   const registerInvoice = async ({
+    paymentHash,
     sats,
     description,
     descriptionHash,
@@ -261,6 +264,7 @@ export const LndService = (): ILightningService | LightningServiceError => {
   }: RegisterInvoiceArgs): Promise<RegisteredInvoice | LightningServiceError> => {
     const input = {
       lnd: defaultLnd,
+      id: paymentHash,
       description,
       description_hash: descriptionHash,
       tokens: sats as number,
@@ -268,7 +272,7 @@ export const LndService = (): ILightningService | LightningServiceError => {
     }
 
     try {
-      const result = await createInvoice(input)
+      const result = await createHodlInvoice(input)
       const request = result.request as EncodedPaymentRequest
       const returnedInvoice = decodeInvoice(request)
       if (returnedInvoice instanceof Error) {
@@ -308,6 +312,11 @@ export const LndService = (): ILightningService | LightningServiceError => {
         createdAt: new Date(invoice.created_at),
         confirmedAt: invoice.confirmed_at ? new Date(invoice.confirmed_at) : undefined,
         isSettled: !!invoice.is_confirmed,
+        isHeld: !!invoice.is_held,
+        heldAt:
+          invoice.payments && invoice.payments.length
+            ? new Date(invoice.payments[0].created_at)
+            : undefined,
         roundedDownReceived: toSats(invoice.received),
         milliSatsReceived: toMilliSatsFromString(invoice.received_mtokens),
         secretPreImage: invoice.secret as SecretPreImage,
@@ -436,6 +445,31 @@ export const LndService = (): ILightningService | LightningServiceError => {
           return false
         default:
           return new UnknownRouteNotFoundError(err)
+      }
+    }
+  }
+
+  const settleInvoice = async ({
+    pubkey,
+    secret,
+  }: {
+    pubkey: Pubkey
+    secret: SecretPreImage
+  }): Promise<true | LightningServiceError> => {
+    try {
+      const lnd = getLndFromPubkey({ pubkey })
+      if (lnd instanceof Error) return lnd
+
+      // Use the secret to claim the funds
+      await settleHodlInvoice({ lnd, secret })
+      return true
+    } catch (err) {
+      const errDetails = parseLndErrorDetails(err)
+      switch (errDetails) {
+        case KnownLndErrorDetails.SecretDoesNotMatchAnyExistingHodlInvoice:
+          return new SecretDoesNotMatchAnyExistingHodlInvoiceError(err)
+        default:
+          return new UnknownLightningServiceError(err)
       }
     }
   }
@@ -579,6 +613,7 @@ export const LndService = (): ILightningService | LightningServiceError => {
       listPendingPayments: listPaymentsFactory(getPendingPayments),
       listFailedPayments,
       deletePaymentByHash,
+      settleInvoice,
       cancelInvoice,
       payInvoiceViaRoutes,
       payInvoiceViaPaymentDetails,
@@ -663,6 +698,7 @@ const KnownLndErrorDetails = {
   SentPaymentNotFound: "SentPaymentNotFound",
   PaymentInTransition: "payment is in transition",
   PaymentForDeleteNotFound: "non bucket element in payments bucket",
+  SecretDoesNotMatchAnyExistingHodlInvoice: "SecretDoesNotMatchAnyExistingHodlInvoice",
 } as const
 
 /* eslint @typescript-eslint/ban-ts-comment: "off" */

--- a/src/services/mongoose/schema.ts
+++ b/src/services/mongoose/schema.ts
@@ -44,6 +44,12 @@ const walletInvoiceSchema = new Schema<WalletInvoiceRecord>({
     },
   },
 
+  secret: {
+    required: true,
+    type: String,
+    length: 64,
+  },
+
   currency: {
     required: true,
     type: String,

--- a/src/services/mongoose/schema.types.d.ts
+++ b/src/services/mongoose/schema.types.d.ts
@@ -65,6 +65,7 @@ interface WalletInvoiceRecord {
   _id: string
   walletId: string
   cents: number
+  secret: string
   currency: string
   timestamp: Date
   selfGenerated: boolean

--- a/test/e2e/trigger.spec.ts
+++ b/test/e2e/trigger.spec.ts
@@ -202,7 +202,9 @@ describe("onchainBlockEventHandler", () => {
     expect(lnInvoice).not.toBeInstanceOf(Error)
 
     const { paymentRequest: request } = lnInvoice as LnInvoice
-    await pay({ lnd: lndOutside1, request })
+    pay({ lnd: lndOutside1, request })
+
+    await sleep(250)
 
     const hash = getHash(request)
     const invoice = await getInvoice({ id: hash, lnd: lnd1 })

--- a/test/helpers/bitcoin-core.ts
+++ b/test/helpers/bitcoin-core.ts
@@ -1,20 +1,14 @@
 import BitcoindClient from "bitcoin-core-ts"
-import {
-  addInvoiceForSelf,
-  createOnChainAddress,
-  getBalanceForWallet,
-} from "@app/wallets"
+import { createOnChainAddress } from "@app/wallets"
 import { getBitcoinCoreRPCConfig } from "@config"
 import { bitcoindDefaultClient, BitcoindWalletClient } from "@services/bitcoind"
-import { baseLogger } from "@services/logger"
 import { LedgerService } from "@services/ledger"
-import { pay } from "lightning"
 
 import { toSats } from "@domain/bitcoin"
 
 import { descriptors } from "./multisig-wallet"
 
-import { checkIsBalanced, lndOutside1, waitUntilBlockHeight } from "."
+import { checkIsBalanced, waitUntilBlockHeight } from "."
 
 export const RANDOM_ADDRESS = "2N1AdXp9qihogpSmSBXSSfgeUFgTYyjVWqo"
 export const bitcoindClient = bitcoindDefaultClient // no wallet
@@ -100,22 +94,6 @@ export const fundWalletIdFromOnchain = async ({
   const balance = await LedgerService().getWalletBalance(walletId)
   if (balance instanceof Error) throw balance
   return toSats(balance)
-}
-
-export const fundWalletIdFromLightning = async ({
-  walletId,
-  amount,
-}: {
-  walletId: WalletId
-  amount: Satoshis | UsdCents
-}) => {
-  const invoice = await addInvoiceForSelf({ walletId, amount })
-  if (invoice instanceof Error) return invoice
-
-  await pay({ lnd: lndOutside1, request: invoice.paymentRequest })
-
-  const balance = await getBalanceForWallet({ walletId, logger: baseLogger })
-  if (balance instanceof Error) throw balance
 }
 
 export const createColdStorageWallet = async (walletName: string) => {

--- a/test/helpers/check-is-balanced.ts
+++ b/test/helpers/check-is-balanced.ts
@@ -1,5 +1,5 @@
 import { updatePendingPayments } from "@app/payments"
-import { updatePendingInvoices, updateOnChainReceipt } from "@app/wallets"
+import { declineHeldInvoices, updateOnChainReceipt } from "@app/wallets"
 import { baseLogger } from "@services/logger"
 import { getBalance as getBitcoindBalance } from "@services/bitcoind"
 
@@ -12,7 +12,7 @@ const logger = baseLogger.child({ module: "test" })
 
 export const checkIsBalanced = async () => {
   await Promise.all([
-    updatePendingInvoices(logger),
+    declineHeldInvoices(logger),
     updatePendingPayments(logger),
     updateOnChainReceipt({ logger }),
   ])

--- a/test/helpers/check-is-balanced.ts
+++ b/test/helpers/check-is-balanced.ts
@@ -1,5 +1,5 @@
 import { updatePendingPayments } from "@app/payments"
-import { declineHeldInvoices, updateOnChainReceipt } from "@app/wallets"
+import { handleHeldInvoices, updateOnChainReceipt } from "@app/wallets"
 import { baseLogger } from "@services/logger"
 import { getBalance as getBitcoindBalance } from "@services/bitcoind"
 
@@ -12,7 +12,7 @@ const logger = baseLogger.child({ module: "test" })
 
 export const checkIsBalanced = async () => {
   await Promise.all([
-    declineHeldInvoices(logger),
+    handleHeldInvoices(logger),
     updatePendingPayments(logger),
     updateOnChainReceipt({ logger }),
   ])

--- a/test/integration/02-user-wallet/02-receive-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-lightning.spec.ts
@@ -1,18 +1,28 @@
-import { Lightning } from "@app"
-import { getDealerUsdWalletId } from "@services/ledger/caching"
-import * as Wallets from "@app/wallets"
 import { MEMO_SHARING_SATS_THRESHOLD } from "@config"
+
+import { Lightning } from "@app"
+import * as Wallets from "@app/wallets"
+import { declineHeldInvoices } from "@app/wallets"
+
 import { toSats } from "@domain/bitcoin"
+import { InvoiceNotFoundError } from "@domain/bitcoin/lightning"
 import { defaultTimeToExpiryInSeconds } from "@domain/bitcoin/lightning/invoice-expiration"
 import { toCents } from "@domain/fiat"
 import { PaymentInitiationMethod, WithdrawalFeePriceMethod } from "@domain/wallets"
 import { WalletCurrency } from "@domain/shared"
+import { CouldNotFindWalletInvoiceError } from "@domain/errors"
+
+import { WalletInvoicesRepository } from "@services/mongoose"
+import { getDealerUsdWalletId } from "@services/ledger/caching"
 import { DealerPriceService } from "@services/dealer-price"
 import { LedgerService } from "@services/ledger"
 import { TransactionsMetadataRepository } from "@services/ledger/services"
+import { LndService } from "@services/lnd"
 import { baseLogger } from "@services/logger"
 
 import { ImbalanceCalculator } from "@domain/ledger/imbalance-calculator"
+
+import { sleep } from "@utils"
 
 import {
   checkIsBalanced,
@@ -21,6 +31,7 @@ import {
   getBalanceHelper,
   getDefaultWalletIdByTestUserRef,
   getHash,
+  getPubKey,
   getUsdWalletIdByTestUserRef,
   lndOutside1,
   pay,
@@ -49,6 +60,93 @@ afterEach(async () => {
 })
 
 describe("UserWallet - Lightning", () => {
+  it("if trigger is missing the invoice, then it should be denied", async () => {
+    /*
+      the reason we are doing this behavior is to limit the discrepancy between our books,
+      and the state of lnd.
+      if we get invoices that lnd has been settled because we were not using holdinvoice,
+      then there would be discrepancy between the time lnd settled the invoice
+      and the time it's being settle in our ledger
+      the reason this could happen is because trigger has to restart
+      the discrepancy in ledger is an okish behavior for bitcoin invoice, because there
+      are no price risk, but it's an unbearable risk for non bitcoin wallets,
+      because of the associated price risk exposure
+    */
+
+    const sats = 50000
+    const memo = "myMemo"
+
+    const lnInvoice = await Wallets.addInvoiceForSelf({
+      walletId: walletIdB as WalletId,
+      amount: toSats(sats),
+      memo,
+    })
+    if (lnInvoice instanceof Error) throw lnInvoice
+    const { paymentRequest: invoice } = lnInvoice
+
+    const checker = await Lightning.PaymentStatusChecker(invoice)
+    if (checker instanceof Error) throw checker
+
+    const isPaidBeforePay = await checker.invoiceIsPaid()
+    expect(isPaidBeforePay).not.toBeInstanceOf(Error)
+    expect(isPaidBeforePay).toBe(false)
+
+    const paymentHash = getHash(invoice)
+    const pubkey = getPubKey(invoice)
+
+    await Promise.all([
+      (async () => {
+        try {
+          await pay({ lnd: lndOutside1, request: invoice })
+        } catch (err) {
+          expect(err[1]).toBe("PaymentRejectedByDestination")
+        }
+      })(),
+      (async () => {
+        await sleep(500)
+
+        // make sure invoice is held
+
+        const lndService = LndService()
+        if (lndService instanceof Error) throw lndService
+
+        {
+          const lnInvoiceLookup = await lndService.lookupInvoice({ pubkey, paymentHash })
+          if (lnInvoiceLookup instanceof Error) throw lnInvoiceLookup
+
+          expect(lnInvoiceLookup.isHeld).toBe(true)
+        }
+
+        // declining invoice
+        await declineHeldInvoices(baseLogger)
+
+        const ledger = LedgerService()
+        const ledgerTxs = await ledger.getTransactionsByHash(paymentHash)
+        if (ledgerTxs instanceof Error) throw ledgerTxs
+        expect(ledgerTxs).toStrictEqual([])
+
+        const isPaidAfterPay = await checker.invoiceIsPaid()
+        expect(isPaidAfterPay).not.toBeInstanceOf(Error)
+        expect(isPaidAfterPay).toBe(false)
+
+        const finalBalance = await getBalanceHelper(walletIdB)
+        expect(finalBalance).toBe(initBalanceB)
+
+        const lnInvoiceLookup = await lndService.lookupInvoice({ pubkey, paymentHash })
+        expect(lnInvoiceLookup).toBeInstanceOf(InvoiceNotFoundError)
+
+        {
+          const walletInvoiceRepo = WalletInvoicesRepository()
+          const result = await walletInvoiceRepo.findByPaymentHash(paymentHash)
+          expect(result).toBeInstanceOf(CouldNotFindWalletInvoiceError)
+        }
+
+        // making sure relooping is a no-op and doesn't throw
+        await declineHeldInvoices(baseLogger)
+      })(),
+    ])
+  })
+
   it("receives payment from outside", async () => {
     // larger amount to not fall below the escrow limit
     const sats = 50000
@@ -72,21 +170,32 @@ describe("UserWallet - Lightning", () => {
 
     const hash = getHash(invoice)
 
-    await pay({ lnd: lndOutside1, request: invoice })
+    const updateInvoice = () =>
+      Wallets.updatePendingInvoiceByPaymentHash({
+        paymentHash: hash as PaymentHash,
+        logger: baseLogger,
+      })
 
-    expect(
-      await Wallets.updatePendingInvoiceByPaymentHash({
-        paymentHash: hash as PaymentHash,
-        logger: baseLogger,
-      }),
-    ).not.toBeInstanceOf(Error)
+    const promises = Promise.all([
+      pay({ lnd: lndOutside1, request: invoice }),
+      (async () => {
+        // TODO: we could use event instead of a sleep to lower test latency
+        await sleep(500)
+        return updateInvoice()
+      })(),
+    ])
+
+    {
+      // first arg is the outsideLndpayResult
+      const [, result] = await promises
+      expect(result).not.toBeInstanceOf(Error)
+    }
+
     // should be idempotent (not return error when called again)
-    expect(
-      await Wallets.updatePendingInvoiceByPaymentHash({
-        paymentHash: hash as PaymentHash,
-        logger: baseLogger,
-      }),
-    ).not.toBeInstanceOf(Error)
+    {
+      const result = await updateInvoice()
+      expect(result).not.toBeInstanceOf(Error)
+    }
 
     const ledger = LedgerService()
     const ledgerMetadata = TransactionsMetadataRepository()
@@ -168,7 +277,10 @@ describe("UserWallet - Lightning", () => {
 
     expect(amount).toBe(sats)
 
-    await pay({ lnd: lndOutside1, request: invoice })
+    pay({ lnd: lndOutside1, request: invoice })
+
+    // TODO: we could use an event instead of a sleep
+    await sleep(500)
 
     expect(
       await Wallets.updatePendingInvoiceByPaymentHash({
@@ -234,7 +346,10 @@ describe("UserWallet - Lightning", () => {
 
     const hash = getHash(invoice)
 
-    await pay({ lnd: lndOutside1, request: invoice, tokens: sats })
+    pay({ lnd: lndOutside1, request: invoice, tokens: sats })
+
+    // TODO: we could use an event instead of a sleep
+    await sleep(500)
 
     expect(
       await Wallets.updatePendingInvoiceByPaymentHash({
@@ -297,7 +412,10 @@ describe("UserWallet - Lightning", () => {
 
     const hash = getHash(invoice)
 
-    await pay({ lnd: lndOutside1, request: invoice, tokens: sats })
+    pay({ lnd: lndOutside1, request: invoice, tokens: sats })
+
+    // TODO: we could use an event instead of a sleep
+    await sleep(500)
 
     expect(
       await Wallets.updatePendingInvoiceByPaymentHash({
@@ -355,7 +473,11 @@ describe("UserWallet - Lightning", () => {
     const { paymentRequest: invoice } = lnInvoice
 
     const hash = getHash(invoice)
-    await pay({ lnd: lndOutside1, request: invoice })
+    pay({ lnd: lndOutside1, request: invoice })
+
+    // TODO: we could use an event instead of a sleep
+    await sleep(500)
+
     expect(
       await Wallets.updatePendingInvoiceByPaymentHash({
         paymentHash: hash as PaymentHash,

--- a/test/jest-e2e.setup.js
+++ b/test/jest-e2e.setup.js
@@ -29,4 +29,4 @@ afterAll(async () => {
   }
 })
 
-jest.setTimeout(process.env.JEST_TIMEOUT || 30000)
+jest.setTimeout(process.env.JEST_TIMEOUT || 90000)

--- a/test/unit/domain/wallet-invoices/wallet-invoice-receiver.spec.ts
+++ b/test/unit/domain/wallet-invoices/wallet-invoice-receiver.spec.ts
@@ -40,6 +40,7 @@ describe("WalletInvoiceReceiver", () => {
   describe("for btc invoice", () => {
     const btcInvoice: WalletInvoice = {
       paymentHash: "paymentHash" as PaymentHash,
+      secret: "secret" as SecretPreImage,
       selfGenerated: false,
       pubkey: "pubkey" as Pubkey,
       usdAmount: undefined,
@@ -76,6 +77,7 @@ describe("WalletInvoiceReceiver", () => {
     describe("with cents amount", () => {
       const amountUsdInvoice: WalletInvoice = {
         paymentHash: "paymentHash" as PaymentHash,
+        secret: "secret" as SecretPreImage,
         recipientWalletDescriptor: recipientUsdWallet,
         selfGenerated: false,
         pubkey: "pubkey" as Pubkey,
@@ -109,6 +111,7 @@ describe("WalletInvoiceReceiver", () => {
     describe("with no amount", () => {
       const noAmountUsdInvoice: WalletInvoice = {
         paymentHash: "paymentHash" as PaymentHash,
+        secret: "secret" as SecretPreImage,
         recipientWalletDescriptor: recipientUsdWallet,
         selfGenerated: false,
         pubkey: "pubkey" as Pubkey,

--- a/test/unit/domain/wallet-invoices/wallet-invoice-validator.spec.ts
+++ b/test/unit/domain/wallet-invoices/wallet-invoice-validator.spec.ts
@@ -5,6 +5,7 @@ import { WalletCurrency } from "@domain/shared"
 describe("WalletInvoiceValidator", () => {
   const walletInvoice: WalletInvoice = {
     paymentHash: "paymentHash" as PaymentHash,
+    secret: "secret" as SecretPreImage,
     recipientWalletDescriptor: {
       id: "toWalletId" as WalletId,
       currency: WalletCurrency.Btc,


### PR DESCRIPTION
_New changes diff: https://github.com/GaloyMoney/galoy/compare/3703545...hodl-add-single-subscribe_

## Discussion

This is a continuation from #1395 where we need to fix the trigger code for subscribing to hodl invoice `ACCEPT`/`CANCEL` events that don't come through the usual `subscribeInvoices` listener (see [here](https://github.com/lightningnetwork/lnd/issues/3120#issuecomment-1160732579)).

This PR will be to bring back in the #1395 changes and to add the subscribe-to-single-invoice code on top of it to get this feature working.

### Open questions
1. ~New implementation: is there a possibility that we end up with single-invoice subscriptions that don't close (if we somehow skip one of the `removeAllListeners` calls)?~

2. ~Previous implementation: how does the `subscribeInvoices` listener get restarted if it errors and `removeAllListeners` gets called?~

## Transition ([see comment](https://github.com/GaloyMoney/galoy/pull/1484#issuecomment-1205762776))

@dolcalmi pointed out that when we first roll this out our "updateInvoice" code will need to handle both hodl and non-hodl invoices. This was an easy fix for the "update" code path ([here](https://github.com/GaloyMoney/galoy/pull/1484/commits/4ae0917c559fe85fa9eb17c9949248fe7f2691c6)). For the "decline held invoices" code path though, I added a temporary fix that we should probably revert as soon as 24 hours passes and we are confident that no old invoices are in the system.

Does this sound right @nicolasburtey?