### PR TITLE
feat: add gql selection incoming pending onchain balance

### DIFF
--- a/src/app/wallets/get-on-chain-txs.ts
+++ b/src/app/wallets/get-on-chain-txs.ts
@@ -1,0 +1,24 @@
+import { BTC_NETWORK, ONCHAIN_MIN_CONFIRMATIONS, SECS_PER_10_MINS } from "@config"
+
+import { OnChainError, TxDecoder } from "@domain/bitcoin/onchain"
+import { CacheKeys } from "@domain/cache"
+
+import { RedisCacheService } from "@services/cache"
+import { OnChainService } from "@services/lnd/onchain-service"
+import { baseLogger } from "@services/logger"
+
+// we are getting both the transactions in the mempool and the transaction that
+// have been mined by not yet credited because they haven't reached enough confirmations
+export default async () =>
+  RedisCacheService().getOrSet({
+    key: CacheKeys.LastOnChainTransactions,
+    ttlSecs: SECS_PER_10_MINS,
+    fn: async () => {
+      const onChain = OnChainService(TxDecoder(BTC_NETWORK))
+      if (onChain instanceof OnChainError) {
+        baseLogger.warn({ onChain }, "impossible to create OnChainService")
+        return onChain
+      }
+      return onChain.listIncomingTransactions(ONCHAIN_MIN_CONFIRMATIONS)
+    },
+  })

--- a/src/app/wallets/get-pending-onchain-balance-for-wallet.ts
+++ b/src/app/wallets/get-pending-onchain-balance-for-wallet.ts
@@ -1,0 +1,52 @@
+import { BTC_NETWORK, ONCHAIN_MIN_CONFIRMATIONS, SECS_PER_10_MINS } from "@config"
+
+import { CacheKeys } from "@domain/cache"
+import { OnChainError, TxDecoder, TxFilter } from "@domain/bitcoin/onchain"
+
+import { baseLogger } from "@services/logger"
+import { RedisCacheService } from "@services/cache"
+import { OnChainService } from "@services/lnd/onchain-service"
+import { IncomingOnChainTxHandler } from "@domain/bitcoin/onchain/incoming-tx-handler"
+
+const redisCache = RedisCacheService()
+
+export const getPendingOnChainBalanceForWallet = async (
+  wallets: Wallet[],
+): Promise<{ [key: WalletId]: CurrencyBaseAmount } | ApplicationError> => {
+  const onChain = OnChainService(TxDecoder(BTC_NETWORK))
+  if (onChain instanceof OnChainError) {
+    baseLogger.warn({ onChain }, "impossible to create OnChainService")
+    return onChain
+  }
+
+  // we are getting both the transactions in the mempool and the transaction that
+  // have been mined by not yet credited because they haven't reached enough confirmations
+  const onChainTxs = await redisCache.getOrSet({
+    key: CacheKeys.LastOnChainTransactions,
+    ttlSecs: SECS_PER_10_MINS,
+    fn: () => onChain.listIncomingTransactions(ONCHAIN_MIN_CONFIRMATIONS),
+  })
+  if (onChainTxs instanceof Error) {
+    baseLogger.warn({ onChainTxs }, "impossible to get listIncomingTransactions")
+    return onChainTxs
+  }
+
+  const filter = TxFilter({
+    confirmationsLessThan: ONCHAIN_MIN_CONFIRMATIONS,
+    addresses: wallets.flatMap((wallet) => wallet.onChainAddresses()),
+  })
+
+  const pendingIncoming = filter.apply(onChainTxs)
+
+  const balancesByWallet =
+    IncomingOnChainTxHandler(pendingIncoming).balanceByWallet(wallets)
+  if (balancesByWallet instanceof Error) return balancesByWallet
+
+  const normalizedBalances = {} as { [key: WalletId]: CurrencyBaseAmount }
+  for (const key of Object.keys(balancesByWallet)) {
+    const walletId = key as WalletId
+    const balance = Number(balancesByWallet[walletId]) as CurrencyBaseAmount
+    normalizedBalances[walletId] = balance
+  }
+  return normalizedBalances
+}

--- a/src/app/wallets/get-pending-onchain-balance-for-wallet.ts
+++ b/src/app/wallets/get-pending-onchain-balance-for-wallet.ts
@@ -9,7 +9,7 @@ import getOnChainTxs from "./get-on-chain-txs"
 
 export const getPendingOnChainBalanceForWallet = async (
   wallets: Wallet[],
-): Promise<{ [key: WalletId]: CurrencyBaseAmount } | ApplicationError> => {
+): Promise<{ [key: WalletId]: BtcPaymentAmount } | ApplicationError> => {
   const onChainTxs = await getOnChainTxs()
   if (onChainTxs instanceof Error) {
     baseLogger.warn({ onChainTxs }, "impossible to get listIncomingTransactions")
@@ -20,18 +20,7 @@ export const getPendingOnChainBalanceForWallet = async (
     confirmationsLessThan: ONCHAIN_MIN_CONFIRMATIONS,
     addresses: wallets.flatMap((wallet) => wallet.onChainAddresses()),
   })
-
   const pendingIncoming = filter.apply(onChainTxs)
 
-  const balancesByWallet =
-    IncomingOnChainTxHandler(pendingIncoming).balanceByWallet(wallets)
-  if (balancesByWallet instanceof Error) return balancesByWallet
-
-  const normalizedBalances = {} as { [key: WalletId]: CurrencyBaseAmount }
-  for (const key of Object.keys(balancesByWallet)) {
-    const walletId = key as WalletId
-    const balance = Number(balancesByWallet[walletId]) as CurrencyBaseAmount
-    normalizedBalances[walletId] = balance
-  }
-  return normalizedBalances
+  return IncomingOnChainTxHandler(pendingIncoming).balanceByWallet(wallets)
 }

--- a/src/app/wallets/get-pending-onchain-balance-for-wallet.ts
+++ b/src/app/wallets/get-pending-onchain-balance-for-wallet.ts
@@ -7,7 +7,7 @@ import { IncomingOnChainTxHandler } from "@domain/bitcoin/onchain/incoming-tx-ha
 
 import getOnChainTxs from "./get-on-chain-txs"
 
