### PR TITLE
chore: upgrade docker compose mongodb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
     environment:
     - MONGODB_ADDRESS=mongodb
   mongodb:
-    image: bitnami/mongodb:4.4.6-debian-10-r0
+    image: bitnami/mongodb:6.0
     environment:
     - MONGODB_PASSWORD=password
     - MONGODB_USERNAME=testGaloy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
     environment:
     - MONGODB_ADDRESS=mongodb
   mongodb:
-    image: bitnami/mongodb:6.0
+    image: bitnami/mongodb:5.0
     environment:
     - MONGODB_PASSWORD=password
     - MONGODB_USERNAME=testGaloy


### PR DESCRIPTION
note: seem the chart has incompatibility for mongodb. maybe something to fix before merging this one?

we are using a quite old ( >2y ) docker image, and probably charts, for mongodb. I think it would be a good idea to upgrade to a more recent version.