### PR TITLE
chore: add PhoneProvider case for connection issues

### DIFF
--- a/src/domain/phone-provider/errors.ts
+++ b/src/domain/phone-provider/errors.ts
@@ -5,6 +5,9 @@ export class PhoneProviderServiceError extends DomainError {}
 export class InvalidPhoneNumberPhoneProviderError extends PhoneProviderServiceError {}
 export class RestrictedRegionPhoneProviderError extends PhoneProviderServiceError {}
 export class UnsubscribedRecipientPhoneProviderError extends PhoneProviderServiceError {}
+export class PhoneProviderConnectionError extends PhoneProviderServiceError {
+  level = ErrorLevel.Warn
+}
 export class UnknownPhoneProviderServiceError extends PhoneProviderServiceError {
   level = ErrorLevel.Critical
 }

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -20,6 +20,7 @@ import {
   InsufficientLiquidityError,
   LndOfflineError,
   OnChainPaymentError,
+  PhoneProviderError,
 } from "@graphql/error"
 import { baseLogger } from "@services/logger"
 
@@ -146,6 +147,10 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "RestrictedRegionPhoneProviderError":
       message = "Phone number is not from a valid region"
       return new ValidationInternalError({ message, logger: baseLogger })
+
+    case "PhoneProviderConnectionError":
+      message = "Phone provider temporarily unreachable"
+      return new PhoneProviderError({ message, logger: baseLogger })
 
     case "UnsubscribedRecipientPhoneProviderError":
       message = "Phone number has opted out of receiving messages"

--- a/src/graphql/error.ts
+++ b/src/graphql/error.ts
@@ -237,6 +237,17 @@ export class PhoneCodeError extends CustomApolloError {
   }
 }
 
+export class PhoneProviderError extends CustomApolloError {
+  constructor(errData: CustomApolloErrorData) {
+    super({
+      message: "Issue with phone provider",
+      forwardToClient: true,
+      code: "PHONE_PROVIDER_ERROR",
+      ...errData,
+    })
+  }
+}
+
 export class InvalidCoordinatesError extends CustomApolloError {
   constructor(errData: CustomApolloErrorData) {
     super({

--- a/src/services/twilio.ts
+++ b/src/services/twilio.ts
@@ -3,6 +3,7 @@ import twilio from "twilio"
 import { getTwilioConfig } from "@config"
 import {
   InvalidPhoneNumberPhoneProviderError,
+  PhoneProviderConnectionError,
   RestrictedRegionPhoneProviderError,
   UnknownPhoneProviderServiceError,
   UnsubscribedRecipientPhoneProviderError,
@@ -35,6 +36,10 @@ export const TwilioClient = (): IPhoneProviderService => {
 
       if (err.message.includes("unsubscribed recipient")) {
         return new UnsubscribedRecipientPhoneProviderError(err)
+      }
+
+      if (err.message.includes("timeout of") && err.message.includes("exceeded")) {
+        return new PhoneProviderConnectionError(err)
       }
 
       return new UnknownPhoneProviderServiceError(err)


### PR DESCRIPTION
## Description

Add an error classification for when we can't connect to the phone provider. Was triggered today by Twilio's SMS service (https://status.twilio.com) being down.

Relevant traces: https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/CDg5iQEg86M

![image](https://user-images.githubusercontent.com/17693119/192392077-1277dcc4-c152-49f7-9ece-d0519a8c7278.png)
