### PR TITLE
feat: add self trade tx type, volume & limits checks

### DIFF
--- a/galoy.yaml
+++ b/galoy.yaml
@@ -125,8 +125,8 @@ accountLimits:
       "2": 5000000
   tradeIntraAccount:
     level:
-      "1": 200000
-      "2": 5000000
+      "1": 5000000
+      "2": 20000000
 spamLimits:
   memoSharingSatsThreshold: 1000
 twoFALimits:

--- a/galoy.yaml
+++ b/galoy.yaml
@@ -123,6 +123,10 @@ accountLimits:
     level:
       "1": 200000
       "2": 5000000
+  tradeIntraAccount:
+    level:
+      "1": 200000
+      "2": 5000000
 spamLimits:
   memoSharingSatsThreshold: 1000
 twoFALimits:

--- a/src/app/payments/helpers.ts
+++ b/src/app/payments/helpers.ts
@@ -58,7 +58,11 @@ export const constructPaymentFlowBuilder = async <
       }) as LPFBWithInvoice<S>)
     : (paymentBuilder.withInvoice(invoice) as LPFBWithInvoice<S>)
 
-  const builderWithSenderWallet = builderWithInvoice.withSenderWallet(senderWallet)
+  const builderWithSenderWallet = builderWithInvoice.withSenderWallet({
+    id: senderWallet.id,
+    currency: senderWallet.currency as S,
+    accountId: senderWallet.accountId,
+  })
 
   let builderAfterRecipientStep: LPFBWithRecipientWallet<S, R> | LPFBWithError
   if (builderWithSenderWallet.isIntraLedger()) {
@@ -145,7 +149,7 @@ export const newCheckIntraledgerLimits = async ({
   if (timestamp1Day instanceof Error) return timestamp1Day
 
   const walletVolume = await ledger.intraledgerTxBaseVolumeAmountSince({
-    walletDescriptor: { id: wallet.id, currency: wallet.currency },
+    walletDescriptor: wallet,
     timestamp: timestamp1Day,
   })
   if (walletVolume instanceof Error) return walletVolume
@@ -178,7 +182,7 @@ export const newCheckTradeIntraAccountLimits = async ({
   if (timestamp1Day instanceof Error) return timestamp1Day
 
   const walletVolume = await ledger.tradeIntraAccountTxBaseVolumeAmountSince({
-    walletDescriptor: { id: wallet.id, currency: wallet.currency },
+    walletDescriptor: wallet,
     timestamp: timestamp1Day,
   })
   if (walletVolume instanceof Error) return walletVolume
@@ -211,7 +215,7 @@ export const newCheckWithdrawalLimits = async ({
   if (timestamp1Day instanceof Error) return timestamp1Day
 
   const walletVolume = await ledger.externalPaymentVolumeAmountSince({
-    walletDescriptor: { id: wallet.id, currency: wallet.currency },
+    walletDescriptor: wallet,
     timestamp: timestamp1Day,
   })
   if (walletVolume instanceof Error) return walletVolume
@@ -243,7 +247,7 @@ export const newCheckTwoFALimits = async ({
   if (timestamp1Day instanceof Error) return timestamp1Day
 
   const walletVolume = await ledger.allPaymentVolumeAmountSince({
-    walletDescriptor: { id: wallet.id, currency: wallet.currency },
+    walletDescriptor: wallet,
     timestamp: timestamp1Day,
   })
   if (walletVolume instanceof Error) return walletVolume

--- a/src/app/payments/helpers.ts
+++ b/src/app/payments/helpers.ts
@@ -1,9 +1,9 @@
 import {
   getTwoFALimits,
   getAccountLimits,
-  MS_PER_DAY,
   MIN_SATS_FOR_PRICE_RATIO_PRECISION,
   getPubkeysToSkipProbe,
+  ONE_DAY,
 } from "@config"
 import { AccountLimitsChecker, TwoFALimitsChecker } from "@domain/accounts"
 import {
@@ -21,8 +21,9 @@ import {
 } from "@services/mongoose"
 import { LndService } from "@services/lnd"
 import { LedgerService } from "@services/ledger"
-import { WalletCurrency } from "@domain/shared"
 import { wrapAsyncToRunInSpan } from "@services/tracing"
+import { WalletCurrency } from "@domain/shared"
+import { timestampDaysAgo } from "@utils"
 
 const ledger = LedgerService()
 
@@ -140,7 +141,9 @@ export const newCheckIntraledgerLimits = async ({
   wallet: Wallet
   priceRatio: PriceRatio
 }) => {
-  const timestamp1Day = new Date(Date.now() - MS_PER_DAY)
+  const timestamp1Day = timestampDaysAgo(ONE_DAY)
+  if (timestamp1Day instanceof Error) return timestamp1Day
+
   const walletVolume = await ledger.intraledgerTxBaseVolumeAmountSince({
     walletDescriptor: { id: wallet.id, currency: wallet.currency },
     timestamp: timestamp1Day,
@@ -171,7 +174,9 @@ export const newCheckTradeIntraAccountLimits = async ({
   wallet: Wallet
   priceRatio: PriceRatio
 }) => {
-  const timestamp1Day = new Date(Date.now() - MS_PER_DAY)
+  const timestamp1Day = timestampDaysAgo(ONE_DAY)
+  if (timestamp1Day instanceof Error) return timestamp1Day
+
   const walletVolume = await ledger.tradeIntraAccountTxBaseVolumeAmountSince({
     walletDescriptor: { id: wallet.id, currency: wallet.currency },
     timestamp: timestamp1Day,
@@ -202,7 +207,9 @@ export const newCheckWithdrawalLimits = async ({
   wallet: Wallet
   priceRatio: PriceRatio
 }) => {
-  const timestamp1Day = new Date(Date.now() - MS_PER_DAY)
+  const timestamp1Day = timestampDaysAgo(ONE_DAY)
+  if (timestamp1Day instanceof Error) return timestamp1Day
+
   const walletVolume = await ledger.externalPaymentVolumeAmountSince({
     walletDescriptor: { id: wallet.id, currency: wallet.currency },
     timestamp: timestamp1Day,
@@ -232,7 +239,9 @@ export const newCheckTwoFALimits = async ({
   wallet: Wallet
   priceRatio: PriceRatio
 }) => {
-  const timestamp1Day = new Date(Date.now() - MS_PER_DAY)
+  const timestamp1Day = timestampDaysAgo(ONE_DAY)
+  if (timestamp1Day instanceof Error) return timestamp1Day
+
   const walletVolume = await ledger.allPaymentVolumeAmountSince({
     walletDescriptor: { id: wallet.id, currency: wallet.currency },
     timestamp: timestamp1Day,

--- a/src/app/payments/helpers.ts
+++ b/src/app/payments/helpers.ts
@@ -36,7 +36,7 @@ export const constructPaymentFlowBuilder = async <
   usdFromBtc,
   btcFromUsd,
 }: {
-  senderWallet: WalletDescriptor<S>
+  senderWallet: Wallet
   invoice: LnInvoice
   uncheckedAmount?: number
   usdFromBtc: (amount: BtcPaymentAmount) => Promise<UsdPaymentAmount | ApplicationError>
@@ -91,6 +91,7 @@ const recipientDetailsFromInvoice = async <R extends WalletCurrency>(
   | {
       id: WalletId
       currency: R
+      accountId: AccountId
       pubkey: Pubkey
       usdPaymentAmount: UsdPaymentAmount | undefined
       username: Username
@@ -123,6 +124,7 @@ const recipientDetailsFromInvoice = async <R extends WalletCurrency>(
   return {
     id: recipientWalletId,
     currency: recipientsWalletCurrency as R,
+    accountId: recipientAccount.id,
     pubkey: recipientPubkey,
     usdPaymentAmount,
     username: recipientUsername,

--- a/src/app/payments/helpers.ts
+++ b/src/app/payments/helpers.ts
@@ -37,7 +37,7 @@ export const constructPaymentFlowBuilder = async <
   usdFromBtc,
   btcFromUsd,
 }: {
-  senderWallet: Wallet
+  senderWallet: WalletDescriptor<S>
   invoice: LnInvoice
   uncheckedAmount?: number
   usdFromBtc: (amount: BtcPaymentAmount) => Promise<UsdPaymentAmount | ApplicationError>
@@ -58,11 +58,7 @@ export const constructPaymentFlowBuilder = async <
       }) as LPFBWithInvoice<S>)
     : (paymentBuilder.withInvoice(invoice) as LPFBWithInvoice<S>)
 
-  const builderWithSenderWallet = builderWithInvoice.withSenderWallet({
-    id: senderWallet.id,
-    currency: senderWallet.currency as S,
-    accountId: senderWallet.accountId,
-  })
+  const builderWithSenderWallet = builderWithInvoice.withSenderWallet(senderWallet)
 
   let builderAfterRecipientStep: LPFBWithRecipientWallet<S, R> | LPFBWithError
   if (builderWithSenderWallet.isIntraLedger()) {
@@ -136,13 +132,13 @@ const recipientDetailsFromInvoice = async <R extends WalletCurrency>(
   }
 }
 
-export const newCheckIntraledgerLimits = async ({
+export const newCheckIntraledgerLimits = async <S extends WalletCurrency>({
   amount,
   wallet,
   priceRatio,
 }: {
   amount: UsdPaymentAmount
-  wallet: Wallet
+  wallet: WalletDescriptor<S>
   priceRatio: PriceRatio
 }) => {
   const timestamp1Day = timestampDaysAgo(ONE_DAY)
@@ -169,13 +165,13 @@ export const newCheckIntraledgerLimits = async ({
   })
 }
 
-export const newCheckTradeIntraAccountLimits = async ({
+export const newCheckTradeIntraAccountLimits = async <S extends WalletCurrency>({
   amount,
   wallet,
   priceRatio,
 }: {
   amount: UsdPaymentAmount
-  wallet: Wallet
+  wallet: WalletDescriptor<S>
   priceRatio: PriceRatio
 }) => {
   const timestamp1Day = timestampDaysAgo(ONE_DAY)
@@ -202,13 +198,13 @@ export const newCheckTradeIntraAccountLimits = async ({
   })
 }
 
-export const newCheckWithdrawalLimits = async ({
+export const newCheckWithdrawalLimits = async <S extends WalletCurrency>({
   amount,
   wallet,
   priceRatio,
 }: {
   amount: UsdPaymentAmount
-  wallet: Wallet
+  wallet: WalletDescriptor<S>
   priceRatio: PriceRatio
 }) => {
   const timestamp1Day = timestampDaysAgo(ONE_DAY)
@@ -234,13 +230,13 @@ export const newCheckWithdrawalLimits = async ({
   })
 }
 
-export const newCheckTwoFALimits = async ({
+export const newCheckTwoFALimits = async <S extends WalletCurrency>({
   amount,
   wallet,
   priceRatio,
 }: {
   amount: UsdPaymentAmount
-  wallet: Wallet
+  wallet: WalletDescriptor<S>
   priceRatio: PriceRatio
 }) => {
   const timestamp1Day = timestampDaysAgo(ONE_DAY)

--- a/src/app/payments/send-intraledger.ts
+++ b/src/app/payments/send-intraledger.ts
@@ -235,7 +235,7 @@ const executePaymentViaIntraledger = async ({
     let metadata:
       | NewAddWalletIdIntraledgerSendLedgerMetadata
       | NewAddWalletIdTradeIntraAccountLedgerMetadata
-    let additionalDebitMetadata = {}
+    let additionalDebitMetadata: { [key: string]: Username | undefined } = {}
     if (senderWallet.accountId === recipientWallet.accountId) {
       metadata = LedgerFacade.WalletIdTradeIntraAccountLedgerMetadata({
         paymentFlow,

--- a/src/app/payments/send-intraledger.ts
+++ b/src/app/payments/send-intraledger.ts
@@ -54,7 +54,7 @@ export const intraledgerPaymentSendWalletId = async ({
   const { senderWallet, recipientWallet, recipientAccount } = validatedPaymentInputs
 
   const { id: recipientWalletId, currency: recipientWalletCurrency } = recipientWallet
-  const { username: recipientUsername } = recipientAccount
+  const { id: recipientAccountId, username: recipientUsername } = recipientAccount
 
   const paymentBuilder = LightningPaymentFlowBuilder({
     localNodeIds: [],
@@ -72,6 +72,7 @@ export const intraledgerPaymentSendWalletId = async ({
   const recipientDetailsForBuilder = {
     id: recipientWalletId,
     currency: recipientWalletCurrency,
+    accountId: recipientAccountId,
     username: recipientUsername,
     pubkey: undefined,
     usdPaymentAmount: undefined,

--- a/src/app/payments/send-intraledger.ts
+++ b/src/app/payments/send-intraledger.ts
@@ -172,7 +172,10 @@ const validateIntraledgerPaymentInputs = async ({
   }
 }
 
-const executePaymentViaIntraledger = async ({
+const executePaymentViaIntraledger = async <
+  S extends WalletCurrency,
+  R extends WalletCurrency,
+>({
   paymentFlow,
   senderAccount,
   senderWallet,
@@ -180,11 +183,11 @@ const executePaymentViaIntraledger = async ({
   recipientWallet,
   memo,
 }: {
-  paymentFlow: PaymentFlow<WalletCurrency, WalletCurrency>
+  paymentFlow: PaymentFlow<S, R>
   senderAccount: Account
-  senderWallet: Wallet
+  senderWallet: WalletDescriptor<S>
   recipientAccount: Account
-  recipientWallet: Wallet
+  recipientWallet: WalletDescriptor<R>
   memo: string | null
 }): Promise<PaymentSendStatus | ApplicationError> => {
   addAttributesToCurrentSpan({

--- a/src/app/payments/send-intraledger.ts
+++ b/src/app/payments/send-intraledger.ts
@@ -223,19 +223,34 @@ const executePaymentViaIntraledger = async ({
       return new ResourceExpiredLockServiceError(signal.error?.message)
     }
 
-    const lnIntraLedgerMetadata = LedgerFacade.WalletIdIntraledgerLedgerMetadata({
-      paymentFlow,
+    let metadata:
+      | NewAddWalletIdIntraledgerSendLedgerMetadata
+      | NewAddWalletIdTradeIntraAccountLedgerMetadata
+    let additionalDebitMetadata = {}
+    if (senderWallet.accountId === recipientWallet.accountId) {
+      metadata = LedgerFacade.WalletIdTradeIntraAccountLedgerMetadata({
+        paymentFlow,
 
-      amountDisplayCurrency: converter.fromUsdAmount(paymentFlow.usdPaymentAmount),
-      feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-      displayCurrency: DisplayCurrency.Usd,
+        amountDisplayCurrency: converter.fromUsdAmount(paymentFlow.usdPaymentAmount),
+        feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+        displayCurrency: DisplayCurrency.Usd,
 
-      memoOfPayer: memo || undefined,
-      senderUsername: senderAccount.username,
-      recipientUsername,
-    })
-    const { metadata, debitAccountAdditionalMetadata: additionalDebitMetadata } =
-      lnIntraLedgerMetadata
+        memoOfPayer: memo || undefined,
+      })
+    } else {
+      ;({ metadata, debitAccountAdditionalMetadata: additionalDebitMetadata } =
+        LedgerFacade.WalletIdIntraledgerLedgerMetadata({
+          paymentFlow,
+
+          amountDisplayCurrency: converter.fromUsdAmount(paymentFlow.usdPaymentAmount),
+          feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+          displayCurrency: DisplayCurrency.Usd,
+
+          memoOfPayer: memo || undefined,
+          senderUsername: senderAccount.username,
+          recipientUsername,
+        }))
+    }
 
     const recipientWalletDescriptor = paymentFlow.recipientWalletDescriptor()
     if (recipientWalletDescriptor === undefined)

--- a/src/app/payments/send-intraledger.ts
+++ b/src/app/payments/send-intraledger.ts
@@ -33,7 +33,11 @@ import { ResourceExpiredLockServiceError } from "@domain/lock"
 import { Accounts } from "@app"
 import { btcFromUsdMidPriceFn, usdFromBtcMidPriceFn } from "@app/shared"
 
-import { newCheckIntraledgerLimits, getPriceRatioForLimits } from "./helpers"
+import {
+  newCheckIntraledgerLimits,
+  getPriceRatioForLimits,
+  newCheckTradeIntraAccountLimits,
+} from "./helpers"
 
 const dealer = NewDealerPriceService()
 
@@ -190,7 +194,11 @@ const executePaymentViaIntraledger = async ({
   const priceRatioForLimits = await getPriceRatioForLimits(paymentFlow)
   if (priceRatioForLimits instanceof Error) return priceRatioForLimits
 
-  const limitCheck = await newCheckIntraledgerLimits({
+  const checkLimits =
+    senderWallet.accountId === recipientWallet.accountId
+      ? newCheckTradeIntraAccountLimits
+      : newCheckIntraledgerLimits
+  const limitCheck = await checkLimits({
     amount: paymentFlow.usdPaymentAmount,
     wallet: senderWallet,
     priceRatio: priceRatioForLimits,

--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -366,7 +366,7 @@ const getPaymentFlow = async <S extends WalletCurrency, R extends WalletCurrency
   inputPaymentAmount,
   uncheckedAmount,
 }: {
-  senderWallet: WalletDescriptor<S>
+  senderWallet: Wallet
   decodedInvoice: LnInvoice
   inputPaymentAmount: PaymentAmount<S>
   uncheckedAmount?: number | undefined

--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -512,21 +512,39 @@ const executePaymentViaIntraledger = async ({
       return new ResourceExpiredLockServiceError(signal.error?.message)
     }
 
-    const lnIntraLedgerMetadata = LedgerFacade.LnIntraledgerLedgerMetadata({
-      paymentHash,
-      pubkey: recipientPubkey,
-      paymentFlow,
+    let metadata:
+      | NewAddLnIntraledgerSendLedgerMetadata
+      | NewAddLnTradeIntraAccountLedgerMetadata
+    let additionalDebitMetadata = {}
+    if (senderWallet.accountId === recipientWallet.accountId) {
+      ;({ metadata, debitAccountAdditionalMetadata: additionalDebitMetadata } =
+        LedgerFacade.LnTradeIntraAccountLedgerMetadata({
+          paymentHash,
+          pubkey: recipientPubkey,
+          paymentFlow,
 
-      amountDisplayCurrency: converter.fromUsdAmount(paymentFlow.usdPaymentAmount),
-      feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-      displayCurrency: DisplayCurrency.Usd,
+          amountDisplayCurrency: converter.fromUsdAmount(paymentFlow.usdPaymentAmount),
+          feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+          displayCurrency: DisplayCurrency.Usd,
 
-      memoOfPayer: memo || undefined,
-      senderUsername,
-      recipientUsername,
-    })
-    const { metadata, debitAccountAdditionalMetadata: additionalDebitMetadata } =
-      lnIntraLedgerMetadata
+          memoOfPayer: memo || undefined,
+        }))
+    } else {
+      ;({ metadata, debitAccountAdditionalMetadata: additionalDebitMetadata } =
+        LedgerFacade.LnIntraledgerLedgerMetadata({
+          paymentHash,
+          pubkey: recipientPubkey,
+          paymentFlow,
+
+          amountDisplayCurrency: converter.fromUsdAmount(paymentFlow.usdPaymentAmount),
+          feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+          displayCurrency: DisplayCurrency.Usd,
+
+          memoOfPayer: memo || undefined,
+          senderUsername,
+          recipientUsername,
+        }))
+    }
 
     const recipientWalletDescriptor = paymentFlow.recipientWalletDescriptor()
     if (recipientWalletDescriptor === undefined)

--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -520,7 +520,7 @@ const executePaymentViaIntraledger = async ({
     let metadata:
       | NewAddLnIntraledgerSendLedgerMetadata
       | NewAddLnTradeIntraAccountLedgerMetadata
-    let additionalDebitMetadata = {}
+    let additionalDebitMetadata: { [key: string]: string | undefined } = {}
     if (senderWallet.accountId === recipientWallet.accountId) {
       ;({ metadata, debitAccountAdditionalMetadata: additionalDebitMetadata } =
         LedgerFacade.LnTradeIntraAccountLedgerMetadata({

--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -367,7 +367,7 @@ const getPaymentFlow = async <S extends WalletCurrency, R extends WalletCurrency
   inputPaymentAmount,
   uncheckedAmount,
 }: {
-  senderWallet: Wallet
+  senderWallet: WalletDescriptor<S>
   decodedInvoice: LnInvoice
   inputPaymentAmount: PaymentAmount<S>
   uncheckedAmount?: number | undefined
@@ -445,14 +445,17 @@ const newCheckAndVerifyTwoFA = async ({
   return true
 }
 
-const executePaymentViaIntraledger = async ({
+const executePaymentViaIntraledger = async <
+  S extends WalletCurrency,
+  R extends WalletCurrency,
+>({
   paymentFlow,
   senderWallet,
   senderUsername,
   memo,
 }: {
-  paymentFlow: PaymentFlow<WalletCurrency, WalletCurrency>
-  senderWallet: Wallet
+  paymentFlow: PaymentFlow<S, R>
+  senderWallet: WalletDescriptor<S>
   senderUsername: Username | undefined
   memo: string | null
 }): Promise<PaymentSendStatus | ApplicationError> => {

--- a/src/app/payments/translations.ts
+++ b/src/app/payments/translations.ts
@@ -10,9 +10,13 @@ import { PaymentInitiationMethod, SettlementMethod } from "@domain/wallets"
 export const PaymentFlowFromLedgerTransaction = <
   S extends WalletCurrency,
   R extends WalletCurrency,
->(
-  ledgerTxn: LedgerTransaction<S>,
-): PaymentFlow<S, R> | ValidationError => {
+>({
+  ledgerTxn,
+  senderAccountId,
+}: {
+  ledgerTxn: LedgerTransaction<S>
+  senderAccountId: AccountId
+}): PaymentFlow<S, R> | ValidationError => {
   if (ledgerTxn.type !== LedgerTransactionType.Payment) {
     return new NonLnPaymentTransactionForPaymentFlowError()
   }
@@ -69,6 +73,7 @@ export const PaymentFlowFromLedgerTransaction = <
   return PaymentFlow({
     senderWalletId,
     senderWalletCurrency,
+    senderAccountId,
     settlementMethod,
     paymentInitiationMethod,
 

--- a/src/app/wallets/private/check-limit-helpers.ts
+++ b/src/app/wallets/private/check-limit-helpers.ts
@@ -1,4 +1,4 @@
-import { getTwoFALimits, getAccountLimits, MS_PER_DAY } from "@config"
+import { getTwoFALimits, getAccountLimits, ONE_DAY } from "@config"
 import { LimitsChecker } from "@domain/accounts"
 import { toSats } from "@domain/bitcoin"
 import { toCents } from "@domain/fiat"
@@ -6,7 +6,7 @@ import { TwoFA, TwoFANewCodeNeededError } from "@domain/twoFA"
 import { WalletCurrency } from "@domain/shared"
 import { LedgerService } from "@services/ledger"
 import { addAttributesToCurrentSpan } from "@services/tracing"
-import { mapObj } from "@utils"
+import { mapObj, timestampDaysAgo } from "@utils"
 
 export const checkIntraledgerLimits = async ({
   amount,
@@ -25,7 +25,8 @@ export const checkIntraledgerLimits = async ({
   if (limitsChecker instanceof Error) return limitsChecker
 
   const ledgerService = LedgerService()
-  const timestamp1DayAgo = new Date(Date.now() - MS_PER_DAY)
+  const timestamp1DayAgo = timestampDaysAgo(ONE_DAY)
+  if (timestamp1DayAgo instanceof Error) return timestamp1DayAgo
 
   const walletVolume = await ledgerService.intraledgerTxBaseVolumeSince({
     walletId,
@@ -59,7 +60,8 @@ export const checkWithdrawalLimits = async ({
   if (limitsChecker instanceof Error) return limitsChecker
 
   const ledgerService = LedgerService()
-  const timestamp1DayAgo = new Date(Date.now() - MS_PER_DAY)
+  const timestamp1DayAgo = timestampDaysAgo(ONE_DAY)
+  if (timestamp1DayAgo instanceof Error) return timestamp1DayAgo
 
   const walletVolume = await ledgerService.externalPaymentVolumeSince({
     walletId,
@@ -93,7 +95,8 @@ export const checkTwoFALimits = async ({
   if (limitsChecker instanceof Error) return limitsChecker
 
   const ledgerService = LedgerService()
-  const timestamp1DayAgo = new Date(Date.now() - MS_PER_DAY)
+  const timestamp1DayAgo = timestampDaysAgo(ONE_DAY)
+  if (timestamp1DayAgo instanceof Error) return timestamp1DayAgo
 
   const walletVolume = await ledgerService.allPaymentVolumeSince({
     walletId,

--- a/src/app/wallets/reimburse-failed-usd.ts
+++ b/src/app/wallets/reimburse-failed-usd.ts
@@ -71,6 +71,7 @@ export const reimburseFailedUsdPayment = async <
   const btcWalletDescriptor = {
     id: recipientBtcWallet.id,
     currency: recipientBtcWallet.currency,
+    accountId: recipientBtcWallet.accountId,
   }
 
   const result = await LedgerFacade.recordReceive({

--- a/src/app/wallets/send-on-chain.ts
+++ b/src/app/wallets/send-on-chain.ts
@@ -168,7 +168,10 @@ export const payOnChainByWalletId = async ({
   })
 }
 
-const executePaymentViaIntraledger = async ({
+const executePaymentViaIntraledger = async <
+  S extends WalletCurrency,
+  R extends WalletCurrency,
+>({
   senderAccount,
   senderWallet,
   recipientWallet,
@@ -179,8 +182,8 @@ const executePaymentViaIntraledger = async ({
   logger,
 }: {
   senderAccount: Account
-  senderWallet: Wallet
-  recipientWallet: Wallet
+  senderWallet: WalletDescriptor<S>
+  recipientWallet: WalletDescriptor<R>
   amount: CurrencyBaseAmount
   address: OnChainAddress
   memo: string | null

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,3 +1,5 @@
+import { toDays } from "@domain/primitives"
+
 export * from "./error"
 export * from "./process"
 export * from "./yaml"
@@ -11,6 +13,8 @@ export const TWO_MONTHS_IN_MS = (60 * MS_PER_DAY) as MilliSeconds
 export const SECS_PER_MIN = 60 as Seconds
 export const SECS_PER_5_MINS = (60 * 5) as Seconds
 export const SECS_PER_10_MINS = (SECS_PER_5_MINS * 2) as Seconds
+
+export const ONE_DAY = toDays(1)
 
 export const MAX_AGE_TIME_CODE = (20 * 60) as Seconds
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -401,8 +401,8 @@ export const configSchema = {
         },
         tradeIntraAccount: {
           level: {
-            "1": 200000,
-            "2": 5000000,
+            "1": 5000000,
+            "2": 20000000,
           },
         },
       },

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -382,8 +382,9 @@ export const configSchema = {
       properties: {
         withdrawal: accountLimitConfigSchema,
         intraLedger: accountLimitConfigSchema,
+        tradeIntraAccount: accountLimitConfigSchema,
       },
-      required: ["withdrawal", "intraLedger"],
+      required: ["withdrawal", "intraLedger", "tradeIntraAccount"],
       additionalProperties: false,
       default: {
         withdrawal: {
@@ -393,6 +394,12 @@ export const configSchema = {
           },
         },
         intraLedger: {
+          level: {
+            "1": 200000,
+            "2": 5000000,
+          },
+        },
+        tradeIntraAccount: {
           level: {
             "1": 200000,
             "2": 5000000,

--- a/src/config/schema.types.d.ts
+++ b/src/config/schema.types.d.ts
@@ -83,6 +83,7 @@ type YamlSchema = {
   accountLimits: {
     withdrawal: AccountLimitsConfig
     intraLedger: AccountLimitsConfig
+    tradeIntraAccount: AccountLimitsConfig
   }
   spamLimits: {
     memoSharingSatsThreshold: number

--- a/src/config/yaml.ts
+++ b/src/config/yaml.ts
@@ -173,6 +173,7 @@ export const getAccountLimits = ({
   return {
     intraLedgerLimit: toCents(accountLimits.intraLedger.level[level]),
     withdrawalLimit: toCents(accountLimits.withdrawal.level[level]),
+    tradeIntraAccountLimit: toCents(accountLimits.tradeIntraAccount.level[level]),
   }
 }
 

--- a/src/domain/accounts/account-validator.ts
+++ b/src/domain/accounts/account-validator.ts
@@ -9,7 +9,9 @@ export const AccountValidator = (
     return new InactiveAccountError(account.id)
   }
 
-  const validateWalletForAccount = (wallet: Wallet): true | ValidationError => {
+  const validateWalletForAccount = <S extends WalletCurrency>(
+    wallet: WalletDescriptor<S>,
+  ): true | ValidationError => {
     if (wallet.accountId !== account.id)
       return new InvalidWalletId(
         JSON.stringify({ accountId: account.id, accountIdFromWallet: wallet.accountId }),

--- a/src/domain/accounts/index.types.d.ts
+++ b/src/domain/accounts/index.types.d.ts
@@ -24,12 +24,18 @@ type AccountLimitsArgs = {
         [l: number]: number
       }
     }
+    tradeIntraAccount: {
+      level: {
+        [l: number]: number
+      }
+    }
   }
 }
 
 interface IAccountLimits {
   intraLedgerLimit: UsdCents
   withdrawalLimit: UsdCents
+  tradeIntraAccountLimit: UsdCents
 }
 
 type AccountContact = {

--- a/src/domain/accounts/index.types.d.ts
+++ b/src/domain/accounts/index.types.d.ts
@@ -125,6 +125,7 @@ type NewLimitsCheckerFn = (
 type AccountLimitsChecker = {
   checkIntraledger: NewLimitsCheckerFn
   checkWithdrawal: NewLimitsCheckerFn
+  checkTradeIntraAccount: NewLimitsCheckerFn
 }
 
 type TwoFALimitsChecker = {

--- a/src/domain/accounts/new-limits-checker.ts
+++ b/src/domain/accounts/new-limits-checker.ts
@@ -1,5 +1,6 @@
 import {
   IntraledgerLimitsExceededError,
+  TradeIntraAccountLimitsExceededError,
   TwoFALimitsExceededError,
   WithdrawalLimitsExceededError,
 } from "@domain/errors"
@@ -73,6 +74,13 @@ export const AccountLimitsChecker = ({
     limitAmount: accountLimits.withdrawalLimit,
     limitError: WithdrawalLimitsExceededError,
     limitErrMsg: `Cannot transfer more than ${accountLimits.withdrawalLimit} cents in 24 hours`,
+    priceRatio,
+  }),
+  checkTradeIntraAccount: checkLimitBase({
+    limitName: "checkTradeIntraAccount",
+    limitAmount: accountLimits.tradeIntraAccountLimit,
+    limitError: TradeIntraAccountLimitsExceededError,
+    limitErrMsg: `Cannot transfer more than ${accountLimits.tradeIntraAccountLimit} cents in 24 hours`,
     priceRatio,
   }),
 })

--- a/src/domain/accounts/new-limits-checker.ts
+++ b/src/domain/accounts/new-limits-checker.ts
@@ -6,82 +6,60 @@ import {
 import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
 import { addAttributesToCurrentSpan } from "@services/tracing"
 
+const checkLimitBase =
+  ({ limitName, limitAmount, limitError, limitErrMsg, priceRatio }) =>
+  async ({
+    amount,
+    walletVolume,
+  }: NewLimiterCheckInputs): Promise<true | LimitsExceededError> => {
+    const volumeInUsdAmount =
+      walletVolume.outgoingBaseAmount.currency === WalletCurrency.Btc
+        ? await priceRatio.convertFromBtc(
+            walletVolume.outgoingBaseAmount as BtcPaymentAmount,
+          )
+        : (walletVolume.outgoingBaseAmount as UsdPaymentAmount)
+
+    const limit = paymentAmountFromNumber({
+      amount: limitAmount,
+      currency: WalletCurrency.Usd,
+    })
+    if (limit instanceof Error) return limit
+    addAttributesToCurrentSpan({
+      "txVolume.outgoingInBase": `${volumeInUsdAmount.amount}`,
+      "txVolume.threshold": `${limit.amount}`,
+      "txVolume.amountInBase": `${amount.amount}`,
+      "txVolume.limitCheck": limitName,
+    })
+
+    const remainingLimit = limit.amount - volumeInUsdAmount.amount
+    if (remainingLimit < amount.amount) {
+      return new limitError(limitErrMsg)
+    }
+    return true
+  }
+
 export const AccountLimitsChecker = ({
   accountLimits,
   priceRatio,
 }: {
   accountLimits: IAccountLimits
   priceRatio: PriceRatio
-}): AccountLimitsChecker => {
-  const checkIntraledger = async ({
-    amount,
-    walletVolume,
-  }: NewLimiterCheckInputs): Promise<true | LimitsExceededError> => {
-    const volumeInUsdAmount =
-      walletVolume.outgoingBaseAmount.currency === WalletCurrency.Btc
-        ? await priceRatio.convertFromBtc(
-            walletVolume.outgoingBaseAmount as BtcPaymentAmount,
-          )
-        : (walletVolume.outgoingBaseAmount as UsdPaymentAmount)
-
-    const limit = paymentAmountFromNumber({
-      amount: accountLimits.intraLedgerLimit,
-      currency: WalletCurrency.Usd,
-    })
-    if (limit instanceof Error) return limit
-    addAttributesToCurrentSpan({
-      "txVolume.outgoingInBase": `${volumeInUsdAmount.amount}`,
-      "txVolume.threshold": `${limit.amount}`,
-      "txVolume.amountInBase": `${amount.amount}`,
-      "txVolume.limitCheck": "checkIntraledger",
-    })
-
-    const remainingLimit = limit.amount - volumeInUsdAmount.amount
-    if (remainingLimit < amount.amount) {
-      return new IntraledgerLimitsExceededError(
-        `Cannot transfer more than ${accountLimits.intraLedgerLimit} cents in 24 hours`,
-      )
-    }
-    return true
-  }
-
-  const checkWithdrawal = async ({
-    amount,
-    walletVolume,
-  }: NewLimiterCheckInputs): Promise<true | LimitsExceededError> => {
-    const volumeInUsdAmount =
-      walletVolume.outgoingBaseAmount.currency === WalletCurrency.Btc
-        ? await priceRatio.convertFromBtc(
-            walletVolume.outgoingBaseAmount as BtcPaymentAmount,
-          )
-        : (walletVolume.outgoingBaseAmount as UsdPaymentAmount)
-
-    const limit = paymentAmountFromNumber({
-      amount: accountLimits.withdrawalLimit,
-      currency: WalletCurrency.Usd,
-    })
-    if (limit instanceof Error) return limit
-    addAttributesToCurrentSpan({
-      "txVolume.outgoingInBase": `${volumeInUsdAmount.amount}`,
-      "txVolume.threshold": `${limit.amount}`,
-      "txVolume.amountInBase": `${amount.amount}`,
-      "txVolume.limitCheck": "checkWithdrawal",
-    })
-
-    const remainingLimit = limit.amount - volumeInUsdAmount.amount
-    if (remainingLimit < amount.amount) {
-      return new WithdrawalLimitsExceededError(
-        `Cannot transfer more than ${accountLimits.withdrawalLimit} cents in 24 hours`,
-      )
-    }
-    return true
-  }
-
-  return {
-    checkIntraledger,
-    checkWithdrawal,
-  }
-}
+}): AccountLimitsChecker => ({
+  checkIntraledger: checkLimitBase({
+    limitName: "checkIntraledger",
+    limitAmount: accountLimits.intraLedgerLimit,
+    limitError: IntraledgerLimitsExceededError,
+    limitErrMsg: `Cannot transfer more than ${accountLimits.intraLedgerLimit} cents in 24 hours`,
+    priceRatio,
+  }),
+  checkWithdrawal: checkLimitBase({
+    limitName: "checkWithdrawal",
+    limitAmount: accountLimits.withdrawalLimit,
+    limitError: WithdrawalLimitsExceededError,
+    limitErrMsg: `Cannot transfer more than ${accountLimits.withdrawalLimit} cents in 24 hours`,
+    priceRatio,
+  }),
+})
 
 export const TwoFALimitsChecker = ({
   twoFALimits,
@@ -89,38 +67,12 @@ export const TwoFALimitsChecker = ({
 }: {
   twoFALimits: TwoFALimits
   priceRatio: PriceRatio
-}): TwoFALimitsChecker => {
-  const checkTwoFA = async ({
-    amount,
-    walletVolume,
-  }: NewLimiterCheckInputs): Promise<true | LimitsExceededError> => {
-    const volumeInUsdAmount =
-      walletVolume.outgoingBaseAmount.currency === WalletCurrency.Btc
-        ? await priceRatio.convertFromBtc(
-            walletVolume.outgoingBaseAmount as BtcPaymentAmount,
-          )
-        : (walletVolume.outgoingBaseAmount as UsdPaymentAmount)
-
-    const limit = paymentAmountFromNumber({
-      amount: twoFALimits.threshold,
-      currency: WalletCurrency.Usd,
-    })
-    if (limit instanceof Error) return limit
-    addAttributesToCurrentSpan({
-      "txVolume.outgoingInBase": `${volumeInUsdAmount.amount}`,
-      "txVolume.threshold": `${limit.amount}`,
-      "txVolume.amountInBase": `${amount.amount}`,
-      "txVolume.limitCheck": "checkTwoFA",
-    })
-
-    const remainingLimit = limit.amount - volumeInUsdAmount.amount
-    if (remainingLimit < amount.amount) {
-      return new TwoFALimitsExceededError()
-    }
-    return true
-  }
-
-  return {
-    checkTwoFA,
-  }
-}
+}): TwoFALimitsChecker => ({
+  checkTwoFA: checkLimitBase({
+    limitName: "checkTwoFA",
+    limitAmount: twoFALimits.threshold,
+    limitError: TwoFALimitsExceededError,
+    limitErrMsg: undefined,
+    priceRatio,
+  }),
+})

--- a/src/domain/accounts/new-limits-checker.ts
+++ b/src/domain/accounts/new-limits-checker.ts
@@ -7,7 +7,23 @@ import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
 import { addAttributesToCurrentSpan } from "@services/tracing"
 
 const checkLimitBase =
-  ({ limitName, limitAmount, limitError, limitErrMsg, priceRatio }) =>
+  ({
+    limitName,
+    limitAmount,
+    limitError,
+    limitErrMsg,
+    priceRatio,
+  }: {
+    limitName:
+      | "checkIntraledger"
+      | "checkWithdrawal"
+      | "checkTradeIntraAccount"
+      | "checkTwoFA"
+    limitAmount: UsdCents
+    limitError: LimitsExceededErrorConstructor
+    limitErrMsg: string | undefined
+    priceRatio: PriceRatio
+  }) =>
   async ({
     amount,
     walletVolume,

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -107,6 +107,7 @@ export class InvalidAccountLevelError extends ValidationError {}
 export class LimitsExceededError extends ValidationError {}
 export class WithdrawalLimitsExceededError extends LimitsExceededError {}
 export class IntraledgerLimitsExceededError extends LimitsExceededError {}
+export class TradeIntraAccountLimitsExceededError extends LimitsExceededError {}
 export class TwoFALimitsExceededError extends LimitsExceededError {}
 
 export class LnRouteValidationError extends ValidationError {}

--- a/src/domain/errors.types.d.ts
+++ b/src/domain/errors.types.d.ts
@@ -4,3 +4,5 @@ type LimitsExceededError = import("./errors").LimitsExceededError
 type TwoFALimitsExceededError = import("./errors").TwoFALimitsExceededError
 type NotImplementedError = import("./errors").NotImplementedError
 type NotReachableError = import("./errors").NotReachableError
+
+type LimitsExceededErrorConstructor = typeof import("./errors").LimitsExceededError

--- a/src/domain/ledger/index.ts
+++ b/src/domain/ledger/index.ts
@@ -40,7 +40,9 @@ export const LedgerTransactionType = {
   IntraLedger: "on_us",
   LnIntraLedger: "ln_on_us",
   OnchainIntraLedger: "onchain_on_us",
-  TradeIntraAccount: "self_trade",
+  WalletIdTradeIntraAccount: "self_trade",
+  LnTradeIntraAccount: "ln_self_trade",
+  OnChainTradeIntraAccount: "onchain_self_trade",
 
   // Admin
   Fee: "fee",
@@ -53,6 +55,7 @@ export const LedgerTransactionType = {
 
 export const isOnChainTransaction = (type: LedgerTransactionType): boolean =>
   type === LedgerTransactionType.OnchainIntraLedger ||
+  type === LedgerTransactionType.OnChainTradeIntraAccount ||
   type === LedgerTransactionType.OnchainReceipt ||
   type === LedgerTransactionType.OnchainPayment
 

--- a/src/domain/ledger/index.ts
+++ b/src/domain/ledger/index.ts
@@ -37,14 +37,12 @@ export const LedgerTransactionType = {
   OnchainReceipt: "onchain_receipt",
   OnchainPayment: "onchain_payment",
   OnchainIntraLedger: "onchain_on_us",
-  OnchainDepositFee: "deposit_fee", // onchain
+
   Fee: "fee",
   Escrow: "escrow",
 
   // TODO: rename. should be routing_revenue
   RoutingRevenue: "routing_fee", // channel-related
-  ExchangeRebalance: "exchange_rebalance", // send/receive btc from the exchange
-  UserRebalance: "user_rebalance", // buy/sell btc in the user wallet
   ToColdStorage: "to_cold_storage",
   ToHotWallet: "to_hot_wallet",
 } as const

--- a/src/domain/ledger/index.ts
+++ b/src/domain/ledger/index.ts
@@ -29,22 +29,26 @@ export const toWalletId = (walletIdPath: LiabilitiesWalletId): WalletId | undefi
 }
 
 export const LedgerTransactionType = {
+  // External
   Invoice: "invoice",
   Payment: "payment",
-  IntraLedger: "on_us",
-  LnIntraLedger: "ln_on_us",
   LnFeeReimbursement: "fee_reimbursement", // lightning
   OnchainReceipt: "onchain_receipt",
   OnchainPayment: "onchain_payment",
+
+  // Internal
+  IntraLedger: "on_us",
+  LnIntraLedger: "ln_on_us",
   OnchainIntraLedger: "onchain_on_us",
+  TradeIntraAccount: "self_trade",
 
+  // Admin
   Fee: "fee",
-  Escrow: "escrow",
-
-  // TODO: rename. should be routing_revenue
-  RoutingRevenue: "routing_fee", // channel-related
   ToColdStorage: "to_cold_storage",
   ToHotWallet: "to_hot_wallet",
+  Escrow: "escrow",
+  // TODO: rename. should be routing_revenue
+  RoutingRevenue: "routing_fee", // channel-related
 } as const
 
 export const isOnChainTransaction = (type: LedgerTransactionType): boolean =>

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -283,6 +283,8 @@ interface ILedgerService {
 
   intraledgerTxBaseVolumeSince: GetVolumeSinceFn
 
+  tradeIntraAccountTxBaseVolumeSince: GetVolumeSinceFn
+
   allTxBaseVolumeSince: GetVolumeSinceFn
 
   lightningTxBaseVolumeSince: GetVolumeSinceFn
@@ -294,6 +296,8 @@ interface ILedgerService {
   externalPaymentVolumeAmountSince: GetVolumeAmountSinceFn
 
   intraledgerTxBaseVolumeAmountSince: GetVolumeAmountSinceFn
+
+  tradeIntraAccountTxBaseVolumeAmountSince: GetVolumeAmountSinceFn
 
   allTxBaseVolumeAmountSince: GetVolumeAmountSinceFn
 

--- a/src/domain/payments/index.types.d.ts
+++ b/src/domain/payments/index.types.d.ts
@@ -88,9 +88,7 @@ type LightningPaymentFlowBuilder<S extends WalletCurrency> = {
 }
 
 type LPFBWithInvoice<S extends WalletCurrency> = {
-  withSenderWallet(
-    senderWallet: WalletDescriptor<S>,
-  ): LPFBWithSenderWallet<S> | LPFBWithError
+  withSenderWallet(senderWallet: Wallet): LPFBWithSenderWallet<S> | LPFBWithError
 }
 
 type LPFBWithSenderWallet<S extends WalletCurrency> = {
@@ -103,7 +101,10 @@ type LPFBWithSenderWallet<S extends WalletCurrency> = {
     currency: recipientWalletCurrency,
     usdPaymentAmount,
   }: WalletDescriptor<R> & {
+    accountId: AccountId
+    pubkey?: Pubkey
     usdPaymentAmount?: UsdPaymentAmount
+    username?: Username
   }): LPFBWithRecipientWallet<S, R> | LPFBWithError
 }
 
@@ -136,6 +137,7 @@ type LPFBWithConversion<S extends WalletCurrency, R extends WalletCurrency> = {
   skipProbeForDestination(): Promise<boolean | DealerPriceServiceError>
 
   isIntraLedger(): Promise<boolean | DealerPriceServiceError>
+  isTradeIntraAccount(): Promise<boolean | DealerPriceServiceError>
 }
 
 type LPFBTest = {
@@ -153,6 +155,7 @@ type LPFBWithError = {
   usdPaymentAmount(): Promise<ValidationError | DealerPriceServiceError>
   skipProbeForDestination(): Promise<ValidationError | DealerPriceServiceError>
   isIntraLedger(): Promise<ValidationError | DealerPriceServiceError>
+  isTradeIntraAccount(): Promise<ValidationError | DealerPriceServiceError>
 }
 interface IPaymentFlowRepository {
   persistNew<S extends WalletCurrency>(
@@ -204,6 +207,7 @@ type LPFBWithSenderWalletState<S extends WalletCurrency> = RequireField<
 > & {
   senderWalletId: WalletId
   senderWalletCurrency: S
+  senderAccountId: AccountId
   usdPaymentAmount?: UsdPaymentAmount
 }
 
@@ -215,6 +219,7 @@ type LPFBWithRecipientWalletState<
   recipientWalletCurrency?: R
   recipientPubkey?: Pubkey
   recipientUsername?: Username
+  recipientAccountId?: AccountId
 }
 
 type LPFBWithConversionState<

--- a/src/domain/payments/index.types.d.ts
+++ b/src/domain/payments/index.types.d.ts
@@ -17,6 +17,7 @@ type PaymentFlowState<
 > = XorPaymentHashProperty & {
   senderWalletId: WalletId
   senderWalletCurrency: S
+  senderAccountId: AccountId
   settlementMethod: SettlementMethod
   paymentInitiationMethod: PaymentInitiationMethod
   descriptionFromInvoice: string
@@ -33,6 +34,7 @@ type PaymentFlowState<
 
   recipientWalletId?: WalletId
   recipientWalletCurrency?: R
+  recipientAccountId?: AccountId
   recipientPubkey?: Pubkey
   recipientUsername?: Username
 
@@ -88,7 +90,9 @@ type LightningPaymentFlowBuilder<S extends WalletCurrency> = {
 }
 
 type LPFBWithInvoice<S extends WalletCurrency> = {
-  withSenderWallet(senderWallet: Wallet): LPFBWithSenderWallet<S> | LPFBWithError
+  withSenderWallet(
+    senderWallet: WalletDescriptor<S>,
+  ): LPFBWithSenderWallet<S> | LPFBWithError
 }
 
 type LPFBWithSenderWallet<S extends WalletCurrency> = {
@@ -96,16 +100,13 @@ type LPFBWithSenderWallet<S extends WalletCurrency> = {
   withoutRecipientWallet<R extends WalletCurrency>():
     | LPFBWithRecipientWallet<S, R>
     | LPFBWithError
-  withRecipientWallet<R extends WalletCurrency>({
-    id: recipientWalletId,
-    currency: recipientWalletCurrency,
-    usdPaymentAmount,
-  }: WalletDescriptor<R> & {
-    accountId: AccountId
-    pubkey?: Pubkey
-    usdPaymentAmount?: UsdPaymentAmount
-    username?: Username
-  }): LPFBWithRecipientWallet<S, R> | LPFBWithError
+  withRecipientWallet<R extends WalletCurrency>(
+    args: WalletDescriptor<R> & {
+      pubkey?: Pubkey
+      usdPaymentAmount?: UsdPaymentAmount
+      username?: Username
+    },
+  ): LPFBWithRecipientWallet<S, R> | LPFBWithError
 }
 
 type LPFBWithRecipientWallet<S extends WalletCurrency, R extends WalletCurrency> = {

--- a/src/domain/payments/payment-flow-builder.ts
+++ b/src/domain/payments/payment-flow-builder.ts
@@ -117,7 +117,7 @@ export const LightningPaymentFlowBuilder = <S extends WalletCurrency>(
 const LPFBWithInvoice = <S extends WalletCurrency>(
   state: LPFBWithInvoiceState,
 ): LPFBWithInvoice<S> | LPFBWithError => {
-  const withSenderWallet = (senderWallet: Wallet) => {
+  const withSenderWallet = (senderWallet: WalletDescriptor<S>) => {
     const {
       id: senderWalletId,
       accountId: senderAccountId,
@@ -438,8 +438,10 @@ const LPFBWithConversion = <S extends WalletCurrency, R extends WalletCurrency>(
 
       senderWalletId: state.senderWalletId,
       senderWalletCurrency: state.senderWalletCurrency,
+      senderAccountId: state.senderAccountId,
       recipientWalletId: state.recipientWalletId,
       recipientWalletCurrency: state.recipientWalletCurrency,
+      recipientAccountId: state.recipientAccountId,
       recipientPubkey: state.recipientPubkey,
       recipientUsername: state.recipientUsername,
 

--- a/src/domain/payments/payment-flow.ts
+++ b/src/domain/payments/payment-flow.ts
@@ -70,13 +70,15 @@ export const PaymentFlow = <S extends WalletCurrency, R extends WalletCurrency>(
   const senderWalletDescriptor = (): WalletDescriptor<S> => ({
     id: state.senderWalletId,
     currency: state.senderWalletCurrency,
+    accountId: state.senderAccountId,
   })
 
   const recipientWalletDescriptor = (): WalletDescriptor<R> | undefined =>
-    state.recipientWalletId && state.recipientWalletCurrency
+    state.recipientWalletId && state.recipientWalletCurrency && state.recipientAccountId
       ? {
           id: state.recipientWalletId,
           currency: state.recipientWalletCurrency,
+          accountId: state.recipientAccountId,
         }
       : undefined
 

--- a/src/domain/shared/index.types.d.ts
+++ b/src/domain/shared/index.types.d.ts
@@ -36,6 +36,7 @@ type DisplayBalanceAmount<T extends DisplayCurrency> = DisplayAmount<T> & {
 type WalletDescriptor<T extends WalletCurrency> = {
   id: WalletId
   currency: T
+  accountId: AccountId
 }
 
 type BtcPaymentAmount = PaymentAmount<"BTC">

--- a/src/domain/shared/index.types.d.ts
+++ b/src/domain/shared/index.types.d.ts
@@ -33,9 +33,11 @@ type DisplayBalanceAmount<T extends DisplayCurrency> = DisplayAmount<T> & {
   readonly brand?: unique symbol
 }
 
-type WalletDescriptor<T extends WalletCurrency> = {
+type PartialWalletDescriptor<T extends WalletCurrency> = {
   id: WalletId
   currency: T
+}
+type WalletDescriptor<T extends WalletCurrency> = PartialWalletDescriptor<T> & {
   accountId: AccountId
 }
 

--- a/src/domain/wallet-invoices/index.types.d.ts
+++ b/src/domain/wallet-invoices/index.types.d.ts
@@ -72,7 +72,7 @@ type WalletInvoice = {
   selfGenerated: boolean
   pubkey: Pubkey
   usdAmount?: UsdPaymentAmount
-  recipientWalletDescriptor: WalletDescriptor<WalletCurrency>
+  recipientWalletDescriptor: PartialWalletDescriptor<WalletCurrency>
   paid: boolean
 }
 
@@ -81,7 +81,6 @@ type WalletInvoiceReceiver = WalletInvoice & {
   btcToCreditReceiver: BtcPaymentAmount
   usdBankFee: UsdPaymentAmount
   btcBankFee: BtcPaymentAmount
-  recipientWalletDescriptor: WalletDescriptor<WalletCurrency>
   receivedAmount: () => BtcPaymentAmount | UsdPaymentAmount
 }
 

--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -94,6 +94,7 @@ const translateLedgerTxnToWalletTxn = <S extends WalletCurrency>(
   let walletTransaction: WalletTransaction
   switch (txType) {
     case LedgerTransactionType.IntraLedger:
+    case LedgerTransactionType.WalletIdTradeIntraAccount:
       walletTransaction = {
         ...baseTransaction,
         initiationVia: {
@@ -110,6 +111,7 @@ const translateLedgerTxnToWalletTxn = <S extends WalletCurrency>(
       break
 
     case LedgerTransactionType.OnchainIntraLedger:
+    case LedgerTransactionType.OnChainTradeIntraAccount:
       walletTransaction = {
         ...baseTransaction,
         initiationVia: {
@@ -140,6 +142,7 @@ const translateLedgerTxnToWalletTxn = <S extends WalletCurrency>(
       break
 
     case LedgerTransactionType.LnIntraLedger:
+    case LedgerTransactionType.LnTradeIntraAccount:
       walletTransaction = {
         ...baseTransaction,
         initiationVia: {

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -41,6 +41,10 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       message = error.message
       return new TransactionRestrictedError({ message, logger: baseLogger })
 
+    case "TradeIntraAccountLimitsExceededError":
+      message = error.message
+      return new TransactionRestrictedError({ message, logger: baseLogger })
+
     case "TwoFANewCodeNeededError":
       message = "Need a 2FA code to proceed with the payment"
       return new TwoFAError({ message, logger: baseLogger })

--- a/src/services/ledger/index.types.d.ts
+++ b/src/services/ledger/index.types.d.ts
@@ -107,21 +107,46 @@ type AddLnIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata & {
   pubkey: Pubkey
 }
 
+type AddLnTradeIntraAccountLedgerMetadata = Omit<
+  AddLnIntraledgerSendLedgerMetadata,
+  "username"
+>
+
 type NewAddLnIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata &
   SendAmountsMetadata & {
     hash: PaymentHash
     pubkey: Pubkey
   }
 
+type NewAddLnTradeIntraAccountLedgerMetadata = Omit<
+  NewAddLnIntraledgerSendLedgerMetadata,
+  "username"
+>
+
 type AddOnChainIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata & {
   payee_addresses: OnChainAddress[]
   sendAll: boolean
 }
 
+type AddOnChainTradeIntraAccountLedgerMetadata = Omit<
+  AddOnChainIntraledgerSendLedgerMetadata,
+  "username"
+>
+
 type AddWalletIdIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata
+
+type AddWalletIdTradeIntraAccountLedgerMetadata = Omit<
+  AddWalletIdIntraledgerSendLedgerMetadata,
+  "username"
+>
 
 type NewAddWalletIdIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata &
   SendAmountsMetadata
+
+type NewAddWalletIdTradeIntraAccountLedgerMetadata = Omit<
+  NewAddWalletIdIntraledgerSendLedgerMetadata,
+  "username"
+>
 
 type ReimbursementLedgerMetadata = SendAmountsMetadata & {
   hash: PaymentHash

--- a/src/services/ledger/tx-metadata.ts
+++ b/src/services/ledger/tx-metadata.ts
@@ -315,6 +315,125 @@ export const LnIntraledgerLedgerMetadata = <
   return { metadata, debitAccountAdditionalMetadata }
 }
 
+export const OnChainTradeIntraAccountLedgerMetadata = ({
+  amountDisplayCurrency,
+  payeeAddresses,
+  sendAll,
+  memoOfPayer,
+}: {
+  amountDisplayCurrency: DisplayCurrencyBaseAmount
+  payeeAddresses: OnChainAddress[]
+  sendAll: boolean
+  memoOfPayer?: string
+}) => {
+  const metadata: AddOnChainTradeIntraAccountLedgerMetadata = {
+    type: LedgerTransactionType.OnChainTradeIntraAccount,
+    pending: false,
+    usd: amountDisplayCurrency,
+    memoPayer: undefined,
+    payee_addresses: payeeAddresses,
+    sendAll,
+  }
+  const debitAccountAdditionalMetadata = {
+    memoPayer: memoOfPayer,
+  }
+  return { metadata, debitAccountAdditionalMetadata }
+}
+
+export const WalletIdTradeIntraAccountLedgerMetadata = <
+  S extends WalletCurrency,
+  R extends WalletCurrency,
+>({
+  paymentFlow,
+  feeDisplayCurrency,
+  amountDisplayCurrency,
+  displayCurrency,
+  memoOfPayer,
+}: {
+  paymentFlow: PaymentFlowState<S, R>
+  feeDisplayCurrency: DisplayCurrencyBaseAmount
+  amountDisplayCurrency: DisplayCurrencyBaseAmount
+  displayCurrency: DisplayCurrency
+  memoOfPayer?: string
+}) => {
+  const {
+    btcPaymentAmount: { amount: satsAmount },
+    usdPaymentAmount: { amount: centsAmount },
+    btcProtocolFee: { amount: satsFee },
+    usdProtocolFee: { amount: centsFee },
+  } = paymentFlow
+
+  const metadata: NewAddWalletIdTradeIntraAccountLedgerMetadata = {
+    type: LedgerTransactionType.WalletIdTradeIntraAccount,
+    pending: false,
+    memoPayer: memoOfPayer,
+
+    usd: (amountDisplayCurrency / 100) as DisplayCurrencyBaseAmount,
+
+    satsFee: toSats(satsFee),
+    displayFee: feeDisplayCurrency,
+    displayAmount: amountDisplayCurrency,
+
+    displayCurrency,
+    centsAmount: toCents(centsAmount),
+    satsAmount: toSats(satsAmount),
+    centsFee: toCents(centsFee),
+  }
+
+  return metadata
+}
+
+export const LnTradeIntraAccountLedgerMetadata = <
+  S extends WalletCurrency,
+  R extends WalletCurrency,
+>({
+  paymentHash,
+  pubkey,
+  paymentFlow,
+  feeDisplayCurrency,
+  amountDisplayCurrency,
+  displayCurrency,
+  memoOfPayer,
+}: {
+  paymentHash: PaymentHash
+  pubkey: Pubkey
+  paymentFlow: PaymentFlowState<S, R>
+  feeDisplayCurrency: DisplayCurrencyBaseAmount
+  amountDisplayCurrency: DisplayCurrencyBaseAmount
+  displayCurrency: DisplayCurrency
+  memoOfPayer?: string
+}) => {
+  const {
+    btcPaymentAmount: { amount: satsAmount },
+    usdPaymentAmount: { amount: centsAmount },
+    btcProtocolFee: { amount: satsFee },
+    usdProtocolFee: { amount: centsFee },
+  } = paymentFlow
+
+  const metadata: NewAddLnTradeIntraAccountLedgerMetadata = {
+    type: LedgerTransactionType.LnTradeIntraAccount,
+    pending: false,
+    memoPayer: undefined,
+    hash: paymentHash,
+    pubkey,
+
+    usd: (amountDisplayCurrency / 100) as DisplayCurrencyBaseAmount,
+
+    satsFee: toSats(satsFee),
+    displayFee: feeDisplayCurrency,
+    displayAmount: amountDisplayCurrency,
+
+    displayCurrency,
+    centsAmount: toCents(centsAmount),
+    satsAmount: toSats(satsAmount),
+    centsFee: toCents(centsFee),
+  }
+  const debitAccountAdditionalMetadata = {
+    memoPayer: memoOfPayer,
+  }
+  return { metadata, debitAccountAdditionalMetadata }
+}
+
 export const LnChannelOpenOrClosingFee = ({ txId }: { txId: OnChainTxHash }) => {
   const metadata: LnChannelOpenOrClosingFee = {
     type: LedgerTransactionType.Fee,

--- a/src/services/ledger/volume.ts
+++ b/src/services/ledger/volume.ts
@@ -22,6 +22,11 @@ export const TxnGroups = {
     LedgerTransactionType.OnchainIntraLedger,
     LedgerTransactionType.LnIntraLedger,
   ],
+  tradeIntraAccountTxBaseVolumeSince: [
+    LedgerTransactionType.WalletIdTradeIntraAccount,
+    LedgerTransactionType.OnChainTradeIntraAccount,
+    LedgerTransactionType.LnTradeIntraAccount,
+  ],
   lightningTxBaseVolumeSince: [
     LedgerTransactionType.Payment,
     LedgerTransactionType.Invoice,
@@ -115,6 +120,7 @@ export const volume = {
   allPaymentVolumeSince: volumeFn("allPaymentVolumeSince"),
   externalPaymentVolumeSince: volumeFn("externalPaymentVolumeSince"),
   intraledgerTxBaseVolumeSince: volumeFn("intraledgerTxBaseVolumeSince"),
+  tradeIntraAccountTxBaseVolumeSince: volumeFn("tradeIntraAccountTxBaseVolumeSince"),
   allTxBaseVolumeSince: volumeFn("allTxBaseVolumeSince"),
   onChainTxBaseVolumeSince: volumeFn("onChainTxBaseVolumeSince"),
   lightningTxBaseVolumeSince: volumeFn("lightningTxBaseVolumeSince"),
@@ -122,6 +128,9 @@ export const volume = {
   allPaymentVolumeAmountSince: volumeAmountFn("allPaymentVolumeSince"),
   externalPaymentVolumeAmountSince: volumeAmountFn("externalPaymentVolumeSince"),
   intraledgerTxBaseVolumeAmountSince: volumeAmountFn("intraledgerTxBaseVolumeSince"),
+  tradeIntraAccountTxBaseVolumeAmountSince: volumeAmountFn(
+    "tradeIntraAccountTxBaseVolumeSince",
+  ),
   allTxBaseVolumeAmountSince: volumeAmountFn("allTxBaseVolumeSince"),
   onChainTxBaseVolumeAmountSince: volumeAmountFn("onChainTxBaseVolumeSince"),
   lightningTxBaseVolumeAmountSince: volumeAmountFn("lightningTxBaseVolumeSince"),

--- a/src/services/lnd/utils.ts
+++ b/src/services/lnd/utils.ts
@@ -1,6 +1,6 @@
 import assert from "assert"
 
-import { MS_PER_DAY, ONCHAIN_SCAN_DEPTH_CHANNEL_UPDATE } from "@config"
+import { MS_PER_DAY, ONCHAIN_SCAN_DEPTH_CHANNEL_UPDATE, ONE_DAY } from "@config"
 import { toSats } from "@domain/bitcoin"
 import {
   defaultTimeToExpiryInSeconds,
@@ -18,6 +18,8 @@ import {
 import { baseLogger } from "@services/logger"
 import { WalletInvoicesRepository, PaymentFlowStateRepository } from "@services/mongoose"
 import { DbMetadata } from "@services/mongoose/schema"
+
+import { timestampDaysAgo } from "@utils"
 
 import { default as axios } from "axios"
 import {
@@ -237,7 +239,8 @@ export const updateRoutingRevenues = async () => {
 
   const after = lastDate.toISOString()
 
-  const endDate = new Date(Date.now() - MS_PER_DAY)
+  const endDate = timestampDaysAgo(ONE_DAY)
+  if (endDate instanceof Error) throw endDate
 
   // Done to remove effect of timezone
   endDate.setUTCHours(0, 0, 0, 0)

--- a/src/services/mongoose/payment-flow.ts
+++ b/src/services/mongoose/payment-flow.ts
@@ -226,6 +226,7 @@ const paymentFlowFromRaw = <S extends WalletCurrency, R extends WalletCurrency>(
 
     senderWalletId: paymentFlowState.senderWalletId as WalletId,
     senderWalletCurrency: paymentFlowState.senderWalletCurrency as S,
+    senderAccountId: paymentFlowState.senderAccountId as AccountId,
     settlementMethod: paymentFlowState.settlementMethod as SettlementMethod,
     paymentInitiationMethod:
       paymentFlowState.paymentInitiationMethod as PaymentInitiationMethod,
@@ -243,6 +244,7 @@ const paymentFlowFromRaw = <S extends WalletCurrency, R extends WalletCurrency>(
 
     recipientWalletId: (paymentFlowState.recipientWalletId as WalletId) || undefined,
     recipientWalletCurrency: (paymentFlowState.recipientWalletCurrency as R) || undefined,
+    recipientAccountId: (paymentFlowState.recipientAccountId as AccountId) || undefined,
     recipientPubkey: (paymentFlowState.recipientPubkey as Pubkey) || undefined,
     recipientUsername: (paymentFlowState.recipientUsername as Username) || undefined,
 
@@ -269,6 +271,7 @@ const rawFromPaymentFlow = <S extends WalletCurrency, R extends WalletCurrency>(
 
     senderWalletId: paymentFlow.senderWalletId,
     senderWalletCurrency: paymentFlow.senderWalletCurrency,
+    senderAccountId: paymentFlow.senderAccountId,
     settlementMethod: paymentFlow.settlementMethod,
     paymentInitiationMethod: paymentFlow.paymentInitiationMethod,
     descriptionFromInvoice: paymentFlow.descriptionFromInvoice,
@@ -285,6 +288,7 @@ const rawFromPaymentFlow = <S extends WalletCurrency, R extends WalletCurrency>(
 
     recipientWalletId: paymentFlow.recipientWalletId,
     recipientWalletCurrency: paymentFlow.recipientWalletCurrency,
+    recipientAccountId: paymentFlow.recipientAccountId,
     recipientPubkey: paymentFlow.recipientPubkey,
     recipientUsername: paymentFlow.recipientUsername,
 

--- a/src/services/mongoose/schema.ts
+++ b/src/services/mongoose/schema.ts
@@ -362,6 +362,7 @@ const paymentFlowStateSchema = new Schema<PaymentFlowStateRecord>(
   {
     senderWalletId: { type: String, required: true },
     senderWalletCurrency: { type: String, required: true },
+    senderAccountId: { type: String, required: true },
     settlementMethod: { type: String, required: true },
     paymentInitiationMethod: { type: String, required: true },
     paymentHash: String,
@@ -379,6 +380,7 @@ const paymentFlowStateSchema = new Schema<PaymentFlowStateRecord>(
 
     recipientWalletId: String,
     recipientWalletCurrency: String,
+    recipientAccountId: String,
     recipientPubkey: String,
     recipientUsername: String,
 

--- a/src/services/mongoose/schema.types.d.ts
+++ b/src/services/mongoose/schema.types.d.ts
@@ -140,6 +140,7 @@ type PaymentFlowStateRecordPartial = XOR<
 > & {
   senderWalletId: string
   senderWalletCurrency: string
+  senderAccountId: string
   settlementMethod: string
   paymentInitiationMethod: string
   createdAt: Date
@@ -156,6 +157,7 @@ type PaymentFlowStateRecordPartial = XOR<
 
   recipientWalletId?: string
   recipientWalletCurrency?: string
+  recipientAccountId?: string
   recipientPubkey?: string
   recipientUsername?: string
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,6 @@
+import { MS_PER_DAY } from "@config"
+import { NonIntegerError } from "@domain/errors"
+
 export async function sleep(ms: MilliSeconds | number) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
@@ -57,6 +60,14 @@ export const mapObj = <T, R>(
 
 export const elapsedSinceTimestamp = (date: Date): Seconds => {
   return ((Date.now() - Number(date)) / 1000) as Seconds
+}
+
+export const checkedInteger = (num: number) =>
+  Number.isInteger(num) ? num : new NonIntegerError()
+
+export const timestampDaysAgo = (days: Days): Date | NonIntegerError => {
+  const check = checkedInteger(days)
+  return check instanceof Error ? check : new Date(Date.now() - days * MS_PER_DAY)
 }
 
 export class ModifiedSet extends Set {

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -1,4 +1,5 @@
 import { generate2fa, save2fa } from "@app/users"
+import { InvalidPhoneNumber } from "@domain/errors"
 import { TwoFAAlreadySetError } from "@domain/twoFA"
 import { gqlAdminSchema } from "@graphql/admin"
 import { ExecutionResult, graphql, Source } from "graphql"
@@ -64,6 +65,15 @@ export const enable2FA = async (userId: UserId) => {
 
 export const chunk = (a, n) =>
   [...Array(Math.ceil(a.length / n))].map((_, i) => a.slice(n * i, n + n * i))
+
+export const randomPhone = (length = 14): PhoneNumber => {
+  const PhoneNumberRegex = /^\+\d{7,14}$/i // FIXME {7,14} to be refined
+
+  const phoneNumber = `+${Math.floor(Math.random() * 10 ** length)}`
+  if (!phoneNumber.match(PhoneNumberRegex)) throw new InvalidPhoneNumber()
+
+  return phoneNumber as PhoneNumber
+}
 
 export const graphqlAdmin = <
   T = Promise<ExecutionResult<ObjMap<unknown>, ObjMap<unknown>>>,

--- a/test/helpers/wallet.ts
+++ b/test/helpers/wallet.ts
@@ -1,5 +1,5 @@
 import { getBalanceForWallet } from "@app/wallets"
-import { getTwoFALimits, MS_PER_DAY } from "@config"
+import { getTwoFALimits, ONE_DAY } from "@config"
 import { toSats } from "@domain/bitcoin"
 import { sub, toCents } from "@domain/fiat"
 import {
@@ -10,6 +10,7 @@ import {
 } from "@domain/shared"
 import { LedgerService } from "@services/ledger"
 import { baseLogger } from "@services/logger"
+import { timestampDaysAgo } from "@utils"
 
 export const getBalanceHelper = async (
   walletId: WalletId,
@@ -30,8 +31,10 @@ export const getRemainingTwoFALimit = async ({
 }: {
   walletId: WalletId
   satsToCents
-}): Promise<UsdCents> => {
-  const timestamp1DayAgo = new Date(Date.now() - MS_PER_DAY)
+}): Promise<UsdCents | ValidationError> => {
+  const timestamp1DayAgo = timestampDaysAgo(ONE_DAY)
+  if (timestamp1DayAgo instanceof Error) return timestamp1DayAgo
+
   const walletVolume = await LedgerService().allPaymentVolumeSince({
     walletId,
     timestamp: timestamp1DayAgo,
@@ -54,7 +57,9 @@ export const newGetRemainingTwoFALimit = async <T extends WalletCurrency>({
   walletDescriptor: WalletDescriptor<T>
   priceRatio: PriceRatio
 }): Promise<UsdPaymentAmount | ApplicationError> => {
-  const timestamp1DayAgo = new Date(Date.now() - MS_PER_DAY)
+  const timestamp1DayAgo = timestampDaysAgo(ONE_DAY)
+  if (timestamp1DayAgo instanceof Error) return timestamp1DayAgo
+
   const walletVolume = await LedgerService().allPaymentVolumeAmountSince({
     walletDescriptor,
     timestamp: timestamp1DayAgo,

--- a/test/integration/02-user-wallet/02-receive-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-lightning.spec.ts
@@ -1,4 +1,4 @@
-import { MEMO_SHARING_SATS_THRESHOLD } from "@config"
+import { MEMO_SHARING_SATS_THRESHOLD, ONE_DAY } from "@config"
 
 import { Lightning } from "@app"
 import * as Wallets from "@app/wallets"
@@ -165,7 +165,7 @@ describe("UserWallet - Lightning", () => {
 
     const imbalanceCalc = ImbalanceCalculator({
       method: WithdrawalFeePriceMethod.proportionalOnImbalance,
-      sinceDaysAgo: 1 as Days,
+      sinceDaysAgo: ONE_DAY,
       volumeLightningFn: ledger.lightningTxBaseVolumeSince,
       volumeOnChainFn: ledger.onChainTxBaseVolumeSince,
     })

--- a/test/integration/02-user-wallet/02-send-lightning-limits.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning-limits.spec.ts
@@ -1,0 +1,123 @@
+import { Payments, Wallets } from "@app"
+import { getMidPriceRatio } from "@app/shared"
+
+import { getDealerConfig } from "@config"
+
+import { LimitsExceededError } from "@domain/errors"
+import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
+
+import {
+  checkIsBalanced,
+  createInvoice,
+  createUserAndWalletFromUserRef,
+  getAccountByTestUserRef,
+  getDefaultWalletIdByTestUserRef,
+  lndOutside1,
+} from "test/helpers"
+
+jest.mock("@app/prices/get-current-price", () => require("test/mocks/get-current-price"))
+
+jest.mock("@services/dealer-price", () => require("test/mocks/dealer-price"))
+
+const accountLimits: IAccountLimits = {
+  intraLedgerLimit: 100 as UsdCents,
+  withdrawalLimit: 100 as UsdCents,
+  tradeIntraAccountLimit: 100 as UsdCents,
+}
+
+jest.mock("@config", () => {
+  return {
+    ...jest.requireActual("@config"),
+    getAccountLimits: jest.fn().mockReturnValue({
+      intraLedgerLimit: 100 as UsdCents,
+      withdrawalLimit: 100 as UsdCents,
+      tradeIntraAccountLimit: 100 as UsdCents,
+    }),
+  }
+})
+
+const usdHedgeEnabled = getDealerConfig().usd.hedgingEnabled
+
+let accountB: Account
+
+let walletIdA: WalletId
+let walletIdB: WalletId
+
+beforeAll(async () => {
+  await createUserAndWalletFromUserRef("A")
+  await createUserAndWalletFromUserRef("B")
+
+  accountB = await getAccountByTestUserRef("B")
+
+  walletIdA = await getDefaultWalletIdByTestUserRef("A")
+  walletIdB = await getDefaultWalletIdByTestUserRef("B")
+})
+
+afterEach(async () => {
+  await checkIsBalanced()
+})
+
+afterAll(() => {
+  jest.restoreAllMocks()
+})
+
+describe("UserWallet Limits - Lightning Pay", () => {
+  it("fails to pay when withdrawalLimit exceeded", async () => {
+    const usdAmountAboveThreshold = paymentAmountFromNumber({
+      amount: accountLimits.withdrawalLimit + 1,
+      currency: WalletCurrency.Usd,
+    })
+    expect(usdAmountAboveThreshold).not.toBeInstanceOf(Error)
+    if (usdAmountAboveThreshold instanceof Error) throw usdAmountAboveThreshold
+
+    const midPriceRatio = await getMidPriceRatio(usdHedgeEnabled)
+    if (midPriceRatio instanceof Error) throw midPriceRatio
+    const btcThresholdAmount = midPriceRatio.convertFromUsd(usdAmountAboveThreshold)
+
+    const { request } = await createInvoice({
+      lnd: lndOutside1,
+      tokens: Number(btcThresholdAmount.amount),
+    })
+    const paymentResult = await Payments.payInvoiceByWalletId({
+      uncheckedPaymentRequest: request,
+      memo: null,
+      senderWalletId: walletIdB,
+      senderAccount: accountB,
+    })
+
+    expect(paymentResult).toBeInstanceOf(LimitsExceededError)
+    const expectedError = `Cannot transfer more than ${accountLimits.withdrawalLimit} cents in 24 hours`
+    expect((paymentResult as Error).message).toBe(expectedError)
+  })
+
+  it("fails to pay when amount exceeds intraLedger limit", async () => {
+    const usdAmountAboveThreshold = paymentAmountFromNumber({
+      amount: accountLimits.intraLedgerLimit + 1,
+      currency: WalletCurrency.Usd,
+    })
+    expect(usdAmountAboveThreshold).not.toBeInstanceOf(Error)
+    if (usdAmountAboveThreshold instanceof Error) throw usdAmountAboveThreshold
+
+    const midPriceRatio = await getMidPriceRatio(usdHedgeEnabled)
+    if (midPriceRatio instanceof Error) throw midPriceRatio
+    const btcThresholdAmount = midPriceRatio.convertFromUsd(usdAmountAboveThreshold)
+
+    const lnInvoice = await Wallets.addInvoiceForSelf({
+      walletId: walletIdA as WalletId,
+      amount: Number(btcThresholdAmount.amount),
+    })
+    if (lnInvoice instanceof Error) throw lnInvoice
+    const { paymentRequest: request } = lnInvoice
+
+    const paymentResult = await Payments.payInvoiceByWalletId({
+      uncheckedPaymentRequest: request,
+      memo: null,
+      senderWalletId: walletIdB,
+      senderAccount: accountB,
+    })
+
+    expect(paymentResult).toBeInstanceOf(LimitsExceededError)
+    const expectedError = `Cannot transfer more than ${accountLimits.intraLedgerLimit} cents in 24 hours`
+    expect((paymentResult as Error).message).toBe(expectedError)
+  })
+})

--- a/test/integration/02-user-wallet/02-send-lightning-limits.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning-limits.spec.ts
@@ -27,6 +27,8 @@ jest.mock("@app/prices/get-current-price", () => require("test/mocks/get-current
 jest.mock("@services/dealer-price", () => require("test/mocks/dealer-price"))
 
 const MOCKED_LIMIT = 100 as UsdCents
+const AMOUNT_ABOVE_THRESHOLD = 10 as UsdCents
+const MOCKED_BALANCE_ABOVE_THRESHOLD = (MOCKED_LIMIT + 20) as UsdCents
 const accountLimits: IAccountLimits = {
   intraLedgerLimit: MOCKED_LIMIT,
   withdrawalLimit: MOCKED_LIMIT,
@@ -287,11 +289,12 @@ describe("UserWallet Limits - Lightning Pay", () => {
       // Create new wallet
       const newWallet = await createAndFundNewWalletForPhone({
         phone,
-        balanceAmount: await btcAmountFromUsdNumber(MOCKED_LIMIT + 20),
+        balanceAmount: await btcAmountFromUsdNumber(MOCKED_BALANCE_ABOVE_THRESHOLD),
       })
 
       // Test limits
-      const usdAmountAboveThreshold = accountLimits.withdrawalLimit + 10
+      const usdAmountAboveThreshold =
+        accountLimits.withdrawalLimit + AMOUNT_ABOVE_THRESHOLD
       const btcThresholdAmount = await btcAmountFromUsdNumber(usdAmountAboveThreshold)
 
       const senderAccount = await AccountsRepository().findById(newWallet.accountId)
@@ -307,11 +310,12 @@ describe("UserWallet Limits - Lightning Pay", () => {
       // Create new wallet
       const newWallet = await createAndFundNewWalletForPhone({
         phone,
-        balanceAmount: await btcAmountFromUsdNumber(MOCKED_LIMIT + 20),
+        balanceAmount: await btcAmountFromUsdNumber(MOCKED_BALANCE_ABOVE_THRESHOLD),
       })
 
       // Test limits
-      const usdAmountAboveThreshold = accountLimits.intraLedgerLimit + 10
+      const usdAmountAboveThreshold =
+        accountLimits.intraLedgerLimit + AMOUNT_ABOVE_THRESHOLD
       const btcThresholdAmount = await btcAmountFromUsdNumber(usdAmountAboveThreshold)
 
       const senderAccount = await AccountsRepository().findById(newWallet.accountId)
@@ -325,7 +329,7 @@ describe("UserWallet Limits - Lightning Pay", () => {
 
     it("fails to pay when amount exceeds tradeIntraAccount limit", async () => {
       const usdFundingAmount = paymentAmountFromNumber({
-        amount: MOCKED_LIMIT + 20,
+        amount: MOCKED_BALANCE_ABOVE_THRESHOLD,
         currency: WalletCurrency.Usd,
       })
       if (usdFundingAmount instanceof Error) throw usdFundingAmount
@@ -342,7 +346,8 @@ describe("UserWallet Limits - Lightning Pay", () => {
       })
 
       // Test limits
-      const usdAmountAboveThreshold = accountLimits.tradeIntraAccountLimit + 10
+      const usdAmountAboveThreshold =
+        accountLimits.tradeIntraAccountLimit + AMOUNT_ABOVE_THRESHOLD
       const btcThresholdAmount = await btcAmountFromUsdNumber(usdAmountAboveThreshold)
 
       const senderAccount = await AccountsRepository().findById(newBtcWallet.accountId)
@@ -365,14 +370,14 @@ describe("UserWallet Limits - Lightning Pay", () => {
 
       // Create new wallet
       const usdFundingAmount = paymentAmountFromNumber({
-        amount: MOCKED_LIMIT + 20,
+        amount: MOCKED_BALANCE_ABOVE_THRESHOLD,
         currency: WalletCurrency.Usd,
       })
       if (usdFundingAmount instanceof Error) throw usdFundingAmount
 
       const newBtcWallet = await createAndFundNewWalletForPhone({
         phone,
-        balanceAmount: await btcAmountFromUsdNumber(MOCKED_LIMIT + 20),
+        balanceAmount: await btcAmountFromUsdNumber(MOCKED_BALANCE_ABOVE_THRESHOLD),
       })
 
       const newUsdWallet = await createAndFundNewWalletForPhone({
@@ -385,7 +390,7 @@ describe("UserWallet Limits - Lightning Pay", () => {
       const partialUsdSendAmount = Math.floor(accountLimits[limit] / SPLITS)
       const partialBtcSendAmount = await btcAmountFromUsdNumber(partialUsdSendAmount)
 
-      const usdAmountAboveThreshold = 10
+      const usdAmountAboveThreshold = AMOUNT_ABOVE_THRESHOLD
       const btcAmountAboveThreshold = await btcAmountFromUsdNumber(
         usdAmountAboveThreshold,
       )

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -113,14 +113,17 @@ jest.mock("@config", () => {
       .mockReturnValueOnce({
         intraLedgerLimit: 100 as UsdCents,
         withdrawalLimit: 100 as UsdCents,
+        tradeIntraAccountLimit: 100 as UsdCents,
       })
       .mockReturnValueOnce({
         intraLedgerLimit: 100 as UsdCents,
         withdrawalLimit: 100 as UsdCents,
+        tradeIntraAccountLimit: 100 as UsdCents,
       })
       .mockReturnValue({
         intraLedgerLimit: 100_000 as UsdCents,
         withdrawalLimit: 100_000 as UsdCents,
+        tradeIntraAccountLimit: 100_000 as UsdCents,
       }),
   }
 })

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -1495,7 +1495,11 @@ describe("UserWallet - Lightning Pay", () => {
         if (midPriceRatio instanceof Error) return midPriceRatio
 
         const remainingLimitAmount = await newGetRemainingTwoFALimit({
-          walletDescriptor: { id: walletIdA, currency: WalletCurrency.Btc },
+          walletDescriptor: {
+            id: walletIdA,
+            currency: WalletCurrency.Btc,
+            accountId: accountA.id,
+          },
           priceRatio: midPriceRatio,
         })
         if (remainingLimitAmount instanceof Error) throw Error

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -5,7 +5,7 @@ import { getMidPriceRatio } from "@app/shared"
 
 import { delete2fa } from "@app/users"
 
-import { getDealerConfig, getDisplayCurrencyConfig, getLocale } from "@config"
+import { getDealerConfig, getDisplayCurrencyConfig, getLocale, ONE_DAY } from "@config"
 
 import { toSats } from "@domain/bitcoin"
 import {
@@ -460,7 +460,7 @@ describe("UserWallet - Lightning Pay", () => {
   it("pay zero amount invoice", async () => {
     const imbalanceCalc = ImbalanceCalculator({
       method: WithdrawalFeePriceMethod.proportionalOnImbalance,
-      sinceDaysAgo: 1 as Days,
+      sinceDaysAgo: ONE_DAY,
       volumeLightningFn: LedgerService().lightningTxBaseVolumeSince,
       volumeOnChainFn: LedgerService().onChainTxBaseVolumeSince,
     })
@@ -581,7 +581,7 @@ describe("UserWallet - Lightning Pay", () => {
   it("pay zero amount invoice with amount less than 1 cent", async () => {
     const imbalanceCalc = ImbalanceCalculator({
       method: WithdrawalFeePriceMethod.proportionalOnImbalance,
-      sinceDaysAgo: 1 as Days,
+      sinceDaysAgo: ONE_DAY,
       volumeLightningFn: LedgerService().lightningTxBaseVolumeSince,
       volumeOnChainFn: LedgerService().onChainTxBaseVolumeSince,
     })

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -102,6 +102,7 @@ jest.mock("@services/dealer-price", () => require("test/mocks/dealer-price"))
 const accountLimits: IAccountLimits = {
   intraLedgerLimit: 100 as UsdCents,
   withdrawalLimit: 100 as UsdCents,
+  tradeIntraAccountLimit: 100 as UsdCents,
 }
 
 jest.mock("@config", () => {

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -5,9 +5,9 @@ import {
   getFeesConfig,
   getOnChainWalletConfig,
   getAccountLimits,
-  MS_PER_DAY,
   getLocale,
   getDisplayCurrencyConfig,
+  ONE_DAY,
 } from "@config"
 import { toSats, toTargetConfs } from "@domain/bitcoin"
 import { PaymentSendStatus } from "@domain/bitcoin/lightning"
@@ -24,7 +24,7 @@ import { PaymentInitiationMethod, SettlementMethod, TxStatus } from "@domain/wal
 import { onchainTransactionEventHandler } from "@servers/trigger"
 import { LedgerService } from "@services/ledger"
 import { baseLogger } from "@services/logger"
-import { sleep } from "@utils"
+import { sleep, timestampDaysAgo } from "@utils"
 
 import { getCurrentPrice } from "@app/prices"
 
@@ -635,7 +635,9 @@ describe("UserWallet - onChainPay", () => {
     })
 
     const ledgerService = LedgerService()
-    const timestamp1DayAgo = new Date(Date.now() - MS_PER_DAY)
+    const timestamp1DayAgo = timestampDaysAgo(ONE_DAY)
+    if (timestamp1DayAgo instanceof Error) return timestamp1DayAgo
+
     const walletVolume = await ledgerService.externalPaymentVolumeSince({
       walletId: walletIdA,
       timestamp: timestamp1DayAgo,
@@ -701,6 +703,7 @@ describe("UserWallet - onChainPay", () => {
         walletId: walletIdA,
         satsToCents: dCConverter.fromSatsToCents,
       })
+      if (remainingLimit instanceof Error) throw remainingLimit
 
       const aboveThreshold = add(remainingLimit, toCents(10))
 

--- a/test/integration/notifications/notification.spec.ts
+++ b/test/integration/notifications/notification.spec.ts
@@ -55,6 +55,7 @@ describe("notification", () => {
         const user = await UsersRepository().findById(ownerId)
         if (user instanceof Error) throw user
 
+        expect(user.deviceTokens).not.toHaveLength(0)
         if (user.deviceTokens && user.deviceTokens.length > 0) usersWithDeviceTokens++
       }
 

--- a/test/integration/notifications/notification.spec.ts
+++ b/test/integration/notifications/notification.spec.ts
@@ -55,7 +55,6 @@ describe("notification", () => {
         const user = await UsersRepository().findById(ownerId)
         if (user instanceof Error) throw user
 
-        expect(user.deviceTokens).not.toHaveLength(0)
         if (user.deviceTokens && user.deviceTokens.length > 0) usersWithDeviceTokens++
       }
 

--- a/test/integration/services/ledger/helpers.ts
+++ b/test/integration/services/ledger/helpers.ts
@@ -235,6 +235,88 @@ export const recordOnChainIntraLedgerPayment = async ({
   })
 }
 
+export const recordLnTradeIntraAccountTxn = async ({
+  senderWalletDescriptor,
+  recipientWalletDescriptor,
+  paymentAmount,
+}) => {
+  const { metadata, debitAccountAdditionalMetadata } =
+    LedgerFacade.LnTradeIntraAccountLedgerMetadata({
+      paymentHash: crypto.randomUUID() as PaymentHash,
+      amountDisplayCurrency: Number(
+        paymentAmount.usd.amount,
+      ) as DisplayCurrencyBaseAmount,
+      feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+      displayCurrency: DisplayCurrency.Usd,
+      pubkey: crypto.randomUUID() as Pubkey,
+      paymentFlow: {
+        btcPaymentAmount: paymentAmount.btc,
+        usdPaymentAmount: paymentAmount.usd,
+        btcProtocolFee: ZERO_SATS,
+        usdProtocolFee: ZERO_CENTS,
+      } as PaymentFlowState<WalletCurrency, WalletCurrency>,
+    })
+
+  return LedgerFacade.recordIntraledger({
+    description: "sends/receives ln trade",
+    amount: paymentAmount,
+    senderWalletDescriptor,
+    recipientWalletDescriptor,
+    metadata,
+    additionalDebitMetadata: debitAccountAdditionalMetadata,
+  })
+}
+
+export const recordWalletIdTradeIntraAccountTxn = async ({
+  senderWalletDescriptor,
+  recipientWalletDescriptor,
+  paymentAmount,
+}) => {
+  const metadata = LedgerFacade.WalletIdTradeIntraAccountLedgerMetadata({
+    amountDisplayCurrency: Number(paymentAmount.usd.amount) as DisplayCurrencyBaseAmount,
+    feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+    displayCurrency: DisplayCurrency.Usd,
+    paymentFlow: {
+      btcPaymentAmount: paymentAmount.btc,
+      usdPaymentAmount: paymentAmount.usd,
+      btcProtocolFee: ZERO_SATS,
+      usdProtocolFee: ZERO_CENTS,
+    } as PaymentFlowState<WalletCurrency, WalletCurrency>,
+  })
+
+  return LedgerFacade.recordIntraledger({
+    description: "sends/receives walletId trade",
+    amount: paymentAmount,
+    senderWalletDescriptor,
+    recipientWalletDescriptor,
+    metadata,
+    additionalDebitMetadata: {},
+  })
+}
+
+export const recordOnChainTradeIntraAccountTxn = async ({
+  senderWalletDescriptor,
+  recipientWalletDescriptor,
+  paymentAmount,
+}) => {
+  const { metadata, debitAccountAdditionalMetadata } =
+    LedgerFacade.OnChainTradeIntraAccountLedgerMetadata({
+      amountDisplayCurrency: Number(
+        paymentAmount.usd.amount,
+      ) as DisplayCurrencyBaseAmount,
+      sendAll: false,
+      payeeAddresses: ["address1" as OnChainAddress],
+    })
+
+  return LedgerFacade.recordIntraledger({
+    description: "sends/receives onchain trade",
+    amount: paymentAmount,
+    senderWalletDescriptor,
+    recipientWalletDescriptor,
+    metadata,
+    additionalDebitMetadata: debitAccountAdditionalMetadata,
+  })
+}
 // Non-LedgerFacade helpers from legacy admin service
 // ======
 

--- a/test/integration/services/ledger/helpers.ts
+++ b/test/integration/services/ledger/helpers.ts
@@ -66,7 +66,10 @@ export const recordReceiveOnChainPayment = async ({
   })
 }
 
-export const recordSendLnPayment = async ({
+export const recordSendLnPayment = async <
+  S extends WalletCurrency,
+  R extends WalletCurrency,
+>({
   walletDescriptor,
   paymentAmount,
   bankFee,
@@ -83,7 +86,7 @@ export const recordSendLnPayment = async ({
       usdPaymentAmount: paymentAmount.usd,
       btcProtocolFee: bankFee.btc,
       usdProtocolFee: bankFee.usd,
-    } as PaymentFlowState<WalletCurrency, WalletCurrency>,
+    } as PaymentFlowState<S, R>,
   })
 
   return LedgerFacade.recordSend({
@@ -118,7 +121,10 @@ export const recordSendOnChainPayment = async ({
   })
 }
 
-export const recordLnFeeReimbursement = async ({
+export const recordLnFeeReimbursement = async <
+  S extends WalletCurrency,
+  R extends WalletCurrency,
+>({
   walletDescriptor,
   paymentAmount,
   bankFee,
@@ -135,7 +141,7 @@ export const recordLnFeeReimbursement = async ({
       usdPaymentAmount: paymentAmount.usd,
       btcProtocolFee: bankFee.btc,
       usdProtocolFee: bankFee.usd,
-    } as PaymentFlowState<WalletCurrency, WalletCurrency>,
+    } as PaymentFlowState<S, R>,
     journalId: "031a419636dbf6d25981d6d2" as LedgerJournalId,
   })
 
@@ -149,7 +155,10 @@ export const recordLnFeeReimbursement = async ({
   })
 }
 
-export const recordLnIntraLedgerPayment = async ({
+export const recordLnIntraLedgerPayment = async <
+  S extends WalletCurrency,
+  R extends WalletCurrency,
+>({
   senderWalletDescriptor,
   recipientWalletDescriptor,
   paymentAmount,
@@ -168,7 +177,7 @@ export const recordLnIntraLedgerPayment = async ({
         usdPaymentAmount: paymentAmount.usd,
         btcProtocolFee: ZERO_SATS,
         usdProtocolFee: ZERO_CENTS,
-      } as PaymentFlowState<WalletCurrency, WalletCurrency>,
+      } as PaymentFlowState<S, R>,
     })
 
   return LedgerFacade.recordIntraledger({
@@ -181,7 +190,10 @@ export const recordLnIntraLedgerPayment = async ({
   })
 }
 
-export const recordWalletIdIntraLedgerPayment = async ({
+export const recordWalletIdIntraLedgerPayment = async <
+  S extends WalletCurrency,
+  R extends WalletCurrency,
+>({
   senderWalletDescriptor,
   recipientWalletDescriptor,
   paymentAmount,
@@ -198,7 +210,7 @@ export const recordWalletIdIntraLedgerPayment = async ({
         usdPaymentAmount: paymentAmount.usd,
         btcProtocolFee: ZERO_SATS,
         usdProtocolFee: ZERO_CENTS,
-      } as PaymentFlowState<WalletCurrency, WalletCurrency>,
+      } as PaymentFlowState<S, R>,
     })
 
   return LedgerFacade.recordIntraledger({

--- a/test/integration/services/ledger/service.spec.ts
+++ b/test/integration/services/ledger/service.spec.ts
@@ -334,11 +334,6 @@ describe("Volumes", () => {
       ToHotWallet: () => testExternalTxSendWLE({ recordTx: recordColdStorageTxSend }),
       ToColdStorage: () =>
         testExternalTxSendWLE({ recordTx: recordColdStorageTxReceive }),
-
-      // Not used:
-      ExchangeRebalance: () => undefined,
-      UserRebalance: () => undefined,
-      OnchainDepositFee: () => undefined,
     }
 
     // Setting up all 'it' tests for each txn type, to check volume is NOT affected
@@ -378,11 +373,6 @@ describe("Volumes", () => {
         testInternalTxReceiveNLE({
           recordTx: recordLnIntraLedgerPayment,
         }),
-
-      // Not used
-      ExchangeRebalance: () => undefined,
-      UserRebalance: () => undefined,
-      OnchainDepositFee: () => undefined,
     }
 
     // Execute tests for specific types included

--- a/test/integration/services/ledger/service.spec.ts
+++ b/test/integration/services/ledger/service.spec.ts
@@ -378,6 +378,7 @@ describe("Volumes", () => {
     // Execute tests for specific types included
     describe("correctly registers transactions amount", () => {
       for (const txType of includedTypes) {
+        expect(Object.keys(txFnsForIncludedTypes)).toContain(txType)
         txFnsForIncludedTypes[txType]()
       }
     })
@@ -385,6 +386,7 @@ describe("Volumes", () => {
     // Execute tests for rest of types excluded
     describe("correctly ignores all other transaction types", () => {
       for (const txType of excludedTypes) {
+        expect(Object.keys(txFnsForExcludedTypes)).toContain(txType)
         txFnsForExcludedTypes[txType]()
       }
     })

--- a/test/integration/services/ledger/service.spec.ts
+++ b/test/integration/services/ledger/service.spec.ts
@@ -1,6 +1,6 @@
 import crypto from "crypto"
 
-import { MS_PER_DAY } from "@config"
+import { ONE_DAY } from "@config"
 
 import {
   AmountCalculator,
@@ -12,7 +12,7 @@ import { LedgerTransactionType } from "@domain/ledger"
 
 import { LedgerService } from "@services/ledger"
 
-import { ModifiedSet } from "@utils"
+import { ModifiedSet, timestampDaysAgo } from "@utils"
 
 import {
   recordLnIntraLedgerPayment,
@@ -81,7 +81,9 @@ const {
 } = ExtendedLedgerTransactionType
 
 describe("Volumes", () => {
-  const timestamp1DayAgo = new Date(Date.now() - MS_PER_DAY)
+  const timestamp1DayAgo = timestampDaysAgo(ONE_DAY)
+  if (timestamp1DayAgo instanceof Error) return timestamp1DayAgo
+
   const walletDescriptor = BtcWalletDescriptor(crypto.randomUUID() as WalletId)
   const walletDescriptorOther = UsdWalletDescriptor(crypto.randomUUID() as WalletId)
 

--- a/test/integration/services/ledger/service.spec.ts
+++ b/test/integration/services/ledger/service.spec.ts
@@ -29,6 +29,9 @@ import {
   recordLnRoutingRevenue,
   recordColdStorageTxReceive,
   recordColdStorageTxSend,
+  recordWalletIdTradeIntraAccountTxn,
+  recordOnChainTradeIntraAccountTxn,
+  recordLnTradeIntraAccountTxn,
 } from "./helpers"
 
 const ledgerService = LedgerService()
@@ -42,6 +45,14 @@ const FullLedgerTransactionType = {
   LnIntraLedgerReceive: LedgerTransactionType.LnIntraLedger,
   OnchainIntraLedgerSend: LedgerTransactionType.OnchainIntraLedger,
   OnchainIntraLedgerReceive: LedgerTransactionType.OnchainIntraLedger,
+
+  WalletIdTradeIntraAccountOut: LedgerTransactionType.WalletIdTradeIntraAccount,
+  WalletIdTradeIntraAccountIn: LedgerTransactionType.WalletIdTradeIntraAccount,
+  LnTradeIntraAccountOut: LedgerTransactionType.LnTradeIntraAccount,
+  LnTradeIntraAccountIn: LedgerTransactionType.LnTradeIntraAccount,
+  OnChainTradeIntraAccountOut: LedgerTransactionType.OnChainTradeIntraAccount,
+  OnChainTradeIntraAccountIn: LedgerTransactionType.OnChainTradeIntraAccount,
+
   EscrowCredit: LedgerTransactionType.Escrow,
   EscrowDebit: LedgerTransactionType.Escrow,
 } as const
@@ -50,6 +61,9 @@ const {
   IntraLedger, // eslint-disable-line @typescript-eslint/no-unused-vars
   LnIntraLedger, // eslint-disable-line @typescript-eslint/no-unused-vars
   OnchainIntraLedger, // eslint-disable-line @typescript-eslint/no-unused-vars
+  WalletIdTradeIntraAccount, // eslint-disable-line @typescript-eslint/no-unused-vars
+  LnTradeIntraAccount, // eslint-disable-line @typescript-eslint/no-unused-vars
+  OnChainTradeIntraAccount, // eslint-disable-line @typescript-eslint/no-unused-vars
   Escrow, // eslint-disable-line @typescript-eslint/no-unused-vars
 
   ...ExtendedLedgerTransactionType
@@ -325,6 +339,30 @@ describe("Volumes", () => {
         testInternalTxReceiveWLE({
           recordTx: recordLnIntraLedgerPayment,
         }),
+      WalletIdTradeIntraAccountOut: () =>
+        testInternalTxSendWLE({
+          recordTx: recordWalletIdTradeIntraAccountTxn,
+        }),
+      LnTradeIntraAccountOut: () =>
+        testInternalTxSendWLE({
+          recordTx: recordLnTradeIntraAccountTxn,
+        }),
+      OnChainTradeIntraAccountOut: () =>
+        testInternalTxSendWLE({
+          recordTx: recordOnChainTradeIntraAccountTxn,
+        }),
+      WalletIdTradeIntraAccountIn: () =>
+        testInternalTxReceiveWLE({
+          recordTx: recordWalletIdTradeIntraAccountTxn,
+        }),
+      LnTradeIntraAccountIn: () =>
+        testInternalTxReceiveWLE({
+          recordTx: recordLnTradeIntraAccountTxn,
+        }),
+      OnChainTradeIntraAccountIn: () =>
+        testInternalTxReceiveWLE({
+          recordTx: recordOnChainTradeIntraAccountTxn,
+        }),
 
       // Used, but no volume checks yet:
       Fee: () => testExternalTxSendWLE({ recordTx: recordLnChannelOpenOrClosingFee }),
@@ -372,6 +410,30 @@ describe("Volumes", () => {
       LnIntraLedgerReceive: () =>
         testInternalTxReceiveNLE({
           recordTx: recordLnIntraLedgerPayment,
+        }),
+      WalletIdTradeIntraAccountOut: () =>
+        testInternalTxSendNLE({
+          recordTx: recordWalletIdTradeIntraAccountTxn,
+        }),
+      LnTradeIntraAccountOut: () =>
+        testInternalTxSendNLE({
+          recordTx: recordLnTradeIntraAccountTxn,
+        }),
+      OnChainTradeIntraAccountOut: () =>
+        testInternalTxSendNLE({
+          recordTx: recordOnChainTradeIntraAccountTxn,
+        }),
+      WalletIdTradeIntraAccountIn: () =>
+        testInternalTxReceiveNLE({
+          recordTx: recordWalletIdTradeIntraAccountTxn,
+        }),
+      LnTradeIntraAccountIn: () =>
+        testInternalTxReceiveNLE({
+          recordTx: recordLnTradeIntraAccountTxn,
+        }),
+      OnChainTradeIntraAccountIn: () =>
+        testInternalTxReceiveNLE({
+          recordTx: recordOnChainTradeIntraAccountTxn,
         }),
     }
 

--- a/test/integration/services/ledger/service.spec.ts
+++ b/test/integration/services/ledger/service.spec.ts
@@ -496,6 +496,22 @@ describe("Volumes", () => {
     })
   })
 
+  describe("Intra-account trade volumes", () => {
+    executeVolumeTests({
+      // Note: Including '...In' types as well would double-count volumes
+      includedTxTypes: [
+        "WalletIdTradeIntraAccountOut",
+        "OnChainTradeIntraAccountOut",
+        "LnTradeIntraAccountOut",
+      ],
+      fetchVolumeAmount: getFetchVolumeAmountFn({
+        volumeFn: ledgerService.tradeIntraAccountTxBaseVolumeSince,
+        volumeAmountFn: ledgerService.tradeIntraAccountTxBaseVolumeAmountSince,
+        volumeType: VolumeType.Out,
+      }),
+    })
+  })
+
   describe("All activity", () => {
     const includedTxTypes = Object.keys(
       UserLedgerTransactionType,

--- a/test/integration/services/lnd/utils.spec.ts
+++ b/test/integration/services/lnd/utils.spec.ts
@@ -1,10 +1,10 @@
-import { MS_PER_DAY } from "@config"
+import { MS_PER_DAY, ONE_DAY } from "@config"
 import { deleteExpiredWalletInvoice, updateRoutingRevenues } from "@services/lnd/utils"
 import { baseLogger } from "@services/logger"
 import { ledgerAdmin } from "@services/mongodb"
 import { DbMetadata, WalletInvoice } from "@services/mongoose/schema"
 
-import { sleep } from "@utils"
+import { sleep, timestampDaysAgo } from "@utils"
 
 import {
   cancelHodlInvoice,
@@ -98,7 +98,8 @@ describe("lndUtils", () => {
     const startDate = new Date(0)
     startDate.setUTCHours(0, 0, 0, 0)
 
-    const endDate = new Date(Date.now() - MS_PER_DAY)
+    const endDate = timestampDaysAgo(ONE_DAY)
+    if (endDate instanceof Error) return endDate
     endDate.setUTCHours(0, 0, 0, 0)
 
     const after = startDate.toISOString()

--- a/test/unit/app/payments/translations.spec.ts
+++ b/test/unit/app/payments/translations.spec.ts
@@ -18,7 +18,9 @@ describe("PaymentFlowFromLedgerTransaction", () => {
 
   const timestamp = new Date()
 
-  const ledgerTxBase = {
+  const senderAccountId = "accountId" as AccountId
+
+  const ledgerTxnBase = {
     walletId: "walletId" as WalletId,
     paymentHash: "paymentHash" as PaymentHash,
     satsAmount,
@@ -59,11 +61,11 @@ describe("PaymentFlowFromLedgerTransaction", () => {
   }
 
   it("builds correct PaymentFlow from btc transaction", () => {
-    const ledgerTx = {
-      ...ledgerTxBase,
+    const ledgerTxn = {
+      ...ledgerTxnBase,
       currency: WalletCurrency.Btc,
     } as LedgerTransaction<WalletCurrency>
-    const paymentFlow = PaymentFlowFromLedgerTransaction(ledgerTx)
+    const paymentFlow = PaymentFlowFromLedgerTransaction({ ledgerTxn, senderAccountId })
     expect(paymentFlow).not.toBeInstanceOf(Error)
 
     const expectedPaymentFlowState = {
@@ -75,11 +77,11 @@ describe("PaymentFlowFromLedgerTransaction", () => {
   })
 
   it("builds correct PaymentFlow from usd transaction", () => {
-    const ledgerTx = {
-      ...ledgerTxBase,
+    const ledgerTxn = {
+      ...ledgerTxnBase,
       currency: WalletCurrency.Usd,
     } as LedgerTransaction<WalletCurrency>
-    const paymentFlow = PaymentFlowFromLedgerTransaction(ledgerTx)
+    const paymentFlow = PaymentFlowFromLedgerTransaction({ ledgerTxn, senderAccountId })
     expect(paymentFlow).not.toBeInstanceOf(Error)
 
     const expectedPaymentFlowState = {
@@ -91,13 +93,13 @@ describe("PaymentFlowFromLedgerTransaction", () => {
   })
 
   it("handles zero fee btc transaction", () => {
-    const ledgerTx = {
-      ...ledgerTxBase,
+    const ledgerTxn = {
+      ...ledgerTxnBase,
       currency: WalletCurrency.Btc,
       satsFee: toSats(0),
       centsFee: toCents(0),
     } as LedgerTransaction<WalletCurrency>
-    const paymentFlow = PaymentFlowFromLedgerTransaction(ledgerTx)
+    const paymentFlow = PaymentFlowFromLedgerTransaction({ ledgerTxn, senderAccountId })
     expect(paymentFlow).not.toBeInstanceOf(Error)
 
     const expectedPaymentFlowState = {
@@ -117,13 +119,13 @@ describe("PaymentFlowFromLedgerTransaction", () => {
   })
 
   it("handles zero fee usd transaction", () => {
-    const ledgerTx = {
-      ...ledgerTxBase,
+    const ledgerTxn = {
+      ...ledgerTxnBase,
       currency: WalletCurrency.Usd,
       satsFee: toSats(0),
       centsFee: toCents(0),
     } as LedgerTransaction<WalletCurrency>
-    const paymentFlow = PaymentFlowFromLedgerTransaction(ledgerTx)
+    const paymentFlow = PaymentFlowFromLedgerTransaction({ ledgerTxn, senderAccountId })
     expect(paymentFlow).not.toBeInstanceOf(Error)
 
     const expectedPaymentFlowState = {
@@ -143,20 +145,20 @@ describe("PaymentFlowFromLedgerTransaction", () => {
   })
 
   it("returns error for transaction with missing walletId", () => {
-    const ledgerTx = {
-      ...ledgerTxBase,
+    const ledgerTxn = {
+      ...ledgerTxnBase,
       walletId: undefined,
     } as LedgerTransaction<WalletCurrency>
-    const paymentFlow = PaymentFlowFromLedgerTransaction(ledgerTx)
+    const paymentFlow = PaymentFlowFromLedgerTransaction({ ledgerTxn, senderAccountId })
     expect(paymentFlow).toBeInstanceOf(MissingPropsInTransactionForPaymentFlowError)
   })
 
   it("returns error for transaction with wrong type", () => {
-    const ledgerTx = {
-      ...ledgerTxBase,
+    const ledgerTxn = {
+      ...ledgerTxnBase,
       type: LedgerTransactionType.LnIntraLedger,
     } as LedgerTransaction<WalletCurrency>
-    const paymentFlow = PaymentFlowFromLedgerTransaction(ledgerTx)
+    const paymentFlow = PaymentFlowFromLedgerTransaction({ ledgerTxn, senderAccountId })
     expect(paymentFlow).toBeInstanceOf(NonLnPaymentTransactionForPaymentFlowError)
   })
 })

--- a/test/unit/config.spec.ts
+++ b/test/unit/config.spec.ts
@@ -21,6 +21,12 @@ const accountLimits = {
       2: toCents(100_000_000),
     },
   },
+  tradeIntraAccount: {
+    level: {
+      1: toCents(5_000_000),
+      2: toCents(100_000_000),
+    },
+  },
 }
 
 describe("config.ts", () => {
@@ -123,12 +129,14 @@ describe("config.ts", () => {
   describe("generates expected constants from a limits config object", () => {
     it("selects user limits for level 1", () => {
       const userLimits = getAccountLimits({ level: 1, accountLimits })
+      expect(userLimits.tradeIntraAccountLimit).toEqual(5_000_000)
       expect(userLimits.intraLedgerLimit).toEqual(5_000_000)
       expect(userLimits.withdrawalLimit).toEqual(2_000_000)
     })
 
     it("selects user limits for level 2", () => {
       const userLimits = getAccountLimits({ level: 2, accountLimits })
+      expect(userLimits.tradeIntraAccountLimit).toEqual(100_000_000)
       expect(userLimits.intraLedgerLimit).toEqual(100_000_000)
       expect(userLimits.withdrawalLimit).toEqual(100_000_000)
     })

--- a/test/unit/domain/ledger/imbalance-calculator.spec.ts
+++ b/test/unit/domain/ledger/imbalance-calculator.spec.ts
@@ -1,3 +1,4 @@
+import { ONE_DAY } from "@config"
 import { toSats } from "@domain/bitcoin"
 import { ImbalanceCalculator } from "@domain/ledger/imbalance-calculator"
 import { WalletCurrency } from "@domain/shared"
@@ -29,7 +30,7 @@ describe("ImbalanceCalculator", () => {
     it("return positive imbalance when receiving sats on ln", async () => {
       const calculator = ImbalanceCalculator({
         method,
-        sinceDaysAgo: 1 as Days,
+        sinceDaysAgo: ONE_DAY,
         volumeLightningFn: VolumeAfterLightningReceiptFn,
         volumeOnChainFn: NoVolumeFn,
       })
@@ -40,7 +41,7 @@ describe("ImbalanceCalculator", () => {
     it("return negative imbalance when sending sats on ln", async () => {
       const calculator = ImbalanceCalculator({
         method,
-        sinceDaysAgo: 1 as Days,
+        sinceDaysAgo: ONE_DAY,
         volumeLightningFn: VolumeAfterLightningPaymentFn,
         volumeOnChainFn: NoVolumeFn,
       })
@@ -51,7 +52,7 @@ describe("ImbalanceCalculator", () => {
     it("return negative imbalance when receiving sats onchain", async () => {
       const calculator = ImbalanceCalculator({
         method,
-        sinceDaysAgo: 1 as Days,
+        sinceDaysAgo: ONE_DAY,
         volumeLightningFn: NoVolumeFn,
         volumeOnChainFn: VolumeAfterOnChainReceiptFn,
       })
@@ -62,7 +63,7 @@ describe("ImbalanceCalculator", () => {
     it("return positive imbalance when sending sats onchain", async () => {
       const calculator = ImbalanceCalculator({
         method,
-        sinceDaysAgo: 1 as Days,
+        sinceDaysAgo: ONE_DAY,
         volumeLightningFn: NoVolumeFn,
         volumeOnChainFn: VolumeAfterOnChainPaymentFn,
       })
@@ -73,7 +74,7 @@ describe("ImbalanceCalculator", () => {
     it("swap out increase imbalance", async () => {
       const calculator = ImbalanceCalculator({
         method,
-        sinceDaysAgo: 1 as Days,
+        sinceDaysAgo: ONE_DAY,
         volumeLightningFn: VolumeAfterLightningReceiptFn,
         volumeOnChainFn: VolumeAfterOnChainPaymentFn,
       })
@@ -84,7 +85,7 @@ describe("ImbalanceCalculator", () => {
     it("swap in reduce decrease imbalance", async () => {
       const calculator = ImbalanceCalculator({
         method,
-        sinceDaysAgo: 1 as Days,
+        sinceDaysAgo: ONE_DAY,
         volumeLightningFn: VolumeAfterLightningPaymentFn,
         volumeOnChainFn: VolumeAfterOnChainReceiptFn,
       })
@@ -99,7 +100,7 @@ describe("ImbalanceCalculator", () => {
     it("no imbalance with flat fees", async () => {
       const calculator = ImbalanceCalculator({
         method,
-        sinceDaysAgo: 1 as Days,
+        sinceDaysAgo: ONE_DAY,
         volumeLightningFn: VolumeAfterLightningReceiptFn,
         volumeOnChainFn: NoVolumeFn,
       })

--- a/test/unit/domain/wallet-invoices/wallet-invoice-builder.spec.ts
+++ b/test/unit/domain/wallet-invoices/wallet-invoice-builder.spec.ts
@@ -7,11 +7,13 @@ describe("WalletInvoiceBuilder", () => {
   const recipientBtcWallet = {
     id: "recipientWalletId" as WalletId,
     currency: WalletCurrency.Btc,
+    accountId: "recipientAccountId" as AccountId,
     username: "Username" as Username,
   }
   const recipientUsdWallet = {
     id: "recipientWalletId" as WalletId,
     currency: WalletCurrency.Usd,
+    accountId: "recipientAccountId" as AccountId,
     username: "Username" as Username,
   }
   const uncheckedAmount = 100

--- a/test/unit/payments/payment-flow-builder.spec.ts
+++ b/test/unit/payments/payment-flow-builder.spec.ts
@@ -26,19 +26,24 @@ describe("LightningPaymentFlowBuilder", () => {
   const senderBtcWallet = {
     id: "senderWalletId" as WalletId,
     currency: WalletCurrency.Btc,
-  }
+    accountId: "senderAccountId" as AccountId,
+  } as Wallet
+
   const recipientBtcWallet = {
     id: "recipientWalletId" as WalletId,
     currency: WalletCurrency.Btc,
+    accountId: "recipientAccountId" as AccountId,
     username: "Username" as Username,
   }
   const senderUsdWallet = {
     id: "walletId" as WalletId,
     currency: WalletCurrency.Usd,
-  }
+    accountId: "senderAccountId" as AccountId,
+  } as Wallet
   const recipientUsdWallet = {
     id: "recipientWalletId" as WalletId,
     currency: WalletCurrency.Usd,
+    accountId: "recipientAccountId" as AccountId,
     username: "Username" as Username,
   }
   const pubkey = "pubkey" as Pubkey

--- a/test/unit/payments/payment-flow.spec.ts
+++ b/test/unit/payments/payment-flow.spec.ts
@@ -15,6 +15,7 @@ describe("PaymentFlowFromLedgerTransaction", () => {
 
   const paymentFlowState: PaymentFlowState<WalletCurrency, WalletCurrency> = {
     senderWalletId: "walletId" as WalletId,
+    senderAccountId: "accountId" as AccountId,
     settlementMethod: SettlementMethod.Lightning,
     paymentInitiationMethod: PaymentInitiationMethod.Lightning,
 

--- a/test/unit/services/ledger/domain/tx-metadata.spec.ts
+++ b/test/unit/services/ledger/domain/tx-metadata.spec.ts
@@ -4,8 +4,11 @@ import { LedgerTransactionType } from "@domain/ledger"
 import { WalletCurrency, ZERO_CENTS, ZERO_SATS } from "@domain/shared"
 import {
   LnIntraledgerLedgerMetadata,
+  LnTradeIntraAccountLedgerMetadata,
   OnChainIntraledgerLedgerMetadata,
+  OnChainTradeIntraAccountLedgerMetadata,
   WalletIdIntraledgerLedgerMetadata,
+  WalletIdTradeIntraAccountLedgerMetadata,
 } from "@services/ledger/tx-metadata"
 
 describe("Tx metadata", () => {
@@ -56,6 +59,27 @@ describe("Tx metadata", () => {
         }),
       )
     })
+    it("onchain trade", () => {
+      const { metadata, debitAccountAdditionalMetadata } =
+        OnChainTradeIntraAccountLedgerMetadata({
+          amountDisplayCurrency,
+          payeeAddresses,
+          sendAll: true,
+          memoOfPayer,
+        })
+
+      expect(metadata).toEqual(
+        expect.objectContaining({
+          memoPayer: undefined,
+          type: LedgerTransactionType.OnChainTradeIntraAccount,
+        }),
+      )
+      expect(debitAccountAdditionalMetadata).toEqual(
+        expect.objectContaining({
+          memoPayer: memoOfPayer,
+        }),
+      )
+    })
 
     it("ln", () => {
       const { metadata, debitAccountAdditionalMetadata } = LnIntraledgerLedgerMetadata({
@@ -98,6 +122,44 @@ describe("Tx metadata", () => {
       )
     })
 
+    it("ln trade", () => {
+      const { metadata, debitAccountAdditionalMetadata } =
+        LnTradeIntraAccountLedgerMetadata({
+          paymentHash,
+          pubkey,
+          paymentFlow,
+
+          amountDisplayCurrency,
+          feeDisplayCurrency,
+          displayCurrency,
+
+          memoOfPayer,
+        })
+
+      expect(metadata).toEqual(
+        expect.objectContaining({
+          memoPayer: undefined,
+          type: LedgerTransactionType.LnTradeIntraAccount,
+
+          usd: (amountDisplayCurrency / 100) as DisplayCurrencyBaseAmount,
+
+          satsFee: toSats(0),
+          displayFee: feeDisplayCurrency,
+          displayAmount: amountDisplayCurrency,
+
+          displayCurrency,
+          centsAmount: toCents(10),
+          satsAmount: toSats(2000),
+          centsFee: toCents(0),
+        }),
+      )
+      expect(debitAccountAdditionalMetadata).toEqual(
+        expect.objectContaining({
+          memoPayer: memoOfPayer,
+        }),
+      )
+    })
+
     it("wallet id", () => {
       const { metadata, debitAccountAdditionalMetadata } =
         WalletIdIntraledgerLedgerMetadata({
@@ -133,6 +195,36 @@ describe("Tx metadata", () => {
       expect(debitAccountAdditionalMetadata).toEqual(
         expect.objectContaining({
           username: recipientUsername,
+        }),
+      )
+    })
+
+    it("wallet id trade", () => {
+      const metadata = WalletIdTradeIntraAccountLedgerMetadata({
+        paymentFlow,
+
+        feeDisplayCurrency,
+        amountDisplayCurrency,
+        displayCurrency,
+
+        memoOfPayer,
+      })
+
+      expect(metadata).toEqual(
+        expect.objectContaining({
+          memoPayer: memoOfPayer,
+          type: LedgerTransactionType.WalletIdTradeIntraAccount,
+
+          usd: (amountDisplayCurrency / 100) as DisplayCurrencyBaseAmount,
+
+          satsFee: toSats(0),
+          displayFee: feeDisplayCurrency,
+          displayAmount: amountDisplayCurrency,
+
+          displayCurrency,
+          centsAmount: toCents(10),
+          satsAmount: toSats(2000),
+          centsFee: toCents(0),
         }),
       )
     })


### PR DESCRIPTION
## Description

This PR is to separate self-trade transaction types from other intraledger transactions. The goal here is to have separate limits for self-trades vs. other intraledger transfers.

It also separates out a new "send-lightning-limits" test file and adds a comprehensive set of tests around limits (now possible because of #1518).

I also did some cleanup and added new methods to our integrations tests to generate wallets/accounts on the fly to make each limits test a bit more self-contained. Before now, we would use wallets that were previously instantiated and used in other tests which created dependencies across different testing functions.