### PR TITLE
chore: handle "unknown" lnd connection error

### DIFF
--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -88,11 +88,7 @@ export const LndService = (): ILightningService | LightningServiceError => {
       const { channel_balance } = await getChannelBalance({ lnd })
       return toSats(channel_balance)
     } catch (err) {
-      const errDetails = parseLndErrorDetails(err)
-      switch (errDetails) {
-        default:
-          return new UnknownLightningServiceError(msgForUnknown(err))
-      }
+      return handleCommonLightningServiceErrors(err)
     }
   }
 
@@ -106,11 +102,7 @@ export const LndService = (): ILightningService | LightningServiceError => {
       const { pending_balance } = await getChannelBalance({ lnd })
       return toSats(pending_balance)
     } catch (err) {
-      const errDetails = parseLndErrorDetails(err)
-      switch (errDetails) {
-        default:
-          return new UnknownLightningServiceError(msgForUnknown(err))
-      }
+      return handleCommonLightningServiceErrors(err)
     }
   }
 
@@ -133,11 +125,7 @@ export const LndService = (): ILightningService | LightningServiceError => {
 
       return toSats(closingChannelBalance)
     } catch (err) {
-      const errDetails = parseLndErrorDetails(err)
-      switch (errDetails) {
-        default:
-          return new UnknownLightningServiceError(msgForUnknown(err))
-      }
+      return handleCommonLightningServiceErrors(err)
     }
   }
 
@@ -261,7 +249,7 @@ export const LndService = (): ILightningService | LightningServiceError => {
         case KnownLndErrorDetails.ProbeForRouteTimedOut:
           return new ProbeForRouteTimedOutError()
         default:
-          return new UnknownRouteNotFoundError(err)
+          return handleCommonRouteNotFoundErrors(err)
       }
     }
   }
@@ -295,11 +283,7 @@ export const LndService = (): ILightningService | LightningServiceError => {
       }
       return registerInvoice
     } catch (err) {
-      const errDetails = parseLndErrorDetails(err)
-      switch (errDetails) {
-        default:
-          return new UnknownLightningServiceError(msgForUnknown(err))
-      }
+      return handleCommonLightningServiceErrors(err)
     }
   }
 
@@ -326,7 +310,7 @@ export const LndService = (): ILightningService | LightningServiceError => {
         case KnownLndErrorDetails.InvoiceNotFound:
           return new InvoiceNotFoundError()
         default:
-          return new UnknownLightningServiceError(msgForUnknown(err))
+          return handleCommonLightningServiceErrors(err)
       }
     }
   }
@@ -381,7 +365,7 @@ export const LndService = (): ILightningService | LightningServiceError => {
               `Corrupted DB error for node with pubkey: ${pubkey}`,
             )
           default:
-            return new UnknownRouteNotFoundError(err)
+            return handleCommonRouteNotFoundErrors(err)
         }
       }
     }
@@ -413,11 +397,7 @@ export const LndService = (): ILightningService | LightningServiceError => {
       }
       return rawInvoices.map(translateLnInvoiceLookup)
     } catch (err) {
-      const errDetails = parseLndErrorDetails(err)
-      switch (errDetails) {
-        default:
-          return new UnknownLightningServiceError(err)
-      }
+      return handleCommonLightningServiceErrors(err)
     }
   }
 
@@ -461,7 +441,7 @@ export const LndService = (): ILightningService | LightningServiceError => {
         case KnownLndErrorDetails.PaymentForDeleteNotFound:
           return false
         default:
-          return new UnknownRouteNotFoundError(err)
+          return handleCommonRouteNotFoundErrors(err)
       }
     }
   }
@@ -486,7 +466,7 @@ export const LndService = (): ILightningService | LightningServiceError => {
         case KnownLndErrorDetails.SecretDoesNotMatchAnyExistingHodlInvoice:
           return new SecretDoesNotMatchAnyExistingHodlInvoiceError(err)
         default:
-          return new UnknownLightningServiceError(err)
+          return handleCommonLightningServiceErrors(err)
       }
     }
   }
@@ -510,7 +490,7 @@ export const LndService = (): ILightningService | LightningServiceError => {
         case KnownLndErrorDetails.InvoiceNotFound:
           return true
         default:
-          return new UnknownLightningServiceError(msgForUnknown(err))
+          return handleCommonLightningServiceErrors(err)
       }
     }
   }
@@ -698,7 +678,7 @@ const lookupPaymentByPubkeyAndHash = async ({
       case KnownLndErrorDetails.SentPaymentNotFound:
         return new PaymentNotFoundError(JSON.stringify({ paymentHash, pubkey }))
       default:
-        return new UnknownLightningServiceError(msgForUnknown(err))
+        return handleCommonLightningServiceErrors(err)
     }
   }
 }
