### PR TITLE
chore: graphql ws2

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@ory/client": "^0.0.1-alpha.123",
     "@ory/kratos-client": "^0.10.1",
     "ajv": "^8.10.0",
-    "apollo-server-core": "^3.10.1",
+    "apollo-server-core": "^3.10.2",
     "apollo-server-errors": "^3.3.1",
     "apollo-server-express": "^3.10.2",
     "axios": "^0.27.2",
@@ -57,16 +57,17 @@
     "csv-writer": "^1.6.0",
     "dedent": "^0.7.0",
     "dotenv": "^16.0.0",
-    "express": "^4.17.2",
+    "express": "^4.18.1",
     "express-jwt": "^7.7.5",
     "firebase-admin": "^11.0.1",
     "google-protobuf": "^3.21.0",
-    "graphql": "^16.3.0",
+    "graphql": "^16.6.0",
     "graphql-middleware": "^6.1.32",
     "graphql-redis-subscriptions": "^2.4.2",
     "graphql-relay": "^0.10.0",
     "graphql-shield": "^7.5.0",
     "graphql-tools": "^8.3.4",
+    "graphql-ws": "^5.10.1",
     "gt3-server-node-express-sdk": "https://github.com/GaloyMoney/gt3-server-node-express-bypass#master",
     "helmet": "^5.1.1",
     "i18n": "^0.15.0",
@@ -96,7 +97,8 @@
     "redlock": "^5.0.0-beta.2",
     "subscriptions-transport-ws": "^0.11.0",
     "twilio": "^3.81.0",
