### PR TITLE
fix: return false for handled error in 'checkAndDeletePaymentForHash'

### DIFF
--- a/src/app/lightning/delete-ln-payments.ts
+++ b/src/app/lightning/delete-ln-payments.ts
@@ -54,6 +54,7 @@ const checkAndDeletePaymentForHash = async ({
               "createdAt" in lnPaymentLookup ? lnPaymentLookup.paymentRequest : undefined,
             sentFromPubkey: pubkey,
           })
+          return false
         }
         return lnPayment
       }

--- a/src/app/lightning/delete-ln-payments.ts
+++ b/src/app/lightning/delete-ln-payments.ts
@@ -54,12 +54,18 @@ const checkAndDeletePaymentForHash = async ({
               "createdAt" in lnPaymentLookup ? lnPaymentLookup.paymentRequest : undefined,
             sentFromPubkey: pubkey,
           })
+
+          addAttributesToCurrentSpan({ existedInRepository: false })
           return false
         }
+        addAttributesToCurrentSpan({ ["existedInRepository.undefined"]: true })
         return lnPayment
       }
 
-      addAttributesToCurrentSpan({ isCompleteRecord: lnPayment.isCompleteRecord })
+      addAttributesToCurrentSpan({
+        existedInRepository: true,
+        isCompleteRecord: lnPayment.isCompleteRecord,
+      })
       if (!lnPayment.isCompleteRecord) return false
 
       const lndService = LndService()


### PR DESCRIPTION
## Description

The code should not return the `CouldNotFindLnPaymentFromHashError` error after it has been handled. These critical error traces [here](https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/GJmWs9kTJDf/trace/jR9FGYEZZEP?fields[]=c_name&fields[]=c_service.name&span=477badc093345d10) should not have been added to these spans for example.

This change fixes that.