### PR TITLE
test: add ledger volume tests

### DIFF
--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -295,6 +295,12 @@ interface ILedgerService {
 
   intraledgerTxBaseVolumeAmountSince: GetVolumeAmountSinceFn
 
+  allTxBaseVolumeAmountSince: GetVolumeAmountSinceFn
+
+  lightningTxBaseVolumeAmountSince: GetVolumeAmountSinceFn
+
+  onChainTxBaseVolumeAmountSince: GetVolumeAmountSinceFn
+
   isOnChainTxRecorded({
     walletId,
     txHash,

--- a/src/services/ledger/index.types.d.ts
+++ b/src/services/ledger/index.types.d.ts
@@ -23,7 +23,7 @@ type RecordReceiveArgs = {
     btc: BtcPaymentAmount
   }
   metadata: ReceiveLedgerMetadata
-  txMetadata: LnLedgerTransactionMetadataUpdate
+  txMetadata?: LnLedgerTransactionMetadataUpdate
   bankFee?: {
     usd: UsdPaymentAmount
     btc: BtcPaymentAmount

--- a/src/services/ledger/volume.ts
+++ b/src/services/ledger/volume.ts
@@ -118,7 +118,11 @@ export const volume = {
   allTxBaseVolumeSince: volumeFn("allTxBaseVolumeSince"),
   onChainTxBaseVolumeSince: volumeFn("onChainTxBaseVolumeSince"),
   lightningTxBaseVolumeSince: volumeFn("lightningTxBaseVolumeSince"),
+
   allPaymentVolumeAmountSince: volumeAmountFn("allPaymentVolumeSince"),
   externalPaymentVolumeAmountSince: volumeAmountFn("externalPaymentVolumeSince"),
   intraledgerTxBaseVolumeAmountSince: volumeAmountFn("intraledgerTxBaseVolumeSince"),
+  allTxBaseVolumeAmountSince: volumeAmountFn("allTxBaseVolumeSince"),
+  onChainTxBaseVolumeAmountSince: volumeAmountFn("onChainTxBaseVolumeSince"),
+  lightningTxBaseVolumeAmountSince: volumeAmountFn("lightningTxBaseVolumeSince"),
 }

--- a/test/integration/services/ledger/facade.spec.ts
+++ b/test/integration/services/ledger/facade.spec.ts
@@ -5,7 +5,7 @@ import * as LedgerFacade from "@services/ledger/facade"
 
 import {
   recordLnIntraLedgerPayment,
-  recordReceivePayment,
+  recordReceiveLnPayment,
   recordSendLnPayment,
 } from "./helpers"
 
@@ -27,7 +27,7 @@ describe("Facade", () => {
 
   describe("recordReceive", () => {
     it("receives to btc wallet", async () => {
-      await recordReceivePayment({
+      await recordReceiveLnPayment({
         walletDescriptor: walletDescriptor1,
         paymentAmount: receiveAmount,
         bankFee,

--- a/test/integration/services/ledger/helpers.ts
+++ b/test/integration/services/ledger/helpers.ts
@@ -238,11 +238,8 @@ export const recordOnChainIntraLedgerPayment = async ({
 // Non-LedgerFacade helpers from legacy admin service
 // ======
 
-export const recordLnChannelOpenOrClosingFee = async ({
-  amount,
-}: {
-  amount: Satoshis
-}) => {
+export const recordLnChannelOpenOrClosingFee = async ({ paymentAmount }) => {
+  const amount = Number(paymentAmount.btc.amount)
   const metadata = LedgerFacade.LnChannelOpenOrClosingFee({
     txId: "txId" as OnChainTxHash,
   })
@@ -257,7 +254,8 @@ export const recordLnChannelOpenOrClosingFee = async ({
   return translateToLedgerJournal(savedEntry)
 }
 
-export const recordLndEscrowDebit = async ({ amount }: { amount: Satoshis }) => {
+export const recordLndEscrowDebit = async ({ paymentAmount }) => {
+  const amount = Number(paymentAmount.btc.amount)
   const metadata = LedgerFacade.Escrow()
 
   const savedEntry = await MainBook.entry("escrow")
@@ -268,7 +266,8 @@ export const recordLndEscrowDebit = async ({ amount }: { amount: Satoshis }) => 
   return translateToLedgerJournal(savedEntry)
 }
 
-export const recordLndEscrowCredit = async ({ amount }: { amount: Satoshis }) => {
+export const recordLndEscrowCredit = async ({ paymentAmount }) => {
+  const amount = Number(paymentAmount.btc.amount)
   const metadata = LedgerFacade.Escrow()
 
   const savedEntry = await MainBook.entry("escrow")
@@ -279,7 +278,8 @@ export const recordLndEscrowCredit = async ({ amount }: { amount: Satoshis }) =>
   return translateToLedgerJournal(savedEntry)
 }
 
-export const recordLnRoutingRevenue = async ({ amount }: { amount: Satoshis }) => {
+export const recordLnRoutingRevenue = async ({ paymentAmount }) => {
+  const amount = Number(paymentAmount.btc.amount)
   const metadata = LedgerFacade.LnRoutingRevenue(new Date(Date.now()))
 
   const bankOwnerPath = toLiabilitiesWalletId(await getBankOwnerWalletId())

--- a/test/integration/services/ledger/helpers.ts
+++ b/test/integration/services/ledger/helpers.ts
@@ -2,12 +2,22 @@ import crypto from "crypto"
 
 import { getDisplayCurrencyConfig } from "@config"
 
-import { ZERO_CENTS, ZERO_SATS } from "@domain/shared"
+import { WalletCurrency, ZERO_CENTS, ZERO_SATS } from "@domain/shared"
 import { DisplayCurrency } from "@domain/fiat"
+import { LedgerTransactionType, toLiabilitiesWalletId } from "@domain/ledger"
 
 import * as LedgerFacade from "@services/ledger/facade"
+import { MainBook } from "@services/ledger/books"
+import { getBankOwnerWalletId } from "@services/ledger/caching"
+import {
+  bitcoindAccountingPath,
+  escrowAccountingPath,
+  lndAccountingPath,
+} from "@services/ledger/accounts"
+import { translateToLedgerJournal } from "@services/ledger"
+import { toSats } from "@domain/bitcoin"
 
-export const recordReceivePayment = async ({
+export const recordReceiveLnPayment = async ({
   walletDescriptor,
   paymentAmount,
   bankFee,
@@ -22,13 +32,37 @@ export const recordReceivePayment = async ({
     pubkey: crypto.randomUUID() as Pubkey,
   })
 
-  await LedgerFacade.recordReceive({
-    description: "receives bitcoin",
+  return LedgerFacade.recordReceive({
+    description: "receives bitcoin via ln",
     amountToCreditReceiver: paymentAmount,
     recipientWalletDescriptor: walletDescriptor,
     bankFee,
     metadata,
     txMetadata: { hash: paymentHash },
+  })
+}
+
+export const recordReceiveOnChainPayment = async ({
+  walletDescriptor,
+  paymentAmount,
+  bankFee,
+}) => {
+  const onChainTxHash = crypto.randomUUID() as OnChainTxHash
+
+  const metadata = LedgerFacade.OnChainReceiveLedgerMetadata({
+    onChainTxHash,
+    fee: bankFee.btc,
+    feeDisplayCurrency: Number(bankFee.usd.amount) as DisplayCurrencyBaseAmount,
+    amountDisplayCurrency: Number(paymentAmount.usd.amount) as DisplayCurrencyBaseAmount,
+    payeeAddresses: ["address1" as OnChainAddress],
+  })
+
+  return LedgerFacade.recordReceive({
+    description: "receives bitcoin via onchain",
+    amountToCreditReceiver: paymentAmount,
+    recipientWalletDescriptor: walletDescriptor,
+    bankFee,
+    metadata,
   })
 }
 
@@ -52,12 +86,66 @@ export const recordSendLnPayment = async ({
     } as PaymentFlowState<WalletCurrency, WalletCurrency>,
   })
 
-  await LedgerFacade.recordSend({
-    description: "sends bitcoin",
+  return LedgerFacade.recordSend({
+    description: "sends bitcoin via ln",
     amountToDebitSender: paymentAmount,
     senderWalletDescriptor: walletDescriptor,
     bankFee,
     metadata,
+  })
+}
+
+export const recordSendOnChainPayment = async ({
+  walletDescriptor,
+  paymentAmount,
+  bankFee,
+}) => {
+  const metadata = LedgerFacade.OnChainSendLedgerMetadata({
+    onChainTxHash: crypto.randomUUID() as OnChainTxHash,
+    fee: bankFee.btc,
+    feeDisplayCurrency: Number(bankFee.usd.amount) as DisplayCurrencyBaseAmount,
+    amountDisplayCurrency: Number(paymentAmount.usd.amount) as DisplayCurrencyBaseAmount,
+    payeeAddresses: ["address1" as OnChainAddress],
+    sendAll: false,
+  })
+
+  return LedgerFacade.recordSend({
+    description: "sends bitcoin via onchain",
+    amountToDebitSender: paymentAmount,
+    senderWalletDescriptor: walletDescriptor,
+    bankFee,
+    metadata,
+  })
+}
+
+export const recordLnFeeReimbursement = async ({
+  walletDescriptor,
+  paymentAmount,
+  bankFee,
+}) => {
+  const paymentHash = crypto.randomUUID() as PaymentHash
+
+  const metadata = LedgerFacade.LnFeeReimbursementReceiveLedgerMetadata({
+    paymentHash,
+    feeDisplayCurrency: Number(bankFee.usd.amount) as DisplayCurrencyBaseAmount,
+    amountDisplayCurrency: Number(paymentAmount.usd.amount) as DisplayCurrencyBaseAmount,
+    displayCurrency: getDisplayCurrencyConfig().code,
+    paymentFlow: {
+      btcPaymentAmount: paymentAmount.btc,
+      usdPaymentAmount: paymentAmount.usd,
+      btcProtocolFee: bankFee.btc,
+      usdProtocolFee: bankFee.usd,
+    } as PaymentFlowState<WalletCurrency, WalletCurrency>,
+    journalId: "031a419636dbf6d25981d6d2" as LedgerJournalId,
+  })
+
+  return LedgerFacade.recordReceive({
+    description: "receives ln fee reimburse",
+    amountToCreditReceiver: paymentAmount,
+    recipientWalletDescriptor: walletDescriptor,
+    bankFee,
+    metadata,
+    txMetadata: { hash: paymentHash },
   })
 }
 
@@ -83,12 +171,179 @@ export const recordLnIntraLedgerPayment = async ({
       } as PaymentFlowState<WalletCurrency, WalletCurrency>,
     })
 
-  await LedgerFacade.recordIntraledger({
-    description: "sends bitcoin",
+  return LedgerFacade.recordIntraledger({
+    description: "sends/receives ln intraledger",
     amount: paymentAmount,
     senderWalletDescriptor,
     recipientWalletDescriptor,
     metadata,
     additionalDebitMetadata: debitAccountAdditionalMetadata,
   })
+}
+
+export const recordWalletIdIntraLedgerPayment = async ({
+  senderWalletDescriptor,
+  recipientWalletDescriptor,
+  paymentAmount,
+}) => {
+  const { metadata, debitAccountAdditionalMetadata } =
+    LedgerFacade.WalletIdIntraledgerLedgerMetadata({
+      amountDisplayCurrency: Number(
+        paymentAmount.usd.amount,
+      ) as DisplayCurrencyBaseAmount,
+      feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+      displayCurrency: DisplayCurrency.Usd,
+      paymentFlow: {
+        btcPaymentAmount: paymentAmount.btc,
+        usdPaymentAmount: paymentAmount.usd,
+        btcProtocolFee: ZERO_SATS,
+        usdProtocolFee: ZERO_CENTS,
+      } as PaymentFlowState<WalletCurrency, WalletCurrency>,
+    })
+
+  return LedgerFacade.recordIntraledger({
+    description: "sends/receives walletId intraledger",
+    amount: paymentAmount,
+    senderWalletDescriptor,
+    recipientWalletDescriptor,
+    metadata,
+    additionalDebitMetadata: debitAccountAdditionalMetadata,
+  })
+}
+
+export const recordOnChainIntraLedgerPayment = async ({
+  senderWalletDescriptor,
+  recipientWalletDescriptor,
+  paymentAmount,
+}) => {
+  const { metadata, debitAccountAdditionalMetadata } =
+    LedgerFacade.OnChainIntraledgerLedgerMetadata({
+      amountDisplayCurrency: Number(
+        paymentAmount.usd.amount,
+      ) as DisplayCurrencyBaseAmount,
+      sendAll: false,
+      payeeAddresses: ["address1" as OnChainAddress],
+    })
+
+  return LedgerFacade.recordIntraledger({
+    description: "sends/receives onchain intraledger",
+    amount: paymentAmount,
+    senderWalletDescriptor,
+    recipientWalletDescriptor,
+    metadata,
+    additionalDebitMetadata: debitAccountAdditionalMetadata,
+  })
+}
+
+// Non-LedgerFacade helpers from legacy admin service
+// ======
+
+export const recordLnChannelOpenOrClosingFee = async ({ fee }: { fee: Satoshis }) => {
+  const metadata = LedgerFacade.LnChannelOpenOrClosingFee({
+    txId: "txId" as OnChainTxHash,
+  })
+
+  const bankOwnerPath = toLiabilitiesWalletId(await getBankOwnerWalletId())
+
+  const savedEntry = await MainBook.entry("LnChannelOpenOrClosingFee")
+    .debit(bankOwnerPath, fee, { ...metadata, currency: WalletCurrency.Btc })
+    .credit(lndAccountingPath, fee, { ...metadata, currency: WalletCurrency.Btc })
+    .commit()
+
+  return translateToLedgerJournal(savedEntry)
+}
+
+export const recordLndEscrowDebit = async ({ amount }: { amount: Satoshis }) => {
+  const metadata = LedgerFacade.Escrow()
+
+  const savedEntry = await MainBook.entry("escrow")
+    .debit(escrowAccountingPath, amount, { ...metadata, currency: WalletCurrency.Btc })
+    .credit(lndAccountingPath, amount, { ...metadata, currency: WalletCurrency.Btc })
+    .commit()
+
+  return translateToLedgerJournal(savedEntry)
+}
+
+export const recordLndEscrowCredit = async ({ amount }: { amount: Satoshis }) => {
+  const metadata = LedgerFacade.Escrow()
+
+  const savedEntry = await MainBook.entry("escrow")
+    .debit(lndAccountingPath, amount, { ...metadata, currency: WalletCurrency.Btc })
+    .credit(escrowAccountingPath, amount, { ...metadata, currency: WalletCurrency.Btc })
+    .commit()
+
+  return translateToLedgerJournal(savedEntry)
+}
+
+export const recordLnRoutingRevenue = async ({ amount }: { amount: Satoshis }) => {
+  const metadata = LedgerFacade.LnRoutingRevenue(new Date(Date.now()))
+
+  const bankOwnerPath = toLiabilitiesWalletId(await getBankOwnerWalletId())
+
+  const savedEntry = await MainBook.entry("routing fee")
+    .debit(lndAccountingPath, amount, { ...metadata, currency: WalletCurrency.Btc })
+    .credit(bankOwnerPath, amount, { ...metadata, currency: WalletCurrency.Btc })
+    .commit()
+
+  return translateToLedgerJournal(savedEntry)
+}
+
+export const recordColdStorageTxReceive = async ({
+  paymentAmount,
+}: {
+  paymentAmount: { usd: UsdPaymentAmount; btc: BtcPaymentAmount }
+}) => {
+  const amount = Number(paymentAmount.btc.amount)
+  const fee = toSats(2000)
+
+  const metadata: AddColdStorageReceiveLedgerMetadata = {
+    type: LedgerTransactionType.ToColdStorage,
+    pending: false,
+    hash: "txHash" as OnChainTxHash,
+    payee_addresses: ["address1" as OnChainAddress],
+    fee,
+    feeUsd: 1 as DisplayCurrencyBaseAmount,
+    usd: Number(paymentAmount.usd.amount) as DisplayCurrencyBaseAmount,
+    currency: WalletCurrency.Btc,
+  }
+
+  const bankOwnerPath = toLiabilitiesWalletId(await getBankOwnerWalletId())
+
+  const savedEntry = await MainBook.entry("cold storage receive")
+    .debit(bankOwnerPath, fee, metadata)
+    .debit(bitcoindAccountingPath, amount, metadata)
+    .credit(lndAccountingPath, amount + fee, metadata)
+    .commit()
+
+  return translateToLedgerJournal(savedEntry)
+}
+
+export const recordColdStorageTxSend = async ({
+  paymentAmount,
+}: {
+  paymentAmount: { usd: UsdPaymentAmount; btc: BtcPaymentAmount }
+}) => {
+  const amount = Number(paymentAmount.btc.amount)
+  const fee = toSats(2000)
+
+  const metadata: AddColdStorageSendLedgerMetadata = {
+    type: LedgerTransactionType.ToHotWallet,
+    pending: false,
+    hash: "txHash" as OnChainTxHash,
+    payee_addresses: ["address1" as OnChainAddress],
+    fee,
+    feeUsd: 1 as DisplayCurrencyBaseAmount,
+    usd: Number(paymentAmount.usd.amount) as DisplayCurrencyBaseAmount,
+    currency: WalletCurrency.Btc,
+  }
+
+  const bankOwnerPath = toLiabilitiesWalletId(await getBankOwnerWalletId())
+
+  const savedEntry = await MainBook.entry("cold storage send")
+    .debit(bankOwnerPath, fee, metadata)
+    .debit(lndAccountingPath, amount, metadata)
+    .credit(bitcoindAccountingPath, amount + fee, metadata)
+    .commit()
+
+  return translateToLedgerJournal(savedEntry)
 }

--- a/test/integration/services/ledger/helpers.ts
+++ b/test/integration/services/ledger/helpers.ts
@@ -238,7 +238,11 @@ export const recordOnChainIntraLedgerPayment = async ({
 // Non-LedgerFacade helpers from legacy admin service
 // ======
 
-export const recordLnChannelOpenOrClosingFee = async ({ fee }: { fee: Satoshis }) => {
+export const recordLnChannelOpenOrClosingFee = async ({
+  amount,
+}: {
+  amount: Satoshis
+}) => {
   const metadata = LedgerFacade.LnChannelOpenOrClosingFee({
     txId: "txId" as OnChainTxHash,
   })
@@ -246,8 +250,8 @@ export const recordLnChannelOpenOrClosingFee = async ({ fee }: { fee: Satoshis }
   const bankOwnerPath = toLiabilitiesWalletId(await getBankOwnerWalletId())
 
   const savedEntry = await MainBook.entry("LnChannelOpenOrClosingFee")
-    .debit(bankOwnerPath, fee, { ...metadata, currency: WalletCurrency.Btc })
-    .credit(lndAccountingPath, fee, { ...metadata, currency: WalletCurrency.Btc })
+    .debit(bankOwnerPath, amount, { ...metadata, currency: WalletCurrency.Btc })
+    .credit(lndAccountingPath, amount, { ...metadata, currency: WalletCurrency.Btc })
     .commit()
 
   return translateToLedgerJournal(savedEntry)

--- a/test/integration/services/ledger/service.spec.ts
+++ b/test/integration/services/ledger/service.spec.ts
@@ -97,9 +97,12 @@ describe("Volumes", () => {
     walletDescriptor: WalletDescriptor<S>,
   ) => Promise<PaymentAmount<S>>
 
+  // Each "TxFn" execute a transaction for a given type and then checks if
+  // the respective tx volume has been affected or not.
   const prepareTxFns = <S extends WalletCurrency>(
     fetchVolumeAmount: fetchVolumeAmountType<S>,
   ) => {
+    // Base function for extra-ledger transactions (onchain/ln)
     const testExternalTx = async ({
       recordTx,
       calcFn,
@@ -124,6 +127,7 @@ describe("Volumes", () => {
       expect(expected).toStrictEqual(actual)
     }
 
+    // Base function for intra-ledger transactions
     const testInternalTx = async ({ recordTx, sender, recipient, calcFn }) => {
       const currentVolumeAmount = await fetchVolumeAmount(
         walletDescriptor as WalletDescriptor<S>,
@@ -141,25 +145,25 @@ describe("Volumes", () => {
       expect(expected).toStrictEqual(actual)
     }
 
-    const sendLimitCalc = calc.add
-    const receiveLimitCalc = calc.sub
-    const noLimitCalc = (a) => a
+    const sendVolumeCalc = calc.add
+    const receiveVolumeCalc = calc.sub
+    const noVolumeCalc = (a) => a
 
     return {
-      withLimitEffect: {
+      withVolumeEffect: {
         testExternalTxSendWLE: (args) =>
           it(`${args.recordTx.name}`, async () =>
-            testExternalTx({ ...args, calcFn: sendLimitCalc })),
+            testExternalTx({ ...args, calcFn: sendVolumeCalc })),
         testExternalTxReceiveWLE: (args) =>
           it(`${args.recordTx.name}`, async () =>
-            testExternalTx({ ...args, calcFn: receiveLimitCalc })),
+            testExternalTx({ ...args, calcFn: receiveVolumeCalc })),
         testInternalTxSendWLE: (args) =>
           it(`send ${args.recordTx.name}`, async () =>
             testInternalTx({
               ...args,
               sender: walletDescriptor,
               recipient: walletDescriptorOther,
-              calcFn: sendLimitCalc,
+              calcFn: sendVolumeCalc,
             })),
         testInternalTxReceiveWLE: (args) =>
           it(`receive ${args.recordTx.name}`, async () =>
@@ -167,20 +171,20 @@ describe("Volumes", () => {
               ...args,
               sender: walletDescriptorOther,
               recipient: walletDescriptor,
-              calcFn: receiveLimitCalc,
+              calcFn: receiveVolumeCalc,
             })),
       },
-      noLimitEffect: {
+      noVolumeEffect: {
         testExternalTxNLE: (args) =>
           it(`${args.recordTx.name}`, async () =>
-            testExternalTx({ ...args, calcFn: noLimitCalc })),
+            testExternalTx({ ...args, calcFn: noVolumeCalc })),
         testInternalTxSendNLE: (args) =>
           it(`send ${args.recordTx.name}`, async () =>
             testInternalTx({
               ...args,
               sender: walletDescriptor,
               recipient: walletDescriptorOther,
-              calcFn: noLimitCalc,
+              calcFn: noVolumeCalc,
             })),
         testInternalTxReceiveNLE: (args) =>
           it(`receive ${args.recordTx.name}`, async () =>
@@ -188,13 +192,13 @@ describe("Volumes", () => {
               ...args,
               sender: walletDescriptorOther,
               recipient: walletDescriptor,
-              calcFn: noLimitCalc,
+              calcFn: noVolumeCalc,
             })),
       },
     }
   }
 
-  const txTypesForLimits = (
+  const txTypesForVolumes = (
     includedTypes: (keyof typeof ExtendedLedgerTransactionType)[],
   ) => {
     const excludedTypes = Object.keys(ExtendedLedgerTransactionType)
@@ -203,7 +207,7 @@ describe("Volumes", () => {
         (key: keyof typeof ExtendedLedgerTransactionType) => !includedTypes.includes(key),
       )
 
-    it("prepares limit tx types", () => {
+    it("prepares volume tx types", () => {
       const includedTypesSet = new ModifiedSet(includedTypes)
       const excludedTypesSet = new ModifiedSet(excludedTypes)
       expect(includedTypesSet.intersect(excludedTypesSet).size).toEqual(0)
@@ -212,142 +216,14 @@ describe("Volumes", () => {
     return { includedTypes, excludedTypes }
   }
 
-  const executeLimitTests = <S extends WalletCurrency>({
-    includedTxTypes,
-    fetchVolumeAmount,
-  }: {
-    includedTxTypes: (keyof typeof UserLedgerTransactionType)[]
-    fetchVolumeAmount: fetchVolumeAmountType<S>
-  }) => {
-    const { includedTypes, excludedTypes } = txTypesForLimits(includedTxTypes)
-
-    const {
-      withLimitEffect: {
-        testExternalTxSendWLE,
-        testExternalTxReceiveWLE,
-        testInternalTxSendWLE,
-        testInternalTxReceiveWLE,
-      },
-      noLimitEffect: {
-        testExternalTxNLE,
-        testInternalTxSendNLE,
-        testInternalTxReceiveNLE,
-      },
-    } = prepareTxFns(fetchVolumeAmount)
-
-    const txFnsForIncludedTypes = {
-      Invoice: () => testExternalTxReceiveWLE({ recordTx: recordReceiveLnPayment }),
-      OnchainReceipt: () =>
-        testExternalTxReceiveWLE({ recordTx: recordReceiveOnChainPayment }),
-      Payment: () => testExternalTxSendWLE({ recordTx: recordSendLnPayment }),
-      OnchainPayment: () => testExternalTxSendWLE({ recordTx: recordSendOnChainPayment }),
-      LnFeeReimbursement: () =>
-        testExternalTxReceiveWLE({
-          recordTx: recordLnFeeReimbursement,
-        }),
-      IntraLedgerSend: () =>
-        testInternalTxSendWLE({
-          recordTx: recordWalletIdIntraLedgerPayment,
-        }),
-      IntraLedgerReceive: () =>
-        testInternalTxReceiveWLE({
-          recordTx: recordWalletIdIntraLedgerPayment,
-        }),
-      OnchainIntraLedgerSend: () =>
-        testInternalTxSendWLE({
-          recordTx: recordOnChainIntraLedgerPayment,
-        }),
-      OnchainIntraLedgerReceive: () =>
-        testInternalTxReceiveWLE({
-          recordTx: recordOnChainIntraLedgerPayment,
-        }),
-      LnIntraLedgerSend: () =>
-        testInternalTxSendWLE({
-          recordTx: recordLnIntraLedgerPayment,
-        }),
-      LnIntraLedgerReceive: () =>
-        testInternalTxReceiveWLE({
-          recordTx: recordLnIntraLedgerPayment,
-        }),
-
-      // Used, but no limit checks yet:
-      Fee: () => testExternalTxSendWLE({ recordTx: recordLnChannelOpenOrClosingFee }),
-      EscrowCredit: () => testExternalTxSendWLE({ recordTx: recordLndEscrowCredit }),
-      EscrowDebit: () => testExternalTxSendWLE({ recordTx: recordLndEscrowDebit }),
-      RoutingRevenue: () => testExternalTxSendWLE({ recordTx: recordLnRoutingRevenue }),
-      ToHotWallet: () => testExternalTxSendWLE({ recordTx: recordColdStorageTxSend }),
-      ToColdStorage: () =>
-        testExternalTxSendWLE({ recordTx: recordColdStorageTxReceive }),
-
-      // Not used:
-      ExchangeRebalance: () => undefined,
-      UserRebalance: () => undefined,
-      OnchainDepositFee: () => undefined,
-    }
-
-    const txFnsForExcludedTypes = {
-      Invoice: () => testExternalTxNLE({ recordTx: recordReceiveLnPayment }),
-      OnchainReceipt: () => testExternalTxNLE({ recordTx: recordReceiveOnChainPayment }),
-      Payment: () => testExternalTxNLE({ recordTx: recordSendLnPayment }),
-      OnchainPayment: () => testExternalTxNLE({ recordTx: recordSendOnChainPayment }),
-      LnFeeReimbursement: () => testExternalTxNLE({ recordTx: recordLnFeeReimbursement }),
-      Fee: () => testExternalTxNLE({ recordTx: recordLnChannelOpenOrClosingFee }),
-      EscrowCredit: () => testExternalTxNLE({ recordTx: recordLndEscrowCredit }),
-      EscrowDebit: () => testExternalTxNLE({ recordTx: recordLndEscrowDebit }),
-      RoutingRevenue: () => testExternalTxNLE({ recordTx: recordLnRoutingRevenue }),
-      ToHotWallet: () => testExternalTxNLE({ recordTx: recordColdStorageTxSend }),
-      ToColdStorage: () => testExternalTxNLE({ recordTx: recordColdStorageTxReceive }),
-      IntraLedgerSend: () =>
-        testInternalTxSendNLE({
-          recordTx: recordWalletIdIntraLedgerPayment,
-        }),
-      IntraLedgerReceive: () =>
-        testInternalTxReceiveNLE({
-          recordTx: recordWalletIdIntraLedgerPayment,
-        }),
-      OnchainIntraLedgerSend: () =>
-        testInternalTxSendNLE({
-          recordTx: recordOnChainIntraLedgerPayment,
-        }),
-      OnchainIntraLedgerReceive: () =>
-        testInternalTxReceiveNLE({
-          recordTx: recordOnChainIntraLedgerPayment,
-        }),
-      LnIntraLedgerSend: () =>
-        testInternalTxSendNLE({
-          recordTx: recordLnIntraLedgerPayment,
-        }),
-      LnIntraLedgerReceive: () =>
-        testInternalTxReceiveNLE({
-          recordTx: recordLnIntraLedgerPayment,
-        }),
-
-      // Not used
-      ExchangeRebalance: () => undefined,
-      UserRebalance: () => undefined,
-      OnchainDepositFee: () => undefined,
-    }
-
-    // Execute tests for types
-    describe("correctly registers transactions amount", () => {
-      for (const txType of includedTypes) {
-        txFnsForIncludedTypes[txType]()
-      }
-    })
-
-    describe("correctly ignores all other transaction types", () => {
-      for (const txType of excludedTypes) {
-        txFnsForExcludedTypes[txType]()
-      }
-    })
-  }
-
+  // Used to manage how 'outgoing'/'incoming' from volumes is applied
   const VolumeType = {
     Out: "out",
     NetOut: "netOut",
     In: "in",
   } as const
 
+  // Used to construct the 'fetchVolumeAmount' fn for a specific volume type
   const getFetchVolumeAmountFn = <S extends WalletCurrency>({
     volumeFn,
     volumeAmountFn,
@@ -403,8 +279,145 @@ describe("Volumes", () => {
     return fetchVolumeAmountFn
   }
 
+  // Executes the tests for each 'describe' for volume types below
+  const executeVolumeTests = <S extends WalletCurrency>({
+    includedTxTypes,
+    fetchVolumeAmount,
+  }: {
+    includedTxTypes: (keyof typeof UserLedgerTransactionType)[]
+    fetchVolumeAmount: fetchVolumeAmountType<S>
+  }) => {
+    const { includedTypes, excludedTypes } = txTypesForVolumes(includedTxTypes)
+
+    const {
+      withVolumeEffect: {
+        testExternalTxSendWLE,
+        testExternalTxReceiveWLE,
+        testInternalTxSendWLE,
+        testInternalTxReceiveWLE,
+      },
+      noVolumeEffect: {
+        testExternalTxNLE,
+        testInternalTxSendNLE,
+        testInternalTxReceiveNLE,
+      },
+    } = prepareTxFns(fetchVolumeAmount)
+
+    // Setting up all 'it' tests for each txn type, to check volume is affected
+    const txFnsForIncludedTypes = {
+      Invoice: () => testExternalTxReceiveWLE({ recordTx: recordReceiveLnPayment }),
+      OnchainReceipt: () =>
+        testExternalTxReceiveWLE({ recordTx: recordReceiveOnChainPayment }),
+      Payment: () => testExternalTxSendWLE({ recordTx: recordSendLnPayment }),
+      OnchainPayment: () => testExternalTxSendWLE({ recordTx: recordSendOnChainPayment }),
+      LnFeeReimbursement: () =>
+        testExternalTxReceiveWLE({
+          recordTx: recordLnFeeReimbursement,
+        }),
+      IntraLedgerSend: () =>
+        testInternalTxSendWLE({
+          recordTx: recordWalletIdIntraLedgerPayment,
+        }),
+      IntraLedgerReceive: () =>
+        testInternalTxReceiveWLE({
+          recordTx: recordWalletIdIntraLedgerPayment,
+        }),
+      OnchainIntraLedgerSend: () =>
+        testInternalTxSendWLE({
+          recordTx: recordOnChainIntraLedgerPayment,
+        }),
+      OnchainIntraLedgerReceive: () =>
+        testInternalTxReceiveWLE({
+          recordTx: recordOnChainIntraLedgerPayment,
+        }),
+      LnIntraLedgerSend: () =>
+        testInternalTxSendWLE({
+          recordTx: recordLnIntraLedgerPayment,
+        }),
+      LnIntraLedgerReceive: () =>
+        testInternalTxReceiveWLE({
+          recordTx: recordLnIntraLedgerPayment,
+        }),
+
+      // Used, but no volume checks yet:
+      Fee: () => testExternalTxSendWLE({ recordTx: recordLnChannelOpenOrClosingFee }),
+      EscrowCredit: () => testExternalTxSendWLE({ recordTx: recordLndEscrowCredit }),
+      EscrowDebit: () => testExternalTxSendWLE({ recordTx: recordLndEscrowDebit }),
+      RoutingRevenue: () => testExternalTxSendWLE({ recordTx: recordLnRoutingRevenue }),
+      ToHotWallet: () => testExternalTxSendWLE({ recordTx: recordColdStorageTxSend }),
+      ToColdStorage: () =>
+        testExternalTxSendWLE({ recordTx: recordColdStorageTxReceive }),
+
+      // Not used:
+      ExchangeRebalance: () => undefined,
+      UserRebalance: () => undefined,
+      OnchainDepositFee: () => undefined,
+    }
+
+    // Setting up all 'it' tests for each txn type, to check volume is NOT affected
+    const txFnsForExcludedTypes = {
+      Invoice: () => testExternalTxNLE({ recordTx: recordReceiveLnPayment }),
+      OnchainReceipt: () => testExternalTxNLE({ recordTx: recordReceiveOnChainPayment }),
+      Payment: () => testExternalTxNLE({ recordTx: recordSendLnPayment }),
+      OnchainPayment: () => testExternalTxNLE({ recordTx: recordSendOnChainPayment }),
+      LnFeeReimbursement: () => testExternalTxNLE({ recordTx: recordLnFeeReimbursement }),
+      Fee: () => testExternalTxNLE({ recordTx: recordLnChannelOpenOrClosingFee }),
+      EscrowCredit: () => testExternalTxNLE({ recordTx: recordLndEscrowCredit }),
+      EscrowDebit: () => testExternalTxNLE({ recordTx: recordLndEscrowDebit }),
+      RoutingRevenue: () => testExternalTxNLE({ recordTx: recordLnRoutingRevenue }),
+      ToHotWallet: () => testExternalTxNLE({ recordTx: recordColdStorageTxSend }),
+      ToColdStorage: () => testExternalTxNLE({ recordTx: recordColdStorageTxReceive }),
+      IntraLedgerSend: () =>
+        testInternalTxSendNLE({
+          recordTx: recordWalletIdIntraLedgerPayment,
+        }),
+      IntraLedgerReceive: () =>
+        testInternalTxReceiveNLE({
+          recordTx: recordWalletIdIntraLedgerPayment,
+        }),
+      OnchainIntraLedgerSend: () =>
+        testInternalTxSendNLE({
+          recordTx: recordOnChainIntraLedgerPayment,
+        }),
+      OnchainIntraLedgerReceive: () =>
+        testInternalTxReceiveNLE({
+          recordTx: recordOnChainIntraLedgerPayment,
+        }),
+      LnIntraLedgerSend: () =>
+        testInternalTxSendNLE({
+          recordTx: recordLnIntraLedgerPayment,
+        }),
+      LnIntraLedgerReceive: () =>
+        testInternalTxReceiveNLE({
+          recordTx: recordLnIntraLedgerPayment,
+        }),
+
+      // Not used
+      ExchangeRebalance: () => undefined,
+      UserRebalance: () => undefined,
+      OnchainDepositFee: () => undefined,
+    }
+
+    // Execute tests for specific types included
+    describe("correctly registers transactions amount", () => {
+      for (const txType of includedTypes) {
+        txFnsForIncludedTypes[txType]()
+      }
+    })
+
+    // Execute tests for rest of types excluded
+    describe("correctly ignores all other transaction types", () => {
+      for (const txType of excludedTypes) {
+        txFnsForExcludedTypes[txType]()
+      }
+    })
+  }
+
+  // EXECUTE TESTS FOR EACH VOLUME TYPE
+  // ==========
+
   describe("All payment volumes", () => {
-    executeLimitTests({
+    executeVolumeTests({
       includedTxTypes: [
         "Payment",
         "OnchainPayment",
@@ -421,7 +434,7 @@ describe("Volumes", () => {
   })
 
   describe("External payment (withdrawal) volumes", () => {
-    executeLimitTests({
+    executeVolumeTests({
       includedTxTypes: ["Payment", "OnchainPayment"],
       fetchVolumeAmount: getFetchVolumeAmountFn({
         volumeFn: ledgerService.externalPaymentVolumeSince,
@@ -432,7 +445,7 @@ describe("Volumes", () => {
   })
 
   describe("Internal payment volumes", () => {
-    executeLimitTests({
+    executeVolumeTests({
       includedTxTypes: ["IntraLedgerSend", "OnchainIntraLedgerSend", "LnIntraLedgerSend"],
       fetchVolumeAmount: getFetchVolumeAmountFn({
         volumeFn: ledgerService.intraledgerTxBaseVolumeSince,
@@ -447,7 +460,7 @@ describe("Volumes", () => {
       UserLedgerTransactionType,
     ) as (keyof typeof UserLedgerTransactionType)[]
 
-    executeLimitTests({
+    executeVolumeTests({
       includedTxTypes,
       fetchVolumeAmount: getFetchVolumeAmountFn({
         volumeFn: ledgerService.allTxBaseVolumeSince,
@@ -458,7 +471,7 @@ describe("Volumes", () => {
   })
 
   describe("All onchain activity", () => {
-    executeLimitTests({
+    executeVolumeTests({
       includedTxTypes: ["OnchainPayment", "OnchainReceipt"],
       fetchVolumeAmount: getFetchVolumeAmountFn({
         volumeFn: ledgerService.onChainTxBaseVolumeSince,
@@ -469,7 +482,7 @@ describe("Volumes", () => {
   })
 
   describe("All ln activity", () => {
-    executeLimitTests({
+    executeVolumeTests({
       includedTxTypes: ["Payment", "Invoice", "LnFeeReimbursement"],
       fetchVolumeAmount: getFetchVolumeAmountFn({
         volumeFn: ledgerService.lightningTxBaseVolumeSince,

--- a/test/integration/services/ledger/service.spec.ts
+++ b/test/integration/services/ledger/service.spec.ts
@@ -45,6 +45,7 @@ const FullLedgerTransactionType = {
   EscrowCredit: LedgerTransactionType.Escrow,
   EscrowDebit: LedgerTransactionType.Escrow,
 } as const
+
 const {
   IntraLedger,
   LnIntraLedger,
@@ -52,6 +53,31 @@ const {
   Escrow,
   ...ExtendedLedgerTransactionType
 } = FullLedgerTransactionType
+
+// Discarded for type-checker
+const _unusedSwappedOutTypes = [IntraLedger, LnIntraLedger, OnchainIntraLedger, Escrow]
+_unusedSwappedOutTypes
+
+const {
+  Fee,
+  RoutingRevenue,
+  ToColdStorage,
+  ToHotWallet,
+  EscrowCredit,
+  EscrowDebit,
+  ...UserLedgerTransactionType
+} = ExtendedLedgerTransactionType
+
+// Discarded for type-checker
+const _unusedAdminTypes = [
+  Fee,
+  RoutingRevenue,
+  ToColdStorage,
+  ToHotWallet,
+  EscrowCredit,
+  EscrowDebit,
+]
+_unusedAdminTypes
 
 describe("Volumes", () => {
   const timestamp1DayAgo = new Date(Date.now() - MS_PER_DAY)
@@ -181,12 +207,6 @@ describe("Volumes", () => {
       const includedTypesSet = new ModifiedSet(includedTypes)
       const excludedTypesSet = new ModifiedSet(excludedTypes)
       expect(includedTypesSet.intersect(excludedTypesSet).size).toEqual(0)
-
-      // Included here to remove lint for these unused variables
-      expect(includedTypes).not.toContain(IntraLedger)
-      expect(includedTypes).not.toContain(LnIntraLedger)
-      expect(includedTypes).not.toContain(OnchainIntraLedger)
-      expect(includedTypes).not.toContain(Escrow)
     })
 
     return { includedTypes, excludedTypes }
@@ -196,7 +216,7 @@ describe("Volumes", () => {
     includedTxTypes,
     fetchVolumeAmount,
   }: {
-    includedTxTypes: (keyof typeof ExtendedLedgerTransactionType)[]
+    includedTxTypes: (keyof typeof UserLedgerTransactionType)[]
     fetchVolumeAmount: fetchVolumeAmountType<S>
   }) => {
     const { includedTypes, excludedTypes } = txTypesForLimits(includedTxTypes)
@@ -423,31 +443,9 @@ describe("Volumes", () => {
   })
 
   describe("All activity", () => {
-    // FIXME: Should be all tx types, why are these not included?
-    const {
-      Fee,
-      RoutingRevenue,
-      ToColdStorage,
-      ToHotWallet,
-      EscrowCredit,
-      EscrowDebit,
-      ...includedTypesObj
-    } = ExtendedLedgerTransactionType
     const includedTxTypes = Object.keys(
-      includedTypesObj,
-    ) as (keyof typeof ExtendedLedgerTransactionType)[]
-
-    const others = [
-      Fee,
-      RoutingRevenue,
-      ToColdStorage,
-      ToHotWallet,
-      EscrowCredit,
-      EscrowDebit,
-    ]
-    expect(
-      new ModifiedSet(others).intersect(new ModifiedSet(includedTxTypes)).size,
-    ).toEqual(0)
+      UserLedgerTransactionType,
+    ) as (keyof typeof UserLedgerTransactionType)[]
 
     executeLimitTests({
       includedTxTypes,

--- a/test/integration/services/ledger/service.spec.ts
+++ b/test/integration/services/ledger/service.spec.ts
@@ -65,10 +65,15 @@ describe("Volumes", () => {
     }
 
     return {
-      testExternalTxSend: async (args) => testExternalTx({ ...args, calcFn: calc.add }),
-      testExternalTxReceive: async (args) =>
-        testExternalTx({ ...args, calcFn: calc.sub }),
-      testExternalTxNoOp: async (args) => testExternalTx({ ...args, calcFn: (a) => a }),
+      testExternalTxSend: (args) =>
+        it(`testExternalSend: ${args.recordTx.name}`, async () =>
+          testExternalTx({ ...args, calcFn: calc.add })),
+      testExternalTxReceive: (args) =>
+        it(`testExternalTxReceive: ${args.recordTx.name}`, async () =>
+          testExternalTx({ ...args, calcFn: calc.sub })),
+      testExternalTxNoOp: (args) =>
+        it(`testExternalTxNoOp: ${args.recordTx.name}`, async () =>
+          testExternalTx({ ...args, calcFn: (a) => a })),
     }
   }
 
@@ -90,34 +95,38 @@ describe("Volumes", () => {
     }
 
     return {
-      testInternalTxSend: async (args) =>
-        testInternalTx({
-          ...args,
-          sender: walletDescriptor,
-          recipient: walletDescriptorOther,
-          calcFn: calc.add,
-        }),
-      testInternalTxReceive: async (args) =>
-        testInternalTx({
-          ...args,
-          sender: walletDescriptorOther,
-          recipient: walletDescriptor,
-          calcFn: calc.sub,
-        }),
-      testInternalTxSendNoOp: async (args) =>
-        testInternalTx({
-          ...args,
-          sender: walletDescriptor,
-          recipient: walletDescriptorOther,
-          calcFn: (a) => a,
-        }),
-      testInternalTxReceiveNoOp: async (args) =>
-        testInternalTx({
-          ...args,
-          sender: walletDescriptorOther,
-          recipient: walletDescriptor,
-          calcFn: (a) => a,
-        }),
+      testInternalTxSend: (args) =>
+        it(`testInternalTxSend: ${args.recordTx.name}`, async () =>
+          testInternalTx({
+            ...args,
+            sender: walletDescriptor,
+            recipient: walletDescriptorOther,
+            calcFn: calc.add,
+          })),
+      testInternalTxReceive: (args) =>
+        it(`testInternalTxReceive: ${args.recordTx.name}`, async () =>
+          testInternalTx({
+            ...args,
+            sender: walletDescriptorOther,
+            recipient: walletDescriptor,
+            calcFn: calc.sub,
+          })),
+      testInternalTxSendNoOp: (args) =>
+        it(`testInternalTxSendNoOp: ${args.recordTx.name}`, async () =>
+          testInternalTx({
+            ...args,
+            sender: walletDescriptor,
+            recipient: walletDescriptorOther,
+            calcFn: (a) => a,
+          })),
+      testInternalTxReceiveNoOp: (args) =>
+        it(`testInternalTxReceiveNoOp: ${args.recordTx.name}`, async () =>
+          testInternalTx({
+            ...args,
+            sender: walletDescriptorOther,
+            recipient: walletDescriptor,
+            calcFn: (a) => a,
+          })),
     }
   }
 
@@ -136,7 +145,8 @@ describe("Volumes", () => {
 
     return {
       testTxWithoutFacadeNoOp: async (args) =>
-        testTxWithoutFacade({ ...args, calcFn: (a) => a }),
+        it(`testTxWithoutFacadeNoOp: ${args.recordTx.name}`, async () =>
+          testTxWithoutFacade({ ...args, calcFn: (a) => a })),
     }
   }
 
@@ -196,14 +206,14 @@ describe("Volumes", () => {
       - LnFeeReimbursement
       - OnchainPayment
     */
-    it("correctly registers withdrawal transactions amount", async () => {
+    describe("correctly registers withdrawal transactions amount", () => {
       // Payment
-      await testExternalTxSend({
+      testExternalTxSend({
         recordTx: recordSendLnPayment,
       })
 
       // OnchainPayment
-      await testExternalTxSend({
+      testExternalTxSend({
         recordTx: recordSendOnChainPayment,
       })
     })
@@ -228,34 +238,34 @@ describe("Volumes", () => {
       - ExchangeRebalance
       - UserRebalance
     */
-    it("correctly ignores all other transaction types", async () => {
+    describe("correctly ignores all other transaction types", () => {
       // TODO: move to "included" above
       // LnFeeReimbursement
-      await testExternalTxNoOp({ recordTx: recordLnFeeReimbursement })
+      testExternalTxNoOp({ recordTx: recordLnFeeReimbursement })
 
       // Invoice (LnReceipt)
-      await testExternalTxNoOp({ recordTx: recordReceiveLnPayment })
+      testExternalTxNoOp({ recordTx: recordReceiveLnPayment })
 
       // Invoice (OnChainReceipt)
-      await testExternalTxNoOp({ recordTx: recordReceiveOnChainPayment })
+      testExternalTxNoOp({ recordTx: recordReceiveOnChainPayment })
 
       // WalletId IntraLedger send
-      await testInternalTxSendNoOp({ recordTx: recordWalletIdIntraLedgerPayment })
+      testInternalTxSendNoOp({ recordTx: recordWalletIdIntraLedgerPayment })
 
       // WalletId IntraLedger receive
-      await testInternalTxReceiveNoOp({ recordTx: recordWalletIdIntraLedgerPayment })
+      testInternalTxReceiveNoOp({ recordTx: recordWalletIdIntraLedgerPayment })
 
       // LnIntraledger send
-      await testInternalTxSendNoOp({ recordTx: recordLnIntraLedgerPayment })
+      testInternalTxSendNoOp({ recordTx: recordLnIntraLedgerPayment })
 
       // LnIntraledger receive
-      await testInternalTxReceiveNoOp({ recordTx: recordLnIntraLedgerPayment })
+      testInternalTxReceiveNoOp({ recordTx: recordLnIntraLedgerPayment })
 
       // OnChain IntraLedger send
-      await testInternalTxSendNoOp({ recordTx: recordOnChainIntraLedgerPayment })
+      testInternalTxSendNoOp({ recordTx: recordOnChainIntraLedgerPayment })
 
       // OnChain IntraLedger receive
-      await testInternalTxReceiveNoOp({ recordTx: recordOnChainIntraLedgerPayment })
+      testInternalTxReceiveNoOp({ recordTx: recordOnChainIntraLedgerPayment })
 
       // Fee
       testTxWithoutFacadeNoOp({ recordTx: recordLnChannelOpenOrClosingFee })
@@ -269,10 +279,10 @@ describe("Volumes", () => {
       testTxWithoutFacadeNoOp({ recordTx: recordLnRoutingRevenue })
 
       // ToColdStorage
-      await testExternalTxNoOp({ recordTx: recordColdStorageTxReceive })
+      testExternalTxNoOp({ recordTx: recordColdStorageTxReceive })
 
       // ToHotWallet
-      await testExternalTxNoOp({ recordTx: recordColdStorageTxSend })
+      testExternalTxNoOp({ recordTx: recordColdStorageTxSend })
     })
   })
 })

--- a/test/integration/services/ledger/service.spec.ts
+++ b/test/integration/services/ledger/service.spec.ts
@@ -47,37 +47,24 @@ const FullLedgerTransactionType = {
 } as const
 
 const {
-  IntraLedger,
-  LnIntraLedger,
-  OnchainIntraLedger,
-  Escrow,
+  IntraLedger, // eslint-disable-line @typescript-eslint/no-unused-vars
+  LnIntraLedger, // eslint-disable-line @typescript-eslint/no-unused-vars
+  OnchainIntraLedger, // eslint-disable-line @typescript-eslint/no-unused-vars
+  Escrow, // eslint-disable-line @typescript-eslint/no-unused-vars
+
   ...ExtendedLedgerTransactionType
 } = FullLedgerTransactionType
 
-// Discarded for type-checker
-const _unusedSwappedOutTypes = [IntraLedger, LnIntraLedger, OnchainIntraLedger, Escrow]
-_unusedSwappedOutTypes
-
 const {
-  Fee,
-  RoutingRevenue,
-  ToColdStorage,
-  ToHotWallet,
-  EscrowCredit,
-  EscrowDebit,
+  Fee, // eslint-disable-line @typescript-eslint/no-unused-vars
+  RoutingRevenue, // eslint-disable-line @typescript-eslint/no-unused-vars
+  ToColdStorage, // eslint-disable-line @typescript-eslint/no-unused-vars
+  ToHotWallet, // eslint-disable-line @typescript-eslint/no-unused-vars
+  EscrowCredit, // eslint-disable-line @typescript-eslint/no-unused-vars
+  EscrowDebit, // eslint-disable-line @typescript-eslint/no-unused-vars
+
   ...UserLedgerTransactionType
 } = ExtendedLedgerTransactionType
-
-// Discarded for type-checker
-const _unusedAdminTypes = [
-  Fee,
-  RoutingRevenue,
-  ToColdStorage,
-  ToHotWallet,
-  EscrowCredit,
-  EscrowDebit,
-]
-_unusedAdminTypes
 
 describe("Volumes", () => {
   const timestamp1DayAgo = new Date(Date.now() - MS_PER_DAY)

--- a/test/integration/services/ledger/service.spec.ts
+++ b/test/integration/services/ledger/service.spec.ts
@@ -1,0 +1,296 @@
+import crypto from "crypto"
+
+import { MS_PER_DAY } from "@config"
+
+import {
+  AmountCalculator,
+  BtcWalletDescriptor,
+  UsdWalletDescriptor,
+  WalletCurrency,
+  ZERO_CENTS,
+  ZERO_SATS,
+} from "@domain/shared"
+import { LedgerTransactionType } from "@domain/ledger"
+import { toSats } from "@domain/bitcoin"
+
+import { LedgerService } from "@services/ledger"
+
+import {
+  recordLnIntraLedgerPayment,
+  recordLnFeeReimbursement,
+  recordReceiveLnPayment,
+  recordSendLnPayment,
+  recordSendOnChainPayment,
+  recordReceiveOnChainPayment,
+  recordWalletIdIntraLedgerPayment,
+  recordOnChainIntraLedgerPayment,
+  recordLnChannelOpenOrClosingFee,
+  recordLndEscrowCredit,
+  recordLndEscrowDebit,
+  recordLnRoutingRevenue,
+  recordColdStorageTxReceive,
+  recordColdStorageTxSend,
+} from "./helpers"
+
+const ledgerService = LedgerService()
+const calc = AmountCalculator()
+
+describe("Withdrawal volumes", () => {
+  const timestamp1DayAgo = new Date(Date.now() - MS_PER_DAY)
+  const walletDescriptor = BtcWalletDescriptor(crypto.randomUUID() as WalletId)
+  const walletDescriptorOther = UsdWalletDescriptor(crypto.randomUUID() as WalletId)
+
+  const receiveAmount = {
+    usd: { amount: 100n, currency: WalletCurrency.Usd },
+    btc: { amount: 200n, currency: WalletCurrency.Btc },
+  }
+  const sendAmount = {
+    usd: { amount: 200n, currency: WalletCurrency.Usd },
+    btc: { amount: 400n, currency: WalletCurrency.Btc },
+  }
+  const zeroAmount = {
+    usd: ZERO_CENTS,
+    btc: ZERO_SATS,
+  }
+  const bankFee = {
+    usd: { amount: 10n, currency: WalletCurrency.Usd },
+    btc: { amount: 20n, currency: WalletCurrency.Btc },
+  }
+
+  const withdrawalTypes: LedgerTransactionTypeKey[] = ["Payment", "OnchainPayment"]
+  const nonWithdrawalTypes = Object.keys(LedgerTransactionType)
+    .map((key) => key as LedgerTransactionTypeKey)
+    .filter((key: LedgerTransactionTypeKey) => !withdrawalTypes.includes(key))
+  console.log(nonWithdrawalTypes)
+
+  const fetchWithdrawalVolumeAmount = async <S extends WalletCurrency>(
+    walletDescriptor: WalletDescriptor<S>,
+  ): Promise<PaymentAmount<S>> => {
+    const walletVolume = await ledgerService.externalPaymentVolumeSince({
+      walletId: walletDescriptor.id,
+      timestamp: timestamp1DayAgo,
+    })
+    expect(walletVolume).not.toBeInstanceOf(Error)
+    if (walletVolume instanceof Error) throw walletVolume
+
+    const walletVolumeAmount = await ledgerService.externalPaymentVolumeAmountSince({
+      walletDescriptor,
+      timestamp: timestamp1DayAgo,
+    })
+    expect(walletVolumeAmount).not.toBeInstanceOf(Error)
+    if (walletVolumeAmount instanceof Error) throw walletVolumeAmount
+
+    const { outgoingBaseAmount: outgoingBase } = walletVolume
+    const { outgoingBaseAmount } = walletVolumeAmount
+    expect(outgoingBase).toEqual(Number(outgoingBaseAmount.amount))
+
+    const { incomingBaseAmount: incomingBase } = walletVolume
+    const { incomingBaseAmount } = walletVolumeAmount
+    expect(incomingBase).toEqual(Number(incomingBaseAmount.amount))
+
+    // FIXME: change in code to aggregate outgoing/incoming into single value
+    return calc.sub(outgoingBaseAmount, incomingBaseAmount)
+  }
+
+  /*
+  Txns expected to count:
+    - Payment
+    - LnFeeReimbursement
+    - OnchainPayment
+  */
+  it("correctly registers withdrawal transactions amount", async () => {
+    const outgoingBaseAmountStart = await fetchWithdrawalVolumeAmount(walletDescriptor)
+
+    const getEndAmounts = async (expectedSentAmount) => ({
+      actual: await fetchWithdrawalVolumeAmount(walletDescriptor),
+      expected: calc.add(outgoingBaseAmountStart, expectedSentAmount),
+    })
+
+    let expectedSentAmount: BtcPaymentAmount = ZERO_SATS
+    let { actual, expected } = await getEndAmounts(expectedSentAmount)
+    expect(expected).toStrictEqual(actual)
+
+    // Payment
+    let result = await recordSendLnPayment({
+      walletDescriptor,
+      paymentAmount: sendAmount,
+      bankFee,
+    })
+    expect(result).not.toBeInstanceOf(Error)
+    expectedSentAmount = calc.add(expectedSentAmount, sendAmount.btc)
+    ;({ actual, expected } = await getEndAmounts(expectedSentAmount))
+    expect(expected).toStrictEqual(actual)
+
+    // OnchainPayment
+    result = await recordSendOnChainPayment({
+      walletDescriptor,
+      paymentAmount: sendAmount,
+      bankFee,
+    })
+    expect(result).not.toBeInstanceOf(Error)
+    expectedSentAmount = calc.add(expectedSentAmount, sendAmount.btc)
+    ;({ actual, expected } = await getEndAmounts(expectedSentAmount))
+    expect(expected).toStrictEqual(actual)
+  })
+
+  /* 
+  Txns expected to skip:
+    - Invoice (LnReceipt)
+    - OnchainReceipt
+    - IntraLedger (WalletId)
+    - LnIntraLedger
+    - OnchainIntraLedger
+
+    Admin:
+    - Fee
+    - Escrow
+    - RoutingRevenue
+    - ToColdStorage
+    - ToHotWallet
+
+    Unused:
+    - OnchainDepositFee
+    - ExchangeRebalance
+    - UserRebalance
+*/
+  it("correctly ignores all other transaction types", async () => {
+    const outgoingBaseAmountStart = await fetchWithdrawalVolumeAmount(walletDescriptor)
+
+    const getEndAmounts = async () => ({
+      actual: await fetchWithdrawalVolumeAmount(walletDescriptor),
+    })
+
+    let { actual } = await getEndAmounts()
+    expect(outgoingBaseAmountStart).toStrictEqual(actual)
+
+    // TODO: move to "included" above
+    // LnFeeReimbursement
+    let result = await recordLnFeeReimbursement({
+      walletDescriptor,
+      paymentAmount: bankFee,
+      bankFee: zeroAmount,
+    })
+    expect(result).not.toBeInstanceOf(Error)
+    ;({ actual } = await getEndAmounts())
+    expect(outgoingBaseAmountStart).toStrictEqual(actual)
+
+    // Invoice (LnReceipt)
+    result = await recordReceiveLnPayment({
+      walletDescriptor,
+      paymentAmount: receiveAmount,
+      bankFee,
+    })
+    expect(result).not.toBeInstanceOf(Error)
+    ;({ actual } = await getEndAmounts())
+    expect(outgoingBaseAmountStart).toStrictEqual(actual)
+
+    // Invoice (OnChainReceipt)
+    result = await recordReceiveOnChainPayment({
+      walletDescriptor,
+      paymentAmount: receiveAmount,
+      bankFee,
+    })
+    expect(result).not.toBeInstanceOf(Error)
+    ;({ actual } = await getEndAmounts())
+    expect(outgoingBaseAmountStart).toStrictEqual(actual)
+
+    // WalletId IntraLedger send
+    result = await recordWalletIdIntraLedgerPayment({
+      senderWalletDescriptor: walletDescriptor,
+      recipientWalletDescriptor: walletDescriptorOther,
+      paymentAmount: sendAmount,
+    })
+    expect(result).not.toBeInstanceOf(Error)
+    ;({ actual } = await getEndAmounts())
+    expect(outgoingBaseAmountStart).toStrictEqual(actual)
+
+    // WalletId IntraLedger receive
+    result = await recordWalletIdIntraLedgerPayment({
+      senderWalletDescriptor: walletDescriptorOther,
+      recipientWalletDescriptor: walletDescriptor,
+      paymentAmount: sendAmount,
+    })
+    expect(result).not.toBeInstanceOf(Error)
+    ;({ actual } = await getEndAmounts())
+    expect(outgoingBaseAmountStart).toStrictEqual(actual)
+
+    // LnIntraledger send
+    result = await recordLnIntraLedgerPayment({
+      senderWalletDescriptor: walletDescriptor,
+      recipientWalletDescriptor: walletDescriptorOther,
+      paymentAmount: sendAmount,
+    })
+    expect(result).not.toBeInstanceOf(Error)
+    ;({ actual } = await getEndAmounts())
+    expect(outgoingBaseAmountStart).toStrictEqual(actual)
+
+    // LnIntraledger receive
+    result = await recordLnIntraLedgerPayment({
+      senderWalletDescriptor: walletDescriptorOther,
+      recipientWalletDescriptor: walletDescriptor,
+      paymentAmount: receiveAmount,
+    })
+    expect(result).not.toBeInstanceOf(Error)
+    ;({ actual } = await getEndAmounts())
+    expect(outgoingBaseAmountStart).toStrictEqual(actual)
+
+    // TODO: OnChain IntraLedger send
+    result = await recordOnChainIntraLedgerPayment({
+      senderWalletDescriptor: walletDescriptor,
+      recipientWalletDescriptor: walletDescriptorOther,
+      paymentAmount: sendAmount,
+    })
+    expect(result).not.toBeInstanceOf(Error)
+    ;({ actual } = await getEndAmounts())
+    expect(outgoingBaseAmountStart).toStrictEqual(actual)
+
+    // TODO: OnChain IntraLedger receive
+    result = await recordOnChainIntraLedgerPayment({
+      senderWalletDescriptor: walletDescriptorOther,
+      recipientWalletDescriptor: walletDescriptor,
+      paymentAmount: receiveAmount,
+    })
+    expect(result).not.toBeInstanceOf(Error)
+    ;({ actual } = await getEndAmounts())
+    expect(outgoingBaseAmountStart).toStrictEqual(actual)
+
+    // TODO: Fee
+    result = await recordLnChannelOpenOrClosingFee({ fee: toSats(bankFee.btc.amount) })
+    expect(result).not.toBeInstanceOf(Error)
+    ;({ actual } = await getEndAmounts())
+    expect(outgoingBaseAmountStart).toStrictEqual(actual)
+
+    // TODO: Escrow
+    result = await recordLndEscrowCredit({ amount: toSats(receiveAmount.btc.amount) })
+    expect(result).not.toBeInstanceOf(Error)
+    ;({ actual } = await getEndAmounts())
+    expect(outgoingBaseAmountStart).toStrictEqual(actual)
+
+    result = await recordLndEscrowDebit({ amount: toSats(receiveAmount.btc.amount) })
+    expect(result).not.toBeInstanceOf(Error)
+    ;({ actual } = await getEndAmounts())
+    expect(outgoingBaseAmountStart).toStrictEqual(actual)
+
+    // TODO: RoutingRevenue
+    result = await recordLnRoutingRevenue({ amount: toSats(receiveAmount.btc.amount) })
+    expect(result).not.toBeInstanceOf(Error)
+    ;({ actual } = await getEndAmounts())
+    expect(outgoingBaseAmountStart).toStrictEqual(actual)
+
+    // TODO: ToColdStorage
+    result = await recordColdStorageTxReceive({
+      paymentAmount: receiveAmount,
+    })
+    expect(result).not.toBeInstanceOf(Error)
+    ;({ actual } = await getEndAmounts())
+    expect(outgoingBaseAmountStart).toStrictEqual(actual)
+
+    // TODO: ToHotWallet
+    result = await recordColdStorageTxSend({
+      paymentAmount: sendAmount,
+    })
+    expect(result).not.toBeInstanceOf(Error)
+    ;({ actual } = await getEndAmounts())
+    expect(outgoingBaseAmountStart).toStrictEqual(actual)
+  })
+})

--- a/test/integration/services/ledger/service.spec.ts
+++ b/test/integration/services/ledger/service.spec.ts
@@ -303,18 +303,19 @@ describe("Volumes", () => {
     })
   }
 
-  describe("Withdrawal volumes", () => {
-    const fetchWithdrawalVolumeAmount = async <S extends WalletCurrency>(
+  const fetchVolumeAmount =
+    ({ volumeFn, volumeAmountFn }) =>
+    async <S extends WalletCurrency>(
       walletDescriptor: WalletDescriptor<S>,
     ): Promise<PaymentAmount<S>> => {
-      const walletVolume = await ledgerService.externalPaymentVolumeSince({
+      const walletVolume = await volumeFn({
         walletId: walletDescriptor.id,
         timestamp: timestamp1DayAgo,
       })
       expect(walletVolume).not.toBeInstanceOf(Error)
       if (walletVolume instanceof Error) throw walletVolume
 
-      const walletVolumeAmount = await ledgerService.externalPaymentVolumeAmountSince({
+      const walletVolumeAmount = await volumeAmountFn({
         walletDescriptor,
         timestamp: timestamp1DayAgo,
       })
@@ -333,9 +334,13 @@ describe("Volumes", () => {
       return calc.sub(outgoingBaseAmount, incomingBaseAmount)
     }
 
+  describe("Withdrawal volumes", () => {
     executeLimitTests({
       includedTxTypes: ["Payment", "OnchainPayment"],
-      fetchVolumeAmount: fetchWithdrawalVolumeAmount,
+      fetchVolumeAmount: fetchVolumeAmount({
+        volumeFn: ledgerService.externalPaymentVolumeSince,
+        volumeAmountFn: ledgerService.externalPaymentVolumeAmountSince,
+      }),
     })
   })
 })


### PR DESCRIPTION
## Description

This PR establishes a baseline to ensure all volumes we have in our codebase are tested for expected behaviour against all our LedgerTransactionType types.

This is partially a cleanup task, and partially in prep for excluding internal "Trade" type transactions from our intraledger volume checks.