### PR TITLE
feat: add max amounts validation for sats/cents inputs

### DIFF
--- a/src/domain/bitcoin/index.ts
+++ b/src/domain/bitcoin/index.ts
@@ -3,6 +3,7 @@ import {
   InvalidSatoshiAmountError,
   InvalidTargetConfirmations,
 } from "@domain/errors"
+import { MAX_SATS, BtcAmountTooLargeError } from "@domain/shared"
 
 export const SATS_PER_BTC = 10 ** 8
 
@@ -38,7 +39,14 @@ export const checkedToCurrencyBaseAmount = (
 }
 
 export const checkedToSats = (amount: number): Satoshis | ValidationError => {
-  if (!(amount && amount > 0)) return new InvalidSatoshiAmountError()
+  if (!(amount && amount > 0)) {
+    return new InvalidSatoshiAmountError()
+  }
+
+  if (amount > MAX_SATS.amount) {
+    return new BtcAmountTooLargeError()
+  }
+
   return toSats(amount)
 }
 

--- a/src/domain/payments/index.ts
+++ b/src/domain/payments/index.ts
@@ -4,7 +4,14 @@ export * from "./payment-flow-builder"
 export * from "./price-ratio"
 export * from "./ln-fees"
 
-import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
+import {
+  MAX_CENTS,
+  MAX_SATS,
+  paymentAmountFromNumber,
+  WalletCurrency,
+  BtcAmountTooLargeError,
+  UsdAmountTooLargeError,
+} from "@domain/shared"
 
 import { InvalidBtcPaymentAmountError, InvalidUsdPaymentAmountError } from "./errors"
 
