### PR TITLE
refactor: change 'KnownErrorDetails' check to a regex

### DIFF
--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -244,10 +244,11 @@ export const LndService = (): ILightningService | LightningServiceError => {
       }
 
       const errDetails = parseLndErrorDetails(err)
-      switch (errDetails) {
-        case KnownLndErrorDetails.InsufficientBalance:
+      const match = (knownErrDetail: RegExp): boolean => knownErrDetail.test(errDetails)
+      switch (true) {
+        case match(KnownLndErrorDetails.InsufficientBalance):
           return new InsufficientBalanceForRoutingError()
-        case KnownLndErrorDetails.ProbeForRouteTimedOut:
+        case match(KnownLndErrorDetails.ProbeForRouteTimedOut):
           return new ProbeForRouteTimedOutError()
         default:
           return handleCommonRouteNotFoundErrors(err)
@@ -307,8 +308,9 @@ export const LndService = (): ILightningService | LightningServiceError => {
       return translateLnInvoiceLookup(invoice)
     } catch (err) {
       const errDetails = parseLndErrorDetails(err)
-      switch (errDetails) {
-        case KnownLndErrorDetails.InvoiceNotFound:
+      const match = (knownErrDetail: RegExp): boolean => knownErrDetail.test(errDetails)
+      switch (true) {
+        case match(KnownLndErrorDetails.InvoiceNotFound):
           return new InvoiceNotFoundError()
         default:
           return handleCommonLightningServiceErrors(err)
@@ -360,8 +362,9 @@ export const LndService = (): ILightningService | LightningServiceError => {
         }
       } catch (err) {
         const errDetails = parseLndErrorDetails(err)
-        switch (errDetails) {
-          case KnownLndErrorDetails.LndDbCorruption:
+        const match = (knownErrDetail: RegExp): boolean => knownErrDetail.test(errDetails)
+        switch (true) {
+          case match(KnownLndErrorDetails.LndDbCorruption):
             return new CorruptLndDbError(
               `Corrupted DB error for node with pubkey: ${pubkey}`,
             )
@@ -438,8 +441,9 @@ export const LndService = (): ILightningService | LightningServiceError => {
       return true
     } catch (err) {
       const errDetails = parseLndErrorDetails(err)
-      switch (errDetails) {
-        case KnownLndErrorDetails.PaymentForDeleteNotFound:
+      const match = (knownErrDetail: RegExp): boolean => knownErrDetail.test(errDetails)
+      switch (true) {
+        case match(KnownLndErrorDetails.PaymentForDeleteNotFound):
           return false
         default:
           return handleCommonRouteNotFoundErrors(err)
@@ -463,8 +467,9 @@ export const LndService = (): ILightningService | LightningServiceError => {
       return true
     } catch (err) {
       const errDetails = parseLndErrorDetails(err)
-      switch (errDetails) {
-        case KnownLndErrorDetails.SecretDoesNotMatchAnyExistingHodlInvoice:
+      const match = (knownErrDetail: RegExp): boolean => knownErrDetail.test(errDetails)
+      switch (true) {
+        case match(KnownLndErrorDetails.SecretDoesNotMatchAnyExistingHodlInvoice):
           return new SecretDoesNotMatchAnyExistingHodlInvoiceError(err)
         default:
           return handleCommonLightningServiceErrors(err)
@@ -487,8 +492,9 @@ export const LndService = (): ILightningService | LightningServiceError => {
       return true
     } catch (err) {
       const errDetails = parseLndErrorDetails(err)
-      switch (errDetails) {
-        case KnownLndErrorDetails.InvoiceNotFound:
+      const match = (knownErrDetail: RegExp): boolean => knownErrDetail.test(errDetails)
+      switch (true) {
+        case match(KnownLndErrorDetails.InvoiceNotFound):
           return true
         default:
           return handleCommonLightningServiceErrors(err)
@@ -675,8 +681,9 @@ const lookupPaymentByPubkeyAndHash = async ({
     return new BadPaymentDataError(JSON.stringify(result))
   } catch (err) {
     const errDetails = parseLndErrorDetails(err)
-    switch (errDetails) {
-      case KnownLndErrorDetails.SentPaymentNotFound:
+    const match = (knownErrDetail: RegExp): boolean => knownErrDetail.test(errDetails)
+    switch (true) {
+      case match(KnownLndErrorDetails.SentPaymentNotFound):
         return new PaymentNotFoundError(JSON.stringify({ paymentHash, pubkey }))
       default:
         return handleCommonLightningServiceErrors(err)
@@ -684,21 +691,21 @@ const lookupPaymentByPubkeyAndHash = async ({
   }
 }
 
-export const KnownLndErrorDetails = {
-  InsufficientBalance: "insufficient local balance",
-  InvoiceNotFound: "unable to locate invoice",
-  InvoiceAlreadyPaid: "invoice is already paid",
-  UnableToFindRoute: "PaymentPathfindingFailedToFindPossibleRoute",
-  LndDbCorruption: "payment isn't initiated",
-  PaymentRejectedByDestination: "PaymentRejectedByDestination",
-  UnknownPaymentHash: "UnknownPaymentHash",
-  PaymentAttemptsTimedOut: "PaymentAttemptsTimedOut",
-  ProbeForRouteTimedOut: "ProbeForRouteTimedOut",
-  SentPaymentNotFound: "SentPaymentNotFound",
-  PaymentInTransition: "payment is in transition",
-  PaymentForDeleteNotFound: "non bucket element in payments bucket",
-  SecretDoesNotMatchAnyExistingHodlInvoice: "SecretDoesNotMatchAnyExistingHodlInvoice",
-  ConnectionDropped: "Connection dropped",
+export const KnownLndErrorDetails: { [key: string]: RegExp } = {
+  InsufficientBalance: /insufficient local balance/,
+  InvoiceNotFound: /unable to locate invoice/,
+  InvoiceAlreadyPaid: /invoice is already paid/,
+  UnableToFindRoute: /PaymentPathfindingFailedToFindPossibleRoute/,
+  LndDbCorruption: /payment isn't initiated/,
+  PaymentRejectedByDestination: /PaymentRejectedByDestination/,
+  UnknownPaymentHash: /UnknownPaymentHash/,
+  PaymentAttemptsTimedOut: /PaymentAttemptsTimedOut/,
+  ProbeForRouteTimedOut: /ProbeForRouteTimedOut/,
+  SentPaymentNotFound: /SentPaymentNotFound/,
+  PaymentInTransition: /payment is in transition/,
+  PaymentForDeleteNotFound: /non bucket element in payments bucket/,
+  SecretDoesNotMatchAnyExistingHodlInvoice: /SecretDoesNotMatchAnyExistingHodlInvoice/,
+  ConnectionDropped: /Connection dropped/,
 } as const
 
 /* eslint @typescript-eslint/ban-ts-comment: "off" */
@@ -802,17 +809,18 @@ const handleSendPaymentLndErrors = ({
   paymentHash: PaymentHash
 }) => {
   const errDetails = parseLndErrorDetails(err)
-  switch (errDetails) {
-    case KnownLndErrorDetails.InvoiceAlreadyPaid:
+  const match = (knownErrDetail: RegExp): boolean => knownErrDetail.test(errDetails)
+  switch (true) {
+    case match(KnownLndErrorDetails.InvoiceAlreadyPaid):
       return new LnAlreadyPaidError()
-    case KnownLndErrorDetails.UnableToFindRoute:
+    case match(KnownLndErrorDetails.UnableToFindRoute):
       return new RouteNotFoundError()
-    case KnownLndErrorDetails.PaymentRejectedByDestination:
-    case KnownLndErrorDetails.UnknownPaymentHash:
+    case match(KnownLndErrorDetails.PaymentRejectedByDestination):
+    case match(KnownLndErrorDetails.UnknownPaymentHash):
       return new InvoiceExpiredOrBadPaymentHashError(paymentHash)
-    case KnownLndErrorDetails.PaymentAttemptsTimedOut:
+    case match(KnownLndErrorDetails.PaymentAttemptsTimedOut):
       return new PaymentAttemptsTimedOutError()
-    case KnownLndErrorDetails.PaymentInTransition:
+    case match(KnownLndErrorDetails.PaymentInTransition):
       return new PaymentInTransitionError(paymentHash)
     default:
       return handleCommonLightningServiceErrors(err)
@@ -821,8 +829,9 @@ const handleSendPaymentLndErrors = ({
 
 const handleCommonLightningServiceErrors = (err: Error) => {
   const errDetails = parseLndErrorDetails(err)
-  switch (errDetails) {
-    case KnownLndErrorDetails.ConnectionDropped:
+  const match = (knownErrDetail: RegExp): boolean => knownErrDetail.test(errDetails)
+  switch (true) {
+    case match(KnownLndErrorDetails.ConnectionDropped):
       return new OffChainServiceUnavailableError()
     default:
       return new UnknownLightningServiceError(msgForUnknown(err))
@@ -831,8 +840,9 @@ const handleCommonLightningServiceErrors = (err: Error) => {
 
 const handleCommonRouteNotFoundErrors = (err: Error) => {
   const errDetails = parseLndErrorDetails(err)
-  switch (errDetails) {
-    case KnownLndErrorDetails.ConnectionDropped:
+  const match = (knownErrDetail: RegExp): boolean => knownErrDetail.test(errDetails)
+  switch (true) {
+    case match(KnownLndErrorDetails.ConnectionDropped):
       return new OffChainServiceUnavailableError()
     default:
       return new UnknownRouteNotFoundError(msgForUnknown(err))

--- a/src/services/lnd/onchain-service.ts
+++ b/src/services/lnd/onchain-service.ts
@@ -216,7 +216,7 @@ const KnownLndErrorDetails = {
   InsufficientFunds: /insufficient funds available to construct transaction/,
   ConnectionDropped: /Connection dropped/,
   CPFPAncestorLimitReached:
-    /unmatched backend error: -26: too-long-mempool-chain, too many unconfirmed ancestors \[limit: 25\]/,
+    /unmatched backend error: -26: too-long-mempool-chain, too many .* \[limit: \d+\]/,
 } as const
 
 export const extractIncomingTransactions = ({

--- a/src/services/lnd/onchain-service.ts
+++ b/src/services/lnd/onchain-service.ts
@@ -52,6 +52,7 @@ export const OnChainService = (
       return toSats(chain_balance)
     } catch (err) {
       const errDetails = parseLndErrorDetails(err)
+
       return new OnChainServiceUnavailableError(errDetails)
     }
   }
@@ -67,6 +68,7 @@ export const OnChainService = (
       return toSats(pending_chain_balance)
     } catch (err) {
       const errDetails = parseLndErrorDetails(err)
+
       return new OnChainServiceUnavailableError(errDetails)
     }
   }
@@ -158,8 +160,9 @@ export const OnChainService = (
       return toSats(fee)
     } catch (err) {
       const errDetails = parseLndErrorDetails(err)
-      switch (errDetails) {
-        case KnownLndErrorDetails.InsufficientFunds:
+      const match = (knownErrDetail: RegExp): boolean => knownErrDetail.test(errDetails)
+      switch (true) {
+        case match(KnownLndErrorDetails.InsufficientFunds):
           return new InsufficientOnChainFundsError()
         default:
           return handleCommonOnChainServiceErrors(err)
@@ -184,8 +187,9 @@ export const OnChainService = (
       return id as OnChainTxHash
     } catch (err) {
       const errDetails = parseLndErrorDetails(err)
-      switch (errDetails) {
-        case KnownLndErrorDetails.CPFPAncestorLimitReached:
+      const match = (knownErrDetail: RegExp): boolean => knownErrDetail.test(errDetails)
+      switch (true) {
+        case match(KnownLndErrorDetails.CPFPAncestorLimitReached):
           return new CPFPAncestorLimitReachedError()
         default:
           return handleCommonOnChainServiceErrors(err)
@@ -209,10 +213,10 @@ export const OnChainService = (
 }
 
 const KnownLndErrorDetails = {
-  InsufficientFunds: "insufficient funds available to construct transaction",
-  ConnectionDropped: "Connection dropped",
+  InsufficientFunds: /insufficient funds available to construct transaction/,
+  ConnectionDropped: /Connection dropped/,
   CPFPAncestorLimitReached:
-    "unmatched backend error: -26: too-long-mempool-chain, too many unconfirmed ancestors [limit: 25]",
+    /unmatched backend error: -26: too-long-mempool-chain, too many unconfirmed ancestors \[limit: 25\]/,
 } as const
 
 export const extractIncomingTransactions = ({
@@ -263,8 +267,9 @@ const getCachedHeight = async (): Promise<number> => {
 
 const handleCommonOnChainServiceErrors = (err: Error) => {
   const errDetails = parseLndErrorDetails(err)
-  switch (errDetails) {
-    case KnownLndErrorDetails.ConnectionDropped:
+  const match = (knownErrDetail: RegExp): boolean => knownErrDetail.test(errDetails)
+  switch (true) {
+    case match(KnownLndErrorDetails.ConnectionDropped):
       return new OnChainServiceUnavailableError()
     default:
       return new UnknownOnChainServiceError(msgForUnknown(err))

--- a/test/integration/02-user-wallet/02-receive-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-lightning.spec.ts
@@ -596,7 +596,7 @@ describe("UserWallet - Lightning", () => {
     } catch (err) {
       getInvoiceErr = err
     }
-    expect(parseLndErrorDetails(getInvoiceErr)).toEqual(
+    expect(parseLndErrorDetails(getInvoiceErr)).toMatch(
       KnownLndErrorDetails.InvoiceNotFound,
     )
 
@@ -831,7 +831,7 @@ describe("Invoice handling from trigger", () => {
       const [result] = await Promise.all([startPay(), delayedListener(subInvoices)])
 
       // See successful payment
-      expect(result).toEqual(KnownLndErrorDetails.PaymentRejectedByDestination)
+      expect(result).toMatch(KnownLndErrorDetails.PaymentRejectedByDestination)
       subInvoices.removeAllListeners()
     })
 


### PR DESCRIPTION
## Description

Change `KnownErrorDetails` error handling switch from string-based to regex-based matching.

This was prompted by error messages [like these](https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/A6XwimZhYiz/trace/dSXA1gVcjan?fields[]=c_name&fields[]=c_service.name&span=400a514d90c78a34) that contain variable details within them. The error to match in this case looked like:
```
"unmatched backend error: -26: too-long-mempool-chain, too many descendants for tx 5a1514156a45546cdda2a0309b6787bfabd13e789e3dc6ea313e51636ecc4d7c [limit: 25]"
```