### PR TITLE
refactor: reimburse sats on failed USD payment (2)

### DIFF
--- a/src/app/payments/update-pending-payments.ts
+++ b/src/app/payments/update-pending-payments.ts
@@ -7,12 +7,14 @@ import {
   LedgerTransactionType,
   UnknownLedgerError,
 } from "@domain/ledger"
+import { ErrorLevel, WalletCurrency } from "@domain/shared"
 
-import { LedgerService } from "@services/ledger"
+import { LedgerService, getDealerWalletIds } from "@services/ledger"
 import { LndService } from "@services/lnd"
 import { LockService } from "@services/lock"
 import { WalletsRepository } from "@services/mongoose"
 import { PaymentFlowStateRepository } from "@services/payment-flow"
+import { recordExceptionInCurrentSpan } from "@services/tracing"
 
 import { Wallets } from "@app"
 import { runInParallel } from "@utils"
@@ -102,13 +104,16 @@ const updatePendingPayment = async ({
     paymentHash,
   })
   if (lnPaymentLookup instanceof Error) {
-    const lightningLogger = logger.child({
-      topic: "payment",
-      protocol: "lightning",
-      transactionType: "payment",
-      onUs: false,
-    })
-    lightningLogger.error({ err: lnPaymentLookup }, "issue fetching payment")
+    logger.error(
+      {
+        err: lnPaymentLookup,
+        topic: "payment",
+        protocol: "lightning",
+        transactionType: "payment",
+        onUs: false,
+      },
+      "issue fetching payment",
+    )
     return lnPaymentLookup
   }
 