@@ -14,6 +21,11 @@ export const checkedToBtcPaymentAmount = (
   if (amount === null) {
     return new InvalidBtcPaymentAmountError()
   }
+
+  if (amount > MAX_SATS.amount) {
+    return new BtcAmountTooLargeError()
+  }
+
   if (Math.floor(amount) != amount) {
     return new InvalidBtcPaymentAmountError()
   }
@@ -27,6 +39,11 @@ export const checkedToUsdPaymentAmount = (
   if (amount === null) {
     return new InvalidUsdPaymentAmountError()
   }
+
+  if (amount > MAX_CENTS.amount) {
+    return new UsdAmountTooLargeError()
+  }
+
   if (Math.floor(amount) != amount) {
     return new InvalidUsdPaymentAmountError()
   }

--- a/src/domain/shared/errors.ts
+++ b/src/domain/shared/errors.ts
@@ -24,3 +24,6 @@ export class BigIntFloatConversionError extends BigIntConversionError {}
 export class UnknownBigIntConversionError extends BigIntConversionError {
   level = ErrorLevel.Critical
 }
+
+export class BtcAmountTooLargeError extends ValidationError {}
+export class UsdAmountTooLargeError extends ValidationError {}

--- a/src/domain/shared/primitives.ts
+++ b/src/domain/shared/primitives.ts
@@ -26,6 +26,18 @@ export const ZERO_BANK_FEE = {
   btcBankFee: ZERO_SATS,
 }
 
+// 100_000 BTC is the max amount you can make a hodl invoice for in lnd
+export const MAX_SATS = {
+  currency: WalletCurrency.Btc,
+  amount: 10_000_000_000_000n,
+} as const
+
+// Assumes optimistic price under sat-cent parity
+export const MAX_CENTS = {
+  currency: WalletCurrency.Usd,
+  amount: 10_000_000_000_000n,
+}
+
 export const BtcWalletDescriptor = (walletId: WalletId) => {
   return {
     id: walletId,

--- a/src/domain/shared/primitives.ts
+++ b/src/domain/shared/primitives.ts
@@ -35,7 +35,7 @@ export const MAX_SATS = {
 // Assumes optimistic price under sat-cent parity
 export const MAX_CENTS = {
   currency: WalletCurrency.Usd,
-  amount: 10_000_000_000_000n,
+  amount: 100_000_000_000_00n,
 }
 
 export const BtcWalletDescriptor = (walletId: WalletId) => {

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -121,6 +121,14 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       message = "A valid usd amount is required"
       return new ValidationInternalError({ message, logger: baseLogger })
 
+    case "BtcAmountTooLargeError":
+      message = "Sats amount passed is too large"
+      return new ValidationInternalError({ message, logger: baseLogger })
+
+    case "UsdAmountTooLargeError":
+      message = "Usd cents amount passed is too large"
+      return new ValidationInternalError({ message, logger: baseLogger })
+
     case "LnPaymentRequestNonZeroAmountRequiredError":
       message = "Invoice does not have a valid amount to pay"
       return new ValidationInternalError({ message, logger: baseLogger })

--- a/src/graphql/types/scalar/cent-amount.ts
+++ b/src/graphql/types/scalar/cent-amount.ts
@@ -1,3 +1,4 @@
+import { MAX_CENTS } from "@domain/shared"
 import { InputValidationError } from "@graphql/error"
 import { GT } from "@graphql/index"
 
@@ -25,10 +26,16 @@ function validCentAmount(value: string | number) {
   } else {
     intValue = Number.parseInt(value, 10)
   }
-  if (Number.isInteger(intValue) && intValue >= 0) {
-    return intValue
+
+  if (!(Number.isInteger(intValue) && intValue >= 0)) {
+    return new InputValidationError({ message: "Invalid value for CentAmount" })
   }
-  return new InputValidationError({ message: "Invalid value for CentAmount" })
+
+  if (intValue > MAX_CENTS.amount) {
+    return new InputValidationError({ message: "Value too big for CentAmount" })
+  }
+
+  return intValue
 }
 
 export default CentAmount

--- a/src/graphql/types/scalar/sat-amount.ts
+++ b/src/graphql/types/scalar/sat-amount.ts
@@ -1,4 +1,4 @@
-import { ErrorLevel } from "@domain/shared"
+import { ErrorLevel, MAX_SATS } from "@domain/shared"
 import { InputValidationError } from "@graphql/error"
 import { GT } from "@graphql/index"
 import { recordExceptionInCurrentSpan } from "@services/tracing"
@@ -34,10 +34,16 @@ function validSatAmount(value: string | number) {
   } else {
     intValue = Number.parseInt(value, 10)
   }
-  if (Number.isInteger(intValue) && intValue >= 0) {
-    return intValue
+
+  if (!(Number.isInteger(intValue) && intValue >= 0)) {
+    return new InputValidationError({ message: "Invalid value for SatAmount" })
   }
-  return new InputValidationError({ message: "Invalid value for SatAmount" })
+
+  if (intValue > MAX_SATS.amount) {
+    return new InputValidationError({ message: "Value too big for SatAmount" })
+  }
+
+  return intValue
 }
 
 export default SatAmount

--- a/test/unit/domain/bitcoin/checked-to-sats.spec.ts
+++ b/test/unit/domain/bitcoin/checked-to-sats.spec.ts
@@ -1,4 +1,5 @@
 import { checkedToSats } from "@domain/bitcoin"
+import { MAX_SATS } from "@domain/shared"
 
 describe("sats-amount-check", () => {
   it("Positive amount value for satoshis passes", () => {
@@ -13,6 +14,11 @@ describe("sats-amount-check", () => {
 
   it("Negative amount value for satoshis fails", () => {
     const sats = checkedToSats(-100)
+    expect(sats).toBeInstanceOf(Error)
+  })
+
+  it("Large amount value for satoshis fails", () => {
+    const sats = checkedToSats(Number(MAX_SATS.amount + 1n))
     expect(sats).toBeInstanceOf(Error)
   })
 })

--- a/test/unit/domain/payments/index.spec.ts
+++ b/test/unit/domain/payments/index.spec.ts
@@ -4,11 +4,24 @@ import {
   InvalidBtcPaymentAmountError,
   InvalidUsdPaymentAmountError,
 } from "@domain/payments"
-import { WalletCurrency } from "@domain/shared"
+import {
+  MAX_CENTS,
+  MAX_SATS,
+  WalletCurrency,
+  BtcAmountTooLargeError,
+  UsdAmountTooLargeError,
+} from "@domain/shared"
 
 describe("checkedToBtcPaymentAmount", () => {
   it("errors on null", () => {
     expect(checkedToBtcPaymentAmount(null)).toBeInstanceOf(InvalidBtcPaymentAmountError)
+  })
+
+  it("errors on amount greater than max value", () => {
+    expect(checkedToBtcPaymentAmount(Number(MAX_SATS.amount + 1n))).toBeInstanceOf(
+      BtcAmountTooLargeError,
+    )
+    expect(checkedToBtcPaymentAmount(Number(MAX_SATS.amount))).toStrictEqual(MAX_SATS)
   })
 
   it("ensures integer amount", () => {
@@ -28,6 +41,13 @@ describe("checkedToBtcPaymentAmount", () => {
 describe("checkedToUsdPaymentAmount", () => {
   it("errors on null", () => {
     expect(checkedToUsdPaymentAmount(null)).toBeInstanceOf(InvalidUsdPaymentAmountError)
+  })
+
+  it("errors on amount greater than max value", () => {
+    expect(checkedToUsdPaymentAmount(Number(MAX_CENTS.amount + 1n))).toBeInstanceOf(
+      UsdAmountTooLargeError,
+    )
+    expect(checkedToUsdPaymentAmount(Number(MAX_CENTS.amount))).toStrictEqual(MAX_CENTS)
   })
 
   it("ensures integer amount", () => {


### PR DESCRIPTION
## Description

This PR adds checks in validation methods to make sure values are no greater than a defined max amount. The max amount used was `100,000` BTC since this is the max value that lnd would let you create an invoice for.

These changes were prompted by 2 error message types observed from lnd for the `createHodlInvoice` method with the following amount inputs ([examples traces](https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/6xBE7yPk9wp)):
- (1) `10_000_000_000_001`
  `'invoice amount 100000.00000001 BTC is too large, max is 100000 BTC'`

- (2) `1_064_138_827_560_000_000`
  `'payments of negative value are not allowed, value is -5772328715153993728'`

- (2) `476_057_064_138_827_560_000_000`
  `'payments of negative value are not allowed, value is -1000'`