### PR TITLE
chore: fix missing gql attributes in spans

### DIFF
--- a/src/services/tracing.ts
+++ b/src/services/tracing.ts
@@ -77,50 +77,47 @@ const recordGqlErrors = ({
     },
     ErrorLevel.Warn,
   )
+
+  const setErrorAttribute = ({ attribute, value }) => {
+    span.setAttribute(`graphql.${subPath}error.${attribute}`, value)
+    if (span.attributes[`graphql.error.${attribute}`] === undefined) {
+      span.setAttribute(`graphql.error.${attribute}`, value)
+    }
+
+    return span
+  }
+
   const firstErr = errors[0]
-  if (firstErr.message != "") {
-    const value = firstErr.message
-    span.setAttribute(`graphql.${subPath}error.message`, value)
-    if (span.attributes[`graphql.error.message`] === undefined) {
-      span.setAttribute(`graphql.error.message`, value)
-    }
-  }
-  if (firstErr.constructor?.name) {
-    const value = firstErr.constructor.name
-    span.setAttribute(`graphql.${subPath}error.type`, value)
-    if (span.attributes[`graphql.error.type`] === undefined) {
-      span.setAttribute(`graphql.error.type`, value)
-    }
-  }
-  if (firstErr.path) {
-    const value = firstErr.path.join(".")
-    span.setAttribute(`graphql.${subPath}error.path`, value)
-    if (span.attributes[`graphql.error.path`] === undefined) {
-      span.setAttribute(`graphql.error.path`, value)
-    }
-  }
-  if (firstErr.extensions?.code) {
-    const value = firstErr.extensions.code
-    span.setAttribute(`graphql.${subPath}error.code`, value)
-    if (span.attributes[`graphql.error.code`] === undefined) {
-      span.setAttribute(`graphql.error.code`, value)
-    }
-  }
+  setErrorAttribute({
+    attribute: "message",
+    value: firstErr.message,
+  })
+
+  setErrorAttribute({
+    attribute: "type",
+    value: firstErr.constructor?.name,
+  })
+
+  setErrorAttribute({
+    attribute: "path",
+    value: firstErr.path,
+  })
+
+  setErrorAttribute({
+    attribute: "code",
+    value: firstErr.extensions?.code,
+  })
+
   if (firstErr.originalError) {
-    if (firstErr.originalError.constructor?.name) {
-      const value = firstErr.originalError.constructor.name
-      span.setAttribute(`graphql.${subPath}error.original.type`, value)
-      if (span.attributes[`graphql.error.original.type`] === undefined) {
-        span.setAttribute(`graphql.error.original.type`, value)
-      }
-    }
-    if (firstErr.originalError.message != "") {
-      const value = firstErr.originalError.message
-      span.setAttribute(`graphql.${subPath}error.original.message`, value)
-      if (span.attributes[`graphql.error.original.message`] === undefined) {
-        span.setAttribute(`graphql.error.original.message`, value)
-      }
-    }
+    setErrorAttribute({
+      attribute: "original.type",
+      value: firstErr.originalError.constructor?.name,
+    })
+
+    setErrorAttribute({
+      attribute: "original.message",
+      value: firstErr.originalError.message,
+    })
   }
 
   // @ts-ignore-next-line no-implicit-any error

--- a/src/services/tracing.ts
+++ b/src/services/tracing.ts
@@ -79,29 +79,47 @@ const recordGqlErrors = ({
   )
   const firstErr = errors[0]
   if (firstErr.message != "") {
-    span.setAttribute(`graphql.${subPath}error.message`, firstErr.message)
+    const value = firstErr.message
+    span.setAttribute(`graphql.${subPath}error.message`, value)
+    if (span.attributes[`graphql.error.message`] === undefined) {
+      span.setAttribute(`graphql.error.message`, value)
+    }
   }
   if (firstErr.constructor?.name) {
-    span.setAttribute(`graphql.${subPath}error.type`, firstErr.constructor.name)
+    const value = firstErr.constructor.name
+    span.setAttribute(`graphql.${subPath}error.type`, value)
+    if (span.attributes[`graphql.error.type`] === undefined) {
+      span.setAttribute(`graphql.error.type`, value)
+    }
   }
   if (firstErr.path) {
-    span.setAttribute(`graphql.${subPath}error.path`, firstErr.path.join("."))
+    const value = firstErr.path.join(".")
+    span.setAttribute(`graphql.${subPath}error.path`, value)
+    if (span.attributes[`graphql.error.path`] === undefined) {
+      span.setAttribute(`graphql.error.path`, value)
+    }
   }
   if (firstErr.extensions?.code) {
-    span.setAttribute(`graphql.${subPath}error.code`, firstErr.extensions.code)
+    const value = firstErr.extensions.code
+    span.setAttribute(`graphql.${subPath}error.code`, value)
+    if (span.attributes[`graphql.error.code`] === undefined) {
+      span.setAttribute(`graphql.error.code`, value)
+    }
   }
   if (firstErr.originalError) {
     if (firstErr.originalError.constructor?.name) {
-      span.setAttribute(
-        `graphql.${subPath}error.original.type`,
-        firstErr.originalError.constructor.name,
-      )
+      const value = firstErr.originalError.constructor.name
+      span.setAttribute(`graphql.${subPath}error.original.type`, value)
+      if (span.attributes[`graphql.error.original.type`] === undefined) {
+        span.setAttribute(`graphql.error.original.type`, value)
+      }
     }
     if (firstErr.originalError.message != "") {
-      span.setAttribute(
-        `graphql.${subPath}error.original.message`,
-        firstErr.originalError.message,
-      )
+      const value = firstErr.originalError.message
+      span.setAttribute(`graphql.${subPath}error.original.message`, value)
+      if (span.attributes[`graphql.error.original.message`] === undefined) {
+        span.setAttribute(`graphql.error.original.message`, value)
+      }
     }
   }
 


### PR DESCRIPTION
## Description

Errors that came back as part of the `data` object in a graphql response weren't being added to the top-level `graphql.error.<attr>` attributes that some of our alerts depend on, but were instead being added to `graphql.<operation>.error.<attr>`. This PR changes this so that:
- data errors are more consistently added under the path `graphql.data.error.<attr>`
- a new `graphql.data.error.<index>.operation.name` was added to persist the `<operation>` sub-path I removed when switching to the new sub-path format here

This PR would also feed into a trigger update ([query](https://ui.honeycomb.io/galoy/datasets/arvin-dev/result/JHgCvW6Gs1q)) for [`unknown-error-code`](https://ui.honeycomb.io/galoy/datasets/galoy-staging/triggers/ArnJY6qQjsC) alert.

Traces:
- [Pre-fix trace](https://ui.honeycomb.io/galoy/datasets/arvin-dev/result/x4b5Uk4Snve/trace/fowBMaZwhjo?fields[]=c_name&fields[]=c_service.name&span=8aa70ae863a97c17)
- [Post-fix trace](https://ui.honeycomb.io/galoy/datasets/arvin-dev/result/tznXwqq4p6x/trace/D6SjGvHxdGe?fields[]=c_name&fields[]=c_service.name&span=e801f1204653f82f)