@@ -119,8 +124,8 @@ const updatePendingPayment = async ({
   }
 
   if (status === PaymentStatus.Settled || status === PaymentStatus.Failed) {
-    const ledgerService = LedgerService()
     return LockService().lockPaymentHash(paymentHash, async () => {
+      const ledgerService = LedgerService()
       const recorded = await ledgerService.isLnTxRecorded(paymentHash)
       if (recorded instanceof Error) {
         paymentLogger.error({ error: recorded }, "we couldn't query pending transaction")
@@ -187,15 +192,32 @@ const updatePendingPayment = async ({
           { success: false, id: paymentHash, payment: pendingPayment },
           "payment has failed. reverting transaction",
         )
-
-        const voided = await ledgerService.revertLightningPayment({
-          journalId: pendingPayment.journalId,
-          paymentHash,
-        })
-        if (voided instanceof Error) {
-          const error = `error voiding payment entry`
-          logger.fatal({ success: false, result: lnPaymentLookup }, error)
-          return voided
+        if (paymentFlow.senderWalletCurrency === WalletCurrency.Btc) {
+          const voided = await ledgerService.revertLightningPayment({
+            journalId: pendingPayment.journalId,
+            paymentHash,
+          })
+          if (voided instanceof Error) {
+            const error = `error voiding payment entry`
+            logger.fatal({ success: false, result: lnPaymentLookup }, error)
+            recordExceptionInCurrentSpan({ error: voided, level: ErrorLevel.Critical })
+            return voided
+          }
+        } else {
+          const reimbursed = await Wallets.reimburseFailedUsdPayment({
+            journalId: pendingPayment.journalId,
+            paymentFlow,
+            accountId: wallet.accountId,
+          })
+          if (reimbursed instanceof Error) {
+            const error = `error reimbursing usd payment entry`
+            logger.fatal({ success: false, result: lnPaymentLookup }, error)
+            recordExceptionInCurrentSpan({
+              error: reimbursed,
+              level: ErrorLevel.Critical,
+            })
+            return reimbursed
+          }
         }
       }
       return true
@@ -213,11 +235,15 @@ const reconstructPendingPaymentFlow = async <
   const ledgerTxns = await LedgerService().getTransactionsByHash(paymentHash)
   if (ledgerTxns instanceof Error) return ledgerTxns
 
+  const dealerWalletIds = Object.values(await getDealerWalletIds())
+
   const payment = ledgerTxns.find(
     (tx) =>
       tx.pendingConfirmation === true &&
       tx.type === LedgerTransactionType.Payment &&
-      tx.debit > 0,
+      tx.debit > 0 &&
+      tx.walletId !== undefined &&
+      !dealerWalletIds.includes(tx.walletId),
   ) as LedgerTransaction<S> | undefined
   if (!payment) return new CouldNotFindTransactionError()
 

--- a/src/app/payments/update-pending-payments.ts
+++ b/src/app/payments/update-pending-payments.ts
@@ -14,7 +14,11 @@ import { LndService } from "@services/lnd"
 import { LockService } from "@services/lock"
 import { WalletsRepository } from "@services/mongoose"
 import { PaymentFlowStateRepository } from "@services/payment-flow"
-import { recordExceptionInCurrentSpan } from "@services/tracing"
+import {
+  addAttributesToCurrentSpan,
+  recordExceptionInCurrentSpan,
+  wrapAsyncToRunInSpan,
+} from "@services/tracing"
 
 import { Wallets } from "@app"
 import { runInParallel } from "@utils"
@@ -50,182 +54,198 @@ export const updatePendingPayments = async (logger: Logger): Promise<void> => {
   logger.info("finish updating pending payments")
 }
 
-export const updatePendingPaymentsByWalletId = async ({
-  walletId,
-  logger,
-}: {
-  walletId: WalletId
-  logger: Logger
-}): Promise<void | ApplicationError> => {
-  const ledgerService = LedgerService()
-  const count = await ledgerService.getPendingPaymentsCount(walletId)
-  if (count instanceof Error) return count
-  if (count === 0) return
+export const updatePendingPaymentsByWalletId = wrapAsyncToRunInSpan({
+  namespace: "app.payments",
+  fnName: "updatePendingPaymentsByWalletId",
+  fn: async ({
+    walletId,
+    logger,
+  }: {
+    walletId: WalletId
+    logger: Logger
+  }): Promise<void | ApplicationError> => {
+    const ledgerService = LedgerService()
+    const count = await ledgerService.getPendingPaymentsCount(walletId)
+    if (count instanceof Error) return count
 
-  const pendingPayments = await ledgerService.listPendingPayments(walletId)
-  if (pendingPayments instanceof Error) return pendingPayments
+    addAttributesToCurrentSpan({ walletId, pendingPaymentsCount: count })
+    if (count === 0) return
 
-  for (const pendingPayment of pendingPayments) {
-    await updatePendingPayment({
-      walletId,
-      pendingPayment,
-      logger,
-    })
-  }
-}
+    const pendingPayments = await ledgerService.listPendingPayments(walletId)
+    if (pendingPayments instanceof Error) return pendingPayments
 
-const updatePendingPayment = async ({
-  walletId,
-  pendingPayment,
-  logger,
-}: {
-  walletId: WalletId
-  pendingPayment: LedgerTransaction<WalletCurrency>
-  logger: Logger
-}): Promise<true | ApplicationError> => {
-  const paymentLogger = logger.child({
-    topic: "payment",
-    protocol: "lightning",
-    transactionType: "payment",
-    onUs: false,
-    payment: pendingPayment,
-  })
-
-  const lndService = LndService()
-  if (lndService instanceof Error) return lndService
-
-  const { paymentHash, pubkey } = pendingPayment
-  // If we had PaymentLedgerType => no need for checking the fields
-  if (!paymentHash)
-    throw new InconsistentDataError("paymentHash missing from payment transaction")
-  if (!pubkey) throw new InconsistentDataError("pubkey missing from payment transaction")
-
-  const lnPaymentLookup = await lndService.lookupPayment({
-    pubkey,
-    paymentHash,
-  })
-  if (lnPaymentLookup instanceof Error) {
-    logger.error(
-      {
-        err: lnPaymentLookup,
-        topic: "payment",
-        protocol: "lightning",
-        transactionType: "payment",
-        onUs: false,
-      },
-      "issue fetching payment",
-    )
-    return lnPaymentLookup
-  }
-
-  let roundedUpFee: Satoshis
-  const { status } = lnPaymentLookup
-  if (status != PaymentStatus.Failed) {
-    roundedUpFee = lnPaymentLookup.confirmedDetails?.roundedUpFee || toSats(0)
-  }
-
-  if (status === PaymentStatus.Settled || status === PaymentStatus.Failed) {
-    return LockService().lockPaymentHash(paymentHash, async () => {
-      const ledgerService = LedgerService()
-      const recorded = await ledgerService.isLnTxRecorded(paymentHash)
-      if (recorded instanceof Error) {
-        paymentLogger.error({ error: recorded }, "we couldn't query pending transaction")
-        return recorded
-      }
-
-      if (recorded) {
-        paymentLogger.info("payment has already been processed")
-        return true
-      }
-
-      const inputAmount = inputAmountFromLedgerTransaction(pendingPayment)
-      if (inputAmount instanceof Error) return inputAmount
-
-      const paymentFlowIndex: PaymentFlowStateIndex = {
-        paymentHash,
+    for (const pendingPayment of pendingPayments) {
+      await updatePendingPayment({
         walletId,
-        inputAmount,
-      }
+        pendingPayment,
+        logger,
+      })
+    }
+  },
+})
 
-      let paymentFlow = await PaymentFlowStateRepository(
-        defaultTimeToExpiryInSeconds,
-      ).markLightningPaymentFlowNotPending(paymentFlowIndex)
-      if (paymentFlow instanceof Error) {
-        paymentFlow = await reconstructPendingPaymentFlow(paymentHash)
-        if (paymentFlow instanceof Error) return paymentFlow
-      }
+const updatePendingPayment = wrapAsyncToRunInSpan({
+  namespace: "app.payments",
+  fnName: "updatePendingPayment",
+  fn: async ({
+    walletId,
+    pendingPayment,
+    logger,
+  }: {
+    walletId: WalletId
+    pendingPayment: LedgerTransaction<WalletCurrency>
+    logger: Logger
+  }): Promise<true | ApplicationError> => {
+    const { paymentHash, pubkey, type: txType } = pendingPayment
+    addAttributesToCurrentSpan({ walletId, paymentHash, txType })
 
-      const settled = await ledgerService.settlePendingLnPayment(paymentHash)
-      if (settled instanceof Error) {
-        paymentLogger.error({ error: settled }, "no transaction to update")
-        return settled
-      }
+    const paymentLogger = logger.child({
+      topic: "payment",
+      protocol: "lightning",
+      transactionType: "payment",
+      onUs: false,
+      payment: pendingPayment,
+    })
 
-      const wallet = await WalletsRepository().findById(walletId)
-      if (wallet instanceof Error) return wallet
+    const lndService = LndService()
+    if (lndService instanceof Error) return lndService
 
-      if (status === PaymentStatus.Settled) {
-        paymentLogger.info(
-          { success: true, id: paymentHash, payment: pendingPayment },
-          "payment has been confirmed",
-        )
+    // If we had PaymentLedgerType => no need for checking the fields
+    if (!paymentHash)
+      throw new InconsistentDataError("paymentHash missing from payment transaction")
+    if (!pubkey)
+      throw new InconsistentDataError("pubkey missing from payment transaction")
 
-        const revealedPreImage = lnPaymentLookup.confirmedDetails?.revealedPreImage
-        if (revealedPreImage)
-          LedgerService().updateMetadataByHash({
-            hash: paymentHash,
+    const lnPaymentLookup = await lndService.lookupPayment({
+      pubkey,
+      paymentHash,
+    })
+    if (lnPaymentLookup instanceof Error) {
+      logger.error(
+        {
+          err: lnPaymentLookup,
+          topic: "payment",
+          protocol: "lightning",
+          transactionType: "payment",
+          onUs: false,
+        },
+        "issue fetching payment",
+      )
+      return lnPaymentLookup
+    }
+
+    let roundedUpFee: Satoshis
+    const { status } = lnPaymentLookup
+    if (status != PaymentStatus.Failed) {
+      roundedUpFee = lnPaymentLookup.confirmedDetails?.roundedUpFee || toSats(0)
+    }
+
+    if (status === PaymentStatus.Settled || status === PaymentStatus.Failed) {
+      return LockService().lockPaymentHash(paymentHash, async () => {
+        const ledgerService = LedgerService()
+        const recorded = await ledgerService.isLnTxRecorded(paymentHash)
+        if (recorded instanceof Error) {
+          paymentLogger.error(
+            { error: recorded },
+            "we couldn't query pending transaction",
+          )
+          return recorded
+        }
+
+        if (recorded) {
+          paymentLogger.info("payment has already been processed")
+          return true
+        }
+
+        const inputAmount = inputAmountFromLedgerTransaction(pendingPayment)
+        if (inputAmount instanceof Error) return inputAmount
+
+        const paymentFlowIndex: PaymentFlowStateIndex = {
+          paymentHash,
+          walletId,
+          inputAmount,
+        }
+
+        let paymentFlow = await PaymentFlowStateRepository(
+          defaultTimeToExpiryInSeconds,
+        ).markLightningPaymentFlowNotPending(paymentFlowIndex)
+        if (paymentFlow instanceof Error) {
+          paymentFlow = await reconstructPendingPaymentFlow(paymentHash)
+          if (paymentFlow instanceof Error) return paymentFlow
+        }
+
+        const settled = await ledgerService.settlePendingLnPayment(paymentHash)
+        if (settled instanceof Error) {
+          paymentLogger.error({ error: settled }, "no transaction to update")
+          return settled
+        }
+
+        const wallet = await WalletsRepository().findById(walletId)
+        if (wallet instanceof Error) return wallet
+
+        if (status === PaymentStatus.Settled) {
+          paymentLogger.info(
+            { success: true, id: paymentHash, payment: pendingPayment },
+            "payment has been confirmed",
+          )
+
+          const revealedPreImage = lnPaymentLookup.confirmedDetails?.revealedPreImage
+          if (revealedPreImage)
+            LedgerService().updateMetadataByHash({
+              hash: paymentHash,
+              revealedPreImage,
+            })
+          if (pendingPayment.feeKnownInAdvance) return true
+
+          const { displayAmount, displayFee } = pendingPayment
+          if (displayAmount === undefined || displayFee === undefined)
+            return new UnknownLedgerError("missing display-related values in transaction")
+
+          return Wallets.reimburseFee({
+            paymentFlow,
+            journalId: pendingPayment.journalId,
+            actualFee: roundedUpFee,
             revealedPreImage,
           })
-        if (pendingPayment.feeKnownInAdvance) return true
-
-        const { displayAmount, displayFee } = pendingPayment
-        if (displayAmount === undefined || displayFee === undefined)
-          return new UnknownLedgerError("missing display-related values in transaction")
-
-        return Wallets.reimburseFee({
-          paymentFlow,
-          journalId: pendingPayment.journalId,
-          actualFee: roundedUpFee,
-          revealedPreImage,
-        })
-      } else if (status === PaymentStatus.Failed) {
-        paymentLogger.warn(
-          { success: false, id: paymentHash, payment: pendingPayment },
-          "payment has failed. reverting transaction",
-        )
-        if (paymentFlow.senderWalletCurrency === WalletCurrency.Btc) {
-          const voided = await ledgerService.revertLightningPayment({
-            journalId: pendingPayment.journalId,
-            paymentHash,
-          })
-          if (voided instanceof Error) {
-            const error = `error voiding payment entry`
-            logger.fatal({ success: false, result: lnPaymentLookup }, error)
-            recordExceptionInCurrentSpan({ error: voided, level: ErrorLevel.Critical })
-            return voided
-          }
-        } else {
-          const reimbursed = await Wallets.reimburseFailedUsdPayment({
-            journalId: pendingPayment.journalId,
-            paymentFlow,
-            accountId: wallet.accountId,
-          })
-          if (reimbursed instanceof Error) {
-            const error = `error reimbursing usd payment entry`
-            logger.fatal({ success: false, result: lnPaymentLookup }, error)
-            recordExceptionInCurrentSpan({
-              error: reimbursed,
-              level: ErrorLevel.Critical,
+        } else if (status === PaymentStatus.Failed) {
+          paymentLogger.warn(
+            { success: false, id: paymentHash, payment: pendingPayment },
+            "payment has failed. reverting transaction",
+          )
+          if (paymentFlow.senderWalletCurrency === WalletCurrency.Btc) {
+            const voided = await ledgerService.revertLightningPayment({
+              journalId: pendingPayment.journalId,
+              paymentHash,
             })
-            return reimbursed
+            if (voided instanceof Error) {
+              const error = `error voiding payment entry`
+              logger.fatal({ success: false, result: lnPaymentLookup }, error)
+              recordExceptionInCurrentSpan({ error: voided, level: ErrorLevel.Critical })
+              return voided
+            }
+          } else {
+            const reimbursed = await Wallets.reimburseFailedUsdPayment({
+              journalId: pendingPayment.journalId,
+              paymentFlow,
+              accountId: wallet.accountId,
+            })
+            if (reimbursed instanceof Error) {
+              const error = `error reimbursing usd payment entry`
+              logger.fatal({ success: false, result: lnPaymentLookup }, error)
+              recordExceptionInCurrentSpan({
+                error: reimbursed,
+                level: ErrorLevel.Critical,
+              })
+              return reimbursed
+            }
           }
         }
-      }
-      return true
-    })
-  }
-  return true
-}
+        return true
+      })
+    }
+    return true
+  },
+})
 
 const reconstructPendingPaymentFlow = async <
   S extends WalletCurrency,

--- a/src/app/wallets/index.ts
+++ b/src/app/wallets/index.ts
@@ -10,6 +10,7 @@ export * from "./update-on-chain-receipt"
 export * from "./update-pending-invoices"
 export * from "./add-invoice-for-wallet"
 export * from "./reimburse-fee"
+export * from "./reimburse-failed-usd"
 export * from "./send-on-chain"
 
 import { WalletsRepository } from "@services/mongoose"

--- a/src/app/wallets/reimburse-failed-usd.ts
+++ b/src/app/wallets/reimburse-failed-usd.ts
@@ -1,0 +1,80 @@
+import { toSats } from "@domain/bitcoin"
+import {
+  CouldNotFindWalletForWalletCurrencyError,
+  InvalidAccountForWalletIdError,
+} from "@domain/errors"
+import { DisplayCurrency, toCents } from "@domain/fiat"
+import { LedgerTransactionType } from "@domain/ledger"
+import { AmountCalculator, WalletCurrency } from "@domain/shared"
+
+import { WalletsRepository } from "@services/mongoose"
+import * as LedgerFacade from "@services/ledger/facade"
+
+const calc = AmountCalculator()
+
+export const reimburseFailedUsdPayment = async <
+  S extends WalletCurrency,
+  R extends WalletCurrency,
+>({
+  paymentFlow,
+  journalId,
+  accountId,
+}: {
+  paymentFlow: PaymentFlow<S, R>
+  journalId: LedgerJournalId
+  accountId: AccountId
+}): Promise<true | ApplicationError> => {
+  const paymentHash = paymentFlow.paymentHashForFlow()
+  if (paymentHash instanceof Error) return paymentHash
+
+  const metadata: FailedPaymentLedgerMetadata = {
+    hash: paymentHash,
+    type: LedgerTransactionType.Payment,
+    pending: false,
+    related_journal: journalId,
+
+    usd: Number(
+      calc.divFloor(paymentFlow.usdPaymentAmount, 100n).amount,
+    ) as DisplayCurrencyBaseAmount,
+
+    satsAmount: toSats(paymentFlow.btcPaymentAmount.amount),
+    centsAmount: toCents(paymentFlow.usdPaymentAmount.amount),
+    satsFee: toSats(paymentFlow.btcProtocolFee.amount),
+    centsFee: toCents(paymentFlow.usdProtocolFee.amount),
+
+    displayAmount: Number(
+      paymentFlow.usdPaymentAmount.amount,
+    ) as DisplayCurrencyBaseAmount,
+    displayFee: Number(paymentFlow.usdProtocolFee.amount) as DisplayCurrencyBaseAmount,
+    displayCurrency: DisplayCurrency.Usd,
+  }
+
+  const txMetadata: LnLedgerTransactionMetadataUpdate = {
+    hash: paymentHash,
+  }
+
+  const { id: senderWalletId } = paymentFlow.senderWalletDescriptor()
+  const recipientWallets = await WalletsRepository().listByAccountId(accountId)
+  if (recipientWallets instanceof Error) return recipientWallets
+  if (!recipientWallets.map((wallet) => wallet.id).includes(senderWalletId)) {
+    return new InvalidAccountForWalletIdError(
+      JSON.stringify({ accountId, walletId: senderWalletId }),
+    )
+  }
+  const btcWallet = recipientWallets.find(
+    (wallet) => wallet.currency === WalletCurrency.Btc,
+  )
+  if (btcWallet === undefined) return new CouldNotFindWalletForWalletCurrencyError()
+  const btcWalletDescriptor = { id: btcWallet.id, currency: btcWallet.currency }
+
+  const result = await LedgerFacade.recordReceive({
+    description: "usd failed payment reimburse",
+    recipientWalletDescriptor: btcWalletDescriptor,
+    amountToCreditReceiver: paymentFlow.totalAmountsForPayment(),
+    metadata,
+    txMetadata,
+  })
+  if (result instanceof Error) return result
+
+  return true
+}

--- a/src/app/wallets/reimburse-failed-usd.ts
+++ b/src/app/wallets/reimburse-failed-usd.ts
@@ -8,6 +8,7 @@ import { LedgerTransactionType } from "@domain/ledger"
 import { AmountCalculator, WalletCurrency } from "@domain/shared"
 
 import { WalletsRepository } from "@services/mongoose"
+import { getNonEndUserWalletIds } from "@services/ledger"
 import * as LedgerFacade from "@services/ledger/facade"
 
 const calc = AmountCalculator()
@@ -58,7 +59,11 @@ export const reimburseFailedUsdPayment = async <
   if (recipientWallets instanceof Error) return recipientWallets
   if (!recipientWallets.map((wallet) => wallet.id).includes(senderWalletId)) {
     return new InvalidAccountForWalletIdError(
-      JSON.stringify({ accountId, walletId: senderWalletId }),
+      JSON.stringify({
+        accountId,
+        walletId: senderWalletId,
+        nonEndUserWalletIds: await getNonEndUserWalletIds(),
+      }),
     )
   }
   const btcWallet = recipientWallets.find(

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -28,6 +28,7 @@ export class CouldNotFindWalletFromUsernameError extends CouldNotFindError {}
 export class CouldNotFindWalletFromUsernameAndCurrencyError extends CouldNotFindError {}
 export class CouldNotFindWalletFromOnChainAddressError extends CouldNotFindError {}
 export class CouldNotFindWalletFromOnChainAddressesError extends CouldNotFindError {}
+export class CouldNotFindWalletForWalletCurrencyError extends CouldNotFindError {}
 export class CouldNotListWalletsFromWalletCurrencyError extends CouldNotFindError {}
 export class NoTransactionToUpdateError extends CouldNotFindError {}
 export class CouldNotFindLightningPaymentFlowError extends CouldNotFindError {}
@@ -68,7 +69,9 @@ export class InvalidPhoneNumber extends ValidationError {}
 export class InvalidKratosUserId extends ValidationError {}
 export class InvalidEmailAddress extends ValidationError {}
 export class InvalidWalletId extends ValidationError {}
+export class InvalidAccountForWalletIdError extends ValidationError {}
 export class InvalidLedgerTransactionId extends ValidationError {}
+export class InvalidLedgerTransactionStateError extends ValidationError {}
 export class AlreadyPaidError extends ValidationError {}
 export class SelfPaymentError extends ValidationError {}
 export class LessThanDustThresholdError extends ValidationError {}

--- a/src/domain/ledger/index.ts
+++ b/src/domain/ledger/index.ts
@@ -1,4 +1,7 @@
-import { InvalidLedgerTransactionId } from "@domain/errors"
+import {
+  InvalidLedgerTransactionId,
+  InvalidLedgerTransactionStateError,
+} from "@domain/errors"
 import { WalletCurrency } from "@domain/shared"
 import { safeBigInt } from "@domain/shared/safe"
 
@@ -70,6 +73,7 @@ export const checkedToLedgerTransactionId = (
 export const inputAmountFromLedgerTransaction = (
   txn: LedgerTransaction<WalletCurrency>,
 ) => {
-  const fee = txn.currency == WalletCurrency.Usd ? txn.feeUsd : txn.fee
+  const fee = txn.currency === WalletCurrency.Usd ? txn.centsFee : txn.satsFee
+  if (fee === undefined) return new InvalidLedgerTransactionStateError()
   return safeBigInt(txn.debit - fee)
 }

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -7,8 +7,9 @@ type LiabilitiesWalletId = string & { [liabilitiesWalletId]: never }
 
 type LedgerTransactionId = string & { readonly brand: unique symbol }
 type LedgerJournalId = string & { readonly brand: unique symbol }
-type LedgerTransactionType =
-  typeof import("./index").LedgerTransactionType[keyof typeof import("./index").LedgerTransactionType]
+type LedgerTransactionTypeObject = typeof import("./index").LedgerTransactionType
+type LedgerTransactionTypeKey = keyof typeof import("./index").LedgerTransactionType
+type LedgerTransactionType = LedgerTransactionTypeObject[LedgerTransactionTypeKey]
 
 type ExtendedLedgerTransactionType =
   typeof import("./index").ExtendedLedgerTransactionType[keyof typeof import("./index").ExtendedLedgerTransactionType]

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -349,7 +349,9 @@ interface ILedgerService {
     hash: OnChainTxHash,
   ): Promise<WalletId | LedgerServiceError>
 
-  listWalletIdsWithPendingPayments: () => AsyncGenerator<WalletId> | LedgerServiceError
+  listEndUserWalletIdsWithPendingPayments: () =>
+    | AsyncGenerator<WalletId>
+    | LedgerServiceError
 
   addColdStorageTxReceive(
     args: AddColdStorageTxReceiveArgs,

--- a/src/domain/shared/index.ts
+++ b/src/domain/shared/index.ts
@@ -1,3 +1,4 @@
 export * from "./primitives"
 export * from "./calculator"
+export * from "./safe"
 export * from "./errors"

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -337,6 +337,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "CouldNotFindWalletFromUsernameAndCurrencyError":
     case "CouldNotFindWalletFromOnChainAddressError":
     case "CouldNotFindWalletFromOnChainAddressesError":
+    case "CouldNotFindWalletForWalletCurrencyError":
     case "CouldNotListWalletsFromWalletCurrencyError":
     case "CouldNotFindLnPaymentFromHashError":
     case "LockError":
@@ -383,6 +384,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "InvalidAccountLevelError":
     case "InvalidWithdrawFeeError":
     case "InvalidUsdCents":
+    case "InvalidAccountForWalletIdError":
     case "NonIntegerError":
     case "ColdStorageError":
     case "ColdStorageServiceError":
@@ -411,6 +413,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "InvalidZeroAmountPriceRatioInputError":
     case "InvalidCurrencyForWalletError":
     case "InvalidLightningPaymentFlowStateError":
+    case "InvalidLedgerTransactionStateError":
     case "BadInputsForFindError":
     case "LnHashPresentInIntraLedgerFlowError":
     case "IntraLedgerHashPresentInLnFlowError":

--- a/src/services/ledger/caching.ts
+++ b/src/services/ledger/caching.ts
@@ -64,3 +64,14 @@ export const getFunderWalletId = async () => {
   cacheFunderWalletId = funderId
   return cacheFunderWalletId
 }
+
+export const getDealerWalletIds = async () => ({
+  dealerBtc: await getDealerBtcWalletId(),
+  dealerUsd: await getDealerUsdWalletId(),
+})
+
+export const getNonEndUserWalletIds = async () => ({
+  ...(await getDealerWalletIds()),
+  bankOwner: await getBankOwnerWalletId(),
+  funder: await getFunderWalletId(),
+})

--- a/src/services/ledger/index.types.d.ts
+++ b/src/services/ledger/index.types.d.ts
@@ -123,12 +123,19 @@ type AddWalletIdIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata
 type NewAddWalletIdIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata &
   SendAmountsMetadata
 
-type FeeReimbursementLedgerMetadata = SendAmountsMetadata & {
+type ReimbursementLedgerMetadata = SendAmountsMetadata & {
   hash: PaymentHash
-  type: LedgerTransactionType
   pending: boolean
   usd: DisplayCurrencyBaseAmount
   related_journal: LedgerJournalId
+}
+
+type FeeReimbursementLedgerMetadata = ReimbursementLedgerMetadata & {
+  type: LedgerTransactionTypeObject["LnFeeReimbursement"]
+}
+
+type FailedPaymentLedgerMetadata = ReimbursementLedgerMetadata & {
+  type: LedgerTransactionTypeObject["Payment"]
 }
 
 type LnRoutingRevenueLedgerMetadata = LedgerMetadata & {
@@ -148,6 +155,7 @@ type LoadLedgerParams = {
 
 type ReceiveLedgerMetadata =
   | FeeReimbursementLedgerMetadata
+  | FailedPaymentLedgerMetadata
   | LnReceiveLedgerMetadata
   | OnChainReceiveLedgerMetadata
 

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -35,6 +35,7 @@ import {
   paymentAmountFromNumber,
   ValidationError,
   WalletCurrency,
+  ZERO_SATS,
 } from "@domain/shared"
 import { TwoFAError } from "@domain/twoFA"
 import { PaymentInitiationMethod, WithdrawalFeePriceMethod } from "@domain/wallets"
@@ -89,9 +90,11 @@ import {
   waitUntilChannelBalanceSyncAll,
 } from "test/helpers"
 
-import { DealerPriceService } from "test/mocks/dealer-price"
+import { DealerPriceService, NewDealerPriceService } from "test/mocks/dealer-price"
 
 const dealerFns = DealerPriceService()
+const newDealerFns = NewDealerPriceService()
+const calc = AmountCalculator()
 
 jest.mock("@app/prices/get-current-price", () => require("test/mocks/get-current-price"))
 
@@ -156,7 +159,7 @@ jest.mock("@services/lnd", () => {
 
 const usdHedgeEnabled = getDealerConfig().usd.hedgingEnabled
 
-let initBalanceA: Satoshis, initBalanceB: Satoshis
+let initBalanceA: Satoshis, initBalanceB: Satoshis, initBalanceUsdB: UsdCents
 const amountInvoice = toSats(1000)
 
 const invoicesRepo = WalletInvoicesRepository()
@@ -197,7 +200,9 @@ beforeAll(async () => {
   accountH = await getAccountByTestUserRef("H")
 
   walletIdA = await getDefaultWalletIdByTestUserRef("A")
+  walletIdUsdA = await getUsdWalletIdByTestUserRef("A")
   walletIdB = await getDefaultWalletIdByTestUserRef("B")
+  walletIdUsdB = await getUsdWalletIdByTestUserRef("B")
   walletIdC = await getDefaultWalletIdByTestUserRef("C")
   walletIdH = await getDefaultWalletIdByTestUserRef("H")
 
@@ -214,9 +219,7 @@ beforeAll(async () => {
 beforeEach(async () => {
   initBalanceA = toSats(await getBalanceHelper(walletIdA))
   initBalanceB = toSats(await getBalanceHelper(walletIdB))
-
-  walletIdUsdB = await getUsdWalletIdByTestUserRef("B")
-  walletIdUsdA = await getUsdWalletIdByTestUserRef("A")
+  initBalanceUsdB = toCents(await getBalanceHelper(walletIdUsdB))
 })
 
 afterEach(async () => {
@@ -1442,6 +1445,113 @@ describe("UserWallet - Lightning Pay", () => {
 
         const finalBalance = await getBalanceHelper(walletIdB)
         expect(finalBalance).toBe(initBalanceB)
+      }, 60000)
+
+      it("reimburse failed USD payment", async () => {
+        const { id } = createInvoiceHash()
+
+        const btcInvoiceAmount = paymentAmountFromNumber({
+          amount: amountInvoice,
+          currency: WalletCurrency.Btc,
+        })
+        if (btcInvoiceAmount instanceof Error) throw btcInvoiceAmount
+        const usdInvoiceAmount = await newDealerFns.getCentsFromSatsForImmediateBuy(
+          btcInvoiceAmount,
+        )
+        if (usdInvoiceAmount instanceof Error) throw usdInvoiceAmount
+
+        const { request } = await createHodlInvoice({
+          id,
+          lnd: lndOutside1,
+          tokens: amountInvoice,
+        })
+        const result = await fn({ account: accountB, walletId: walletIdUsdB })({
+          invoice: request,
+        })
+        if (result instanceof Error) throw result
+
+        expect(result).toBe(PaymentSendStatus.Pending)
+        baseLogger.info("payment has timeout. status is pending.")
+        const intermediateBalance = await getBalanceHelper(walletIdUsdB)
+
+        const priceRatio = PriceRatio({
+          btc: btcInvoiceAmount,
+          usd: usdInvoiceAmount,
+        })
+        if (priceRatio instanceof Error) return priceRatio
+        const btcProtocolFee = applyMaxFee
+          ? LnFees().maxProtocolFee({
+              amount: btcInvoiceAmount.amount,
+              currency: WalletCurrency.Btc,
+            })
+          : ZERO_SATS
+        const usdProtocolFee = priceRatio.convertFromBtc(btcProtocolFee)
+
+        const amountInvoiceWithFee = calc.add(usdInvoiceAmount, usdProtocolFee)
+
+        expect(intermediateBalance).toBe(
+          initBalanceUsdB - Number(amountInvoiceWithFee.amount),
+        )
+
+        await cancelHodlInvoice({ id, lnd: lndOutside1 })
+
+        await waitFor(async () => {
+          const updatedPayments = await Payments.updatePendingPaymentsByWalletId({
+            walletId: walletIdUsdB,
+            logger: baseLogger,
+          })
+          if (updatedPayments instanceof Error) throw updatedPayments
+
+          const count = await LedgerService().getPendingPaymentsCount(walletIdUsdB)
+          if (count instanceof Error) throw count
+
+          return count === 0
+        })
+
+        // Test 'lnpayment' is failed
+        const lnPaymentUpdateOnSettled = await Lightning.updateLnPayments()
+        if (lnPaymentUpdateOnSettled instanceof Error) throw lnPaymentUpdateOnSettled
+
+        const lnPaymentOnSettled = await LnPaymentsRepository().findByPaymentHash(
+          id as PaymentHash,
+        )
+        expect(lnPaymentOnSettled).not.toBeInstanceOf(Error)
+        if (lnPaymentOnSettled instanceof Error) throw lnPaymentOnSettled
+
+        const lndService = LndService()
+        if (lndService instanceof Error) throw lndService
+        const payments = await lndService.listFailedPayments({
+          pubkey: lnPaymentOnSettled.sentFromPubkey,
+          after: undefined,
+        })
+        if (payments instanceof Error) throw payments
+
+        const payment = payments.lnPayments.find((p) => p.paymentHash === id)
+        expect(payment).not.toBeUndefined()
+        if (payment === undefined) throw new Error("Could not find payment in lnd")
+
+        expect(lnPaymentOnSettled.status).toBe(PaymentStatus.Failed)
+
+        // Check for invoice
+        const invoice = await getInvoiceAttempt({ lnd: lndOutside1, id })
+        expect(invoice).toBeNull()
+
+        // wait for balance updates because invoice event
+        // arrives before wallet balances updates in lnd
+        await waitUntilChannelBalanceSyncAll()
+
+        // Check BTC wallet balance
+        const btcAmountInvoiceWithFee = calc.add(btcInvoiceAmount, btcProtocolFee)
+        const finalBalanceBtc = await getBalanceHelper(walletIdB)
+        expect(finalBalanceBtc).toBe(
+          initBalanceB + Number(btcAmountInvoiceWithFee.amount),
+        )
+
+        // Check USD wallet balance
+        const finalBalanceUsd = await getBalanceHelper(walletIdUsdB)
+        expect(finalBalanceUsd).toBe(
+          initBalanceUsdB - Number(amountInvoiceWithFee.amount),
+        )
       }, 60000)
 
       it(`fails to pay above 2fa limit without 2fa token`, async () => {

--- a/test/mocks/dealer-price/index.ts
+++ b/test/mocks/dealer-price/index.ts
@@ -31,7 +31,7 @@ export const DealerPriceService = (): IDealerPriceService => ({
     timeToExpiryInSeconds: Seconds,
   ): Promise<UsdCents> =>
     toCents(
-      (Math.floor(Number(amount) * getBuyUsdQuoteFromSats) * timeToExpiryInSeconds) /
+      (Math.floor(Number(amount) / getBuyUsdQuoteFromSats) * timeToExpiryInSeconds) /
         timeToExpiryInSeconds,
     ),
   getCentsFromSatsForFutureSell: async (
@@ -39,7 +39,7 @@ export const DealerPriceService = (): IDealerPriceService => ({
     timeToExpiryInSeconds: Seconds,
   ): Promise<UsdCents> =>
     toCents(
-      (Math.floor(Number(amount) * getSellUsdQuoteFromSats) * timeToExpiryInSeconds) /
+      (Math.floor(Number(amount) / getSellUsdQuoteFromSats) * timeToExpiryInSeconds) /
         timeToExpiryInSeconds,
     ),
 
@@ -94,7 +94,7 @@ export const NewDealerPriceService = (
     amount: BtcPaymentAmount,
   ): Promise<UsdPaymentAmount | DealerPriceServiceError> => {
     const amountForPayment =
-      (Math.floor(Number(amount.amount) * getBuyUsdQuoteFromSats) *
+      (Math.floor(Number(amount.amount) / getBuyUsdQuoteFromSats) *
         timeToExpiryInSeconds) /
       timeToExpiryInSeconds
 
@@ -107,7 +107,7 @@ export const NewDealerPriceService = (
     amount: BtcPaymentAmount,
   ): Promise<UsdPaymentAmount | DealerPriceServiceError> => {
     const amountForPayment =
-      (Math.floor(Number(amount.amount) * getSellUsdQuoteFromSats) *
+      (Math.floor(Number(amount.amount) / getSellUsdQuoteFromSats) *
         timeToExpiryInSeconds) /
       timeToExpiryInSeconds
 

--- a/test/unit/payments/payment-flow.spec.ts
+++ b/test/unit/payments/payment-flow.spec.ts
@@ -1,8 +1,9 @@
 import { toSats } from "@domain/bitcoin"
 import { InsufficientBalanceError, InvalidCurrencyForWalletError } from "@domain/errors"
 import { toCents } from "@domain/fiat"
+import { inputAmountFromLedgerTransaction } from "@domain/ledger"
 import { PaymentFlow } from "@domain/payments"
-import { WalletCurrency } from "@domain/shared"
+import { WalletCurrency, safeBigInt } from "@domain/shared"
 import { PaymentInitiationMethod, SettlementMethod } from "@domain/wallets"
 
 describe("PaymentFlowFromLedgerTransaction", () => {
@@ -110,5 +111,55 @@ describe("PaymentFlowFromLedgerTransaction", () => {
         })
       })
     }
+  })
+
+  describe("inputAmountFromLedgerTransaction", () => {
+    const baseLedgerTransaction = {
+      fee: toSats(1),
+      usd: 0.2,
+      feeUsd: 0.01,
+
+      satsAmount: toSats(1000),
+      centsAmount: toCents(20),
+      satsFee: toSats(1),
+      centsFee: toCents(1),
+      displayAmount: 20 as DisplayCurrencyBaseAmount,
+      displayFee: 1 as DisplayCurrencyBaseAmount,
+      displayCurrency: "USD",
+    }
+
+    const btcLedgerTransaction = {
+      debit: toSats(1001),
+      credit: toSats(0),
+      currency: "BTC",
+      ...baseLedgerTransaction,
+    } as LedgerTransaction<"BTC">
+
+    const usdLedgerTransaction = {
+      debit: toCents(21),
+      credit: toCents(0),
+      currency: "USD",
+      ...baseLedgerTransaction,
+    } as LedgerTransaction<"USD">
+
+    it("calculates the correct input amount given a BTC LedgerTransaction", () => {
+      const inputAmount = inputAmountFromLedgerTransaction(btcLedgerTransaction)
+      expect(inputAmount).not.toBeInstanceOf(Error)
+
+      const satsAmount = safeBigInt(baseLedgerTransaction.satsAmount)
+      expect(satsAmount).not.toBeInstanceOf(Error)
+
+      expect(inputAmount).toEqual(satsAmount)
+    })
+
+    it("calculates the correct input amount given a USD LedgerTransaction", () => {
+      const inputAmount = inputAmountFromLedgerTransaction(usdLedgerTransaction)
+      expect(inputAmount).not.toBeInstanceOf(Error)
+
+      const centsAmount = safeBigInt(baseLedgerTransaction.centsAmount)
+      expect(centsAmount).not.toBeInstanceOf(Error)
+
+      expect(inputAmount).toEqual(centsAmount)
+    })
   })
 })


### PR DESCRIPTION
_Diff for new changes: https://github.com/GaloyMoney/galoy/compare/e5e7b318d3b4f9d7b83313fa00b03477bf495bc2...reimburse-failed-usd-2_

## Description

Retrying the changeset from #1535 (reverted in #1541) with improved tracing to help debug issues.