-    "uuid-by-string": "^3.0.4"
+    "uuid-by-string": "^3.0.4",
+    "ws": "^8.8.1"
   },
   "devDependencies": {
     "@apollo/client": "^3.6.6",
@@ -152,11 +154,9 @@
     "ts-node-dev": "^2.0.0",
     "tsconfig-paths": "^4.1.0",
     "tscpaths": "^0.0.9",
-    "typescript": "^4.7.3",
-    "ws": "^8.8.1"
+    "typescript": "^4.7.3"
   },
   "resolutions": {
-    "**/**/ws": ">=7.4.6",
     "**/**/json-bigint": ">=1.0.0",
     "**/**/lodash": ">=4.17.12",
     "**/**/lodash.merge": ">=4.6.2"

--- a/src/domain/users-ips/index.ts
+++ b/src/domain/users-ips/index.ts
@@ -1,8 +1,11 @@
-export const parseIps = (ips: undefined | string | string[]): IpAddress | undefined => {
+export const parseIps = (
+  ips: undefined | string | string[] | unknown,
+): IpAddress | undefined => {
   if (!ips) return undefined
 
   if (Array.isArray(ips) && ips.length) {
-    return toIpAddress(ips[0])
+    if (typeof ips[0] === "string") return toIpAddress(ips[0])
+    return undefined
   }
 
   if (typeof ips === "string") {

--- a/src/servers/graphql-admin-server.ts
+++ b/src/servers/graphql-admin-server.ts
@@ -11,7 +11,7 @@ import { GALOY_ADMIN_PORT } from "@config"
 
 import { gqlAdminSchema } from "../graphql"
 
-import { startApolloServer, isAuthenticated, isEditor } from "./graphql-server"
+import { isAuthenticated, isEditor, serverPath } from "./helper"
 
 dotenv.config()
 
@@ -42,6 +42,8 @@ export async function startApolloServerForAdminSchema() {
   )
 
   const schema = applyMiddleware(gqlAdminSchema, permissions)
+
+  const { startApolloServer } = await import(serverPath)
   return startApolloServer({ schema, port: GALOY_ADMIN_PORT, type: "admin" })
 }
 

--- a/src/servers/graphql-main-server.ts
+++ b/src/servers/graphql-main-server.ts
@@ -10,7 +10,7 @@ import { GALOY_API_PORT } from "@config"
 
 import { gqlMainSchema } from "../graphql"
 
-import { isAuthenticated, startApolloServer } from "./graphql-server"
+import { isAuthenticated, serverPath } from "./helper"
 import { walletIdMiddleware } from "./middlewares/wallet-id"
 
 const graphqlLogger = baseLogger.child({ module: "graphql" })
@@ -60,6 +60,9 @@ export async function startApolloServerForCoreSchema() {
   )
 
   const schema = applyMiddleware(gqlMainSchema, permissions, walletIdMiddleware)
+
+  const { startApolloServer } = await import(serverPath)
+
   return startApolloServer({
     schema,
     port: GALOY_API_PORT,

--- a/src/servers/graphql-server-legacy.ts
+++ b/src/servers/graphql-server-legacy.ts
@@ -130,7 +130,7 @@ export const startApolloServer = async ({
   const app = express()
   const httpServer = createServer(app)
 
-  const apolloPulgins = [
+  const apolloPlugins = [
     ApolloServerPluginDrainHttpServer({ httpServer }),
     apolloConfig.playground
       ? ApolloServerPluginLandingPageGraphQLPlayground({
@@ -146,7 +146,7 @@ export const startApolloServer = async ({
   ]
 
   if (isProd && enableApolloUsageReporting) {
-    apolloPulgins.push(
+    apolloPlugins.push(
       ApolloServerPluginUsageReporting({
         rewriteError(err) {
           graphqlLogger.error(err, "Error caught in rewriteError")
@@ -159,7 +159,7 @@ export const startApolloServer = async ({
   const apolloServer = new ApolloServer({
     schema,
     introspection: apolloConfig.playground,
-    plugins: apolloPulgins,
+    plugins: apolloPlugins,
     context: async (context) => {
       // @ts-expect-error: TODO
       const tokenPayload = context.req?.token ?? null

--- a/src/servers/graphql-server-new.ts
+++ b/src/servers/graphql-server-new.ts
@@ -1,0 +1,312 @@
+import { createServer } from "http"
+import crypto from "crypto"
+
+import { Accounts, Users } from "@app"
+import { getApolloConfig, getGeetestConfig, isDev, isProd, JWT_SECRET } from "@config"
+import Geetest from "@services/geetest"
+import { baseLogger } from "@services/logger"
+import {
+  ACCOUNT_USERNAME,
+  addAttributesToCurrentSpan,
+  addAttributesToCurrentSpanAndPropagate,
+  SemanticAttributes,
+} from "@services/tracing"
+import {
+  ApolloServerPluginDrainHttpServer,
+  ApolloServerPluginLandingPageDisabled,
+  ApolloServerPluginLandingPageGraphQLPlayground,
+  ApolloServerPluginUsageReporting,
+} from "apollo-server-core"
+import { ApolloError, ApolloServer } from "apollo-server-express"
+import express from "express"
+import { expressjwt } from "express-jwt"
+import { GraphQLError, GraphQLSchema } from "graphql"
+import { useServer } from "graphql-ws/lib/use/ws"
+import helmet from "helmet"
+import * as jwt from "jsonwebtoken"
+import PinoHttp from "pino-http"
+import { WebSocketServer } from "ws"
+
+import { mapError } from "@graphql/error-map"
+
+import { parseIps } from "@domain/users-ips"
+
+import { playgroundTabs } from "../graphql/playground"
+
+import authRouter from "./auth-router"
+import healthzHandler from "./middlewares/healthz"
+
+const graphqlLogger = baseLogger.child({
+  module: "graphql",
+})
+
+const apolloConfig = getApolloConfig()
+
+const GRAPHQL_PATH = "/graphql"
+
+const jwtAlgorithms: jwt.Algorithm[] = ["HS256"]
+
+const geeTestConfig = getGeetestConfig()
+const geetest = Geetest(geeTestConfig)
+
+const sessionContext = ({
+  tokenPayload,
+  ip,
+  body,
+}: {
+  tokenPayload: jwt.JwtPayload | null
+  ip: IpAddress | undefined
+  body: unknown
+}): Promise<GraphQLContext> => {
+  const userId = tokenPayload?.uid ?? null
+
+  // TODO move from crypto.randomUUID() to a Jaeger standard
+  const logger = graphqlLogger.child({ tokenPayload, id: crypto.randomUUID(), body })
+
+  let domainUser: User | null = null
+  let domainAccount: Account | undefined
+  return addAttributesToCurrentSpanAndPropagate(
+    {
+      [SemanticAttributes.ENDUSER_ID]: userId,
+      [SemanticAttributes.HTTP_CLIENT_IP]: ip,
+    },
+    async () => {
+      if (userId) {
+        const loggedInUser = await Users.getUserForLogin({ userId, ip, logger })
+        if (loggedInUser instanceof Error)
+          throw new ApolloError("Invalid user authentication", "INVALID_AUTHENTICATION", {
+            reason: loggedInUser,
+          })
+        domainUser = loggedInUser
+
+        const loggedInDomainAccount = await Accounts.getAccount(
+          domainUser.defaultAccountId,
+        )
+        if (loggedInDomainAccount instanceof Error) throw Error
+        domainAccount = loggedInDomainAccount
+      }
+
+      addAttributesToCurrentSpan({ [ACCOUNT_USERNAME]: domainAccount?.username })
+
+      return {
+        logger,
+        uid: userId,
+        // FIXME: we should not return this for the admin graphql endpoint
+        domainUser,
+        domainAccount,
+        geetest,
+        ip,
+      }
+    },
+  )
+}
+
+export const startApolloServer = async ({
+  schema,
+  port,
+  startSubscriptionServer = false,
+  enableApolloUsageReporting = false,
+  type,
+}: {
+  schema: GraphQLSchema
+  port: string | number
+  startSubscriptionServer?: boolean
+  enableApolloUsageReporting?: boolean
+  type: string
+}): Promise<Record<string, unknown>> => {
+  const app = express()
+  const httpServer = createServer(app)
+
+  const apolloPlugins = [
+    ApolloServerPluginDrainHttpServer({ httpServer }),
+    apolloConfig.playground
+      ? ApolloServerPluginLandingPageGraphQLPlayground({
+          settings: { "schema.polling.enable": false },
+          tabs: [
+            {
+              endpoint: apolloConfig.playgroundUrl,
+              ...playgroundTabs.default,
+            },
+          ],
+        })
+      : ApolloServerPluginLandingPageDisabled(),
+  ]
+
+  if (isProd && enableApolloUsageReporting) {
+    apolloPlugins.push(
+      ApolloServerPluginUsageReporting({
+        rewriteError(err) {
+          graphqlLogger.error(err, "Error caught in rewriteError")
+          return err
+        },
+      }),
+    )
+  }
+
+  if (startSubscriptionServer) {
+    const wsServer = new WebSocketServer({
+      server: httpServer,
+      path: GRAPHQL_PATH,
+    })
+
+    const serverCleanup = useServer(
+      {
+        schema,
+        // onConnect: // TODO: if token is present, but jwt.verify fails, close connection
+        context: (ctx) => {
+          const connectionParams = ctx.connectionParams as Record<string, string>
+
+          // TODO: check if nginx pass the ip to the header
+          // TODO: ip not been used currently for subscription.
+          // implement some rate limiting.
+          const ipString = isDev
+            ? connectionParams?.ip
+            : connectionParams?.["x-real-ip"] || connectionParams?.["x-forwarded-for"]
+
+          const ip = parseIps(ipString)
+
+          if (connectionParams) {
+            let tokenPayload: string | jwt.JwtPayload | null = null
+            const authz =
+              (connectionParams.authorization as string) ||
+              (connectionParams.Authorization as string)
+            if (authz) {
+              const rawToken = authz.slice(7)
+              tokenPayload = jwt.verify(rawToken, JWT_SECRET, {
+                algorithms: jwtAlgorithms,
+              })
+              if (typeof tokenPayload === "string") {
+                throw new Error("tokenPayload should be an object")
+              }
+            }
+            return sessionContext({
+              tokenPayload,
+
+              ip,
+              // TODO: Resolve what's needed here
+              body: null,
+            })
+          }
+        },
+      },
+      wsServer,
+    )
+
+    ;["SIGINT", "SIGTERM"].forEach((signal) => {
+      process.on(signal, () => wsServer.close())
+    })
+
+    apolloPlugins.push({
+      async serverWillStart() {
+        return {
+          async drainServer() {
+            await serverCleanup.dispose()
+          },
+        }
+      },
+    })
+  }
+
+  const apolloServer = new ApolloServer({
+    schema,
+    introspection: apolloConfig.playground,
+    plugins: apolloPlugins,
+    context: async (context) => {
+      // @ts-expect-error: TODO
+      const tokenPayload = context.req?.token ?? null
+
+      const body = context.req?.body ?? null
+
+      const ipString = isDev
+        ? context.req?.ip
+        : context.req?.headers["x-real-ip"] || context.req?.headers["x-forwarded-for"]
+
+      const ip = parseIps(ipString)
+
+      return sessionContext({
+        tokenPayload,
+        ip,
+        body,
+      })
+    },
+    formatError: (err) => {
+      try {
+        const reportErrorToClient =
+          err instanceof ApolloError || err instanceof GraphQLError
+
+        const reportedError = {
+          message: err.message,
+          locations: err.locations,
+          path: err.path,
+          code: err.extensions?.code,
+        }
+
+        return reportErrorToClient
+          ? reportedError
+          : { message: `Error processing GraphQL request ${reportedError.code}` }
+      } catch (err) {
+        return mapError(err)
+      }
+    },
+  })
+
+  app.use("/auth", authRouter)
+
+  const enablePolicy = apolloConfig.playground ? false : undefined
+
+  app.use(
+    helmet({
+      crossOriginEmbedderPolicy: enablePolicy,
+      crossOriginOpenerPolicy: enablePolicy,
+      crossOriginResourcePolicy: enablePolicy,
+      contentSecurityPolicy: enablePolicy,
+    }),
+  )
+
+  app.use(
+    PinoHttp({
+      logger: graphqlLogger,
+      wrapSerializers: false,
+      autoLogging: {
+        ignore: (req) => req.url === "/healthz",
+      },
+    }),
+  )
+
+  app.use(
+    expressjwt({
+      secret: JWT_SECRET,
+      algorithms: jwtAlgorithms,
+      credentialsRequired: false,
+      requestProperty: "token",
+    }),
+  )
+
+  // Health check
+  app.get(
+    "/healthz",
+    healthzHandler({
+      checkDbConnectionStatus: true,
+      checkRedisStatus: true,
+      checkLndsStatus: false,
+    }),
+  )
+
+  await apolloServer.start()
+
+  apolloServer.applyMiddleware({ app, path: GRAPHQL_PATH })
+
+  return new Promise((resolve, reject) => {
+    httpServer.listen({ port }, () => {
+      console.log(
+        `🚀 "${type}" server ready at http://localhost:${port}${apolloServer.graphqlPath}`,
+      )
+      resolve({ app, httpServer, apolloServer })
+    })
+
+    httpServer.on("error", (err) => {
+      console.error(err)
+      reject(err)
+    })
+  })
+}

--- a/src/servers/graphql-subscriptions.ts
+++ b/src/servers/graphql-subscriptions.ts
@@ -1,0 +1,280 @@
+import { createServer } from "http"
+import crypto from "crypto"
+
+import { Accounts, Users } from "@app"
+import { getApolloConfig, getGeetestConfig, isDev, isProd, JWT_SECRET } from "@config"
+import Geetest from "@services/geetest"
+import { baseLogger } from "@services/logger"
+import {
+  ACCOUNT_USERNAME,
+  addAttributesToCurrentSpan,
+  addAttributesToCurrentSpanAndPropagate,
+  SemanticAttributes,
+} from "@services/tracing"
+import {
+  ApolloServerPluginDrainHttpServer,
+  ApolloServerPluginLandingPageDisabled,
+  ApolloServerPluginLandingPageGraphQLPlayground,
+  ApolloServerPluginUsageReporting,
+} from "apollo-server-core"
+import { ApolloError, ApolloServer } from "apollo-server-express"
+import express from "express"
+import { GraphQLError, GraphQLSchema } from "graphql"
+import { useServer } from "graphql-ws/lib/use/ws"
+import helmet from "helmet"
+import * as jwt from "jsonwebtoken"
+import PinoHttp from "pino-http"
+import { WebSocketServer } from "ws"
+
+import { mapError } from "@graphql/error-map"
+
+import { parseIps } from "@domain/users-ips"
+
+import { playgroundTabs } from "../graphql/playground"
+
+import healthzHandler from "./middlewares/healthz"
+
+const graphqlLogger = baseLogger.child({
+  module: "graphql",
+})
+
+const apolloConfig = getApolloConfig()
+
+const GRAPHQL_PATH = "/graphql"
+
+const jwtAlgorithms: jwt.Algorithm[] = ["HS256"]
+
+const geeTestConfig = getGeetestConfig()
+const geetest = Geetest(geeTestConfig)
+
+const sessionContext = ({
+  tokenPayload,
+  ip,
+  body,
+}: {
+  tokenPayload: jwt.JwtPayload | null
+  ip: IpAddress | undefined
+  body: unknown
+}): Promise<GraphQLContext> => {
+  const userId = tokenPayload?.uid ?? null
+
+  // TODO move from crypto.randomUUID() to a Jaeger standard
+  const logger = graphqlLogger.child({ tokenPayload, id: crypto.randomUUID(), body })
+
+  let domainUser: User | null = null
+  let domainAccount: Account | undefined
+  return addAttributesToCurrentSpanAndPropagate(
+    {
+      [SemanticAttributes.ENDUSER_ID]: userId,
+      [SemanticAttributes.HTTP_CLIENT_IP]: ip,
+    },
+    async () => {
+      if (userId) {
+        const loggedInUser = await Users.getUserForLogin({ userId, ip, logger })
+        if (loggedInUser instanceof Error)
+          throw new ApolloError("Invalid user authentication", "INVALID_AUTHENTICATION", {
+            reason: loggedInUser,
+          })
+        domainUser = loggedInUser
+
+        const loggedInDomainAccount = await Accounts.getAccount(
+          domainUser.defaultAccountId,
+        )
+        if (loggedInDomainAccount instanceof Error) throw Error
+        domainAccount = loggedInDomainAccount
+      }
+
+      addAttributesToCurrentSpan({ [ACCOUNT_USERNAME]: domainAccount?.username })
+
+      return {
+        logger,
+        uid: userId,
+        // FIXME: we should not return this for the admin graphql endpoint
+        domainUser,
+        domainAccount,
+        geetest,
+        ip,
+      }
+    },
+  )
+}
+
+export const startSubscription = async ({
+  schema,
+  port,
+  enableApolloUsageReporting = false,
+  type,
+}: {
+  // TODO: Schema needs to be edited. only expose subscription.
+  schema: GraphQLSchema
+  port: string | number
+  enableApolloUsageReporting?: boolean
+  type: string
+}): Promise<Record<string, unknown>> => {
+  const app = express()
+  const httpServer = createServer(app)
+
+  const apolloPlugins = [
+    ApolloServerPluginDrainHttpServer({ httpServer }),
+    apolloConfig.playground
+      ? ApolloServerPluginLandingPageGraphQLPlayground({
+          settings: { "schema.polling.enable": false },
+          tabs: [
+            {
+              endpoint: apolloConfig.playgroundUrl,
+              ...playgroundTabs.default,
+            },
+          ],
+        })
+      : ApolloServerPluginLandingPageDisabled(),
+  ]
+
+  if (isProd && enableApolloUsageReporting) {
+    apolloPlugins.push(
+      ApolloServerPluginUsageReporting({
+        rewriteError(err) {
+          graphqlLogger.error(err, "Error caught in rewriteError")
+          return err
+        },
+      }),
+    )
+  }
+
+  const wsServer = new WebSocketServer({
+    server: httpServer,
+    path: GRAPHQL_PATH,
+  })
+
+  const serverCleanup = useServer(
+    {
+      schema,
+      // onConnect: // TODO: if token is present, but jwt.verify fails, close connection
+      context: (ctx) => {
+        const connectionParams = ctx.connectionParams as Record<string, string>
+
+        // TODO: check if nginx pass the ip to the header
+        // TODO: ip not been used currently for subscription.
+        // implement some rate limiting.
+        const ipString = isDev
+          ? connectionParams?.ip
+          : connectionParams?.["x-real-ip"] || connectionParams?.["x-forwarded-for"]
+
+        const ip = parseIps(ipString)
+
+        if (connectionParams) {
+          let tokenPayload: string | jwt.JwtPayload | null = null
+          const authz =
+            (connectionParams.authorization as string) ||
+            (connectionParams.Authorization as string)
+          if (authz) {
+            const rawToken = authz.slice(7)
+            tokenPayload = jwt.verify(rawToken, JWT_SECRET, {
+              algorithms: jwtAlgorithms,
+            })
+            if (typeof tokenPayload === "string") {
+              throw new Error("tokenPayload should be an object")
+            }
+          }
+          return sessionContext({
+            tokenPayload,
+
+            ip,
+            // TODO: Resolve what's needed here
+            body: null,
+          })
+        }
+      },
+    },
+    wsServer,
+  )
+
+  ;["SIGINT", "SIGTERM"].forEach((signal) => {
+    process.on(signal, () => wsServer.close())
+  })
+
+  apolloPlugins.push({
+    async serverWillStart() {
+      return {
+        async drainServer() {
+          await serverCleanup.dispose()
+        },
+      }
+    },
+  })
+
+  const apolloServer = new ApolloServer({
+    schema,
+    plugins: apolloPlugins,
+    introspection: apolloConfig.playground,
+
+    // if this subscription only?
+    formatError: (err) => {
+      try {
+        const reportErrorToClient =
+          err instanceof ApolloError || err instanceof GraphQLError
+
+        const reportedError = {
+          message: err.message,
+          locations: err.locations,
+          path: err.path,
+          code: err.extensions?.code,
+        }
+
+        return reportErrorToClient
+          ? reportedError
+          : { message: `Error processing GraphQL request ${reportedError.code}` }
+      } catch (err) {
+        return mapError(err)
+      }
+    },
+  })
+
+  const enablePolicy = apolloConfig.playground ? false : undefined
+
+  app.use(
+    helmet({
+      crossOriginEmbedderPolicy: enablePolicy,
+      crossOriginOpenerPolicy: enablePolicy,
+      crossOriginResourcePolicy: enablePolicy,
+      contentSecurityPolicy: enablePolicy,
+    }),
+  )
+
+  app.use(
+    PinoHttp({
+      logger: graphqlLogger,
+      wrapSerializers: false,
+      autoLogging: {
+        ignore: (req) => req.url === "/healthz",
+      },
+    }),
+  )
+
+  // Health check
+  app.get(
+    "/healthz",
+    healthzHandler({
+      checkDbConnectionStatus: true,
+      checkRedisStatus: true,
+      checkLndsStatus: false,
+    }),
+  )
+
+  await apolloServer.start()
+
+  apolloServer.applyMiddleware({ app, path: GRAPHQL_PATH })
+
+  return new Promise((resolve, reject) => {
+    httpServer.listen({ port }, () => {
+      console.log(
+        `🚀 "${type}" server ready at http://localhost:${port}${apolloServer.graphqlPath}`,
+      )
+      resolve({ app, httpServer, apolloServer })
+    })
+
+    httpServer.on("error", (err) => {
+      console.error(err)
+      reject(err)
+    })
+  })
+}

--- a/src/servers/helper.ts
+++ b/src/servers/helper.ts
@@ -1,0 +1,21 @@
+import { rule } from "graphql-shield"
+
+export const isAuthenticated = rule({ cache: "contextual" })(
+  (parent, args, ctx: GraphQLContextForUser) => {
+    return ctx.uid !== null ? true : "NOT_AUTHENTICATED"
+  },
+)
+
+export const isEditor = rule({ cache: "contextual" })(
+  (parent, args, ctx: GraphQLContextForUser) => {
+    return ctx.domainUser.isEditor ? true : "NOT_AUTHORIZED"
+  },
+)
+
+const shouldGetNewServer = () => {
+  return process.env.NEW_SERVER?.toLowerCase() === "true"
+}
+
+export const serverPath = shouldGetNewServer()
+  ? "./graphql-server-new"
+  : "./graphql-server-legacy"

--- a/test/helpers/integration-server.ts
+++ b/test/helpers/integration-server.ts
@@ -10,6 +10,7 @@ export const startServer = async (command: string): Promise<PID> => {
   return new Promise<PID>((resolve) => {
     const serverProcess = childProcess.spawn("make", [command], {
       killSignal: "SIGKILL",
+      env: { ...process.env, NEW_SERVER: "true" }, // TODO: remove NEW_SERVER after WS migration
     })
     const serverPid = serverProcess.pid as PID
     serverProcess.stdout.on("data", (data) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3151,7 +3151,7 @@ apollo-reporting-protobuf@^3.3.1, apollo-reporting-protobuf@^3.3.2:
   dependencies:
     "@apollo/protobufjs" "1.2.4"
 
-apollo-server-core@^3.10.1, apollo-server-core@^3.10.2:
+apollo-server-core@^3.10.2:
   version "3.10.2"
   resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-3.10.2.tgz#04c5c3fc96b6c7d7f84fdc7356cf9830de4db561"
   integrity sha512-/1o9KPoAMgcjJJ9Y0IH1665wf9d02L/m/mcfBOHiFmRgeGkNgrhTy59BxQTBK241USAWMhwMpp171cv/hM5Dng==
@@ -3396,6 +3396,11 @@ astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
+
+async-limiter@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
+  integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
 async-redis@^1.1.7:
   version "1.1.7"
@@ -5402,7 +5407,7 @@ express-unless@^2.0.2:
   resolved "https://registry.yarnpkg.com/express-unless/-/express-unless-2.1.0.tgz#090a56de501130e63b8c1aa708cf0bbf4e9c2320"
   integrity sha512-666xLp2L3eM1hYhabyZq0HTdedDdcM9QdKsQSROl610VMc2f98KKenc8M3XTPuS/4zpa0QoB8gyDh8K1d8jgDw==
 
-express@4.18.1, express@^4.17.1, express@^4.17.2:
+express@4.18.1, express@^4.17.1, express@^4.18.1:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.18.1.tgz#7797de8b9c72c857b9cd0e14a5eea80666267caf"
   integrity sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==
@@ -6454,6 +6459,11 @@ graphql-tools@^8.3.4:
   optionalDependencies:
     "@apollo/client" "~3.2.5 || ~3.3.0 || ~3.4.0 || ~3.5.0 || ~3.6.0"
 
+graphql-ws@^5.10.1:
+  version "5.10.1"
+  resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.10.1.tgz#c5402a62f1be13e244ab90a6306b94f643577312"
+  integrity sha512-MKm/3SRd1vj5Km8NaujsgeGRTKZQjUN5HRnIMJ8dL2UznKoxvrtQyJqTmqJt0f6vQd9AooDg/+baXo3huiY4Ew==
+
 graphql@^15.5.1:
   version "15.8.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.8.0.tgz#33410e96b012fa3bdb1091cc99a94769db212b38"
@@ -6463,6 +6473,11 @@ graphql@^16.3.0:
   version "16.5.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.5.0.tgz#41b5c1182eaac7f3d47164fb247f61e4dfb69c85"
   integrity sha512-qbHgh8Ix+j/qY+a/ZcJnFQ+j8ezakqPiHwPiZhV/3PgGlgf96QMBB5/f2rkiC9sgLoy/xvT6TSiaf2nTHJh5iA==
+
+graphql@^16.6.0:
+  version "16.6.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
+  integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
 
 grpc-tools@^1.11.2:
   version "1.11.2"
@@ -12193,6 +12208,11 @@ uint8array-tools@0.0.7:
   resolved "https://registry.yarnpkg.com/uint8array-tools/-/uint8array-tools-0.0.7.tgz#a7a2bb5d8836eae2fade68c771454e6a438b390d"
   integrity sha512-vrrNZJiusLWoFWBqz5Y5KMCgP9W9hnjZHzZiZRT8oNAkq3d5Z5Oe76jAvVVSRh4U8GGR90N2X1dWtrhvx6L8UQ==
 
+ultron@~1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
+  integrity sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==
+
 unbox-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.2.tgz#29032021057d5e6cdbd08c5129c226dff8ed6f9e"
@@ -12611,10 +12631,39 @@ write-file-atomic@^4.0.1:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
-ws@8.6.0, ws@8.7.0, ws@8.8.0, ws@8.8.1, ws@>=7.4.6, ws@^3.2.0, "ws@^5.2.0 || ^6.0.0 || ^7.0.0", ws@^8.8.1:
+ws@8.6.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.6.0.tgz#e5e9f1d9e7ff88083d0c0dd8281ea662a42c9c23"
+  integrity sha512-AzmM3aH3gk0aX7/rZLYvjdvZooofDu3fFOzGqcSnQ1tOcTWwhM/o+q++E8mAyVVIyUdajrkzWUGftaVSDLn1bw==
+
+ws@8.7.0:
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.7.0.tgz#eaf9d874b433aa00c0e0d8752532444875db3957"
+  integrity sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==
+
+ws@8.8.0:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.8.0.tgz#8e71c75e2f6348dbf8d78005107297056cb77769"
+  integrity sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==
+
+ws@8.8.1, ws@^8.8.1:
   version "8.8.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.8.1.tgz#5dbad0feb7ade8ecc99b830c1d77c913d4955ff0"
   integrity sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==
+
+ws@^3.2.0:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
+  integrity sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==
+  dependencies:
+    async-limiter "~1.0.0"
+    safe-buffer "~5.1.0"
+    ultron "~1.1.0"
+
+"ws@^5.2.0 || ^6.0.0 || ^7.0.0":
+  version "7.5.9"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
+  integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
 
 xml@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
fix https://github.com/GaloyMoney/galoy/issues/1365, plus some security consideration using the old library: https://github.com/enisdenjo/graphql-ws/issues/3

I ran into issues when I was importing both subscriptions-transport-ws and graphql-ws at the same time. instead of trying to understand the root of this, I decided to duplicated graphql-server and dynamically, at runtime, one or the other websocket library would be used.

by default the old library would be used - so that we can enable the use of the new library in another PR in the charts/deployment repo.

I recommend that we use a new url for BBW to do the migration from the mobile app. we could use api.bbw.sv to replace the current url. api.bbw.sv would have the graphql-ws library. mainnet.graphql.galoy.io would have the subscriptions-transport-ws library.



legacy server (when no env variable is set) --> api.mainnet.galoy.io
"new" server (when NEW_SERVER is set) --> api.bbw.sv



note: I didn't see there was a way to do backward compability with both subscription services

[ws](https://github.com/websockets/ws) server usage with [subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws) backwards compatibility