### PR TITLE
fix: translate OnChainTxns retrieved from cache

### DIFF
--- a/src/app/lightning/get-balances.ts
+++ b/src/app/lightning/get-balances.ts
@@ -39,6 +39,7 @@ export const getOffChainBalance = async (): Promise<Satoshis | ApplicationError>
 
       return sumBalances(balances)
     },
+    inflateFn: async (arg: Promise<Satoshis>) => arg,
   })
 
 export const getOpeningChannelBalance = async (): Promise<Satoshis | ApplicationError> =>
@@ -57,6 +58,7 @@ export const getOpeningChannelBalance = async (): Promise<Satoshis | Application
 
       return sumBalances(balances)
     },
+    inflateFn: async (arg: Promise<Satoshis>) => arg,
   })
 
 export const getClosingChannelBalance = async (): Promise<Satoshis | ApplicationError> =>
@@ -75,6 +77,7 @@ export const getClosingChannelBalance = async (): Promise<Satoshis | Application
 
       return sumBalances(balances)
     },
+    inflateFn: async (arg: Promise<Satoshis>) => arg,
   })
 
 export const getOnChainBalance = async (): Promise<Satoshis | ApplicationError> =>
@@ -101,6 +104,7 @@ export const getOnChainBalance = async (): Promise<Satoshis | ApplicationError> 
 
       return toSats(onChain + onChainPending)
     },
