### PR TITLE
feat: add spans to update-invoices sub-functions

### DIFF
--- a/src/app/wallets/update-pending-invoices.ts
+++ b/src/app/wallets/update-pending-invoices.ts
@@ -17,7 +17,11 @@ import {
 } from "@services/mongoose"
 import { NotificationsService } from "@services/notifications"
 import * as LedgerFacade from "@services/ledger/facade"
-import { addAttributesToCurrentSpan } from "@services/tracing"
+import {
+  addAttributesToCurrentSpan,
+  asyncRunInSpan,
+  SemanticAttributes,
+} from "@services/tracing"
 
 import { elapsedSinceTimestamp, runInParallel } from "@utils"
 
@@ -78,158 +82,170 @@ const updatePendingInvoice = async ({
 }: {
   walletInvoice: WalletInvoice
   logger: Logger
-}): Promise<boolean | ApplicationError> => {
-  const lndService = LndService()
-  if (lndService instanceof Error) return lndService
-
-  const walletInvoicesRepo = WalletInvoicesRepository()
-
-  const { pubkey, paymentHash, secret, recipientWalletDescriptor } = walletInvoice
-
-  const pendingInvoiceLogger = logger.child({
-    hash: paymentHash,
-    walletId: recipientWalletDescriptor.id,
-    topic: "payment",
-    protocol: "lightning",
-    transactionType: "receipt",
-    onUs: false,
-  })
-
-  const lnInvoiceLookup = await lndService.lookupInvoice({ pubkey, paymentHash })
-  if (lnInvoiceLookup instanceof InvoiceNotFoundError) {
-    const isDeleted = await walletInvoicesRepo.deleteByPaymentHash(paymentHash)
-    if (isDeleted instanceof Error) {
-      pendingInvoiceLogger.error("impossible to delete WalletInvoice entry")
-      return isDeleted
-    }
-    return false
-  }
-  if (lnInvoiceLookup instanceof Error) return lnInvoiceLookup
-
-  const {
-    lnInvoice: { description },
-    roundedDownReceived,
-  } = lnInvoiceLookup
-
-  if (walletInvoice.paid) {
-    pendingInvoiceLogger.info("invoice has already been processed")
-    return true
-  }
-
-  if (!lnInvoiceLookup.isHeld && !lnInvoiceLookup.isSettled) {
-    pendingInvoiceLogger.info("invoice has not been paid yet")
-    return false
-  }
-
-  const receivedBtc = paymentAmountFromNumber({
-    amount: roundedDownReceived,
-    currency: WalletCurrency.Btc,
-  })
-  if (receivedBtc instanceof Error) return receivedBtc
-
-  const walletInvoiceReceiver = await WalletInvoiceReceiver({
-    walletInvoice,
-    receivedBtc,
-    usdFromBtc: dealer.getCentsFromSatsForImmediateBuy,
-    usdFromBtcMidPrice: usdFromBtcMidPriceFn,
-  })
-  if (walletInvoiceReceiver instanceof Error) return walletInvoiceReceiver
-
-  const lockService = LockService()
-  return lockService.lockPaymentHash(paymentHash, async () => {
-    // we're getting the invoice another time, now behind the lock, to avoid potential race condition
-    const invoiceToUpdate = await walletInvoicesRepo.findByPaymentHash(paymentHash)
-    if (invoiceToUpdate instanceof CouldNotFindError) {
-      pendingInvoiceLogger.error({ paymentHash }, "WalletInvoice doesn't exist")
-      return false
-    }
-    if (invoiceToUpdate instanceof Error) return invoiceToUpdate
-    if (walletInvoice.paid) {
-      pendingInvoiceLogger.info("invoice has already been processed")
-      return true
-    }
-
-    const displayCurrencyPerSat = await getCurrentPrice()
-    if (displayCurrencyPerSat instanceof Error) return displayCurrencyPerSat
-
-    if (!lnInvoiceLookup.isSettled) {
-      const invoiceSettled = await lndService.settleInvoice({ pubkey, secret })
-      if (invoiceSettled instanceof Error) return invoiceSettled
-    }
-
-    const invoicePaid = await walletInvoicesRepo.markAsPaid(paymentHash)
-    if (invoicePaid instanceof Error) return invoicePaid
-
-    // TODO: this should be a in a mongodb transaction session with the ledger transaction below
-    // markAsPaid could be done after the transaction, but we should in that case not only look
-    // for walletInvoicesRepo, but also in the ledger to make sure in case the process crash in this
-    // loop that an eventual consistency doesn't lead to a double credit
-
-    const metadata = LedgerFacade.LnReceiveLedgerMetadata({
-      paymentHash,
-      fee: walletInvoiceReceiver.btcBankFee,
-      feeDisplayCurrency: Number(
-        walletInvoiceReceiver.usdBankFee.amount,
-      ) as DisplayCurrencyBaseAmount,
-      amountDisplayCurrency: Number(
-        walletInvoiceReceiver.usdToCreditReceiver.amount,
-      ) as DisplayCurrencyBaseAmount,
-      pubkey: walletInvoiceReceiver.pubkey,
-    })
-
-    //TODO: add displayCurrency: displayPaymentAmount.currency,
-    const result = await LedgerFacade.recordReceive({
-      description,
-      recipientWalletDescriptor: walletInvoiceReceiver.recipientWalletDescriptor,
-      amountToCreditReceiver: {
-        usd: walletInvoiceReceiver.usdToCreditReceiver,
-        btc: walletInvoiceReceiver.btcToCreditReceiver,
+}): Promise<boolean | ApplicationError> =>
+  asyncRunInSpan(
+    "app.invoices.updatePendingInvoice",
+    {
+      attributes: {
+        [SemanticAttributes.CODE_FUNCTION]: "updatePendingInvoice",
+        [SemanticAttributes.CODE_NAMESPACE]: "invoices",
+        paymentHash: walletInvoice.paymentHash,
+        pubkey: walletInvoice.pubkey,
       },
-      bankFee: {
-        usd: walletInvoiceReceiver.usdBankFee,
-        btc: walletInvoiceReceiver.btcBankFee,
-      },
-      metadata,
-      txMetadata: {
-        hash: metadata.hash,
-      },
-    })
+    },
+    async () => {
+      const lndService = LndService()
+      if (lndService instanceof Error) return lndService
 
-    if (result instanceof Error) return result
+      const walletInvoicesRepo = WalletInvoicesRepository()
 
-    const recipientWallet = await WalletsRepository().findById(
-      recipientWalletDescriptor.id,
-    )
-    if (recipientWallet instanceof Error) return recipientWallet
+      const { pubkey, paymentHash, secret, recipientWalletDescriptor } = walletInvoice
 
-    const { usdToCreditReceiver: displayAmount } = walletInvoiceReceiver
-    const displayPaymentAmount: DisplayPaymentAmount<DisplayCurrency> = {
-      amount: Number((Number(displayAmount.amount) / 100).toFixed(2)),
-      currency: displayAmount.currency,
-    } as DisplayPaymentAmount<DisplayCurrency>
+      const pendingInvoiceLogger = logger.child({
+        hash: paymentHash,
+        walletId: recipientWalletDescriptor.id,
+        topic: "payment",
+        protocol: "lightning",
+        transactionType: "receipt",
+        onUs: false,
+      })
 
-    const recipientAccount = await AccountsRepository().findById(
-      recipientWallet.accountId,
-    )
-    if (recipientAccount instanceof Error) return recipientAccount
+      const lnInvoiceLookup = await lndService.lookupInvoice({ pubkey, paymentHash })
+      if (lnInvoiceLookup instanceof InvoiceNotFoundError) {
+        const isDeleted = await walletInvoicesRepo.deleteByPaymentHash(paymentHash)
+        if (isDeleted instanceof Error) {
+          pendingInvoiceLogger.error("impossible to delete WalletInvoice entry")
+          return isDeleted
+        }
+        return false
+      }
+      if (lnInvoiceLookup instanceof Error) return lnInvoiceLookup
 
-    const recipientUser = await UsersRepository().findById(recipientAccount.ownerId)
-    if (recipientUser instanceof Error) return recipientUser
+      const {
+        lnInvoice: { description },
+        roundedDownReceived,
+      } = lnInvoiceLookup
 
-    const notificationsService = NotificationsService()
-    notificationsService.lightningTxReceived({
-      recipientAccountId: recipientWallet.accountId,
-      recipientWalletId: recipientWallet.id,
-      paymentAmount: walletInvoiceReceiver.receivedAmount(),
-      displayPaymentAmount,
-      paymentHash,
-      recipientDeviceTokens: recipientUser.deviceTokens,
-      recipientLanguage: recipientUser.language,
-    })
+      if (walletInvoice.paid) {
+        pendingInvoiceLogger.info("invoice has already been processed")
+        return true
+      }
 
-    return true
-  })
-}
+      if (!lnInvoiceLookup.isHeld && !lnInvoiceLookup.isSettled) {
+        pendingInvoiceLogger.info("invoice has not been paid yet")
+        return false
+      }
+
+      const receivedBtc = paymentAmountFromNumber({
+        amount: roundedDownReceived,
+        currency: WalletCurrency.Btc,
+      })
+      if (receivedBtc instanceof Error) return receivedBtc
+
+      const walletInvoiceReceiver = await WalletInvoiceReceiver({
+        walletInvoice,
+        receivedBtc,
+        usdFromBtc: dealer.getCentsFromSatsForImmediateBuy,
+        usdFromBtcMidPrice: usdFromBtcMidPriceFn,
+      })
+      if (walletInvoiceReceiver instanceof Error) return walletInvoiceReceiver
+
+      const lockService = LockService()
+      return lockService.lockPaymentHash(paymentHash, async () => {
+        // we're getting the invoice another time, now behind the lock, to avoid potential race condition
+        const invoiceToUpdate = await walletInvoicesRepo.findByPaymentHash(paymentHash)
+        if (invoiceToUpdate instanceof CouldNotFindError) {
+          pendingInvoiceLogger.error({ paymentHash }, "WalletInvoice doesn't exist")
+          return false
+        }
+        if (invoiceToUpdate instanceof Error) return invoiceToUpdate
+        if (walletInvoice.paid) {
+          pendingInvoiceLogger.info("invoice has already been processed")
+          return true
+        }
+
+        const displayCurrencyPerSat = await getCurrentPrice()
+        if (displayCurrencyPerSat instanceof Error) return displayCurrencyPerSat
+
+        if (!lnInvoiceLookup.isSettled) {
+          const invoiceSettled = await lndService.settleInvoice({ pubkey, secret })
+          if (invoiceSettled instanceof Error) return invoiceSettled
+        }
+
+        const invoicePaid = await walletInvoicesRepo.markAsPaid(paymentHash)
+        if (invoicePaid instanceof Error) return invoicePaid
+
+        // TODO: this should be a in a mongodb transaction session with the ledger transaction below
+        // markAsPaid could be done after the transaction, but we should in that case not only look
+        // for walletInvoicesRepo, but also in the ledger to make sure in case the process crash in this
+        // loop that an eventual consistency doesn't lead to a double credit
+
+        const metadata = LedgerFacade.LnReceiveLedgerMetadata({
+          paymentHash,
+          fee: walletInvoiceReceiver.btcBankFee,
+          feeDisplayCurrency: Number(
+            walletInvoiceReceiver.usdBankFee.amount,
+          ) as DisplayCurrencyBaseAmount,
+          amountDisplayCurrency: Number(
+            walletInvoiceReceiver.usdToCreditReceiver.amount,
+          ) as DisplayCurrencyBaseAmount,
+          pubkey: walletInvoiceReceiver.pubkey,
+        })
+
+        //TODO: add displayCurrency: displayPaymentAmount.currency,
+        const result = await LedgerFacade.recordReceive({
+          description,
+          recipientWalletDescriptor: walletInvoiceReceiver.recipientWalletDescriptor,
+          amountToCreditReceiver: {
+            usd: walletInvoiceReceiver.usdToCreditReceiver,
+            btc: walletInvoiceReceiver.btcToCreditReceiver,
+          },
+          bankFee: {
+            usd: walletInvoiceReceiver.usdBankFee,
+            btc: walletInvoiceReceiver.btcBankFee,
+          },
+          metadata,
+          txMetadata: {
+            hash: metadata.hash,
+          },
+        })
+
+        if (result instanceof Error) return result
+
+        const recipientWallet = await WalletsRepository().findById(
+          recipientWalletDescriptor.id,
+        )
+        if (recipientWallet instanceof Error) return recipientWallet
+
+        const { usdToCreditReceiver: displayAmount } = walletInvoiceReceiver
+        const displayPaymentAmount: DisplayPaymentAmount<DisplayCurrency> = {
+          amount: Number((Number(displayAmount.amount) / 100).toFixed(2)),
+          currency: displayAmount.currency,
+        } as DisplayPaymentAmount<DisplayCurrency>
+
+        const recipientAccount = await AccountsRepository().findById(
+          recipientWallet.accountId,
+        )
+        if (recipientAccount instanceof Error) return recipientAccount
+
+        const recipientUser = await UsersRepository().findById(recipientAccount.ownerId)
+        if (recipientUser instanceof Error) return recipientUser
+
+        const notificationsService = NotificationsService()
+        notificationsService.lightningTxReceived({
+          recipientAccountId: recipientWallet.accountId,
+          recipientWalletId: recipientWallet.id,
+          paymentAmount: walletInvoiceReceiver.receivedAmount(),
+          displayPaymentAmount,
+          paymentHash,
+          recipientDeviceTokens: recipientUser.deviceTokens,
+          recipientLanguage: recipientUser.language,
+        })
+
+        return true
+      })
+    },
+  )
 
 export const declineHeldInvoice = async ({
   pubkey,

--- a/src/servers/trigger.ts
+++ b/src/servers/trigger.ts
@@ -17,7 +17,7 @@ import {
 
 import { ONCHAIN_MIN_CONFIRMATIONS } from "@config"
 
-import { Prices } from "@app"
+import { Prices as PricesWithSpans, Wallets as WalletWithSpans } from "@app"
 import * as Wallets from "@app/wallets"
 import { uploadBackup } from "@app/admin/backup"
 
@@ -95,7 +95,7 @@ export const onchainTransactionEventHandler = async (
 
     let displayPaymentAmount: DisplayPaymentAmount<DisplayCurrency> | undefined
 
-    const price = await Prices.getCurrentPrice()
+    const price = await PricesWithSpans.getCurrentPrice()
     const displayCurrencyPerSat = price instanceof Error ? undefined : price
     if (displayCurrencyPerSat) {
       const converter = DisplayCurrencyConverter(displayCurrencyPerSat)
@@ -143,7 +143,7 @@ export const onchainTransactionEventHandler = async (
 
       let displayPaymentAmount: DisplayPaymentAmount<DisplayCurrency> | undefined
 
-      const price = await Prices.getCurrentPrice()
+      const price = await PricesWithSpans.getCurrentPrice()
       const displayCurrencyPerSat = price instanceof Error ? undefined : price
       if (displayCurrencyPerSat) {
         const converter = DisplayCurrencyConverter(displayCurrencyPerSat)
@@ -176,7 +176,7 @@ export const onchainTransactionEventHandler = async (
 
 export const onchainBlockEventHandler = async (height: number) => {
   const scanDepth = (ONCHAIN_MIN_CONFIRMATIONS + 1) as ScanDepth
-  const txNumber = await Wallets.updateOnChainReceipt({ scanDepth, logger })
+  const txNumber = await WalletWithSpans.updateOnChainReceipt({ scanDepth, logger })
   if (txNumber instanceof Error) {
     logger.error(
       { error: txNumber },
@@ -192,7 +192,7 @@ export const invoiceUpdateEventHandler = async (
 ): Promise<boolean | ApplicationError> => {
   logger.info({ invoice }, "invoiceUpdateEventHandler")
   return invoice.is_held
-    ? Wallets.updatePendingInvoiceByPaymentHash({
+    ? WalletWithSpans.updatePendingInvoiceByPaymentHash({
         paymentHash: invoice.id as PaymentHash,
         logger,
       })
@@ -200,7 +200,7 @@ export const invoiceUpdateEventHandler = async (
 }
 
 export const publishSingleCurrentPrice = async () => {
-  const displayCurrencyPerSat = await Prices.getCurrentPrice()
+  const displayCurrencyPerSat = await PricesWithSpans.getCurrentPrice()
   if (displayCurrencyPerSat instanceof Error) {
     return logger.error({ err: displayCurrencyPerSat }, "can't publish the price")
   }


### PR DESCRIPTION
## Description

This PR is to wrap the handle-invoice sub functions in their own spans so that we can collect function-level attributes for each invoice processed.

## Additional Context

### `wrapAsyncToRunInSpan`
We are now switching away from `asyncRunInSpan` to `wrapAsyncToRunInSpan` to be able to standardise how we name/namespace things more easily and to be able to flag if a span is a `root` span (doesn't get nested under other spans).

### Auto wrapping
If we import a module like:
-  `import * as Wallets from "@app/wallets"` there is no wrapping
-  `import { Wallets } from "@app"` there is auto wrapping

For this PR, I mixed the two by importing Wallets twice and renaming the one with wrapping at the import level. This was to not doubly wrap `declineHeldInvoices` but also to apply missing wrapping to the other `Wallets` methods in `trigger.ts`.
