### PR TITLE
refactor: fix exposed error messages via API

### DIFF
--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -27,7 +27,7 @@ const assertUnreachable = (x: never): never => {
 
 export const mapError = (error: ApplicationError): CustomApolloError => {
   const errorName = error.name as ApplicationErrorKey
-  let message: string = errorName || ""
+  let message = ""
   switch (errorName) {
     case "WithdrawalLimitsExceededError":
       message = error.message
@@ -97,9 +97,6 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       message = "User tried to pay themselves"
       return new SelfPaymentError({ message, logger: baseLogger })
 
-    case "InsufficientBalanceError":
-      return new InsufficientBalanceError({ message, logger: baseLogger })
-
     case "LnInvoiceMissingPaymentSecretError":
       message = "Invoice is missing its 'payment secret' value"
       return new InvoiceDecodeError({ message, logger: baseLogger })
@@ -119,6 +116,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "InvalidBtcPaymentAmountError":
       message = "A valid satoshi amount is required"
       return new ValidationInternalError({ message, logger: baseLogger })
+
     case "InvalidUsdPaymentAmountError":
       message = "A valid usd amount is required"
       return new ValidationInternalError({ message, logger: baseLogger })
@@ -227,21 +225,33 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       message = "Invalid lightning request, couldn't decode."
       return new InvoiceDecodeError({ message, logger: baseLogger })
 
-    case "UnknownRepositoryError":
-      return new DbError({ message, logger: baseLogger, level: "fatal" })
-
-    case "UnknownLedgerError":
-      return new DbError({ message, logger: baseLogger, level: "fatal" })
-
     case "PaymentInTransitionError":
       message = "Payment was sent and is still in transition."
       return new LightningPaymentError({ message, logger: baseLogger })
 
-    case "UnknownLightningServiceError":
-      return new LightningPaymentError({ message, logger: baseLogger })
+    case "UsernameNotAvailableError":
+      message = "username not available"
+      return new UsernameError({ message, logger: baseLogger })
 
-    case "UnknownTwoFAError":
+    case "UsernameIsImmutableError":
+      message = "username is immutable"
+      return new UsernameError({ message, logger: baseLogger })
+
+    case "TwoFANeedToBeSetBeforeDeletionError":
+      message = "TwoFA need to be set before removal"
       return new TwoFAError({ message, logger: baseLogger })
+
+    case "TwoFAAlreadySetError":
+      message = "TwoFA is already set"
+      return new TwoFAError({ message, logger: baseLogger })
+
+    case "InvalidWalletId":
+      message = "Invalid walletId for account."
+      return new ValidationInternalError({ message, logger: baseLogger })
+
+    case "InsufficientBalanceError":
+      message = error.message
+      return new InsufficientBalanceError({ message, logger: baseLogger })
 
     case "InvalidCoordinatesError":
       return new InvalidCoordinatesError({ logger: baseLogger })
@@ -249,32 +259,25 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "InvalidBusinessTitleLengthError":
       return new InvalidBusinessTitleLengthError({ logger: baseLogger })
 
-    case "UsernameNotAvailableError":
-      message = "username not available"
-      return new UsernameError({ logger: baseLogger, message })
-
-    case "UsernameIsImmutableError":
-      message = "username is immutable"
-      return new UsernameError({ logger: baseLogger, message })
-
-    case "TwoFANeedToBeSetBeforeDeletionError":
-      message = "TwoFA need to be set before removal"
-      return new TwoFAError({ logger: baseLogger, message })
-
-    case "TwoFAAlreadySetError":
-      message = "TwoFA is already set"
-      return new TwoFAError({ logger: baseLogger, message })
-
     case "RebalanceNeededError":
       return new RebalanceNeededError({ logger: baseLogger })
-
-    case "InvalidWalletId":
-      message = "Invalid walletId for account."
-      return new ValidationInternalError({ message, logger: baseLogger })
 
     // ----------
     // Unhandled below here
     // ----------
+    case "UnknownRepositoryError":
+    case "UnknownLedgerError":
+      message = `Unknown error occurred (code: ${error.name})`
+      return new DbError({ message, logger: baseLogger, level: "fatal" })
+
+    case "UnknownLightningServiceError":
+      message = `Unknown error occurred (code: ${error.name})`
+      return new LightningPaymentError({ message, logger: baseLogger })
+
+    case "UnknownTwoFAError":
+      message = `Unknown error occurred (code: ${error.name})`
+      return new TwoFAError({ message, logger: baseLogger })
+
     case "RateLimiterExceededError":
     case "RateLimitError":
     case "RateLimitServiceError":

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -27,7 +27,7 @@ const assertUnreachable = (x: never): never => {
 
 export const mapError = (error: ApplicationError): CustomApolloError => {
   const errorName = error.name as ApplicationErrorKey
-  let message = error.message || errorName || ""
+  let message: string = errorName || ""
   switch (errorName) {
     case "WithdrawalLimitsExceededError":
       message = error.message

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -278,10 +278,24 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       message = `Unknown error occurred (code: ${error.name})`
       return new TwoFAError({ message, logger: baseLogger })
 
+    case "UnknownRateLimitServiceError":
+    case "UnknownLockServiceError":
+    case "UnknownPriceServiceError":
+    case "UnknownOnChainServiceError":
+    case "UnknownNotificationsServiceError":
+    case "UnknownIpFetcherServiceError":
+    case "UnknownCacheServiceError":
+    case "UnknownPhoneProviderServiceError":
+    case "UnknownColdStorageServiceError":
+    case "UnknownDealerPriceServiceError":
+    case "UnknownPubSubError":
+    case "UnknownBigIntConversionError":
+      message = `Unknown error occurred (code: ${error.name})`
+      return new UnknownClientError({ message, logger: baseLogger })
+
     case "RateLimiterExceededError":
     case "RateLimitError":
     case "RateLimitServiceError":
-    case "UnknownRateLimitServiceError":
     case "CouldNotFindUserError":
     case "TwoFAError":
     case "LedgerError":
@@ -329,27 +343,22 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "LockServiceError":
     case "ResourceAttemptsLockServiceError":
     case "ResourceExpiredLockServiceError":
-    case "UnknownLockServiceError":
     case "PriceError":
     case "PriceServiceError":
     case "PriceNotAvailableError":
     case "DealerPriceNotAvailableError":
     case "PriceHistoryNotAvailableError":
-    case "UnknownPriceServiceError":
     case "OnChainError":
     case "TransactionDecodeError":
     case "OnChainServiceError":
-    case "UnknownOnChainServiceError":
     case "CouldNotFindOnChainTransactionError":
     case "OnChainServiceUnavailableError":
     case "NotificationsError":
     case "NotificationsServiceError":
     case "InvalidDeviceNotificationsServiceError":
-    case "UnknownNotificationsServiceError":
     case "AccountError":
     case "IpFetcherError":
     case "IpFetcherServiceError":
-    case "UnknownIpFetcherServiceError":
     case "CouldNotFindTransactionError":
     case "CouldNotFindTransactionMetadataError":
     case "InvalidLedgerTransactionId":
@@ -357,10 +366,8 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "CacheNotAvailableError":
     case "CacheServiceError":
     case "CacheUndefinedError":
-    case "UnknownCacheServiceError":
     case "UserPhoneCodeAttemptPhoneMinIntervalRateLimiterExceededError":
     case "PhoneProviderServiceError":
-    case "UnknownPhoneProviderServiceError":
     case "MissingPhoneMetadataError":
     case "InvalidPhoneMetadataTypeError":
     case "InvalidPhoneMetadataCountryError":
@@ -382,7 +389,6 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "InvalidCurrentColdStorageWalletServiceError":
     case "InsufficientBalanceForRebalanceError":
     case "InvalidOrNonWalletTransactionError":
-    case "UnknownColdStorageServiceError":
     case "FeeDifferenceError":
     case "NoTransactionToSettleError":
     case "CorruptLndDbError":
@@ -390,7 +396,6 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "NotReachableError":
     case "DealerPriceError":
     case "DealerPriceServiceError":
-    case "UnknownDealerPriceServiceError":
     case "InvalidNegativeAmountError":
     case "DomainError":
     case "ErrorLevel":
@@ -411,10 +416,8 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "IntraLedgerHashPresentInLnFlowError":
     case "PubSubError":
     case "PubSubServiceError":
-    case "UnknownPubSubError":
     case "BigIntConversionError":
     case "BigIntFloatConversionError":
-    case "UnknownBigIntConversionError":
     case "SafeWrapperError":
     case "InvalidFeeProbeStateError":
     case "InvalidPubKeyError":

--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -85,7 +85,10 @@ export const LndService = (): ILightningService | LightningServiceError => {
       return toSats(channel_balance)
     } catch (err) {
       const errDetails = parseLndErrorDetails(err)
-      return new UnknownLightningServiceError(errDetails)
+      switch (errDetails) {
+        default:
+          return new UnknownLightningServiceError(msgForUnknown(err))
+      }
     }
   }
 
@@ -100,7 +103,10 @@ export const LndService = (): ILightningService | LightningServiceError => {
       return toSats(pending_balance)
     } catch (err) {
       const errDetails = parseLndErrorDetails(err)
-      return new UnknownLightningServiceError(errDetails)
+      switch (errDetails) {
+        default:
+          return new UnknownLightningServiceError(msgForUnknown(err))
+      }
     }
   }
 
@@ -124,7 +130,10 @@ export const LndService = (): ILightningService | LightningServiceError => {
       return toSats(closingChannelBalance)
     } catch (err) {
       const errDetails = parseLndErrorDetails(err)
-      return new UnknownLightningServiceError(errDetails)
+      switch (errDetails) {
+        default:
+          return new UnknownLightningServiceError(msgForUnknown(err))
+      }
     }
   }
 
@@ -283,7 +292,7 @@ export const LndService = (): ILightningService | LightningServiceError => {
       const errDetails = parseLndErrorDetails(err)
       switch (errDetails) {
         default:
-          return new UnknownLightningServiceError(JSON.stringify(err))
+          return new UnknownLightningServiceError(msgForUnknown(err))
       }
     }
   }
@@ -324,7 +333,7 @@ export const LndService = (): ILightningService | LightningServiceError => {
         case KnownLndErrorDetails.InvoiceNotFound:
           return new InvoiceNotFoundError()
         default:
-          return new UnknownLightningServiceError(JSON.stringify(err))
+          return new UnknownLightningServiceError(msgForUnknown(err))
       }
     }
   }
