### PR TITLE
chore: add temporary 'UncaughtTypescriptError' for debugging

### DIFF
--- a/src/app/wallets/get-pending-onchain-balance-for-wallet.ts
+++ b/src/app/wallets/get-pending-onchain-balance-for-wallet.ts
@@ -21,6 +21,7 @@ export const getPendingOnChainBalanceForWallets = async (
     addresses: wallets.flatMap((wallet) => wallet.onChainAddresses()),
   })
   const pendingIncoming = filter.apply(onChainTxs)
+  if (pendingIncoming instanceof Error) return pendingIncoming
 
   return IncomingOnChainTxHandler(pendingIncoming).balanceByWallet(wallets)
 }

--- a/src/app/wallets/get-transactions-by-addresses.ts
+++ b/src/app/wallets/get-transactions-by-addresses.ts
@@ -58,6 +58,9 @@ export const getTransactionsForWalletsByAddresses = async ({
   })
 
   const pendingIncoming = filter.apply(onChainTxs)
+  if (pendingIncoming instanceof Error) {
+    return PartialResult.partial(confirmedHistory.transactions, pendingIncoming)
+  }
 
   let price = await getCurrentPrice()
   if (price instanceof Error) {

--- a/src/app/wallets/get-transactions-for-wallet.ts
+++ b/src/app/wallets/get-transactions-for-wallet.ts
@@ -62,6 +62,9 @@ export const getTransactionsForWallets = async (
   })
 
   const pendingIncoming = filter.apply(onChainTxs)
+  if (pendingIncoming instanceof Error) {
+    return PartialResult.partial(confirmedHistory.transactions, pendingIncoming)
+  }
 
   let price = await getCurrentPrice()
   if (price instanceof Error) {

--- a/src/domain/bitcoin/onchain/index.types.d.ts
+++ b/src/domain/bitcoin/onchain/index.types.d.ts
@@ -51,7 +51,9 @@ type TxFilterArgs = {
 }
 
 type TxFilter = {
-  apply(txs: IncomingOnChainTransaction[]): IncomingOnChainTransaction[]
+  apply(
+    txs: IncomingOnChainTransaction[],
+  ): IncomingOnChainTransaction[] | UncaughtTypescriptError
 }
 
 type LookupOnChainFeeArgs = {

--- a/src/domain/bitcoin/onchain/tx-filter.ts
+++ b/src/domain/bitcoin/onchain/tx-filter.ts
@@ -1,27 +1,36 @@
+import { UncaughtTypescriptError } from "@domain/errors"
+
 export const TxFilter = ({
   confirmationsLessThan,
   confirmationsGreaterThanOrEqual,
   addresses,
 }: TxFilterArgs): TxFilter => {
-  const apply = (txs: IncomingOnChainTransaction[]): IncomingOnChainTransaction[] => {
-    return txs.filter(({ confirmations, rawTx: { outs } }) => {
-      if (
-        !!confirmationsGreaterThanOrEqual &&
-        confirmations < confirmationsGreaterThanOrEqual
-      ) {
-        return false
-      }
-      if (!!confirmationsLessThan && confirmations >= confirmationsLessThan) {
-        return false
-      }
-      if (
-        !!addresses &&
-        !outs.some((out) => out.address !== null && addresses.includes(out.address))
-      ) {
-        return false
-      }
-      return true
-    })
+  const apply = (
+    txs: IncomingOnChainTransaction[],
+  ): IncomingOnChainTransaction[] | UncaughtTypescriptError => {
+    try {
+      return txs.filter(({ confirmations, rawTx: { outs } }) => {
+        if (
+          !!confirmationsGreaterThanOrEqual &&
+          confirmations < confirmationsGreaterThanOrEqual
+        ) {
+          return false
+        }
+        if (!!confirmationsLessThan && confirmations >= confirmationsLessThan) {
+          return false
+        }
+        if (
+          !!addresses &&
+          !outs.some((out) => out.address !== null && addresses.includes(out.address))
+        ) {
+          return false
+        }
+        return true
+      })
+    } catch (err) {
+      // txs.filter has thrown TypeError recently unexpectedly
+      return new UncaughtTypescriptError(`${txs}`)
+    }
   }
 
   return { apply }

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -8,6 +8,11 @@ export class RepositoryError extends DomainError {}
 export class UnknownRepositoryError extends RepositoryError {
   level = ErrorLevel.Critical
 }
+
+export class UncaughtTypescriptError extends RepositoryError {
+  level = ErrorLevel.Critical
+}
+
 export class PersistError extends RepositoryError {}
 export class DuplicateError extends RepositoryError {}
 

--- a/src/domain/errors.types.d.ts
+++ b/src/domain/errors.types.d.ts
@@ -4,3 +4,4 @@ type LimitsExceededError = import("./errors").LimitsExceededError
 type TwoFALimitsExceededError = import("./errors").TwoFALimitsExceededError
 type NotImplementedError = import("./errors").NotImplementedError
 type NotReachableError = import("./errors").NotReachableError
+type UncaughtTypescriptError = import("./errors").UncaughtTypescriptError

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -325,6 +325,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "UnknownDealerPriceServiceError":
     case "UnknownPubSubError":
     case "UnknownBigIntConversionError":
+    case "UncaughtTypescriptError":
       message = `Unknown error occurred (code: ${error.name})`
       return new UnknownClientError({ message, logger: baseLogger })
 

--- a/test/unit/domain/bitcoin/onchain/tx-filter.spec.ts
+++ b/test/unit/domain/bitcoin/onchain/tx-filter.spec.ts
@@ -35,6 +35,7 @@ describe("TxFilter", () => {
       }),
     ])
 
+    if (filteredTxs instanceof Error) throw filteredTxs
     expect(filteredTxs.length).toEqual(1)
   })
 


### PR DESCRIPTION
## Description

Proposal for figuring out an open issue.

There's a `TypeError` coming in from the `txs.filter` call that seems to only happen if `txs` is an instance of `Error` or a non-array object. We'd get a different error message if `txs` was `undefined` or `[]`. According to the type checker this should not be possible though, and I can't seem to replicate locally. This PR is to add visibility to what could possibly be happening in prod.

Once we figure this out, we should be able to cleanly revert these changes.