### PR TITLE
fix: skip writing errors as serialized objects to cache

### DIFF
--- a/src/domain/cache/index.types.d.ts
+++ b/src/domain/cache/index.types.d.ts
@@ -5,7 +5,7 @@ type CacheKeys =
 
 type LocalCacheSetArgs<T> = {
   key: CacheKeys | string
-  value: T
+  value: NonError<T>
   ttlSecs: Seconds
 }
 

--- a/src/domain/index.types.d.ts
+++ b/src/domain/index.types.d.ts
@@ -1,0 +1,1 @@
+type NonError<T> = T extends Error ? never : T

--- a/src/services/cache/local-cache.ts
+++ b/src/services/cache/local-cache.ts
@@ -42,6 +42,11 @@ export const LocalCacheService = (): ICacheService => {
     if (!(cachedData instanceof Error)) return cachedData
 
     const data = await getForCaching()
+
+    // Typescript can't parse 'ReturnType<F>' to filter out 'Error' types
+    if (data instanceof Error) return data
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     set<ReturnType<F>>({ key, value: data, ttlSecs })
     return data
   }

--- a/src/services/cache/redis-cache.ts
+++ b/src/services/cache/redis-cache.ts
@@ -48,8 +48,11 @@ export const RedisCacheService = (): ICacheService => {
     }
 
     const data = await getForCaching()
-    if (data instanceof Error) return data
 
+    // Typescript can't parse 'ReturnType<F>' to filter out 'Error' types
+    if (data instanceof Error) return data
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     set<ReturnType<F>>({ key, value: data, ttlSecs })
     return data
   }

--- a/src/services/cache/redis-cache.ts
+++ b/src/services/cache/redis-cache.ts
@@ -48,6 +48,8 @@ export const RedisCacheService = (): ICacheService => {
     }
 
     const data = await getForCaching()
+    if (data instanceof Error) return data
+
     set<ReturnType<F>>({ key, value: data, ttlSecs })
     return data
   }


### PR DESCRIPTION
## Description

We recently had an issue (see #1662) where an unexpected object was somehow being read out of redis caching. On diving in further into this, I found that the root cause is because the redis `setCache` method can actually cache an `Error` object by just caching its readable properties, and when this is read back out from cache it comes out as a non-Error type object that looks like:
```ts
{ name: "OnChainServiceError", level: "critical" }
```

The fix here is to include a new `NonError` type as part of the `set` method's args signature, and to fix places where this lint breaks.
