### PR TITLE
feat: skip fee probe for flagged destinations

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -188,3 +188,7 @@ kratosConfig:
 
 captcha:
   mandatory: false
+
+skipFeeProbe:
+  muun:
+    - "038f8f113c580048d847d6949371726653e02b928196bad310e3eda39ff61723f6"

--- a/src/app/payments/get-protocol-fee.ts
+++ b/src/app/payments/get-protocol-fee.ts
@@ -1,10 +1,4 @@
-import { getPubkeysToSkipProbe, intersect } from "@config"
-
-import {
-  decodeInvoice,
-  defaultTimeToExpiryInSeconds,
-  parseFinalHopsFromInvoice,
-} from "@domain/bitcoin/lightning"
+import { decodeInvoice, defaultTimeToExpiryInSeconds } from "@domain/bitcoin/lightning"
 import { checkedToWalletId } from "@domain/wallets"
 import {
   LnPaymentRequestNonZeroAmountRequiredError,
@@ -136,10 +130,7 @@ const estimateLightningFee = async ({
       return PartialResult.err(lndService)
     }
 
-    const skipProbe =
-      intersect(parseFinalHopsFromInvoice(invoice), getPubkeysToSkipProbe()).length > 0
-
-    const routeResult = skipProbe
+    const routeResult = (await builder.skipProbeForDestination())
       ? new SkipProbeForPubkeyError()
       : await lndService.findRouteForInvoice({
           invoice,

--- a/src/app/payments/helpers.ts
+++ b/src/app/payments/helpers.ts
@@ -3,6 +3,7 @@ import {
   getAccountLimits,
   MS_PER_DAY,
   MIN_SATS_FOR_PRICE_RATIO_PRECISION,
+  getPubkeysToSkipProbe,
 } from "@config"
 import { AccountLimitsChecker, TwoFALimitsChecker } from "@domain/accounts"
 import {
@@ -44,6 +45,7 @@ export const constructPaymentFlowBuilder = async <
   if (lndService instanceof Error) return lndService
   const paymentBuilder = LightningPaymentFlowBuilder({
     localNodeIds: lndService.listAllPubkeys(),
+    flaggedPubkeys: getPubkeysToSkipProbe(),
     usdFromBtcMidPriceFn,
     btcFromUsdMidPriceFn,
   })

--- a/src/app/payments/send-intraledger.ts
+++ b/src/app/payments/send-intraledger.ts
@@ -1,3 +1,5 @@
+import { getPubkeysToSkipProbe } from "@config"
+
 import { ErrorLevel, WalletCurrency } from "@domain/shared"
 import { checkedToWalletId, SettlementMethod } from "@domain/wallets"
 import { AccountValidator } from "@domain/accounts"
@@ -56,6 +58,7 @@ export const intraledgerPaymentSendWalletId = async ({
 
   const paymentBuilder = LightningPaymentFlowBuilder({
     localNodeIds: [],
+    flaggedPubkeys: getPubkeysToSkipProbe(),
     usdFromBtcMidPriceFn,
     btcFromUsdMidPriceFn,
   })

--- a/src/app/payments/translations.ts
+++ b/src/app/payments/translations.ts
@@ -74,6 +74,7 @@ export const PaymentFlowFromLedgerTransaction = <
 
     paymentHash,
     descriptionFromInvoice: "",
+    skipProbeForDestination: false,
     createdAt,
     paymentSentAndPending: true,
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -356,7 +356,11 @@ export const configSchema = {
     skipFeeProbe: {
       type: "object",
       patternProperties: {
-        "^.*$": { type: "array", items: { type: "string" }, uniqueItems: true },
+        "^.*$": {
+          type: "array",
+          items: { type: "string", maxLength: 66 },
+          uniqueItems: true,
+        },
       },
       additionalProperties: false,
     },

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -353,6 +353,13 @@ export const configSchema = {
       required: ["mandatory"],
       additionalProperties: false,
     },
+    skipFeeProbe: {
+      type: "object",
+      patternProperties: {
+        "^.*$": { type: "array", items: { type: "string" }, uniqueItems: true },
+      },
+      additionalProperties: false,
+    },
   },
   required: [
     "name",

--- a/src/config/schema.types.d.ts
+++ b/src/config/schema.types.d.ts
@@ -132,4 +132,7 @@ type YamlSchema = {
   captcha: {
     mandatory: boolean
   }
+  skipFeeProbe: {
+    [key: string]: Pubkey[]
+  }
 }

--- a/src/config/utils.ts
+++ b/src/config/utils.ts
@@ -3,5 +3,8 @@ import mergeWith from "lodash.mergewith"
 export const merge = (defaultConfig: unknown, customConfig: unknown) =>
   mergeWith(defaultConfig, customConfig, (a, b) => (Array.isArray(b) ? b : undefined))
 
-export const intersect = <T>(a: T[], b: T[]): T[] =>
-  Array.from(new Set(a)).filter((i) => new Set(b).has(i))
+export class ModifiedSet extends Set {
+  intersect<T>(otherSet: Set<T>): Set<T> {
+    return new ModifiedSet(Array.from(this).filter((i) => otherSet.has(i)))
+  }
+}

--- a/src/config/utils.ts
+++ b/src/config/utils.ts
@@ -2,3 +2,6 @@ import mergeWith from "lodash.mergewith"
 
 export const merge = (defaultConfig: unknown, customConfig: unknown) =>
   mergeWith(defaultConfig, customConfig, (a, b) => (Array.isArray(b) ? b : undefined))
+
+export const intersect = <T>(a: T[], b: T[]): T[] =>
+  Array.from(new Set(a)).filter((i) => new Set(b).has(i))

--- a/src/config/utils.ts
+++ b/src/config/utils.ts
@@ -2,9 +2,3 @@ import mergeWith from "lodash.mergewith"
 
 export const merge = (defaultConfig: unknown, customConfig: unknown) =>
   mergeWith(defaultConfig, customConfig, (a, b) => (Array.isArray(b) ? b : undefined))
-
-export class ModifiedSet extends Set {
-  intersect<T>(otherSet: Set<T>): Set<T> {
-    return new ModifiedSet(Array.from(this).filter((i) => otherSet.has(i)))
-  }
-}

--- a/src/config/yaml.ts
+++ b/src/config/yaml.ts
@@ -82,6 +82,14 @@ export const getLightningAddressDomainAliases = (): string[] =>
   yamlConfig.lightningAddressDomainAliases
 export const getLocale = (): string => yamlConfig.locale || "en"
 
+export const pubkeysSkipProbe = (): Pubkey[] => {
+  const pubkeys = [] as Pubkey[]
+  for (const keys of Object.values(yamlConfig.skipFeeProbe)) {
+    pubkeys.push(...keys)
+  }
+  return pubkeys
+}
+
 const i18n = new I18n()
 i18n.configure({
   objectNotation: true,

--- a/src/config/yaml.ts
+++ b/src/config/yaml.ts
@@ -82,7 +82,7 @@ export const getLightningAddressDomainAliases = (): string[] =>
   yamlConfig.lightningAddressDomainAliases
 export const getLocale = (): string => yamlConfig.locale || "en"
 
-export const pubkeysSkipProbe = (): Pubkey[] => {
+export const getPubkeysToSkipProbe = (): Pubkey[] => {
   const pubkeys = [] as Pubkey[]
   for (const keys of Object.values(yamlConfig.skipFeeProbe)) {
     pubkeys.push(...keys)

--- a/src/domain/bitcoin/lightning/index.ts
+++ b/src/domain/bitcoin/lightning/index.ts
@@ -27,3 +27,15 @@ export const checkedToPubkey = (pubkey: string): Pubkey | InvalidPubKeyError => 
   }
   return new InvalidPubKeyError("Pubkey conversion error")
 }
+
+export const parseFinalHopsFromInvoice = (invoice: LnInvoice): Pubkey[] => {
+  const pubkeys = [] as Pubkey[]
+  const routes = invoice.routeHints
+  for (const route of routes) {
+    const lastIdx = route.length - 1
+    const penUltIndex = route.length > 1 ? lastIdx - 1 : lastIdx
+    const lastHop = route[penUltIndex]
+    pubkeys.push(lastHop.nodePubkey)
+  }
+  return Array.from(new Set(pubkeys))
+}

--- a/src/domain/payments/errors.ts
+++ b/src/domain/payments/errors.ts
@@ -9,6 +9,7 @@ export class LnPaymentRequestZeroAmountRequiredError extends ValidationError {}
 export class LnPaymentRequestInTransitError extends ValidationError {}
 export class LnHashPresentInIntraLedgerFlowError extends ValidationError {}
 export class IntraLedgerHashPresentInLnFlowError extends ValidationError {}
+export class SkipProbeForPubkeyError extends ValidationError {}
 export class NonLnPaymentTransactionForPaymentFlowError extends ValidationError {
   level = ErrorLevel.Critical
 }

--- a/src/domain/payments/index.types.d.ts
+++ b/src/domain/payments/index.types.d.ts
@@ -180,6 +180,7 @@ type BtcFromUsdMidPriceFn = (
 
 type LightningPaymentFlowBuilderConfig = {
   localNodeIds: Pubkey[]
+  flaggedPubkeys: Pubkey[]
   usdFromBtcMidPriceFn: UsdFromBtcMidPriceFn
   btcFromUsdMidPriceFn: BtcFromUsdMidPriceFn
 }

--- a/src/domain/payments/index.types.d.ts
+++ b/src/domain/payments/index.types.d.ts
@@ -20,6 +20,7 @@ type PaymentFlowState<
   settlementMethod: SettlementMethod
   paymentInitiationMethod: PaymentInitiationMethod
   descriptionFromInvoice: string
+  skipProbeForDestination: boolean
   createdAt: Date
   paymentSentAndPending: boolean
 
@@ -132,6 +133,7 @@ type LPFBWithConversion<S extends WalletCurrency, R extends WalletCurrency> = {
 
   btcPaymentAmount(): Promise<BtcPaymentAmount | DealerPriceServiceError>
   usdPaymentAmount(): Promise<UsdPaymentAmount | DealerPriceServiceError>
+  skipProbeForDestination(): Promise<boolean | DealerPriceServiceError>
 
   isIntraLedger(): Promise<boolean | DealerPriceServiceError>
 }
@@ -149,6 +151,7 @@ type LPFBWithError = {
   withoutRoute(): Promise<ValidationError | DealerPriceServiceError>
   btcPaymentAmount(): Promise<ValidationError | DealerPriceServiceError>
   usdPaymentAmount(): Promise<ValidationError | DealerPriceServiceError>
+  skipProbeForDestination(): Promise<ValidationError | DealerPriceServiceError>
   isIntraLedger(): Promise<ValidationError | DealerPriceServiceError>
 }
 interface IPaymentFlowRepository {
@@ -191,6 +194,7 @@ type LPFBWithInvoiceState = LightningPaymentFlowBuilderConfig &
     uncheckedAmount?: number
     btcProtocolFee?: BtcPaymentAmount
     usdProtocolFee?: UsdPaymentAmount
+    skipProbeForDestination: boolean
   }
 
 type LPFBWithSenderWalletState<S extends WalletCurrency> = RequireField<

--- a/src/domain/payments/payment-flow-builder.ts
+++ b/src/domain/payments/payment-flow-builder.ts
@@ -1,11 +1,11 @@
-import { getPubkeysToSkipProbe, ModifiedSet } from "@config"
-
 import { ValidationError, WalletCurrency } from "@domain/shared"
 import { SelfPaymentError } from "@domain/errors"
 import { PaymentInitiationMethod, SettlementMethod } from "@domain/wallets"
 import { checkedToBtcPaymentAmount, checkedToUsdPaymentAmount } from "@domain/payments"
 import { generateIntraLedgerHash } from "@domain/payments/get-intraledger-hash"
 import { parseFinalHopsFromInvoice } from "@domain/bitcoin/lightning"
+
+import { ModifiedSet } from "@utils"
 
 import {
   InvalidLightningPaymentFlowBuilderStateError,
@@ -46,7 +46,7 @@ export const LightningPaymentFlowBuilder = <S extends WalletCurrency>(
 
   const skipProbeFromInvoice = (invoice: LnInvoice): boolean => {
     const invoicePubkeySet = new ModifiedSet(parseFinalHopsFromInvoice(invoice))
-    const flaggedPubkeySet = new ModifiedSet(getPubkeysToSkipProbe())
+    const flaggedPubkeySet = new ModifiedSet(config.flaggedPubkeys)
 
     return invoicePubkeySet.intersect(flaggedPubkeySet).size > 0
   }

--- a/src/domain/payments/payment-flow-builder.ts
+++ b/src/domain/payments/payment-flow-builder.ts
@@ -492,14 +492,14 @@ const LPFBWithConversion = <S extends WalletCurrency, R extends WalletCurrency>(
   }
 
   const btcPaymentAmount = async () => {
-    const state = await Promise.resolve(statePromise)
+    const state = await statePromise
     if (state instanceof Error) return state
 
     return state.btcPaymentAmount
   }
 
   const usdPaymentAmount = async () => {
-    const state = await Promise.resolve(statePromise)
+    const state = await statePromise
     if (state instanceof Error) return state
 
     return state.usdPaymentAmount
@@ -513,7 +513,7 @@ const LPFBWithConversion = <S extends WalletCurrency, R extends WalletCurrency>(
   }
 
   const isIntraLedger = async () => {
-    const state = await Promise.resolve(statePromise)
+    const state = await statePromise
     if (state instanceof Error) return state
 
     return state.settlementMethod === SettlementMethod.IntraLedger

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -415,6 +415,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "SafeWrapperError":
     case "InvalidFeeProbeStateError":
     case "InvalidPubKeyError":
+    case "SkipProbeForPubkeyError":
       message = `Unknown error occurred (code: ${error.name}${
         error.message ? ": " + error.message : ""
       })`

--- a/src/services/payment-flow/index.ts
+++ b/src/services/payment-flow/index.ts
@@ -229,6 +229,7 @@ const paymentFlowFromRaw = <S extends WalletCurrency, R extends WalletCurrency>(
     paymentInitiationMethod:
       paymentFlowState.paymentInitiationMethod as PaymentInitiationMethod,
     descriptionFromInvoice: paymentFlowState.descriptionFromInvoice,
+    skipProbeForDestination: paymentFlowState.skipProbeForDestination,
     createdAt: paymentFlowState.createdAt,
     paymentSentAndPending: paymentFlowState.paymentSentAndPending,
 
@@ -270,6 +271,7 @@ const rawFromPaymentFlow = <S extends WalletCurrency, R extends WalletCurrency>(
     settlementMethod: paymentFlow.settlementMethod,
     paymentInitiationMethod: paymentFlow.paymentInitiationMethod,
     descriptionFromInvoice: paymentFlow.descriptionFromInvoice,
+    skipProbeForDestination: paymentFlow.skipProbeForDestination,
     createdAt: paymentFlow.createdAt,
     paymentSentAndPending: paymentFlow.paymentSentAndPending,
 

--- a/src/services/payment-flow/schema.types.d.ts
+++ b/src/services/payment-flow/schema.types.d.ts
@@ -13,6 +13,7 @@ type PaymentFlowStateRecordPartial = XOR<
   createdAt: Date
   paymentSentAndPending: boolean
   descriptionFromInvoice: string
+  skipProbeForDestination: boolean
 
   btcPaymentAmount: number
   usdPaymentAmount: number

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -58,3 +58,9 @@ export const mapObj = <T, R>(
 export const elapsedSinceTimestamp = (date: Date): Seconds => {
   return ((Date.now() - Number(date)) / 1000) as Seconds
 }
+
+export class ModifiedSet extends Set {
+  intersect<T>(otherSet: Set<T>): Set<T> {
+    return new ModifiedSet(Array.from(this).filter((i) => otherSet.has(i)))
+  }
+}

--- a/test/unit/payments/payment-flow-builder.spec.ts
+++ b/test/unit/payments/payment-flow-builder.spec.ts
@@ -10,6 +10,9 @@ import { AmountCalculator, ValidationError, WalletCurrency } from "@domain/share
 
 const calc = AmountCalculator()
 
+const muunPubkey =
+  "038f8f113c580048d847d6949371726653e02b928196bad310e3eda39ff61723f6" as Pubkey
+
 describe("LightningPaymentFlowBuilder", () => {
   const paymentRequestWithAmount =
     "lnbc210u1p32zq9xpp5dpzhj6e7y6d4ggs6awh7m4eupuemas0gq06pqjgy9tq35740jlfsdqqcqzpgxqyz5vqsp58t3zalj5sc563g0xpcgx9lfkeqrx7m7xw53v2txc2pr60jcwn0vq9qyyssqkatadajwt0n285teummg4urul9t3shddnf05cfxzsfykvscxm4zqz37j87sahvz3kul0lzgz2svltdm933yr96du84zpyn8rx6fst4sp43jh32" as EncodedPaymentRequest
@@ -85,6 +88,7 @@ describe("LightningPaymentFlowBuilder", () => {
   describe("ln initiated, ln settled", () => {
     const lightningBuilder = LightningPaymentFlowBuilder({
       localNodeIds: [],
+      flaggedPubkeys: [muunPubkey],
       usdFromBtcMidPriceFn,
       btcFromUsdMidPriceFn,
     })
@@ -451,6 +455,7 @@ describe("LightningPaymentFlowBuilder", () => {
   describe("ln initiated, intraledger settled", () => {
     const intraledgerBuilder = LightningPaymentFlowBuilder({
       localNodeIds: [invoiceWithAmount.destination, invoiceWithNoAmount.destination],
+      flaggedPubkeys: [muunPubkey],
       usdFromBtcMidPriceFn,
       btcFromUsdMidPriceFn,
     })
@@ -855,6 +860,7 @@ describe("LightningPaymentFlowBuilder", () => {
   describe("intraledger initiated, intraledger settled", () => {
     const intraledgerBuilder = LightningPaymentFlowBuilder({
       localNodeIds: [],
+      flaggedPubkeys: [muunPubkey],
       usdFromBtcMidPriceFn,
       btcFromUsdMidPriceFn,
     })
@@ -1076,6 +1082,7 @@ describe("LightningPaymentFlowBuilder", () => {
       it("returns a ValidationError", async () => {
         const payment = await LightningPaymentFlowBuilder({
           localNodeIds: [],
+          flaggedPubkeys: [muunPubkey],
           usdFromBtcMidPriceFn,
           btcFromUsdMidPriceFn,
         })
@@ -1095,6 +1102,7 @@ describe("LightningPaymentFlowBuilder", () => {
       it("returns a ValidationError", async () => {
         const payment = await LightningPaymentFlowBuilder({
           localNodeIds: [],
+          flaggedPubkeys: [muunPubkey],
           usdFromBtcMidPriceFn,
           btcFromUsdMidPriceFn,
         })
@@ -1114,6 +1122,7 @@ describe("LightningPaymentFlowBuilder", () => {
       it("returns a ValidationError", async () => {
         const payment = await LightningPaymentFlowBuilder({
           localNodeIds: [],
+          flaggedPubkeys: [muunPubkey],
           usdFromBtcMidPriceFn,
           btcFromUsdMidPriceFn,
         })
@@ -1133,6 +1142,7 @@ describe("LightningPaymentFlowBuilder", () => {
       it("returns InvalidLightningPaymentFlowBuilderStateError", async () => {
         const payment = await LightningPaymentFlowBuilder({
           localNodeIds: [invoiceWithAmount.destination],
+          flaggedPubkeys: [muunPubkey],
           usdFromBtcMidPriceFn,
           btcFromUsdMidPriceFn,
         })
@@ -1153,6 +1163,7 @@ describe("LightningPaymentFlowBuilder", () => {
       it("returns ImpossibleLightningPaymentFlowBuilderStateError", async () => {
         const payment = await LightningPaymentFlowBuilder({
           localNodeIds: [invoiceWithAmount.destination],
+          flaggedPubkeys: [muunPubkey],
           usdFromBtcMidPriceFn,
           btcFromUsdMidPriceFn,
         })
@@ -1173,6 +1184,7 @@ describe("LightningPaymentFlowBuilder", () => {
       it("returns ImpossibleLightningPaymentFlowBuilderStateError", async () => {
         const payment = await LightningPaymentFlowBuilder({
           localNodeIds: [invoiceWithNoAmount.destination],
+          flaggedPubkeys: [muunPubkey],
           usdFromBtcMidPriceFn,
           btcFromUsdMidPriceFn,
         })
@@ -1196,6 +1208,7 @@ describe("LightningPaymentFlowBuilder", () => {
       it("returns ImpossibleLightningPaymentFlowBuilderStateError", async () => {
         const payment = await LightningPaymentFlowBuilder({
           localNodeIds: [invoiceWithAmount.destination],
+          flaggedPubkeys: [muunPubkey],
           usdFromBtcMidPriceFn,
           btcFromUsdMidPriceFn,
         })

--- a/test/unit/payments/payment-flow-builder.spec.ts
+++ b/test/unit/payments/payment-flow-builder.spec.ts
@@ -14,6 +14,9 @@ describe("LightningPaymentFlowBuilder", () => {
   const paymentRequestWithAmount =
     "lnbc210u1p32zq9xpp5dpzhj6e7y6d4ggs6awh7m4eupuemas0gq06pqjgy9tq35740jlfsdqqcqzpgxqyz5vqsp58t3zalj5sc563g0xpcgx9lfkeqrx7m7xw53v2txc2pr60jcwn0vq9qyyssqkatadajwt0n285teummg4urul9t3shddnf05cfxzsfykvscxm4zqz37j87sahvz3kul0lzgz2svltdm933yr96du84zpyn8rx6fst4sp43jh32" as EncodedPaymentRequest
   const invoiceWithAmount = decodeInvoice(paymentRequestWithAmount) as LnInvoice
+  const muunPaymentRequestWithAmount =
+    "lnbc10u1p3w0mf7pp5v9xg3eksnsyrsa3vk5uv00rvye4wf9n0744xgtx0kcrafeanvx7sdqqcqzzgxqyz5vqrzjqwnvuc0u4txn35cafc7w94gxvq5p3cu9dd95f7hlrh0fvs46wpvhddrwgrqy63w5eyqqqqryqqqqthqqpyrzjqw8c7yfutqqy3kz8662fxutjvef7q2ujsxtt45csu0k688lkzu3lddrwgrqy63w5eyqqqqryqqqqthqqpysp53n0sc9hvqgdkrv4ppwrm2pa0gcysa8r2swjkrkjnxkcyrsjmxu4s9qypqsq5zvh7glzpas4l9ptxkdhgefyffkn8humq6amkrhrh2gq02gv8emxrynkwke3uwgf4cfevek89g4020lgldxgusmse79h4caqg30qq2cqmyrc7d" as EncodedPaymentRequest
+  const muunInvoiceWithAmount = decodeInvoice(muunPaymentRequestWithAmount) as LnInvoice
   const paymentRequestWithNoAmount =
     "lnbc1p3zn402pp54skf32qeal5jnfm73u5e3d9h5448l4yutszy0kr9l56vdsy8jefsdqqcqzpuxqyz5vqsp5c6z7a4lrey4ejvhx5q4l83jm9fhy34dsqgxnceem4dgz6fmh456s9qyyssqkxkg6ke6nt39dusdhpansu8j0r5f7gadwcampnw2g8ap0fccteer7hzjc8tgat9m5wxd98nxjxhwx0ha6g95v9edmgd30f0m8kujslgpxtzt6w" as EncodedPaymentRequest
   const invoiceWithNoAmount = decodeInvoice(paymentRequestWithNoAmount) as LnInvoice
@@ -96,6 +99,7 @@ describe("LightningPaymentFlowBuilder", () => {
 
     describe("invoice with amount", () => {
       const withAmountBuilder = lightningBuilder.withInvoice(invoiceWithAmount)
+      const withMuunAmountBuilder = lightningBuilder.withInvoice(muunInvoiceWithAmount)
       const checkInvoice = (payment) => {
         expect(payment).toEqual(
           expect.objectContaining({
@@ -110,6 +114,10 @@ describe("LightningPaymentFlowBuilder", () => {
           .withSenderWallet(senderBtcWallet)
           .withoutRecipientWallet()
 
+        const withMuunBtcWalletBuilder = withMuunAmountBuilder
+          .withSenderWallet(senderBtcWallet)
+          .withoutRecipientWallet()
+
         const checkSenderWallet = (payment) => {
           expect(payment).toEqual(
             expect.objectContaining({
@@ -118,6 +126,14 @@ describe("LightningPaymentFlowBuilder", () => {
             }),
           )
         }
+
+        it("sets 'skipProbe' property to true for flagged destination invoice", async () => {
+          const muunBuilder = await withMuunBtcWalletBuilder.withConversion({
+            usdFromBtc,
+            btcFromUsd,
+          })
+          expect(muunBuilder.skipProbeForDestination()).toBeTruthy()
+        })
 
         it("uses mid price and max btc fees", async () => {
           const payment = await withBtcWalletBuilder
@@ -153,6 +169,7 @@ describe("LightningPaymentFlowBuilder", () => {
               usdPaymentAmount,
               btcProtocolFee,
               usdProtocolFee,
+              skipProbeForDestination: false,
             }),
           )
         })
@@ -193,6 +210,7 @@ describe("LightningPaymentFlowBuilder", () => {
               },
               outgoingNodePubkey: pubkey,
               cachedRoute: rawRoute,
+              skipProbeForDestination: false,
             }),
           )
 
@@ -213,6 +231,7 @@ describe("LightningPaymentFlowBuilder", () => {
             expect.objectContaining({
               senderWalletId: senderUsdWallet.id,
               senderWalletCurrency: senderUsdWallet.currency,
+              skipProbeForDestination: false,
             }),
           )
         }
@@ -251,6 +270,7 @@ describe("LightningPaymentFlowBuilder", () => {
               usdPaymentAmount,
               btcProtocolFee,
               usdProtocolFee,
+              skipProbeForDestination: false,
             }),
           )
         })
@@ -291,6 +311,7 @@ describe("LightningPaymentFlowBuilder", () => {
               },
               outgoingNodePubkey: pubkey,
               cachedRoute: rawRoute,
+              skipProbeForDestination: false,
             }),
           )
 
@@ -312,6 +333,7 @@ describe("LightningPaymentFlowBuilder", () => {
         expect(payment).toEqual(
           expect.objectContaining({
             inputAmount: uncheckedAmount,
+            skipProbeForDestination: false,
           }),
         )
       }
@@ -330,6 +352,7 @@ describe("LightningPaymentFlowBuilder", () => {
                 amount: uncheckedAmount,
                 currency: WalletCurrency.Btc,
               },
+              skipProbeForDestination: false,
             }),
           )
         }
@@ -371,6 +394,7 @@ describe("LightningPaymentFlowBuilder", () => {
               usdPaymentAmount,
               btcProtocolFee,
               usdProtocolFee,
+              skipProbeForDestination: false,
             }),
           )
         })
@@ -390,6 +414,7 @@ describe("LightningPaymentFlowBuilder", () => {
                 amount: uncheckedAmount,
                 currency: WalletCurrency.Usd,
               },
+              skipProbeForDestination: false,
             }),
           )
         }
@@ -415,6 +440,7 @@ describe("LightningPaymentFlowBuilder", () => {
             expect.objectContaining({
               btcPaymentAmount,
               btcProtocolFee: LnFees().maxProtocolFee(btcPaymentAmount),
+              skipProbeForDestination: false,
             }),
           )
         })

--- a/test/unit/payments/payment-flow.spec.ts
+++ b/test/unit/payments/payment-flow.spec.ts
@@ -19,6 +19,7 @@ describe("PaymentFlowFromLedgerTransaction", () => {
 
     paymentHash: "paymentHash" as PaymentHash,
     descriptionFromInvoice: "",
+    skipProbeForDestination: false,
     createdAt: timestamp,
     paymentSentAndPending: true,
 


### PR DESCRIPTION
## Description

This PR fixes an issue where some services will always fail the fee probe whether there is a route or not (e.g. Muun). This is an issue because the attempt is logged in lnd's mission-control and it blocks any real payments attempts that are tried soon after the probe.

This PR allows us to configure flagged destinations that will fail and to skip the probe and simply return a max fee for these routes.