### PR TITLE
chore(tracing): add check to catch undefined gql 'source'

### DIFF
--- a/src/graphql/root/subscription/my-updates.ts
+++ b/src/graphql/root/subscription/my-updates.ts
@@ -14,7 +14,7 @@ import InvoicePaymentStatus from "@graphql/types/scalar/invoice-payment-status"
 import { Prices } from "@app"
 import { PubSubService } from "@services/pubsub"
 import { customPubSubTrigger, PubSubDefaultTriggers } from "@domain/pubsub"
-import { AuthenticationError } from "@graphql/error"
+import { AuthenticationError, UnknownClientError } from "@graphql/error"
 import { baseLogger } from "@services/logger"
 
 const pubsub = PubSubService()
@@ -122,6 +122,14 @@ const MeSubscription = {
     if (!ctx.uid) {
       throw new AuthenticationError({
         message: "Not Authenticated for subscription",
+        logger: baseLogger,
+      })
+    }
+
+    if (source === undefined) {
+      throw new UnknownClientError({
+        message: "Got 'undefined' payload",
+        level: "fatal",
         logger: baseLogger,
       })
     }

--- a/src/graphql/root/subscription/price.ts
+++ b/src/graphql/root/subscription/price.ts
@@ -6,9 +6,12 @@ import { GT } from "@graphql/index"
 import PricePayload from "@graphql/types/payload/price"
 import SatAmount from "@graphql/types/scalar/sat-amount"
 import ExchangeCurrencyUnit from "@graphql/types/scalar/exchange-currency-unit"
+import { UnknownClientError } from "@graphql/error"
 
 import { Prices } from "@app"
 import { PubSubService } from "@services/pubsub"
+import { baseLogger } from "@services/logger"
+
 import { customPubSubTrigger, PubSubDefaultTriggers } from "@domain/pubsub"
 
 const pubsub = PubSubService()
@@ -47,6 +50,14 @@ const PriceSubscription = {
     source: { errors: IError[]; satUsdCentPrice?: number },
     args: PriceResolveArgs,
   ) => {
+    if (source === undefined) {
+      throw new UnknownClientError({
+        message: "Got 'undefined' payload",
+        level: "fatal",
+        logger: baseLogger,
+      })
+    }
+
     if (source.errors) {
       return { errors: source.errors }
     }


### PR DESCRIPTION
## Description

This PR is an attempt to find somewhere in the graphql layer where `errors` property is being read from an `undefined` object. Looking at the code, these changes seem like a good first attempt at finding this issue.

Relevant traces: https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/xj4WGXgcjpj

_Found from this query for errors with missing error codes that could become an alert: [query](https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/pvvg6LLveDD)_