-export const getPendingOnChainBalanceForWallet = async (
+export const getPendingOnChainBalanceForWallets = async (
   wallets: Wallet[],
 ): Promise<{ [key: WalletId]: BtcPaymentAmount } | ApplicationError> => {
   const onChainTxs = await getOnChainTxs()

--- a/src/app/wallets/get-transactions-by-addresses.ts
+++ b/src/app/wallets/get-transactions-by-addresses.ts
@@ -1,19 +1,16 @@
-import { BTC_NETWORK, ONCHAIN_MIN_CONFIRMATIONS, SECS_PER_10_MINS } from "@config"
+import { ONCHAIN_MIN_CONFIRMATIONS } from "@config"
 
 import { getCurrentPrice } from "@app/prices"
 import { PartialResult } from "@app/partial-result"
 
-import { CacheKeys } from "@domain/cache"
 import { LedgerError } from "@domain/ledger"
 import { WalletTransactionHistory } from "@domain/wallets"
-import { OnChainError, TxDecoder, TxFilter } from "@domain/bitcoin/onchain"
+import { TxFilter } from "@domain/bitcoin/onchain"
 
 import { baseLogger } from "@services/logger"
 import { LedgerService } from "@services/ledger"
-import { RedisCacheService } from "@services/cache"
-import { OnChainService } from "@services/lnd/onchain-service"
 
-const redisCache = RedisCacheService()
+import getOnChainTxs from "./get-on-chain-txs"
 
 export const getTransactionsForWalletsByAddresses = async ({
   wallets,
@@ -34,22 +31,7 @@ export const getTransactionsForWalletsByAddresses = async ({
 
   const confirmedHistory = WalletTransactionHistory.fromLedger(ledgerTransactions)
 
-  const listIncomingToUpdateCache = async () => {
-    const onChain = OnChainService(TxDecoder(BTC_NETWORK))
-    if (onChain instanceof OnChainError) {
-      baseLogger.warn({ onChain }, "impossible to create OnChainService")
-      return onChain
-    }
-    return onChain.listIncomingTransactions(ONCHAIN_MIN_CONFIRMATIONS)
-  }
-
-  // we are getting both the transactions in the mempool and the transaction that
-  // have been mined by not yet credited because they haven't reached enough confirmations
-  const onChainTxs = await redisCache.getOrSet({
-    key: CacheKeys.LastOnChainTransactions,
-    ttlSecs: SECS_PER_10_MINS,
-    fn: listIncomingToUpdateCache,
-  })
+  const onChainTxs = await getOnChainTxs()
   if (onChainTxs instanceof Error) {
     baseLogger.warn({ onChainTxs }, "impossible to get listIncomingTransactions")
     return PartialResult.partial(confirmedHistory.transactions, onChainTxs)

--- a/src/app/wallets/get-transactions-for-wallet.ts
+++ b/src/app/wallets/get-transactions-for-wallet.ts
@@ -1,21 +1,18 @@
-import { BTC_NETWORK, ONCHAIN_MIN_CONFIRMATIONS, SECS_PER_10_MINS } from "@config"
+import { ONCHAIN_MIN_CONFIRMATIONS } from "@config"
 
 import { getCurrentPrice } from "@app/prices"
 import { PartialResult } from "@app/partial-result"
 
-import { CacheKeys } from "@domain/cache"
 import { LedgerError } from "@domain/ledger"
 import { RepositoryError } from "@domain/errors"
 import { WalletTransactionHistory } from "@domain/wallets"
-import { OnChainError, TxDecoder, TxFilter } from "@domain/bitcoin/onchain"
+import { TxFilter } from "@domain/bitcoin/onchain"
 
 import { baseLogger } from "@services/logger"
 import { LedgerService } from "@services/ledger"
-import { RedisCacheService } from "@services/cache"
 import { WalletsRepository } from "@services/mongoose"
-import { OnChainService } from "@services/lnd/onchain-service"
 
-const redisCache = RedisCacheService()
+import getOnChainTxs from "./get-on-chain-txs"
 
 // FIXME(nicolas): remove only used in tests
 export const getTransactionsForWalletId = async ({
@@ -41,22 +38,7 @@ export const getTransactionsForWallets = async (
 
   const confirmedHistory = WalletTransactionHistory.fromLedger(ledgerTransactions)
 
-  const listIncomingToUpdateCache = async () => {
-    const onChain = OnChainService(TxDecoder(BTC_NETWORK))
-    if (onChain instanceof OnChainError) {
-      baseLogger.warn({ onChain }, "impossible to create OnChainService")
-      return onChain
-    }
-    return onChain.listIncomingTransactions(ONCHAIN_MIN_CONFIRMATIONS)
-  }
-
-  // we are getting both the transactions in the mempool and the transaction that
-  // have been mined by not yet credited because they haven't reached enough confirmations
-  const onChainTxs = await redisCache.getOrSet({
-    key: CacheKeys.LastOnChainTransactions,
-    ttlSecs: SECS_PER_10_MINS,
-    fn: listIncomingToUpdateCache,
-  })
+  const onChainTxs = await getOnChainTxs()
   if (onChainTxs instanceof Error) {
     baseLogger.warn({ onChainTxs }, "impossible to get listIncomingTransactions")
     return PartialResult.partial(confirmedHistory.transactions, onChainTxs)

--- a/src/app/wallets/get-transactions-for-wallet.ts
+++ b/src/app/wallets/get-transactions-for-wallet.ts
@@ -41,10 +41,13 @@ export const getTransactionsForWallets = async (
 
   const confirmedHistory = WalletTransactionHistory.fromLedger(ledgerTransactions)
 
-  const onChain = OnChainService(TxDecoder(BTC_NETWORK))
-  if (onChain instanceof OnChainError) {
-    baseLogger.warn({ onChain }, "impossible to create OnChainService")
-    return PartialResult.partial(confirmedHistory.transactions, onChain)
+  const listIncomingToUpdateCache = async () => {
+    const onChain = OnChainService(TxDecoder(BTC_NETWORK))
+    if (onChain instanceof OnChainError) {
+      baseLogger.warn({ onChain }, "impossible to create OnChainService")
+      return onChain
+    }
+    return onChain.listIncomingTransactions(ONCHAIN_MIN_CONFIRMATIONS)
   }
 
   // we are getting both the transactions in the mempool and the transaction that
@@ -52,7 +55,7 @@ export const getTransactionsForWallets = async (
   const onChainTxs = await redisCache.getOrSet({
     key: CacheKeys.LastOnChainTransactions,
     ttlSecs: SECS_PER_10_MINS,
-    fn: () => onChain.listIncomingTransactions(ONCHAIN_MIN_CONFIRMATIONS),
+    fn: listIncomingToUpdateCache,
   })
   if (onChainTxs instanceof Error) {
     baseLogger.warn({ onChainTxs }, "impossible to get listIncomingTransactions")

--- a/src/app/wallets/index.ts
+++ b/src/app/wallets/index.ts
@@ -1,5 +1,6 @@
 export * from "./create-on-chain-address"
 export * from "./get-balance-for-wallet"
+export * from "./get-pending-onchain-balance-for-wallet"
 export * from "./get-transactions-for-wallet"
 export * from "./get-last-on-chain-address"
 export * from "./get-on-chain-fee"

--- a/src/domain/bitcoin/onchain/incoming-tx-handler.ts
+++ b/src/domain/bitcoin/onchain/incoming-tx-handler.ts
@@ -1,0 +1,66 @@
+import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
+
+export const IncomingOnChainTxHandler = (
+  txns: IncomingOnChainTransaction[],
+): IncomingOnChainTxHandler => {
+  const balanceByAddress = (): { [key: OnChainAddress]: bigint } | ValidationError => {
+    const pendingBalances = txns.map(balanceFromIncomingTx)
+
+    const balancesByAddress = {} as { [key: OnChainAddress]: bigint }
+    for (const balances of pendingBalances) {
+      if (balances instanceof Error) return balances
+      for (const key of Object.keys(balances)) {
+        const address = key as OnChainAddress
+        balancesByAddress[address] =
+          (balancesByAddress[address] || 0n) + balances[address]
+      }
+    }
+    return balancesByAddress
+  }
+
+  const balanceByWallet = (
+    wallets: Wallet[],
+  ): { [key: WalletId]: bigint } | ValidationError => {
+    const balancesByAddress = balanceByAddress()
+    if (balancesByAddress instanceof Error) return balancesByAddress
+
+    const balancesByWallet = {} as { [key: WalletId]: bigint }
+    for (const wallet of wallets) {
+      balancesByWallet[wallet.id] = 0n
+      for (const key of Object.keys(balancesByAddress)) {
+        const address = key as OnChainAddress
+        if (wallet.onChainAddresses().includes(address as OnChainAddress)) {
+          balancesByWallet[wallet.id] += balancesByAddress[address]
+        }
+      }
+    }
+
+    return balancesByWallet
+  }
+
+  const balanceFromIncomingTx = (
+    tx: IncomingOnChainTransaction,
+  ): { [key: OnChainAddress]: bigint } | ValidationError => {
+    const balanceByAddress = {} as { [key: OnChainAddress]: bigint }
+    const {
+      rawTx: { outs },
+    } = tx
+    for (const out of outs) {
+      if (!out.address) continue
+      balanceByAddress[out.address] = balanceByAddress[out.address] || 0n
+      const outAmount = paymentAmountFromNumber({
+        amount: out.sats,
+        currency: WalletCurrency.Btc,
+      })
+      if (outAmount instanceof Error) return outAmount
+
+      balanceByAddress[out.address] = balanceByAddress[out.address] + outAmount.amount
+    }
+    return balanceByAddress
+  }
+
+  return {
+    balanceByAddress,
+    balanceByWallet,
+  }
+}

--- a/src/domain/bitcoin/onchain/incoming-tx-handler.ts
+++ b/src/domain/bitcoin/onchain/incoming-tx-handler.ts
@@ -15,7 +15,7 @@ export const IncomingOnChainTxHandler = (
     | ValidationError => {
     const pendingBalances = txns.map(balanceFromIncomingTx)
 
-    const balancesByAddress = {} as { [key: OnChainAddress]: BtcPaymentAmount }
+    const balancesByAddress: { [key: OnChainAddress]: BtcPaymentAmount } = {}
     for (const balances of pendingBalances) {
       if (balances instanceof Error) return balances
       for (const key of Object.keys(balances)) {
@@ -35,7 +35,7 @@ export const IncomingOnChainTxHandler = (
     const balancesByAddress = balanceByAddress()
     if (balancesByAddress instanceof Error) return balancesByAddress
 
-    const balancesByWallet = {} as { [key: WalletId]: BtcPaymentAmount }
+    const balancesByWallet: { [key: WalletId]: BtcPaymentAmount } = {}
     for (const wallet of wallets) {
       balancesByWallet[wallet.id] = ZERO_SATS
       for (const key of Object.keys(balancesByAddress)) {
@@ -55,7 +55,7 @@ export const IncomingOnChainTxHandler = (
   const balanceFromIncomingTx = (
     tx: IncomingOnChainTransaction,
   ): { [key: OnChainAddress]: BtcPaymentAmount } | ValidationError => {
-    const balanceByAddress = {} as { [key: OnChainAddress]: BtcPaymentAmount }
+    const balanceByAddress: { [key: OnChainAddress]: BtcPaymentAmount } = {}
     const {
       rawTx: { outs },
     } = tx

--- a/src/domain/bitcoin/onchain/incoming-tx-handler.ts
+++ b/src/domain/bitcoin/onchain/incoming-tx-handler.ts
@@ -61,14 +61,16 @@ export const IncomingOnChainTxHandler = (
     } = tx
     for (const out of outs) {
       if (!out.address) continue
-      balanceByAddress[out.address] = balanceByAddress[out.address] || ZERO_SATS
       const outAmount = paymentAmountFromNumber({
         amount: out.sats,
         currency: WalletCurrency.Btc,
       })
       if (outAmount instanceof Error) return outAmount
 
-      balanceByAddress[out.address] = calc.add(balanceByAddress[out.address], outAmount)
+      balanceByAddress[out.address] = calc.add(
+        balanceByAddress[out.address] || ZERO_SATS,
+        outAmount,
+      )
     }
     return balanceByAddress
   }

--- a/src/domain/bitcoin/onchain/incoming-tx-handler.ts
+++ b/src/domain/bitcoin/onchain/incoming-tx-handler.ts
@@ -40,7 +40,7 @@ export const IncomingOnChainTxHandler = (
       balancesByWallet[wallet.id] = ZERO_SATS
       for (const key of Object.keys(balancesByAddress)) {
         const address = key as OnChainAddress
-        if (wallet.onChainAddresses().includes(address as OnChainAddress)) {
+        if (wallet.onChainAddresses().includes(address)) {
           balancesByWallet[wallet.id] = calc.add(
             balancesByWallet[wallet.id],
             balancesByAddress[address],

--- a/src/domain/bitcoin/onchain/incoming-tx-handler.ts
+++ b/src/domain/bitcoin/onchain/incoming-tx-handler.ts
@@ -1,18 +1,29 @@
-import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
+import {
+  AmountCalculator,
+  paymentAmountFromNumber,
+  WalletCurrency,
+  ZERO_SATS,
+} from "@domain/shared"
+
+const calc = AmountCalculator()
 
 export const IncomingOnChainTxHandler = (
   txns: IncomingOnChainTransaction[],
 ): IncomingOnChainTxHandler => {
-  const balanceByAddress = (): { [key: OnChainAddress]: bigint } | ValidationError => {
+  const balanceByAddress = ():
+    | { [key: OnChainAddress]: BtcPaymentAmount }
+    | ValidationError => {
     const pendingBalances = txns.map(balanceFromIncomingTx)
 
-    const balancesByAddress = {} as { [key: OnChainAddress]: bigint }
+    const balancesByAddress = {} as { [key: OnChainAddress]: BtcPaymentAmount }
     for (const balances of pendingBalances) {
       if (balances instanceof Error) return balances
       for (const key of Object.keys(balances)) {
         const address = key as OnChainAddress
-        balancesByAddress[address] =
-          (balancesByAddress[address] || 0n) + balances[address]
+        balancesByAddress[address] = calc.add(
+          balancesByAddress[address] || ZERO_SATS,
+          balances[address],
+        )
       }
     }
     return balancesByAddress
@@ -20,17 +31,20 @@ export const IncomingOnChainTxHandler = (
 
   const balanceByWallet = (
     wallets: Wallet[],
-  ): { [key: WalletId]: bigint } | ValidationError => {
+  ): { [key: WalletId]: BtcPaymentAmount } | ValidationError => {
     const balancesByAddress = balanceByAddress()
     if (balancesByAddress instanceof Error) return balancesByAddress
 
-    const balancesByWallet = {} as { [key: WalletId]: bigint }
+    const balancesByWallet = {} as { [key: WalletId]: BtcPaymentAmount }
     for (const wallet of wallets) {
-      balancesByWallet[wallet.id] = 0n
+      balancesByWallet[wallet.id] = ZERO_SATS
       for (const key of Object.keys(balancesByAddress)) {
         const address = key as OnChainAddress
         if (wallet.onChainAddresses().includes(address as OnChainAddress)) {
-          balancesByWallet[wallet.id] += balancesByAddress[address]
+          balancesByWallet[wallet.id] = calc.add(
+            balancesByWallet[wallet.id],
+            balancesByAddress[address],
+          )
         }
       }
     }
@@ -40,21 +54,21 @@ export const IncomingOnChainTxHandler = (
 
   const balanceFromIncomingTx = (
     tx: IncomingOnChainTransaction,
-  ): { [key: OnChainAddress]: bigint } | ValidationError => {
-    const balanceByAddress = {} as { [key: OnChainAddress]: bigint }
+  ): { [key: OnChainAddress]: BtcPaymentAmount } | ValidationError => {
+    const balanceByAddress = {} as { [key: OnChainAddress]: BtcPaymentAmount }
     const {
       rawTx: { outs },
     } = tx
     for (const out of outs) {
       if (!out.address) continue
-      balanceByAddress[out.address] = balanceByAddress[out.address] || 0n
+      balanceByAddress[out.address] = balanceByAddress[out.address] || ZERO_SATS
       const outAmount = paymentAmountFromNumber({
         amount: out.sats,
         currency: WalletCurrency.Btc,
       })
       if (outAmount instanceof Error) return outAmount
 
-      balanceByAddress[out.address] = balanceByAddress[out.address] + outAmount.amount
+      balanceByAddress[out.address] = calc.add(balanceByAddress[out.address], outAmount)
     }
     return balanceByAddress
   }

--- a/src/domain/bitcoin/onchain/incoming-tx-handler.ts
+++ b/src/domain/bitcoin/onchain/incoming-tx-handler.ts
@@ -10,7 +10,7 @@ const calc = AmountCalculator()
 export const IncomingOnChainTxHandler = (
   txns: IncomingOnChainTransaction[],
 ): IncomingOnChainTxHandler => {
-  const balanceByAddress = ():
+  const balanceByTxnsAddresses = ():
     | { [key: OnChainAddress]: BtcPaymentAmount }
     | ValidationError => {
     const pendingBalances = txns.map(balanceFromIncomingTx)
@@ -32,7 +32,7 @@ export const IncomingOnChainTxHandler = (
   const balanceByWallet = (
     wallets: Wallet[],
   ): { [key: WalletId]: BtcPaymentAmount } | ValidationError => {
-    const balancesByAddress = balanceByAddress()
+    const balancesByAddress = balanceByTxnsAddresses()
     if (balancesByAddress instanceof Error) return balancesByAddress
 
     const balancesByWallet: { [key: WalletId]: BtcPaymentAmount } = {}
@@ -76,7 +76,7 @@ export const IncomingOnChainTxHandler = (
   }
 
   return {
-    balanceByAddress,
+    balanceByTxnsAddresses,
     balanceByWallet,
   }
 }

--- a/src/domain/bitcoin/onchain/index.types.d.ts
+++ b/src/domain/bitcoin/onchain/index.types.d.ts
@@ -64,6 +64,11 @@ type PayToAddressArgs = {
   targetConfirmations: TargetConfirmations
 }
 
+type IncomingOnChainTxHandler = {
+  balanceByAddress(): { [key: OnChainAddress]: bigint } | ValidationError
+  balanceByWallet(wallets: Wallet[]): { [key: WalletId]: bigint } | ValidationError
+}
+
 interface IOnChainService {
   listActivePubkeys(): Pubkey[]
 

--- a/src/domain/bitcoin/onchain/index.types.d.ts
+++ b/src/domain/bitcoin/onchain/index.types.d.ts
@@ -65,8 +65,10 @@ type PayToAddressArgs = {
 }
 
 type IncomingOnChainTxHandler = {
-  balanceByAddress(): { [key: OnChainAddress]: bigint } | ValidationError
-  balanceByWallet(wallets: Wallet[]): { [key: WalletId]: bigint } | ValidationError
+  balanceByAddress(): { [key: OnChainAddress]: BtcPaymentAmount } | ValidationError
+  balanceByWallet(
+    wallets: Wallet[],
+  ): { [key: WalletId]: BtcPaymentAmount } | ValidationError
 }
 
 interface IOnChainService {

--- a/src/domain/bitcoin/onchain/index.types.d.ts
+++ b/src/domain/bitcoin/onchain/index.types.d.ts
@@ -65,7 +65,7 @@ type PayToAddressArgs = {
 }
 
 type IncomingOnChainTxHandler = {
-  balanceByAddress(): { [key: OnChainAddress]: BtcPaymentAmount } | ValidationError
+  balanceByTxnsAddresses(): { [key: OnChainAddress]: BtcPaymentAmount } | ValidationError
   balanceByWallet(
     wallets: Wallet[],
   ): { [key: WalletId]: BtcPaymentAmount } | ValidationError

--- a/src/graphql/admin/schema.graphql
+++ b/src/graphql/admin/schema.graphql
@@ -71,6 +71,11 @@ type BTCWallet implements Wallet {
   id: ID!
 
   """
+  An unconfirmed incoming onchain balance stored in BTC.
+  """
+  pendingIncomingBalance: SignedAmount!
+
+  """
   A list of BTC transactions associated with this wallet.
   """
   transactions(
@@ -475,6 +480,11 @@ type UsdWallet implements Wallet {
   accountId: ID!
   balance: SignedAmount!
   id: ID!
+
+  """
+  An unconfirmed incoming onchain balance stored in BTC.
+  """
+  pendingIncomingBalance: SignedAmount!
   transactions(
     """
     Returns the items in the list that come after the specified cursor.
@@ -554,6 +564,7 @@ interface Wallet {
   accountId: ID!
   balance: SignedAmount!
   id: ID!
+  pendingIncomingBalance: SignedAmount!
 
   """
   Transactions are ordered anti-chronologically,

--- a/src/graphql/admin/schema.graphql
+++ b/src/graphql/admin/schema.graphql
@@ -71,7 +71,7 @@ type BTCWallet implements Wallet {
   id: ID!
 
   """
-  An unconfirmed incoming onchain balance stored in BTC.
+  An unconfirmed incoming onchain balance.
   """
   pendingIncomingBalance: SignedAmount!
 
@@ -482,7 +482,7 @@ type UsdWallet implements Wallet {
   id: ID!
 
   """
-  An unconfirmed incoming onchain balance stored in BTC.
+  An unconfirmed incoming onchain balance.
   """
   pendingIncomingBalance: SignedAmount!
   transactions(

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -3,14 +3,15 @@ import { WalletCurrency } from "@domain/shared"
 
 import { mapError } from "./error-map"
 
+const QueryDoesNotMatchWalletCurrencyError = "QueryDoesNotMatchWalletCurrencyError"
+const MutationDoesNotMatchWalletCurrencyError = "MutationDoesNotMatchWalletCurrencyError"
+
 export const validateIsBtcWalletForMutation = async (
   walletId: WalletId,
 ): Promise<true | { errors: [{ message: string }] }> => {
   const wallet = await WalletsRepository().findById(walletId)
   if (wallet instanceof Error) return { errors: [{ message: mapError(wallet).message }] }
 
-  const MutationDoesNotMatchWalletCurrencyError =
-    "MutationDoesNotMatchWalletCurrencyError"
   if (wallet.currency === WalletCurrency.Usd) {
     return { errors: [{ message: MutationDoesNotMatchWalletCurrencyError }] }
   }
@@ -23,10 +24,12 @@ export const validateIsUsdWalletForMutation = async (
   const wallet = await WalletsRepository().findById(walletId)
   if (wallet instanceof Error) return { errors: [{ message: mapError(wallet).message }] }
 
-  const MutationDoesNotMatchWalletCurrencyError =
-    "MutationDoesNotMatchWalletCurrencyError"
   if (wallet.currency === WalletCurrency.Btc) {
     return { errors: [{ message: MutationDoesNotMatchWalletCurrencyError }] }
   }
   return true
+}
+
+export const notBtcWalletForQueryError: { errors: [{ message: string }] } = {
+  errors: [{ message: QueryDoesNotMatchWalletCurrencyError }],
 }

--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -59,6 +59,11 @@ type BTCWallet implements Wallet {
   id: ID!
 
   """
+  An unconfirmed incoming onchain balance stored in BTC.
+  """
+  pendingIncomingBalance: SignedAmount!
+
+  """
   A list of BTC transactions associated with this wallet.
   """
   transactions(
@@ -1059,6 +1064,11 @@ type UsdWallet implements Wallet {
   accountId: ID!
   balance: SignedAmount!
   id: ID!
+
+  """
+  An unconfirmed incoming onchain balance stored in BTC.
+  """
+  pendingIncomingBalance: SignedAmount!
   transactions(
     """
     Returns the items in the list that come after the specified cursor.
@@ -1254,6 +1264,7 @@ interface Wallet {
   accountId: ID!
   balance: SignedAmount!
   id: ID!
+  pendingIncomingBalance: SignedAmount!
 
   """
   Transactions are ordered anti-chronologically,

--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -59,7 +59,7 @@ type BTCWallet implements Wallet {
   id: ID!
 
   """
-  An unconfirmed incoming onchain balance stored in BTC.
+  An unconfirmed incoming onchain balance.
   """
   pendingIncomingBalance: SignedAmount!
 
@@ -1066,7 +1066,7 @@ type UsdWallet implements Wallet {
   id: ID!
 
   """
-  An unconfirmed incoming onchain balance stored in BTC.
+  An unconfirmed incoming onchain balance.
   """
   pendingIncomingBalance: SignedAmount!
   transactions(

--- a/src/graphql/types/abstract/wallet.ts
+++ b/src/graphql/types/abstract/wallet.ts
@@ -24,6 +24,9 @@ const IWallet = GT.Interface({
     balance: {
       type: GT.NonNull(SignedAmount),
     },
+    pendingIncomingBalance: {
+      type: GT.NonNull(SignedAmount),
+    },
     transactions: {
       description: dedent`Transactions are ordered anti-chronologically,
       ie: the newest transaction will be first`,

--- a/src/graphql/types/object/btc-wallet.ts
+++ b/src/graphql/types/object/btc-wallet.ts
@@ -43,6 +43,15 @@ const BtcWallet = GT.Object<Wallet>({
         return balanceSats
       },
     },
+    pendingIncomingBalance: {
+      type: GT.NonNull(SignedAmount),
+      description: "An unconfirmed incoming onchain balance stored in BTC.",
+      resolve: async (source) => {
+        const balanceSats = await Wallets.getPendingOnChainBalanceForWallet([source])
+        if (balanceSats instanceof Error) throw mapError(balanceSats)
+        return balanceSats[source.id]
+      },
+    },
     transactions: {
       type: TransactionConnection,
       args: connectionArgs,

--- a/src/graphql/types/object/btc-wallet.ts
+++ b/src/graphql/types/object/btc-wallet.ts
@@ -1,4 +1,5 @@
 import { GT } from "@graphql/index"
+import { normalizePaymentAmount } from "@graphql/root/mutation"
 import { connectionArgs, connectionFromArray } from "@graphql/connections"
 import { mapError } from "@graphql/error-map"
 
@@ -49,7 +50,7 @@ const BtcWallet = GT.Object<Wallet>({
       resolve: async (source) => {
         const balanceSats = await Wallets.getPendingOnChainBalanceForWallet([source])
         if (balanceSats instanceof Error) throw mapError(balanceSats)
-        return balanceSats[source.id]
+        return normalizePaymentAmount(balanceSats[source.id]).amount
       },
     },
     transactions: {

--- a/src/graphql/types/object/btc-wallet.ts
+++ b/src/graphql/types/object/btc-wallet.ts
@@ -48,7 +48,7 @@ const BtcWallet = GT.Object<Wallet>({
       type: GT.NonNull(SignedAmount),
       description: "An unconfirmed incoming onchain balance.",
       resolve: async (source) => {
-        const balanceSats = await Wallets.getPendingOnChainBalanceForWallet([source])
+        const balanceSats = await Wallets.getPendingOnChainBalanceForWallets([source])
         if (balanceSats instanceof Error) throw mapError(balanceSats)
         return normalizePaymentAmount(balanceSats[source.id]).amount
       },

--- a/src/graphql/types/object/btc-wallet.ts
+++ b/src/graphql/types/object/btc-wallet.ts
@@ -46,7 +46,7 @@ const BtcWallet = GT.Object<Wallet>({
     },
     pendingIncomingBalance: {
       type: GT.NonNull(SignedAmount),
-      description: "An unconfirmed incoming onchain balance stored in BTC.",
+      description: "An unconfirmed incoming onchain balance.",
       resolve: async (source) => {
         const balanceSats = await Wallets.getPendingOnChainBalanceForWallet([source])
         if (balanceSats instanceof Error) throw mapError(balanceSats)

--- a/src/graphql/types/object/usd-wallet.ts
+++ b/src/graphql/types/object/usd-wallet.ts
@@ -42,6 +42,15 @@ const UsdWallet = GT.Object<Wallet>({
         return Math.floor(balanceCents)
       },
     },
+    pendingIncomingBalance: {
+      type: GT.NonNull(SignedAmount),
+      description: "An unconfirmed incoming onchain balance stored in BTC.",
+      resolve: async (source) => {
+        const balanceSats = await Wallets.getPendingOnChainBalanceForWallet([source])
+        if (balanceSats instanceof Error) throw mapError(balanceSats)
+        return balanceSats[source.id]
+      },
+    },
     transactions: {
       type: TransactionConnection,
       args: connectionArgs,

--- a/src/graphql/types/object/usd-wallet.ts
+++ b/src/graphql/types/object/usd-wallet.ts
@@ -45,7 +45,7 @@ const UsdWallet = GT.Object<Wallet>({
     },
     pendingIncomingBalance: {
       type: GT.NonNull(SignedAmount),
-      description: "An unconfirmed incoming onchain balance stored in BTC.",
+      description: "An unconfirmed incoming onchain balance.",
       resolve: () => notBtcWalletForQueryError,
     },
     transactions: {

--- a/src/graphql/types/object/usd-wallet.ts
+++ b/src/graphql/types/object/usd-wallet.ts
@@ -1,5 +1,6 @@
 import { GT } from "@graphql/index"
 import { connectionArgs, connectionFromArray } from "@graphql/connections"
+import { notBtcWalletForQueryError } from "@graphql/helpers"
 import { mapError } from "@graphql/error-map"
 
 import { Wallets } from "@app"
@@ -45,11 +46,7 @@ const UsdWallet = GT.Object<Wallet>({
     pendingIncomingBalance: {
       type: GT.NonNull(SignedAmount),
       description: "An unconfirmed incoming onchain balance stored in BTC.",
-      resolve: async (source) => {
-        const balanceSats = await Wallets.getPendingOnChainBalanceForWallet([source])
-        if (balanceSats instanceof Error) throw mapError(balanceSats)
-        return balanceSats[source.id]
-      },
+      resolve: () => notBtcWalletForQueryError,
     },
     transactions: {
       type: TransactionConnection,

--- a/test/integration/02-user-wallet/02-receive-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-onchain.spec.ts
@@ -604,6 +604,11 @@ async function testTxnsByAddressWrapper({
   const commonAddressPendingSet = txnAddressesWithPendingSet.intersect(new Set(addresses))
   expect(commonAddressPendingSet.size).toEqual(addresses.length)
 
+  // Test pending onchain transactions balance use-case
+  const pendingBalances = await Wallets.getPendingOnChainBalanceForWallet([wallet])
+  const expectedPendingBalance = amountSats * addresses.length
+  expect(pendingBalances[walletId]).toEqual(expectedPendingBalance)
+
   // Confirm pending onchain transactions
   await confirmSent({
     walletClient: bitcoindOutside,

--- a/test/integration/02-user-wallet/02-receive-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-onchain.spec.ts
@@ -605,7 +605,7 @@ async function testTxnsByAddressWrapper({
   expect(commonAddressPendingSet.size).toEqual(addresses.length)
 
   // Test pending onchain transactions balance use-case
-  const pendingBalances = await Wallets.getPendingOnChainBalanceForWallet([wallet])
+  const pendingBalances = await Wallets.getPendingOnChainBalanceForWallets([wallet])
   if (pendingBalances instanceof Error) throw pendingBalances
   const expectedPendingBalance = amountSats * addresses.length
   expect(Number(pendingBalances[walletId].amount)).toEqual(expectedPendingBalance)

--- a/test/integration/02-user-wallet/02-receive-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-onchain.spec.ts
@@ -606,8 +606,9 @@ async function testTxnsByAddressWrapper({
 
   // Test pending onchain transactions balance use-case
   const pendingBalances = await Wallets.getPendingOnChainBalanceForWallet([wallet])
+  if (pendingBalances instanceof Error) throw pendingBalances
   const expectedPendingBalance = amountSats * addresses.length
-  expect(pendingBalances[walletId]).toEqual(expectedPendingBalance)
+  expect(Number(pendingBalances[walletId].amount)).toEqual(expectedPendingBalance)
 
   // Confirm pending onchain transactions
   await confirmSent({

--- a/test/unit/domain/bitcoin/onchain/incoming-tx-handler.spec.ts
+++ b/test/unit/domain/bitcoin/onchain/incoming-tx-handler.spec.ts
@@ -1,0 +1,135 @@
+import { toSats } from "@domain/bitcoin"
+import { IncomingOnChainTxHandler } from "@domain/bitcoin/onchain/incoming-tx-handler"
+
+describe("handleIncomingOnChainTransactions", () => {
+  const incomingTxns: IncomingOnChainTransaction[] = [
+    {
+      confirmations: 0,
+      rawTx: {
+        txHash: "txHash1" as OnChainTxHash,
+        outs: [
+          {
+            sats: toSats(100),
+            address: "walletId0-address1" as OnChainAddress,
+          },
+          {
+            sats: toSats(200),
+            address: "change-address1" as OnChainAddress,
+          },
+        ],
+      },
+      fee: toSats(0),
+      createdAt: new Date(Date.now()),
+      uniqueAddresses: () => [] as OnChainAddress[],
+    },
+    {
+      confirmations: 0,
+      rawTx: {
+        txHash: "txHash2" as OnChainTxHash,
+        outs: [
+          {
+            sats: toSats(300),
+            address: "walletId0-address2" as OnChainAddress,
+          },
+          {
+            sats: toSats(400),
+            address: "change-address2" as OnChainAddress,
+          },
+        ],
+      },
+      fee: toSats(0),
+      createdAt: new Date(Date.now()),
+      uniqueAddresses: () => [] as OnChainAddress[],
+    },
+    {
+      confirmations: 0,
+      rawTx: {
+        txHash: "txHash3" as OnChainTxHash,
+        outs: [
+          {
+            sats: toSats(500),
+            address: "walletId1-address1" as OnChainAddress,
+          },
+          {
+            sats: toSats(600),
+            address: "change-address3" as OnChainAddress,
+          },
+        ],
+      },
+      fee: toSats(0),
+      createdAt: new Date(Date.now()),
+      uniqueAddresses: () => [] as OnChainAddress[],
+    },
+  ]
+
+  const handler = IncomingOnChainTxHandler(incomingTxns)
+
+  describe("balance by address", () => {
+    it("calculates balances by addresses in txns", () => {
+      const expectedBalancesByAddress = {
+        ["walletId0-address1"]: 100n,
+        ["change-address1"]: 200n,
+        ["walletId0-address2"]: 300n,
+        ["change-address2"]: 400n,
+        ["walletId1-address1"]: 500n,
+        ["change-address3"]: 600n,
+      }
+      const balancesByAddress = handler.balanceByAddress()
+      expect(balancesByAddress).toStrictEqual(expectedBalancesByAddress)
+    })
+  })
+
+  describe("balance by wallet", () => {
+    const walletsInitial = [
+      {
+        id: "walletId0",
+        onChainAddressIdentifiers: [
+          { pubkey: "pubkey", address: "walletId0-address1" },
+          { pubkey: "pubkey", address: "walletId0-address2" },
+        ],
+      },
+      {
+        id: "walletId1",
+        onChainAddressIdentifiers: [{ pubkey: "pubkey", address: "walletId1-address1" }],
+      },
+      {
+        id: "walletId2",
+        onChainAddressIdentifiers: [],
+      },
+    ]
+    const wallets: Wallet[] = walletsInitial.map(
+      (wallet) =>
+        ({
+          ...wallet,
+          onChainAddresses: () =>
+            wallet.onChainAddressIdentifiers.map(({ address }) => address),
+        } as Wallet),
+    )
+
+    it("calculates balances for a set of wallets", () => {
+      const expectedBalancesByWallet = {
+        walletId0: 400n,
+        walletId1: 500n,
+        walletId2: 0n,
+      }
+
+      // Handles multiple wallets
+      const balancesByWallets = handler.balanceByWallet(wallets)
+      expect(balancesByWallets).toStrictEqual(expectedBalancesByWallet)
+
+      // Handles a single wallet
+      const balancesByWallet0 = handler.balanceByWallet([wallets[0]])
+      expect(balancesByWallet0).toStrictEqual({
+        walletId0: expectedBalancesByWallet.walletId0,
+      })
+      const balancesByWallet1 = handler.balanceByWallet([wallets[1]])
+      expect(balancesByWallet1).toStrictEqual({
+        walletId1: expectedBalancesByWallet.walletId1,
+      })
+      const balancesByWallet2 = handler.balanceByWallet([wallets[2]])
+      expect(balancesByWallet2).toStrictEqual({
+        walletId2: expectedBalancesByWallet.walletId2,
+      })
+    })
+  })
+})

--- a/test/unit/domain/bitcoin/onchain/incoming-tx-handler.spec.ts
+++ b/test/unit/domain/bitcoin/onchain/incoming-tx-handler.spec.ts
@@ -3,6 +3,7 @@ import { IncomingOnChainTxHandler } from "@domain/bitcoin/onchain/incoming-tx-ha
 
 describe("handleIncomingOnChainTransactions", () => {
   const incomingTxns: IncomingOnChainTransaction[] = [
+    // walletId0 1st txn
     {
       confirmations: 0,
       rawTx: {
@@ -22,6 +23,8 @@ describe("handleIncomingOnChainTransactions", () => {
       createdAt: new Date(Date.now()),
       uniqueAddresses: () => [] as OnChainAddress[],
     },
+
+    // walletId0 2nd txn
     {
       confirmations: 0,
       rawTx: {
@@ -41,6 +44,8 @@ describe("handleIncomingOnChainTransactions", () => {
       createdAt: new Date(Date.now()),
       uniqueAddresses: () => [] as OnChainAddress[],
     },
+
+    // walletId1 1st txn
     {
       confirmations: 0,
       rawTx: {
@@ -60,6 +65,31 @@ describe("handleIncomingOnChainTransactions", () => {
       createdAt: new Date(Date.now()),
       uniqueAddresses: () => [] as OnChainAddress[],
     },
+
+    // Tx with multiple outputs from walletId0 & walletId1
+    {
+      confirmations: 0,
+      rawTx: {
+        txHash: "txHash4" as OnChainTxHash,
+        outs: [
+          {
+            sats: toSats(700),
+            address: "walletId0-address1" as OnChainAddress,
+          },
+          {
+            sats: toSats(800),
+            address: "walletId0-address2" as OnChainAddress,
+          },
+          {
+            sats: toSats(900),
+            address: "walletId1-address1" as OnChainAddress,
+          },
+        ],
+      },
+      fee: toSats(0),
+      createdAt: new Date(Date.now()),
+      uniqueAddresses: () => [] as OnChainAddress[],
+    },
   ]
 
   const handler = IncomingOnChainTxHandler(incomingTxns)
@@ -67,11 +97,11 @@ describe("handleIncomingOnChainTransactions", () => {
   describe("balance by address", () => {
     it("calculates balances by addresses in txns", () => {
       const expectedBalancesByAddress = {
-        ["walletId0-address1"]: 100n,
+        ["walletId0-address1"]: 800n,
         ["change-address1"]: 200n,
-        ["walletId0-address2"]: 300n,
+        ["walletId0-address2"]: 1100n,
         ["change-address2"]: 400n,
-        ["walletId1-address1"]: 500n,
+        ["walletId1-address1"]: 1400n,
         ["change-address3"]: 600n,
       }
       const balancesByAddress = handler.balanceByAddress()
@@ -108,8 +138,8 @@ describe("handleIncomingOnChainTransactions", () => {
 
     it("calculates balances for a set of wallets", () => {
       const expectedBalancesByWallet = {
-        walletId0: 400n,
-        walletId1: 500n,
+        walletId0: 1900n,
+        walletId1: 1400n,
         walletId2: 0n,
       }
 

--- a/test/unit/domain/bitcoin/onchain/incoming-tx-handler.spec.ts
+++ b/test/unit/domain/bitcoin/onchain/incoming-tx-handler.spec.ts
@@ -123,7 +123,7 @@ describe("handleIncomingOnChainTransactions", () => {
         ["change-address3"]: 600n,
       }
 
-      const balancesByAddress = handler.balanceByAddress()
+      const balancesByAddress = handler.balanceByTxnsAddresses()
       expect(balancesByAddress).toStrictEqual(balancesByKey(expectedAmountsByAddress))
     })
   })


### PR DESCRIPTION
## Discussion

There is a subset of transactions that is currently not added to our ledger or accounted for in our balances. These are the incoming onchain transactions for a user that haven't met the required number of confirmations onchain as yet.

This PR is to calculate the sum of these pending transactions for a user and expose this balance via a new selection.

### Reasoning

If an API user would like to retrieve the pending incoming balance (unconfirmed onchain txns) for a wallet, their only option right now would be to use the `transactions` selection and:
- **paginate until their very 1st transaction**
   Because transactions can have different fees at different times, there's no guarantee that a confirmed transaction does not have prior unconfirmed transactions for that wallet still pending before it

- **filter by onchain & pending**
   There's no way (I think) otherwise to filter transactions at the graphql level, so all transactions must be fetched

- **sum the transaction amounts**

If we assume an API user wanting to retrieve their pending incoming onchain balance is a legitimate use-case, the rationale for having a selection that calculates this value for the user is similar to the one for exposing a `balance` selection instead of having the user also calculate this from `transactions` selection on the fly.

