### PR TITLE
chore: remove redundant redis set

### DIFF
--- a/src/app/wallets/get-transactions-by-addresses.ts
+++ b/src/app/wallets/get-transactions-by-addresses.ts
@@ -51,11 +51,6 @@ export const getTransactionsForWalletsByAddresses = async ({
     baseLogger.warn({ onChainTxs }, "impossible to get listIncomingTransactions")
     return PartialResult.partial(confirmedHistory.transactions, onChainTxs)
   }
-  redisCache.set({
-    key: CacheKeys.LastOnChainTransactions,
-    value: onChainTxs,
-    ttlSecs: SECS_PER_10_MINS,
-  })
 
   const allAddresses: OnChainAddress[] = []
   const addressesByWalletId: { [walletid: string]: OnChainAddress[] } = {}


### PR DESCRIPTION
## Description

Remnant from prior implementation (#1511), `set` is redundant because `getOrSet` handles setting the value just above.