### PR TITLE
refactor: return partial with fee if PaymentFlow persist fails

### DIFF
--- a/src/app/payments/get-protocol-fee.ts
+++ b/src/app/payments/get-protocol-fee.ts
@@ -156,7 +156,11 @@ const estimateLightningFee = async ({
   const persistedPayment = await PaymentFlowStateRepository(
     defaultTimeToExpiryInSeconds,
   ).persistNew(paymentFlow)
-  if (persistedPayment instanceof Error) return PartialResult.err(persistedPayment)
+  if (persistedPayment instanceof Error)
+    return PartialResult.partial(
+      paymentFlow.protocolFeeInSenderWalletCurrency(),
+      persistedPayment,
+    )
 
   return PartialResult.ok(persistedPayment.protocolFeeInSenderWalletCurrency())
 }


### PR DESCRIPTION
## Description

Once we have a complete `PaymentFlow` object in the fee-estimation use-case we should always be able to return some fee (either calculated or max).