### PR TITLE
debug: add script to clean pending payments for dead lnd nodes

### DIFF
--- a/src/debug/clean-pending-payments-for-dead-node.ts
+++ b/src/debug/clean-pending-payments-for-dead-node.ts
@@ -1,0 +1,85 @@
+/**
+ * how to run:
+ *	. ./.envrc && yarn ts-node \
+ *		--files \
+ *			-r tsconfig-paths/register \
+ *			-r src/services/tracing.ts \
+ *		src/debug/clean-pending-payments-for-dead-node.ts
+ */
+
+import { LedgerTransactionType, UnknownLedgerError } from "@domain/ledger"
+
+import { isUp } from "@services/lnd/health"
+import { params as unauthParams } from "@services/lnd/unauth"
+
+import { setupMongoConnection } from "@services/mongodb"
+import { LedgerService, translateToLedgerTx } from "@services/ledger"
+import { LockService } from "@services/lock"
+import { baseLogger } from "@services/logger"
+
+import { MainBook } from "@services/ledger/books"
+
+const DEAD_LND_PUBKEYS = [
+  "02ae3c066e67cf3951bb5230cf4e13aee053bc06465cd25f870988b691469140b0", // dead node in hack environment
+]
+
+const listAllPendingPayments = async (): Promise<
+  LedgerTransaction<WalletCurrency>[] | LedgerError
+> => {
+  try {
+    const { results } = await MainBook.ledger({
+      type: LedgerTransactionType.Payment,
+      pending: true,
+    })
+
+    return results.filter((tx) => tx.debit > 0).map((tx) => translateToLedgerTx(tx))
+  } catch (err) {
+    return new UnknownLedgerError(err)
+  }
+}
+
+const main = async (): Promise<true | ApplicationError> => {
+  const pendingPayments = await listAllPendingPayments()
+  if (pendingPayments instanceof Error) return pendingPayments
+
+  for (const payment of pendingPayments) {
+    const { paymentHash, pubkey } = payment
+    if (pubkey === undefined) continue
+    if (paymentHash === undefined) continue
+
+    if (DEAD_LND_PUBKEYS.includes(pubkey)) {
+      await LockService().lockPaymentHash(
+        paymentHash,
+        async (): Promise<true | LedgerServiceError> => {
+          const ledgerService = LedgerService()
+          const settled = await ledgerService.settlePendingLnPayment(paymentHash)
+          if (settled instanceof Error) {
+            baseLogger.error({ error: settled }, "no transaction to update")
+            return settled
+          }
+
+          const voided = await ledgerService.revertLightningPayment({
+            journalId: payment.journalId,
+            paymentHash,
+          })
+          if (voided instanceof Error) {
+            const error = `error voiding payment entry`
+            baseLogger.fatal({ success: false, result: payment }, error)
+            return voided
+          }
+          return true
+        },
+      )
+    }
+  }
+
+  return true
+}
+
+setupMongoConnection(false)
+  .then(async (mongoose) => {
+    await Promise.all(unauthParams.map((lndParams) => isUp(lndParams)))
+    await main()
+    if (mongoose) await mongoose.connection.close()
+  })
+  .catch((err) => console.log(err))

--- a/src/debug/clean-pending-payments-for-dead-node.ts
+++ b/src/debug/clean-pending-payments-for-dead-node.ts
@@ -1,6 +1,7 @@
 /**
  * how to run:
- *	. ./.envrc && yarn ts-node \
+ *	. ./.envrc && PUBKEY="" \
+ *    yarn ts-node \
  *		--files \
  *			-r tsconfig-paths/register \
  *			-r src/services/tracing.ts \
@@ -19,9 +20,7 @@ import { baseLogger } from "@services/logger"
 
 import { MainBook } from "@services/ledger/books"
 
-const DEAD_LND_PUBKEYS = [
-  "02ae3c066e67cf3951bb5230cf4e13aee053bc06465cd25f870988b691469140b0", // dead node in hack environment
-]
+const PUBKEY = process.env.PUBKEY
 
 const listAllPendingPayments = async (): Promise<
   LedgerTransaction<WalletCurrency>[] | LedgerError
@@ -47,7 +46,8 @@ const main = async (): Promise<true | ApplicationError> => {
     if (pubkey === undefined) continue
     if (paymentHash === undefined) continue
 
-    if (DEAD_LND_PUBKEYS.includes(pubkey)) {
+    if (PUBKEY && PUBKEY === pubkey) {
+      console.log("HERE 0:", `deleting ${paymentHash}`)
       await LockService().lockPaymentHash(
         paymentHash,
         async (): Promise<true | LedgerServiceError> => {


### PR DESCRIPTION
## Description

Script to clean pending payments leftover from nodes that have been permanently removed for a given environment. Will fix traces like these: https://ui.honeycomb.io/galoy/datasets/galoy-hack/result/defJvEY2iuA