@@ -833,7 +813,23 @@ const handleSendPaymentLndErrors = ({
     case KnownLndErrorDetails.PaymentInTransition:
       return new PaymentInTransitionError(paymentHash)
     default:
+      return handleCommonLightningServiceErrors(err)
+  }
+}
+
+const handleCommonLightningServiceErrors = (err: Error) => {
+  const errDetails = parseLndErrorDetails(err)
+  switch (errDetails) {
+    default:
       return new UnknownLightningServiceError(msgForUnknown(err))
+  }
+}
+
+const handleCommonRouteNotFoundErrors = (err: Error) => {
+  const errDetails = parseLndErrorDetails(err)
+  switch (errDetails) {
+    default:
+      return new UnknownRouteNotFoundError(msgForUnknown(err))
   }
 }
 

--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -37,6 +37,7 @@ import {
   LightningServiceError,
   LnAlreadyPaidError,
   LnPaymentPendingError,
+  OffChainServiceUnavailableError,
   PaymentAttemptsTimedOutError,
   PaymentInTransitionError,
   PaymentNotFoundError,
@@ -697,6 +698,7 @@ export const KnownLndErrorDetails = {
   PaymentInTransition: "payment is in transition",
   PaymentForDeleteNotFound: "non bucket element in payments bucket",
   SecretDoesNotMatchAnyExistingHodlInvoice: "SecretDoesNotMatchAnyExistingHodlInvoice",
+  ConnectionDropped: "Connection dropped",
 } as const
 
 /* eslint @typescript-eslint/ban-ts-comment: "off" */
@@ -820,6 +822,8 @@ const handleSendPaymentLndErrors = ({
 const handleCommonLightningServiceErrors = (err: Error) => {
   const errDetails = parseLndErrorDetails(err)
   switch (errDetails) {
+    case KnownLndErrorDetails.ConnectionDropped:
+      return new OffChainServiceUnavailableError()
     default:
       return new UnknownLightningServiceError(msgForUnknown(err))
   }
@@ -828,6 +832,8 @@ const handleCommonLightningServiceErrors = (err: Error) => {
 const handleCommonRouteNotFoundErrors = (err: Error) => {
   const errDetails = parseLndErrorDetails(err)
   switch (errDetails) {
+    case KnownLndErrorDetails.ConnectionDropped:
+      return new OffChainServiceUnavailableError()
     default:
       return new UnknownRouteNotFoundError(msgForUnknown(err))
   }

--- a/src/services/lnd/onchain-service.ts
+++ b/src/services/lnd/onchain-service.ts
@@ -92,8 +92,7 @@ export const OnChainService = (
         after,
       })
     } catch (err) {
-      const errDetails = parseLndErrorDetails(err)
-      return new UnknownOnChainServiceError(errDetails)
+      return handleCommonOnChainServiceErrors(err)
     }
   }
 
@@ -126,8 +125,7 @@ export const OnChainService = (
 
       return { address: address as OnChainAddress, pubkey }
     } catch (err) {
-      const errDetails = parseLndErrorDetails(err)
-      return new UnknownOnChainServiceError(errDetails)
+      return handleCommonOnChainServiceErrors(err)
     }
   }
 
@@ -162,7 +160,7 @@ export const OnChainService = (
         case KnownLndErrorDetails.InsufficientFunds:
           return new InsufficientOnChainFundsError()
         default:
-          return new UnknownOnChainServiceError(err)
+          return handleCommonOnChainServiceErrors(err)
       }
     }
   }
@@ -183,8 +181,7 @@ export const OnChainService = (
 
       return id as OnChainTxHash
     } catch (err) {
-      const errDetails = parseLndErrorDetails(err)
-      return new UnknownOnChainServiceError(errDetails)
+      return handleCommonOnChainServiceErrors(err)
     }
   }
 
@@ -252,3 +249,17 @@ const getCachedHeight = async (): Promise<number> => {
   if (cachedHeight instanceof Error) return 0
   return cachedHeight
 }
+
+const handleCommonOnChainServiceErrors = (err: Error) => {
+  const errDetails = parseLndErrorDetails(err)
+  switch (errDetails) {
+    default:
+      return new UnknownOnChainServiceError(msgForUnknown(err))
+  }
+}
+
+const msgForUnknown = (err: Error) =>
+  JSON.stringify({
+    parsedLndErrorDetails: parseLndErrorDetails(err),
+    detailsFromLnd: err,
+  })

--- a/src/services/lnd/onchain-service.ts
+++ b/src/services/lnd/onchain-service.ts
@@ -202,6 +202,7 @@ export const OnChainService = (
 
 const KnownLndErrorDetails = {
   InsufficientFunds: "insufficient funds available to construct transaction",
+  ConnectionDropped: "Connection dropped",
 } as const
 
 export const extractIncomingTransactions = ({
@@ -253,6 +254,8 @@ const getCachedHeight = async (): Promise<number> => {
 const handleCommonOnChainServiceErrors = (err: Error) => {
   const errDetails = parseLndErrorDetails(err)
   switch (errDetails) {
+    case KnownLndErrorDetails.ConnectionDropped:
+      return new OnChainServiceUnavailableError()
     default:
       return new UnknownOnChainServiceError(msgForUnknown(err))
   }


### PR DESCRIPTION
## Description

Handle `Unknown..` service error that was forwarded to users (see [traces](https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/bT7dHGfgeCT)). This is in prep for a new alert.