### PR TITLE
feat: add invoice payment status query

### DIFF
--- a/src/graphql/main/queries.ts
+++ b/src/graphql/main/queries.ts
@@ -4,15 +4,16 @@ import { GT } from "@graphql/index"
 
 import MeQuery from "@graphql/root/query/me"
 import GlobalsQuery from "@graphql/root/query/globals"
-import UsernameAvailableQuery from "@graphql/root/query/username-available"
-import AccountDefaultWalletIdQuery from "@graphql/root/query/account-default-wallet-id"
-import AccountDefaultWalletQuery from "@graphql/root/query/account-default-wallet"
-import BusinessMapMarkersQuery from "@graphql/root/query/business-map-markers"
-import MobileVersionsQuery from "@graphql/root/query/mobile-versions"
-import QuizQuestionsQuery from "@graphql/root/query/quiz-questions"
-import BtcPriceListQuery from "@graphql/root/query/btc-price-list"
-import OnChainTxFeeQuery from "@graphql/root/query/on-chain-tx-fee-query"
 import BtcPriceQuery from "@graphql/root/query/btc-price"
+import BtcPriceListQuery from "@graphql/root/query/btc-price-list"
+import QuizQuestionsQuery from "@graphql/root/query/quiz-questions"
+import MobileVersionsQuery from "@graphql/root/query/mobile-versions"
+import OnChainTxFeeQuery from "@graphql/root/query/on-chain-tx-fee-query"
+import UsernameAvailableQuery from "@graphql/root/query/username-available"
+import BusinessMapMarkersQuery from "@graphql/root/query/business-map-markers"
+import AccountDefaultWalletQuery from "@graphql/root/query/account-default-wallet"
+import AccountDefaultWalletIdQuery from "@graphql/root/query/account-default-wallet-id"
+import LnInvoicePaymentStatusQuery from "@graphql/root/query/ln-invoice-payment-status"
 
 import {
   addAttributesToCurrentSpanAndPropagate,
@@ -32,6 +33,7 @@ const fields = {
   btcPrice: BtcPriceQuery,
   btcPriceList: BtcPriceListQuery,
   onChainTxFee: OnChainTxFeeQuery,
+  lnInvoicePaymentStatus: LnInvoicePaymentStatusQuery,
 } as const
 
 const addTracing = (trcFields: typeof fields) => {

--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -852,6 +852,7 @@ type Query {
   btcPriceList(range: PriceGraphRange!): [PricePoint]
   businessMapMarkers: [MapMarker]
   globals: Globals
+  lnInvoicePaymentStatus(input: LnInvoicePaymentStatusInput!): InvoicePaymentStatus!
   me: User
   mobileVersions: [MobileVersions]
   onChainTxFee(

--- a/src/graphql/root/query/ln-invoice-payment-status.ts
+++ b/src/graphql/root/query/ln-invoice-payment-status.ts
@@ -1,0 +1,29 @@
+import { Lightning } from "@app"
+
+import { GT } from "@graphql/index"
+import { mapError } from "@graphql/error-map"
+import InvoicePaymentStatus from "@graphql/types/scalar/invoice-payment-status"
+import LnInvoicePaymentStatusInput from "@graphql/types/object/ln-invoice-payment-status-input"
+
+const LnInvoicePaymentStatusQuery = GT.Field({
+  type: GT.NonNull(InvoicePaymentStatus),
+  args: {
+    input: { type: GT.NonNull(LnInvoicePaymentStatusInput) },
+  },
+  resolve: async (_, args) => {
+    const { paymentRequest } = args.input
+    if (paymentRequest instanceof Error) throw paymentRequest
+
+    const paymentStatusChecker = await Lightning.PaymentStatusChecker(paymentRequest)
+    if (paymentStatusChecker instanceof Error) throw mapError(paymentStatusChecker)
+
+    const paid = await paymentStatusChecker.invoiceIsPaid()
+    if (paid instanceof Error) throw mapError(paid)
+
+    if (paid) return "PAID"
+
+    return "PENDING"
+  },
+})
+
+export default LnInvoicePaymentStatusQuery

--- a/src/graphql/root/subscription/ln-invoice-payment-status.ts
+++ b/src/graphql/root/subscription/ln-invoice-payment-status.ts
@@ -1,19 +1,14 @@
-import { GT } from "@graphql/index"
-import LnPaymentRequest from "@graphql/types/scalar/ln-payment-request"
-import LnInvoicePaymentStatusPayload from "@graphql/types/payload/ln-invoice-payment-status"
-
 import { Lightning } from "@app"
-import { PubSubService } from "@services/pubsub"
+
 import { customPubSubTrigger, PubSubDefaultTriggers } from "@domain/pubsub"
 
-const pubsub = PubSubService()
+import { PubSubService } from "@services/pubsub"
 
-const LnInvoicePaymentStatusInput = GT.Input({
-  name: "LnInvoicePaymentStatusInput",
-  fields: () => ({
-    paymentRequest: { type: GT.NonNull(LnPaymentRequest) },
-  }),
-})
+import { GT } from "@graphql/index"
+import LnInvoicePaymentStatusPayload from "@graphql/types/payload/ln-invoice-payment-status"
+import LnInvoicePaymentStatusInput from "@graphql/types/object/ln-invoice-payment-status-input"
+
+const pubsub = PubSubService()
 
 type LnInvoicePaymentSubscribeArgs = {
   input: {

--- a/src/graphql/types/object/ln-invoice-payment-status-input.ts
+++ b/src/graphql/types/object/ln-invoice-payment-status-input.ts
@@ -1,0 +1,11 @@
+import { GT } from "@graphql/index"
+import LnPaymentRequest from "@graphql/types/scalar/ln-payment-request"
+
+const LnInvoicePaymentStatusInput = GT.Input({
+  name: "LnInvoicePaymentStatusInput",
+  fields: () => ({
+    paymentRequest: { type: GT.NonNull(LnPaymentRequest) },
+  }),
+})
+
+export default LnInvoicePaymentStatusInput

--- a/test/e2e/servers/graphql-main-server/galoy-pay-testing.spec.ts
+++ b/test/e2e/servers/graphql-main-server/galoy-pay-testing.spec.ts
@@ -11,7 +11,8 @@ import USER_LOGIN from "./mutations/user-login.gql"
 import ME from "./queries/me.gql"
 import NODE_IDS from "./queries/node-ids.gql"
 import USER_DEFAULT_WALLET_ID from "./queries/user-default-walletid.gql"
-import LN_INVOICE_PAYMENT_STATUS from "./subscriptions/ln-invoice-payment-status.gql"
+import LN_INVOICE_PAYMENT_STATUS_QUERY from "./queries/ln-invoice-payment-status.gql"
+import LN_INVOICE_PAYMENT_STATUS_SUBSCRIPTION from "./subscriptions/ln-invoice-payment-status.gql"
 import PRICE from "./subscriptions/price.gql"
 
 import {
@@ -219,7 +220,7 @@ describe("galoy-pay", () => {
   })
 
   describe("lnInvoicePaymentStatus", () => {
-    const subscriptionQuery = LN_INVOICE_PAYMENT_STATUS
+    const subscriptionQuery = LN_INVOICE_PAYMENT_STATUS_SUBSCRIPTION
 
     it("returns payment status when paid", async () => {
       // Create an invoice on behalf of userA
@@ -257,6 +258,13 @@ describe("galoy-pay", () => {
 
       // Assert the the invoice is paid
       expect(result.data.lnInvoicePaymentStatus.status).toEqual("PAID")
+
+      const statusQueryResult = await apolloClient.query({
+        query: LN_INVOICE_PAYMENT_STATUS_QUERY,
+        variables: { input: subscribeToPaymentInput },
+      })
+
+      expect(statusQueryResult.data.status).toEqual("PAID")
     })
   })
 

--- a/test/e2e/servers/graphql-main-server/queries/ln-invoice-payment-status.gql
+++ b/test/e2e/servers/graphql-main-server/queries/ln-invoice-payment-status.gql
@@ -1,0 +1,3 @@
+query LnInvoicePaymentStatus($input: LnInvoicePaymentStatusInput!) {
+  status: lnInvoicePaymentStatus(input: $input)
+}

--- a/test/e2e/servers/graphql-main-server/with-auth-requests.spec.ts
+++ b/test/e2e/servers/graphql-main-server/with-auth-requests.spec.ts
@@ -366,7 +366,7 @@ describe("graphql", () => {
       const { invoice, errors } = result.data.lnUsdInvoiceCreate
       expect(errors).toHaveLength(0)
       expect(invoice).toHaveProperty("paymentRequest")
-      expect(invoice.paymentRequest.startsWith("lnbcrt4")).toBeTruthy()
+      expect(invoice.paymentRequest.startsWith("lnbcrt")).toBeTruthy()
       expect(invoice).toHaveProperty("paymentHash")
       expect(invoice).toHaveProperty("paymentSecret")
     })


### PR DESCRIPTION
Add `lnInvoicePaymentStatus` public query (same behavior and name as its subscription). This will avoid the use of fee probe for status validation (-_-) 

### How to test

```graphql
query LnInvoicePaymentStatus($input: LnInvoicePaymentStatusInput!) {
  status: lnInvoicePaymentStatus(input: $input)
}
```

```grapqhl
{ "input": { "paymentRequest": "lnbcrt500u...k8n2p" } }
```