### PR TITLE
fix: trigger firing too many hodl invoice listeners

### DIFF
--- a/src/domain/bitcoin/lightning/index.types.d.ts
+++ b/src/domain/bitcoin/lightning/index.types.d.ts
@@ -52,6 +52,7 @@ type LnInvoiceLookup = {
   readonly confirmedAt: Date | undefined
   readonly isSettled: boolean
   readonly isHeld: boolean
+  readonly isCanceled?: boolean
   readonly heldAt: Date | undefined
   readonly roundedDownReceived: Satoshis
   readonly milliSatsReceived: MilliSatoshis

--- a/src/servers/trigger.ts
+++ b/src/servers/trigger.ts
@@ -339,17 +339,11 @@ export const setupInvoiceSubscribe = ({
   pubkey: Pubkey
   subInvoices: EventEmitter
 }) => {
-  subInvoices.on(
-    "invoice_updated",
-    (
-      invoice: SubscribeToInvoicesInvoiceUpdatedEvent & /* fix upstream */ {
-        is_canceled: boolean
-      },
-    ) => {
-      !(invoice.is_confirmed || invoice.is_canceled)
-        ? listenerHodlInvoice({ lnd, paymentHash: invoice.id as PaymentHash })
-        : undefined
-    },
+  subInvoices.on("invoice_updated", (invoice: SubscribeToInvoicesInvoiceUpdatedEvent) =>
+    // Note: canceled and expired invoices don't come in here, only confirmed check req'd
+    !invoice.is_confirmed
+      ? listenerHodlInvoice({ lnd, paymentHash: invoice.id as PaymentHash })
+      : undefined,
   )
   subInvoices.on("error", (err) => {
     baseLogger.info({ err }, "error subInvoices")

--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -737,6 +737,7 @@ const translateLnInvoiceLookup = (
   createdAt: new Date(invoice.created_at),
   confirmedAt: invoice.confirmed_at ? new Date(invoice.confirmed_at) : undefined,
   isSettled: !!invoice.is_confirmed,
+  isCanceled: !!invoice.is_canceled,
   isHeld: !!invoice.is_held,
   heldAt:
     invoice.payments && invoice.payments.length


### PR DESCRIPTION
## Description

There was an issue where trigger would open new subscriptions for every settled or held invoice and then cancel the subscription if the invoice is settled already. This PR checks for the invoice status before opening the subscription.

Note, lnd automatically deletes canceled invoices with [these settings](https://github.com/GaloyMoney/charts/blob/cd01038b09d99c58bb374b79609d206d4f00148d/charts/lnd/values.yaml#L87) (h/t @openoms):
```
; If true, we'll attempt to garbage collect canceled invoices upon start.
; gc-canceled-invoices-on-startup=true

; If true, we'll delete newly canceled invoices on the fly.
; gc-canceled-invoices-on-the-fly=true 
```

_Honeycomb query showing problem: [link](https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/8F2VG9fMbtD)_