@@ -459,7 +468,7 @@ export const LndService = (): ILightningService | LightningServiceError => {
         case KnownLndErrorDetails.InvoiceNotFound:
           return true
         default:
-          return new UnknownLightningServiceError(JSON.stringify(err))
+          return new UnknownLightningServiceError(msgForUnknown(err))
       }
     }
   }
@@ -645,7 +654,7 @@ const lookupPaymentByPubkeyAndHash = async ({
       case KnownLndErrorDetails.SentPaymentNotFound:
         return new PaymentNotFoundError(JSON.stringify({ paymentHash, pubkey }))
       default:
-        return new UnknownLightningServiceError(JSON.stringify(err))
+        return new UnknownLightningServiceError(msgForUnknown(err))
     }
   }
 }
@@ -756,6 +765,12 @@ const handleSendPaymentLndErrors = ({
     case KnownLndErrorDetails.PaymentInTransition:
       return new PaymentInTransitionError(paymentHash)
     default:
-      return new UnknownLightningServiceError(JSON.stringify(err))
+      return new UnknownLightningServiceError(msgForUnknown(err))
   }
 }
+
+const msgForUnknown = (err: Error) =>
+  JSON.stringify({
+    parsedLndErrorDetails: parseLndErrorDetails(err),
+    detailsFromLnd: err,
+  })


### PR DESCRIPTION
## Description

This PR cleans up our error handling at the boundary between the application service and the graphql api (adapter). It was prompted by [this error message](https://chat.galoy.io/galoy/pl/huh38waxjfga5gb8fknsy8g7uy) below that was leaked through to the frontend.

We also standardise the error message that gets added to `UnknownLightningServiceError` in this PR.

---
### Screenshot
![New Project](https://user-images.githubusercontent.com/17693119/183545867-7bf0d18f-1662-44d6-8449-15baf2ffb9e4.jpg)

