### PR TITLE
fix: 'critical' status suppressed from reversal transactions

### DIFF
--- a/src/app/wallets/reimburse-failed-usd.ts
+++ b/src/app/wallets/reimburse-failed-usd.ts
@@ -74,7 +74,7 @@ export const reimburseFailedUsdPayment = async <
   }
 
   const result = await LedgerFacade.recordReceive({
-    description: "usd failed payment reimburse",
+    description: "Usd payment canceled",
     recipientWalletDescriptor: btcWalletDescriptor,
     amountToCreditReceiver: paymentFlow.totalAmountsForPayment(),
     metadata,

--- a/src/domain/shared/errors.types.d.ts
+++ b/src/domain/shared/errors.types.d.ts
@@ -1,0 +1,1 @@
+type DomainError = import("./errors").DomainError

--- a/src/domain/shared/index.ts
+++ b/src/domain/shared/index.ts
@@ -1,4 +1,16 @@
+import { ErrorLevel } from "./errors"
+
 export * from "./primitives"
 export * from "./calculator"
 export * from "./safe"
 export * from "./errors"
+
+export const setErrorWarn = (error: DomainError): DomainError => {
+  error.level = ErrorLevel.Warn
+  return error
+}
+
+export const setErrorCritical = (error: DomainError): DomainError => {
+  error.level = ErrorLevel.Critical
+  return error
+}


### PR DESCRIPTION
## Description

This PR fixes an issue where the error was being recorded twice from `updatePendingPayment` txn reversals, and the second instance of it (from the return statement) was overwriting the `critical` error level from the first instance in the span attributes.
- [Pre-fix trace](https://ui.honeycomb.io/galoy/datasets/arvin-dev/result/tsieg7hWCGz/trace/3D9Ja83hgKA?fields[]=c_name&fields[]=c_service.name&span=954e8400b489147b)
- [Post-fix trace](https://ui.honeycomb.io/galoy/datasets/arvin-dev/result/9YihCh4Vrp5/trace/E8jYox5g8mn?fields[]=c_name&fields[]=c_service.name&span=949d04fd9e79953a)