### PR TITLE
fix(test): payment request validation in e2e test

### DIFF
--- a/test/e2e/servers/graphql-main-server/with-auth-requests.spec.ts
+++ b/test/e2e/servers/graphql-main-server/with-auth-requests.spec.ts
@@ -366,7 +366,7 @@ describe("graphql", () => {
       const { invoice, errors } = result.data.lnUsdInvoiceCreate
       expect(errors).toHaveLength(0)
       expect(invoice).toHaveProperty("paymentRequest")
-      expect(invoice.paymentRequest.startsWith("lnbcrt4")).toBeTruthy()
+      expect(invoice.paymentRequest.startsWith("lnbcrt")).toBeTruthy()
       expect(invoice).toHaveProperty("paymentHash")
       expect(invoice).toHaveProperty("paymentSecret")
     })


### PR DESCRIPTION
## Description 

Change in stablesats dependency surfaced this, `4` was part of the invoice amount.