### PR TITLE
fix: reimburse-usd-payment being dependent on input walletId

### DIFF
--- a/src/app/payments/update-pending-payments.ts
+++ b/src/app/payments/update-pending-payments.ts
@@ -26,8 +26,7 @@ import { PaymentFlowFromLedgerTransaction } from "./translations"
 
 export const updatePendingPayments = async (logger: Logger): Promise<void> => {
   const ledgerService = LedgerService()
-  const walletIdsWithPendingPayments =
-    ledgerService.listEndUserWalletIdsWithPendingPayments()
+  const walletIdsWithPendingPayments = ledgerService.listWalletIdsWithPendingPayments()
 
   if (walletIdsWithPendingPayments instanceof Error) {
     logger.error(

--- a/src/app/payments/update-pending-payments.ts
+++ b/src/app/payments/update-pending-payments.ts
@@ -68,7 +68,7 @@ export const updatePendingPaymentsByWalletId = wrapAsyncToRunInSpan({
     const count = await ledgerService.getPendingPaymentsCount(walletId)
     if (count instanceof Error) return count
 
-    addAttributesToCurrentSpan({ walletId, pendingPaymentsCount: count })
+    addAttributesToCurrentSpan({ pendingPaymentsCount: count })
     if (count === 0) return
 
     const pendingPayments = await ledgerService.listPendingPayments(walletId)

--- a/src/app/payments/update-pending-payments.ts
+++ b/src/app/payments/update-pending-payments.ts
@@ -12,7 +12,6 @@ import { ErrorLevel, WalletCurrency } from "@domain/shared"
 import { LedgerService, getNonEndUserWalletIds } from "@services/ledger"
 import { LndService } from "@services/lnd"
 import { LockService } from "@services/lock"
-import { WalletsRepository } from "@services/mongoose"
 import { PaymentFlowStateRepository } from "@services/payment-flow"
 import {
   addAttributesToCurrentSpan,
@@ -180,9 +179,6 @@ const updatePendingPayment = wrapAsyncToRunInSpan({
           return settled
         }
 
-        const wallet = await WalletsRepository().findById(walletId)
-        if (wallet instanceof Error) return wallet
-
         if (status === PaymentStatus.Settled) {
           paymentLogger.info(
             { success: true, id: paymentHash, payment: pendingPayment },
@@ -227,7 +223,6 @@ const updatePendingPayment = wrapAsyncToRunInSpan({
             const reimbursed = await Wallets.reimburseFailedUsdPayment({
               journalId: pendingPayment.journalId,
               paymentFlow,
-              accountId: wallet.accountId,
             })
             if (reimbursed instanceof Error) {
               const error = `error reimbursing usd payment entry`

--- a/src/app/wallets/reimburse-failed-usd.ts
+++ b/src/app/wallets/reimburse-failed-usd.ts
@@ -1,14 +1,10 @@
 import { toSats } from "@domain/bitcoin"
-import {
-  CouldNotFindWalletForWalletCurrencyError,
-  InvalidAccountForWalletIdError,
-} from "@domain/errors"
+import { CouldNotFindWalletForWalletCurrencyError } from "@domain/errors"
 import { DisplayCurrency, toCents } from "@domain/fiat"
 import { LedgerTransactionType } from "@domain/ledger"
 import { AmountCalculator, WalletCurrency } from "@domain/shared"
 
 import { WalletsRepository } from "@services/mongoose"
-import { getNonEndUserWalletIds } from "@services/ledger"
 import * as LedgerFacade from "@services/ledger/facade"
 
 const calc = AmountCalculator()
@@ -19,11 +15,9 @@ export const reimburseFailedUsdPayment = async <
 >({
   paymentFlow,
   journalId,
-  accountId,
 }: {
   paymentFlow: PaymentFlow<S, R>
   journalId: LedgerJournalId
-  accountId: AccountId
 }): Promise<true | ApplicationError> => {
   const paymentHash = paymentFlow.paymentHashForFlow()
   if (paymentHash instanceof Error) return paymentHash
@@ -54,23 +48,27 @@ export const reimburseFailedUsdPayment = async <
     hash: paymentHash,
   }
 
-  const { id: senderWalletId } = paymentFlow.senderWalletDescriptor()
-  const recipientWallets = await WalletsRepository().listByAccountId(accountId)
-  if (recipientWallets instanceof Error) return recipientWallets
-  if (!recipientWallets.map((wallet) => wallet.id).includes(senderWalletId)) {
-    return new InvalidAccountForWalletIdError(
-      JSON.stringify({
-        accountId,
-        walletId: senderWalletId,
-        nonEndUserWalletIds: await getNonEndUserWalletIds(),
-      }),
+  const walletsRepo = WalletsRepository()
+  const { id: recipientWalletId } = paymentFlow.senderWalletDescriptor()
+  const recipientWallet = await walletsRepo.findById(recipientWalletId)
+  if (recipientWallet instanceof Error) return recipientWallet
+
+  let recipientBtcWallet =
+    recipientWallet.currency === WalletCurrency.Btc ? recipientWallet : undefined
+  if (recipientBtcWallet === undefined) {
+    const recipientWallets = await walletsRepo.listByAccountId(recipientWallet.accountId)
+    if (recipientWallets instanceof Error) return recipientWallets
+
+    recipientBtcWallet = recipientWallets.find(
+      (wallet) => wallet.currency === WalletCurrency.Btc,
     )
+    if (recipientBtcWallet === undefined)
+      return new CouldNotFindWalletForWalletCurrencyError()
   }
-  const btcWallet = recipientWallets.find(
-    (wallet) => wallet.currency === WalletCurrency.Btc,
-  )
-  if (btcWallet === undefined) return new CouldNotFindWalletForWalletCurrencyError()
-  const btcWalletDescriptor = { id: btcWallet.id, currency: btcWallet.currency }
+  const btcWalletDescriptor = {
+    id: recipientBtcWallet.id,
+    currency: recipientBtcWallet.currency,
+  }
 
   const result = await LedgerFacade.recordReceive({
     description: "usd failed payment reimburse",

--- a/src/app/wallets/reimburse-failed-usd.ts
+++ b/src/app/wallets/reimburse-failed-usd.ts
@@ -1,5 +1,5 @@
 import { toSats } from "@domain/bitcoin"
-import { CouldNotFindWalletForWalletCurrencyError } from "@domain/errors"
+import { CouldNotFindBtcWalletForAccountError } from "@domain/errors"
 import { DisplayCurrency, toCents } from "@domain/fiat"
 import { LedgerTransactionType } from "@domain/ledger"
 import { AmountCalculator, WalletCurrency } from "@domain/shared"
@@ -62,8 +62,11 @@ export const reimburseFailedUsdPayment = async <
     recipientBtcWallet = recipientWallets.find(
       (wallet) => wallet.currency === WalletCurrency.Btc,
     )
-    if (recipientBtcWallet === undefined)
-      return new CouldNotFindWalletForWalletCurrencyError()
+    if (recipientBtcWallet === undefined) {
+      return new CouldNotFindBtcWalletForAccountError(
+        JSON.stringify({ accountId: recipientWallet.accountId }),
+      )
+    }
   }
   const btcWalletDescriptor = {
     id: recipientBtcWallet.id,

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -69,7 +69,6 @@ export class InvalidPhoneNumber extends ValidationError {}
 export class InvalidKratosUserId extends ValidationError {}
 export class InvalidEmailAddress extends ValidationError {}
 export class InvalidWalletId extends ValidationError {}
-export class InvalidAccountForWalletIdError extends ValidationError {}
 export class InvalidLedgerTransactionId extends ValidationError {}
 export class InvalidLedgerTransactionStateError extends ValidationError {}
 export class AlreadyPaidError extends ValidationError {}

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -28,12 +28,14 @@ export class CouldNotFindWalletFromUsernameError extends CouldNotFindError {}
 export class CouldNotFindWalletFromUsernameAndCurrencyError extends CouldNotFindError {}
 export class CouldNotFindWalletFromOnChainAddressError extends CouldNotFindError {}
 export class CouldNotFindWalletFromOnChainAddressesError extends CouldNotFindError {}
-export class CouldNotFindWalletForWalletCurrencyError extends CouldNotFindError {}
 export class CouldNotListWalletsFromWalletCurrencyError extends CouldNotFindError {}
 export class NoTransactionToUpdateError extends CouldNotFindError {}
 export class CouldNotFindLightningPaymentFlowError extends CouldNotFindError {}
 export class CouldNotUpdateLightningPaymentFlowError extends CouldNotFindError {}
 export class NoExpiredLightningPaymentFlowsError extends CouldNotFindError {}
+export class CouldNotFindBtcWalletForAccountError extends CouldNotFindError {
+  level = ErrorLevel.Critical
+}
 export class CouldNotFindLnPaymentFromHashError extends CouldNotFindError {
   level = ErrorLevel.Critical
 }

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -349,9 +349,7 @@ interface ILedgerService {
     hash: OnChainTxHash,
   ): Promise<WalletId | LedgerServiceError>
 
-  listEndUserWalletIdsWithPendingPayments: () =>
-    | AsyncGenerator<WalletId>
-    | LedgerServiceError
+  listWalletIdsWithPendingPayments: () => AsyncGenerator<WalletId> | LedgerServiceError
 
   addColdStorageTxReceive(
     args: AddColdStorageTxReceiveArgs,

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -337,7 +337,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "CouldNotFindWalletFromUsernameAndCurrencyError":
     case "CouldNotFindWalletFromOnChainAddressError":
     case "CouldNotFindWalletFromOnChainAddressesError":
-    case "CouldNotFindWalletForWalletCurrencyError":
+    case "CouldNotFindBtcWalletForAccountError":
     case "CouldNotListWalletsFromWalletCurrencyError":
     case "CouldNotFindLnPaymentFromHashError":
     case "LockError":

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -384,7 +384,6 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "InvalidAccountLevelError":
     case "InvalidWithdrawFeeError":
     case "InvalidUsdCents":
-    case "InvalidAccountForWalletIdError":
     case "NonIntegerError":
     case "ColdStorageError":
     case "ColdStorageServiceError":

--- a/src/services/ledger/index.ts
+++ b/src/services/ledger/index.ts
@@ -324,7 +324,7 @@ export const LedgerService = (): ILedgerService => {
     return walletId
   }
 
-  const listEndUserWalletIdsWithPendingPayments = async function* ():
+  const listWalletIdsWithPendingPayments = async function* ():
     | AsyncGenerator<WalletId>
     | LedgerServiceError {
     let transactions
@@ -343,11 +343,8 @@ export const LedgerService = (): ILedgerService => {
       return new UnknownLedgerError(error)
     }
 
-    const nonEndUserWalletIds = Object.values(await caching.getNonEndUserWalletIds())
     for await (const { _id } of transactions) {
-      const walletId = toWalletId(_id)
-      if (walletId === undefined || nonEndUserWalletIds.includes(walletId)) continue
-      yield walletId
+      yield toWalletId(_id)
     }
   }
 
@@ -368,7 +365,7 @@ export const LedgerService = (): ILedgerService => {
       isOnChainTxRecorded,
       isLnTxRecorded,
       getWalletIdByTransactionHash,
-      listEndUserWalletIdsWithPendingPayments,
+      listWalletIdsWithPendingPayments,
       ...admin,
       ...intraledger,
       ...volume,


### PR DESCRIPTION
## Description

This PR fixes the issue that came from the assumption that we would only pass end-user walletIds to the `updatePendingPayment` method. The changes here instead pull the relevant btc wallet reimbursement info from the PaymentFlow created for a given payment hash.