### PR TITLE
chore: Fix mongodb migration test return code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test: unit integration
 test-migrate:
 	docker compose down -v
 	docker compose build
-	docker compose up mongodb-migrate
+	docker compose up mongodb-migrate --exit-code-from mongodb-migrate
 
 unit:
 	yarn test:unit

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -16,7 +16,7 @@ services:
     - "6379:6379"
   mongodb:
     environment:
-    - MONGODB_ADVERTISED_HOSTNAME=127.0.0.1
+    - MONGODB_ADVERTISED_HOSTNAME=mongodb
     ports:
     - "27017:27017"
   postgres-price-history:


### PR DESCRIPTION
I don't think `docker compose up` will return the exit code from the container it's starting.