+    inflateFn: async (arg: Promise<Satoshis>) => arg,
   })
 
 const sumBalances = (balances: (Satoshis | Error)[]): Satoshis => {

--- a/src/app/lightning/get-balances.ts
+++ b/src/app/lightning/get-balances.ts
@@ -27,7 +27,7 @@ export const getOffChainBalance = async (): Promise<Satoshis | ApplicationError>
   cache.getOrSet({
     key: CacheKeys.OffChainBalance,
     ttlSecs: SECS_PER_MIN,
-    fn: async () => {
+    getForCaching: async () => {
       const offChainService = LndService()
       if (offChainService instanceof Error) return offChainService
 
@@ -39,14 +39,13 @@ export const getOffChainBalance = async (): Promise<Satoshis | ApplicationError>
 
       return sumBalances(balances)
     },
-    inflateFn: async (arg: Promise<Satoshis>) => arg,
   })
 
 export const getOpeningChannelBalance = async (): Promise<Satoshis | ApplicationError> =>
   cache.getOrSet({
     key: CacheKeys.OpeningChannelBalance,
     ttlSecs: SECS_PER_MIN,
-    fn: async () => {
+    getForCaching: async () => {
       const offChainService = LndService()
       if (offChainService instanceof Error) return offChainService
 
@@ -58,14 +57,13 @@ export const getOpeningChannelBalance = async (): Promise<Satoshis | Application
 
       return sumBalances(balances)
     },
-    inflateFn: async (arg: Promise<Satoshis>) => arg,
   })
 
 export const getClosingChannelBalance = async (): Promise<Satoshis | ApplicationError> =>
   cache.getOrSet({
     key: CacheKeys.ClosingChannelBalance,
     ttlSecs: SECS_PER_MIN,
-    fn: async () => {
+    getForCaching: async () => {
       const offChainService = LndService()
       if (offChainService instanceof Error) return offChainService
 
@@ -77,14 +75,13 @@ export const getClosingChannelBalance = async (): Promise<Satoshis | Application
 
       return sumBalances(balances)
     },
-    inflateFn: async (arg: Promise<Satoshis>) => arg,
   })
 
 export const getOnChainBalance = async (): Promise<Satoshis | ApplicationError> =>
   cache.getOrSet({
     key: CacheKeys.OnChainBalance,
     ttlSecs: SECS_PER_MIN,
-    fn: async () => {
+    getForCaching: async () => {
       const onChainService = OnChainService(TxDecoder(BTC_NETWORK))
       if (onChainService instanceof Error) return onChainService
 
@@ -104,7 +101,6 @@ export const getOnChainBalance = async (): Promise<Satoshis | ApplicationError> 
 
       return toSats(onChain + onChainPending)
     },
-    inflateFn: async (arg: Promise<Satoshis>) => arg,
   })
 
 const sumBalances = (balances: (Satoshis | Error)[]): Satoshis => {

--- a/src/app/wallets/private/get-on-chain-txs.ts
+++ b/src/app/wallets/private/get-on-chain-txs.ts
@@ -15,7 +15,7 @@ export const getOnChainTxs = async (): Promise<
   RedisCacheService().getOrSet({
     key: CacheKeys.LastOnChainTransactions,
     ttlSecs: SECS_PER_10_MINS,
-    fn: async () => {
+    getForCaching: async () => {
       const onChain = OnChainService(TxDecoder(BTC_NETWORK))
       if (onChain instanceof OnChainError) {
         baseLogger.warn({ onChain }, "impossible to create OnChainService")
@@ -23,7 +23,7 @@ export const getOnChainTxs = async (): Promise<
       }
       return onChain.listIncomingTransactions(ONCHAIN_MIN_CONFIRMATIONS)
     },
-    inflateFn: async (txnsPromise: Promise<IncomingOnChainTransactionFromCache[]>) => {
+    inflate: async (txnsPromise: Promise<IncomingOnChainTransactionFromCache[]>) => {
       const txns = await txnsPromise
       if (txns instanceof Error) return txns
 

--- a/src/domain/bitcoin/onchain/index.ts
+++ b/src/domain/bitcoin/onchain/index.ts
@@ -44,11 +44,7 @@ export const IncomingOnChainTransaction = ({
   rawTx,
   fee,
   createdAt,
-  uniqueAddresses: () =>
-    rawTx.outs.reduce<OnChainAddress[]>((a: OnChainAddress[], o: TxOut) => {
-      if (o.address && !a.includes(o.address)) a.push(o.address)
-      return a
-    }, []),
+  uniqueAddresses: () => uniqueAddressesForTxn(rawTx),
 })
 
 export const OutgoingOnChainTransaction = ({
@@ -66,9 +62,11 @@ export const OutgoingOnChainTransaction = ({
   rawTx,
   fee,
   createdAt,
-  uniqueAddresses: () =>
-    rawTx.outs.reduce<OnChainAddress[]>((a: OnChainAddress[], o: TxOut) => {
-      if (o.address && !a.includes(o.address)) a.push(o.address)
-      return a
-    }, []),
+  uniqueAddresses: () => uniqueAddressesForTxn(rawTx),
 })
+
+export const uniqueAddressesForTxn = (rawTx: OnChainTransaction) =>
+  rawTx.outs.reduce<OnChainAddress[]>((a: OnChainAddress[], o: TxOut) => {
+    if (o.address && !a.includes(o.address)) a.push(o.address)
+    return a
+  }, [])

--- a/src/domain/bitcoin/onchain/index.types.d.ts
+++ b/src/domain/bitcoin/onchain/index.types.d.ts
@@ -25,6 +25,13 @@ type IncomingOnChainTransaction = {
   uniqueAddresses: () => OnChainAddress[]
 }
 
+type IncomingOnChainTransactionFromCache = {
+  confirmations: number
+  rawTx: OnChainTransaction
+  fee: Satoshis
+  createdAt: string
+}
+
 type OutgoingOnChainTransaction = {
   confirmations: number
   rawTx: OnChainTransaction

--- a/src/domain/cache/index.types.d.ts
+++ b/src/domain/cache/index.types.d.ts
@@ -11,9 +11,9 @@ type LocalCacheSetArgs<T> = {
 
 type LocalCacheGetOrSetArgs<C, F extends () => ReturnType<F>> = {
   key: CacheKeys | string
-  fn: F
   ttlSecs: Seconds
-  inflateFn: (arg: C) => ReturnType<F>
+  getForCaching: F
+  inflate?: (arg: C) => ReturnType<F>
 }
 
 interface ICacheService {

--- a/src/domain/cache/index.types.d.ts
+++ b/src/domain/cache/index.types.d.ts
@@ -9,17 +9,18 @@ type LocalCacheSetArgs<T> = {
   ttlSecs: Seconds
 }
 
-type LocalCacheGetOrSetArgs<F extends () => ReturnType<F>> = {
+type LocalCacheGetOrSetArgs<C, F extends () => ReturnType<F>> = {
   key: CacheKeys | string
   fn: F
   ttlSecs: Seconds
+  inflateFn: (arg: C) => ReturnType<F>
 }
 
 interface ICacheService {
   set<T>(args: LocalCacheSetArgs<T>): Promise<T | CacheServiceError>
   get<T>(key: CacheKeys | string): Promise<T | CacheServiceError>
-  getOrSet<F extends () => ReturnType<F>>(
-    args: LocalCacheGetOrSetArgs<F>,
+  getOrSet<C, F extends () => ReturnType<F>>(
+    args: LocalCacheGetOrSetArgs<C, F>,
   ): Promise<ReturnType<F>>
   clear(key: CacheKeys | string): Promise<true | CacheServiceError>
 }

--- a/src/servers/exporter.ts
+++ b/src/servers/exporter.ts
@@ -259,6 +259,7 @@ const createWalletGauge = ({
           key: name,
           ttlSecs: toSeconds(SECS_PER_5_MINS * 3),
           fn: getWalletBalancePromise,
+          inflateFn: async (arg: Promise<number>) => arg,
         })
       }
     },

--- a/src/servers/exporter.ts
+++ b/src/servers/exporter.ts
@@ -258,8 +258,7 @@ const createWalletGauge = ({
         return cache.getOrSet({
           key: name,
           ttlSecs: toSeconds(SECS_PER_5_MINS * 3),
-          fn: getWalletBalancePromise,
-          inflateFn: async (arg: Promise<number>) => arg,
+          getForCaching: getWalletBalancePromise,
         })
       }
     },

--- a/src/services/cache/local-cache.ts
+++ b/src/services/cache/local-cache.ts
@@ -35,14 +35,13 @@ export const LocalCacheService = (): ICacheService => {
 
   const getOrSet = async <C, F extends () => ReturnType<F>>({
     key,
-    fn,
+    getForCaching,
     ttlSecs,
-    inflateFn,
   }: LocalCacheGetOrSetArgs<C, F>): Promise<ReturnType<F>> => {
-    const cachedData = await get<C>(key)
-    if (!(cachedData instanceof Error)) return inflateFn(cachedData)
+    const cachedData = await get<ReturnType<F>>(key)
+    if (!(cachedData instanceof Error)) return cachedData
 
-    const data = await fn()
+    const data = await getForCaching()
     set<ReturnType<F>>({ key, value: data, ttlSecs })
     return data
   }

--- a/src/services/cache/local-cache.ts
+++ b/src/services/cache/local-cache.ts
@@ -33,13 +33,14 @@ export const LocalCacheService = (): ICacheService => {
     }
   }
 
-  const getOrSet = async <F extends () => ReturnType<F>>({
+  const getOrSet = async <C, F extends () => ReturnType<F>>({
     key,
     fn,
     ttlSecs,
-  }: LocalCacheGetOrSetArgs<F>): Promise<ReturnType<F>> => {
-    const cachedData = await get<ReturnType<F>>(key)
-    if (!(cachedData instanceof Error)) return cachedData
+    inflateFn,
+  }: LocalCacheGetOrSetArgs<C, F>): Promise<ReturnType<F>> => {
+    const cachedData = await get<C>(key)
+    if (!(cachedData instanceof Error)) return inflateFn(cachedData)
 
     const data = await fn()
     set<ReturnType<F>>({ key, value: data, ttlSecs })

--- a/src/services/cache/redis-cache.ts
+++ b/src/services/cache/redis-cache.ts
@@ -35,14 +35,19 @@ export const RedisCacheService = (): ICacheService => {
 
   const getOrSet = async <C, F extends () => ReturnType<F>>({
     key,
-    fn,
     ttlSecs,
-    inflateFn,
+    getForCaching,
+    inflate,
   }: LocalCacheGetOrSetArgs<C, F>): Promise<ReturnType<F>> => {
-    const cachedData = await get<C>(key)
-    if (!(cachedData instanceof Error)) return inflateFn(cachedData)
+    if (inflate) {
+      const cachedData = await get<C>(key)
+      if (!(cachedData instanceof Error)) return inflate(cachedData)
+    } else {
+      const cachedData = await get<ReturnType<F>>(key)
+      if (!(cachedData instanceof Error)) return cachedData
+    }
 
-    const data = await fn()
+    const data = await getForCaching()
     set<ReturnType<F>>({ key, value: data, ttlSecs })
     return data
   }

--- a/src/services/cache/redis-cache.ts
+++ b/src/services/cache/redis-cache.ts
@@ -33,13 +33,14 @@ export const RedisCacheService = (): ICacheService => {
     }
   }
 
-  const getOrSet = async <F extends () => ReturnType<F>>({
+  const getOrSet = async <C, F extends () => ReturnType<F>>({
     key,
     fn,
     ttlSecs,
-  }: LocalCacheGetOrSetArgs<F>): Promise<ReturnType<F>> => {
-    const cachedData = await get<ReturnType<F>>(key)
-    if (!(cachedData instanceof Error)) return cachedData
+    inflateFn,
+  }: LocalCacheGetOrSetArgs<C, F>): Promise<ReturnType<F>> => {
+    const cachedData = await get<C>(key)
+    if (!(cachedData instanceof Error)) return inflateFn(cachedData)
 
     const data = await fn()
     set<ReturnType<F>>({ key, value: data, ttlSecs })

--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -20,8 +20,6 @@ import {
   settleHodlInvoice,
   getInvoices,
   GetInvoicesResult,
-  GetClosedChannelsResult,
-  GetWalletInfoResult,
 } from "lightning"
 import lnService from "ln-service"
 
@@ -772,11 +770,10 @@ const resolvePaymentStatus = async ({
   const currentBlockHeight = await cache.getOrSet({
     key: CacheKeys.BlockHeight,
     ttlSecs: SECS_PER_5_MINS,
-    fn: async () => {
+    getForCaching: async () => {
       const { current_block_height } = await getWalletInfo({ lnd })
       return current_block_height
     },
-    inflateFn: async (arg: Promise<GetWalletInfoResult["current_block_height"]>) => arg,
   })
 
   const timeout = pending?.timeout || payment?.timeout
@@ -786,11 +783,10 @@ const resolvePaymentStatus = async ({
     const closedChannels = await cache.getOrSet({
       key: CacheKeys.ClosedChannels,
       ttlSecs: SECS_PER_5_MINS,
-      fn: async () => {
+      getForCaching: async () => {
         const { channels } = await getClosedChannels({ lnd })
         return channels
       },
-      inflateFn: async (arg: Promise<GetClosedChannelsResult["channels"]>) => arg,
     })
 
     const failed = pending.paths

--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -20,6 +20,8 @@ import {
   settleHodlInvoice,
   getInvoices,
   GetInvoicesResult,
+  GetClosedChannelsResult,
+  GetWalletInfoResult,
 } from "lightning"
 import lnService from "ln-service"
 
@@ -774,6 +776,7 @@ const resolvePaymentStatus = async ({
       const { current_block_height } = await getWalletInfo({ lnd })
       return current_block_height
     },
+    inflateFn: async (arg: Promise<GetWalletInfoResult["current_block_height"]>) => arg,
   })
 
   const timeout = pending?.timeout || payment?.timeout
@@ -787,6 +790,7 @@ const resolvePaymentStatus = async ({
         const { channels } = await getClosedChannels({ lnd })
         return channels
       },
+      inflateFn: async (arg: Promise<GetClosedChannelsResult["channels"]>) => arg,
     })
 
     const failed = pending.paths

--- a/test/integration/02-user-wallet/02-receive-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-onchain.spec.ts
@@ -312,6 +312,7 @@ describe("UserWallet - On chain", () => {
 
     await sleep(1000)
 
+    // Check pendingTx from chain
     const { result: txs, error } = await Wallets.getTransactionsForWalletId({
       walletId: walletIdA,
     })
@@ -325,6 +326,20 @@ describe("UserWallet - On chain", () => {
     expect(pendingTx.settlementVia.type).toBe("onchain")
     expect(pendingTx.settlementAmount).toBe(amountSats)
     expect(pendingTx.initiationVia.address).toBe(address)
+    expect(pendingTx.createdAt).toBeInstanceOf(Date)
+
+    // Check pendingTx from cache
+    const { result: txsFromCache, error: errorFromCache } =
+      await Wallets.getTransactionsForWalletId({
+        walletId: walletIdA,
+      })
+    if (errorFromCache instanceof Error || txsFromCache === null) {
+      throw errorFromCache
+    }
+    const pendingTxsFromCache = txsFromCache.filter(
+      ({ status }) => status === TxStatus.Pending,
+    )
+    expect(pendingTxsFromCache[0]?.createdAt).toBeInstanceOf(Date)
 
     await sleep(1000)
 

--- a/test/integration/services/cache/index.spec.ts
+++ b/test/integration/services/cache/index.spec.ts
@@ -1,0 +1,88 @@
+import { createHash, randomBytes } from "crypto"
+
+import { SECS_PER_10_MINS } from "@config"
+
+import { toSats } from "@domain/bitcoin"
+import { uniqueAddressesForTxn } from "@domain/bitcoin/onchain"
+
+import { RedisCacheService } from "@services/cache"
+
+const randomString = (length) => {
+  const sha256 = (buffer: Buffer) => createHash("sha256").update(buffer).digest("hex")
+  return sha256(randomBytes(32)).slice(0, length)
+}
+
+const redis = RedisCacheService()
+
+const nonCacheCounts = {
+  getOrSet: 0,
+}
+
+const incomingTxns: IncomingOnChainTransaction[] = [
+  {
+    confirmations: 0,
+    rawTx: {
+      txHash: "txHash1" as OnChainTxHash,
+      outs: [
+        {
+          address: "walletId0-address1" as OnChainAddress,
+          sats: toSats(100),
+        },
+        {
+          sats: toSats(200),
+          address: "change-address1" as OnChainAddress,
+        },
+      ],
+    },
+    fee: toSats(0),
+    createdAt: new Date(Date.now()),
+    uniqueAddresses: () => [] as OnChainAddress[],
+  },
+]
+
+const getOnChainTxs = async (key): Promise<IncomingOnChainTransaction[]> =>
+  redis.getOrSet({
+    key,
+    ttlSecs: SECS_PER_10_MINS,
+    getForCaching: async (): Promise<IncomingOnChainTransaction[]> => {
+      nonCacheCounts.getOrSet++
+      return incomingTxns
+    },
+    inflate: async (txnsPromise: Promise<IncomingOnChainTransactionFromCache[]>) =>
+      (await txnsPromise).map(inflateIncomingOnChainTxFromCache),
+  })
+
+const inflateIncomingOnChainTxFromCache = (
+  txn: IncomingOnChainTransactionFromCache | IncomingOnChainTransaction,
+): IncomingOnChainTransaction => ({
+  ...txn,
+  createdAt: new Date(txn.createdAt),
+  uniqueAddresses: () => uniqueAddressesForTxn(txn.rawTx),
+})
+
+describe("Redis Cache", () => {
+  it("getOrSet", async () => {
+    const key = `bitcoin:${randomString(8)}`
+
+    expect(nonCacheCounts.getOrSet).toEqual(0)
+
+    const txns1 = await getOnChainTxs(key)
+    expect(nonCacheCounts.getOrSet).toEqual(1)
+    expect(txns1).toStrictEqual(incomingTxns)
+
+    const txns2 = await getOnChainTxs(key)
+    expect(nonCacheCounts.getOrSet).toEqual(1)
+    // Non-stringify 'txns2' returns "Received: serializes to the same string"
+    expect(JSON.stringify(txns2)).toStrictEqual(JSON.stringify(incomingTxns))
+
+    const newKey = `bitcoin:${randomString(8)}`
+    const txns3 = await getOnChainTxs(newKey)
+    expect(nonCacheCounts.getOrSet).toEqual(2)
+    expect(txns3).toStrictEqual(incomingTxns)
+
+    const txns4 = await getOnChainTxs(key)
+    expect(nonCacheCounts.getOrSet).toEqual(2)
+    // Non-stringify 'txns4' returns "Received: serializes to the same string"
+    expect(JSON.stringify(txns4)).toStrictEqual(JSON.stringify(incomingTxns))
+  })
+})


### PR DESCRIPTION
## Description

This is a first draft for the fix for issues: #1399, #1528, https://github.com/GaloyMoney/galoy-mobile/issues/548

The issue is that the full `IncomingOnChainTransaction` type isn't persisted in redis, but our code assumes this full type comes back via `get`. There needs to be a translation method somewhere to convert from redis persistence back to our domain type.

This is a first draft demonstrating the fix, but this fix may also be executed via a new repository that is specifically an `IncomingOnChainTransactionsRepository` function.

### TODO
- [x] Add tests to capture issue and fix (done: https://github.com/GaloyMoney/galoy/pull/1529/commits/784117b199be215470e26c481a7f47afd8287a29)
- [x] ~Potentially refactor to repository pattern~ we decided to leave as cache service
- [x] Figure out some sort of "Cachable" interface (done: https://github.com/GaloyMoney/galoy/pull/1529/commits/6f6d0f2821b3a9953c78cccd89d678b859edcdd8)
  - Type notes: https://github.com/GaloyMoney/galoy/pull/1529#issuecomment-1239522635

## Details

Original object:
```ts
{
  confirmations: 0,
  rawTx: {
    txHash: '688b2092df3c9f451b65d9b0b55515d8c8311559052542b50b4b953755539354',
    outs: [Array]
  },
  fee: 0,
  createdAt: 2022-08-12T05:11:59.000Z,
  uniqueAddresses: [Function: uniqueAddresses]
}
```

Object from redis:
```ts
{
  confirmations: 0,
  rawTx: {
    txHash: '688b2092df3c9f451b65d9b0b55515d8c8311559052542b50b4b953755539354',
    outs: [Array]
  },
  fee: 0,
  createdAt: '2022-08-12T05:11:59.000Z',
}

```