### PR TITLE
chore: replace hodl invoice transition code

### DIFF
--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -108,3 +108,6 @@ export class BadAmountForRouteError extends LnRouteValidationError {}
 
 export class InvalidAccountStatusError extends ValidationError {}
 export class InactiveAccountError extends InvalidAccountStatusError {}
+export class InvalidNonHodlInvoiceError extends ValidationError {
+  level = ErrorLevel.Critical
+}

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -445,6 +445,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "SecretDoesNotMatchAnyExistingHodlInvoiceError":
     case "CaptchaError":
     case "UnknownCaptchaError":
+    case "InvalidNonHodlInvoiceError":
       message = `Unknown error occurred (code: ${error.name}${
         error.message ? ": " + error.message : ""
       })`


### PR DESCRIPTION
## Description

This is to remove temporary transition code originally added [here](https://github.com/GaloyMoney/galoy/pull/1484/commits/ab09b400de6b03e86ae8066e528c5836ffd014c8) to handle any non-hodl invoices generated by the prior version of the code that needed to be settled with the new version of the code.

I opted to add an error message to detect if non-hodl invoice somehow come into our system instead of removing the check entirely. I'm not sure what circumstances this could happen under (value is [never false](https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/6VyrRQbWNwy)), so I'm also ok with removing the check entirely.