### PR TITLE
fix: all rsync exclude local-regtest-lnd-data

### DIFF
--- a/ci/tasks/test-e2e.sh
+++ b/ci/tasks/test-e2e.sh
@@ -33,7 +33,7 @@ ssh ${ADDITIONAL_SSH_OPTS} ${DOCKER_HOST_USER}@${DOCKER_HOST_IP} \
   "cd ${REPO_PATH}; sudo rm -rf lib"
 
 echo "Syncing repo to docker-host... "
-rsync --delete -avr -e "ssh -l ${DOCKER_HOST_USER} ${ADDITIONAL_SSH_OPTS}" \
+rsync --delete --exclude dev/lnd/local-regtest-lnd-data -avr -e "ssh -l ${DOCKER_HOST_USER} ${ADDITIONAL_SSH_OPTS}" \
   ${REPO_PATH}/ ${DOCKER_HOST_IP}:${REPO_PATH} > /dev/null
 echo "Done!"
 
@@ -46,7 +46,7 @@ pushd ${REPO_PATH}
 
 make create-tmp-env-ci
 echo "Syncing repo to docker-host... "
-rsync --delete -avr -e "ssh -l ${DOCKER_HOST_USER} ${ADDITIONAL_SSH_OPTS}" \
+rsync --delete --exclude dev/lnd/local-regtest-lnd-data -avr -e "ssh -l ${DOCKER_HOST_USER} ${ADDITIONAL_SSH_OPTS}" \
   ./ ${DOCKER_HOST_IP}:${REPO_PATH} > /dev/null
 echo "Done!"
 

--- a/ci/tasks/test-integration.sh
+++ b/ci/tasks/test-integration.sh
@@ -29,7 +29,7 @@ export DOCKER_HOST_USER="sa_$(cat ${CI_ROOT}/gcloud-creds.json  | jq -r '.client
 export ADDITIONAL_SSH_OPTS="-o StrictHostKeyChecking=no -i ${CI_ROOT}/login.ssh"
 
 echo "Syncing repo to docker-host... "
-rsync --delete -avr -e "ssh -l ${DOCKER_HOST_USER} ${ADDITIONAL_SSH_OPTS}" \
+rsync --delete --exclude dev/lnd/local-regtest-lnd-data -avr -e "ssh -l ${DOCKER_HOST_USER} ${ADDITIONAL_SSH_OPTS}" \
   ${REPO_PATH}/ ${DOCKER_HOST_IP}:${REPO_PATH} > /dev/null
 echo "Done!"
 
@@ -42,7 +42,7 @@ pushd ${REPO_PATH}
 
 make create-tmp-env-ci
 echo "Syncing repo to docker-host... "
-rsync --delete -avr -e "ssh -l ${DOCKER_HOST_USER} ${ADDITIONAL_SSH_OPTS}" \
+rsync --delete --exclude dev/lnd/local-regtest-lnd-data -avr -e "ssh -l ${DOCKER_HOST_USER} ${ADDITIONAL_SSH_OPTS}" \
   ./ ${DOCKER_HOST_IP}:${REPO_PATH} > /dev/null
 echo "Done!"
 


### PR DESCRIPTION
fixing only the non vendored files which are used here