### PR TITLE
chore: add complexity logic at the graphql level

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
     "google-protobuf": "^3.21.0",
     "graphql": "^16.3.0",
     "graphql-middleware": "^6.1.32",
+    "graphql-query-complexity": "^0.12.0",
+    "graphql-query-complexity-apollo-plugin": "^1.0.2",
     "graphql-redis-subscriptions": "^2.4.2",
     "graphql-relay": "^0.10.0",
     "graphql-shield": "^7.5.0",

--- a/src/graphql/admin/root/mutation/account-add-usd-wallet.ts
+++ b/src/graphql/admin/root/mutation/account-add-usd-wallet.ts
@@ -22,6 +22,9 @@ const AccountsAddUsdWalletMutation = GT.Field<
   null,
   GraphQLContextForUser
 >({
+  extensions: {
+    complexity: 120,
+  },
   type: WalletDetailsPayload,
   args: {
     input: { type: GT.NonNull(AccountsAddUsdWalletInput) },

--- a/src/graphql/admin/root/mutation/account-update-level.ts
+++ b/src/graphql/admin/root/mutation/account-update-level.ts
@@ -23,6 +23,9 @@ const AccountUpdateLevelMutation = GT.Field<{
     level: AccountLevel | Error
   }
 }>({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(AccountDetailPayload),
   args: {
     input: { type: GT.NonNull(AccountUpdateLevelInput) },

--- a/src/graphql/admin/root/mutation/account-update-status.ts
+++ b/src/graphql/admin/root/mutation/account-update-status.ts
@@ -27,6 +27,9 @@ const AccountUpdateStatusMutation = GT.Field<
   null,
   GraphQLContextForUser
 >({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(AccountDetailPayload),
   args: {
     input: { type: GT.NonNull(AccountUpdateStatusInput) },

--- a/src/graphql/admin/root/mutation/business-update-map-info.ts
+++ b/src/graphql/admin/root/mutation/business-update-map-info.ts
@@ -23,6 +23,9 @@ const BusinessUpdateMapInfoInput = GT.Input({
 })
 
 const BusinessUpdateMapInfoMutation = GT.Field({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(AccountDetailPayload),
   args: {
     input: { type: GT.NonNull(BusinessUpdateMapInfoInput) },

--- a/src/graphql/admin/root/mutation/cold-storage-rebalance-to-hot-wallet.ts
+++ b/src/graphql/admin/root/mutation/cold-storage-rebalance-to-hot-wallet.ts
@@ -15,6 +15,9 @@ const ColdStorageRebalanceToHotWalletInput = GT.Input({
 })
 
 const ColdStorageRebalanceToHotWalletMutation = GT.Field({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(PsbtDetailPayload),
   args: {
     input: { type: GT.NonNull(ColdStorageRebalanceToHotWalletInput) },

--- a/src/graphql/root/mutation/account-update-default-wallet-id.ts
+++ b/src/graphql/root/mutation/account-update-default-wallet-id.ts
@@ -13,6 +13,9 @@ const AccountUpdateDefaultWalletIdInput = GT.Input({
 })
 
 const AccountUpdateDefaultWalletIdMutation = GT.Field({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(AccountUpdateDefaultWalletIdPayload),
   args: {
     input: { type: GT.NonNull(AccountUpdateDefaultWalletIdInput) },

--- a/src/graphql/root/mutation/captcha-create-challenge.ts
+++ b/src/graphql/root/mutation/captcha-create-challenge.ts
@@ -3,6 +3,9 @@ import { GT } from "@graphql/index"
 import CaptchaCreateChallengePayload from "@graphql/types/payload/captcha-create-challenge"
 
 const CaptchaCreateChallengeMutation = GT.Field({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(CaptchaCreateChallengePayload),
   resolve: async (_, __, { geetest }) => {
     // TODO: store the request and determine what to do if things fail here...

--- a/src/graphql/root/mutation/captcha-request-auth-code.ts
+++ b/src/graphql/root/mutation/captcha-request-auth-code.ts
@@ -16,6 +16,9 @@ const CaptchaRequestAuthCodeInput = GT.Input({
 })
 
 const CaptchaRequestAuthCodeMutation = GT.Field({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(SuccessPayload),
   args: {
     input: { type: GT.NonNull(CaptchaRequestAuthCodeInput) },

--- a/src/graphql/root/mutation/device-notification-token-create.ts
+++ b/src/graphql/root/mutation/device-notification-token-create.ts
@@ -16,6 +16,9 @@ const DeviceNotificationTokenCreateMutation = GT.Field<
   null,
   GraphQLContextForUser
 >({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(SuccessPayload),
   args: {
     input: { type: GT.NonNull(DeviceNotificationTokenCreateInput) },

--- a/src/graphql/root/mutation/intraledger-payment-send.ts
+++ b/src/graphql/root/mutation/intraledger-payment-send.ts
@@ -20,6 +20,9 @@ const IntraLedgerPaymentSendInput = GT.Input({
 })
 
 const IntraLedgerPaymentSendMutation = GT.Field({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(PaymentSendPayload),
   description: dedent`Actions a payment which is internal to the ledger e.g. it does
   not use onchain/lightning. Returns payment status (success,

--- a/src/graphql/root/mutation/intraledger-usd-payment-send.ts
+++ b/src/graphql/root/mutation/intraledger-usd-payment-send.ts
@@ -20,6 +20,9 @@ const IntraLedgerUsdPaymentSendInput = GT.Input({
 })
 
 const IntraLedgerUsdPaymentSendMutation = GT.Field({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(PaymentSendPayload),
   description: dedent`Actions a payment which is internal to the ledger e.g. it does
   not use onchain/lightning. Returns payment status (success,

--- a/src/graphql/root/mutation/ln-invoice-create-on-behalf-of-recipient.ts
+++ b/src/graphql/root/mutation/ln-invoice-create-on-behalf-of-recipient.ts
@@ -24,6 +24,9 @@ const LnInvoiceCreateOnBehalfOfRecipientInput = GT.Input({
 })
 
 const LnInvoiceCreateOnBehalfOfRecipientMutation = GT.Field({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(LnInvoicePayload),
   description: dedent`Returns a lightning invoice for an associated wallet.
   When invoice is paid the value will be credited to a BTC wallet.

--- a/src/graphql/root/mutation/ln-invoice-create.ts
+++ b/src/graphql/root/mutation/ln-invoice-create.ts
@@ -21,6 +21,9 @@ const LnInvoiceCreateInput = GT.Input({
 })
 
 const LnInvoiceCreateMutation = GT.Field({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(LnInvoicePayload),
   description: dedent`Returns a lightning invoice for an associated wallet.
   When invoice is paid the value will be credited to a BTC wallet.

--- a/src/graphql/root/mutation/ln-invoice-fee-probe.ts
+++ b/src/graphql/root/mutation/ln-invoice-fee-probe.ts
@@ -25,6 +25,9 @@ const LnInvoiceFeeProbeMutation = GT.Field<{
     paymentRequest: EncodedPaymentRequest | InputValidationError
   }
 }>({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(SatAmountPayload),
   args: {
     input: { type: GT.NonNull(LnInvoiceFeeProbeInput) },

--- a/src/graphql/root/mutation/ln-invoice-payment-send.ts
+++ b/src/graphql/root/mutation/ln-invoice-payment-send.ts
@@ -38,6 +38,9 @@ const LnInvoicePaymentSendMutation = GT.Field<
   null,
   GraphQLContextForUser
 >({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(PaymentSendPayload),
   description: dedent`Pay a lightning invoice using a balance from a wallet which is owned by the account of the current user.
   Provided wallet can be USD or BTC and must have sufficient balance to cover amount in lightning invoice.

--- a/src/graphql/root/mutation/ln-noamount-invoice-create-on-behalf-of-recipient.ts
+++ b/src/graphql/root/mutation/ln-noamount-invoice-create-on-behalf-of-recipient.ts
@@ -19,6 +19,9 @@ const LnNoAmountInvoiceCreateOnBehalfOfRecipientInput = GT.Input({
 })
 
 const LnNoAmountInvoiceCreateOnBehalfOfRecipientMutation = GT.Field({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(LnNoAmountInvoicePayload),
   description: dedent`Returns a lightning invoice for an associated wallet.
   Can be used to receive any supported currency value (currently USD or BTC).

--- a/src/graphql/root/mutation/ln-noamount-invoice-create.ts
+++ b/src/graphql/root/mutation/ln-noamount-invoice-create.ts
@@ -19,6 +19,9 @@ const LnNoAmountInvoiceCreateInput = GT.Input({
 })
 
 const LnNoAmountInvoiceCreateMutation = GT.Field({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(LnNoAmountInvoicePayload),
   description: dedent`Returns a lightning invoice for an associated wallet.
   Can be used to receive any supported currency value (currently USD or BTC).

--- a/src/graphql/root/mutation/ln-noamount-invoice-fee-probe.ts
+++ b/src/graphql/root/mutation/ln-noamount-invoice-fee-probe.ts
@@ -22,6 +22,9 @@ const LnNoAmountInvoiceFeeProbeInput = GT.Input({
 })
 
 const LnNoAmountInvoiceFeeProbeMutation = GT.Field({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(SatAmountPayload),
   args: {
     input: { type: GT.NonNull(LnNoAmountInvoiceFeeProbeInput) },

--- a/src/graphql/root/mutation/ln-noamount-invoice-payment-send.ts
+++ b/src/graphql/root/mutation/ln-noamount-invoice-payment-send.ts
@@ -45,6 +45,9 @@ const LnNoAmountInvoicePaymentSendMutation = GT.Field<
   null,
   GraphQLContextForUser
 >({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(PaymentSendPayload),
   description: dedent`Pay a lightning invoice using a balance from a wallet which is owned by the account of the current user.
   Provided wallet must be BTC and must have sufficient balance to cover amount specified in mutation request.

--- a/src/graphql/root/mutation/ln-noamount-usd-invoice-fee-probe.ts
+++ b/src/graphql/root/mutation/ln-noamount-usd-invoice-fee-probe.ts
@@ -22,6 +22,9 @@ const LnNoAmountUsdInvoiceFeeProbeInput = GT.Input({
 })
 
 const LnNoAmountUsdInvoiceFeeProbeMutation = GT.Field({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(CentAmountPayload),
   args: {
     input: { type: GT.NonNull(LnNoAmountUsdInvoiceFeeProbeInput) },

--- a/src/graphql/root/mutation/ln-noamount-usd-invoice-payment-send.ts
+++ b/src/graphql/root/mutation/ln-noamount-usd-invoice-payment-send.ts
@@ -42,6 +42,9 @@ const LnNoAmountUsdInvoicePaymentSendMutation = GT.Field<
   null,
   GraphQLContextForUser
 >({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(PaymentSendPayload),
   description: dedent`Pay a lightning invoice using a balance from a wallet which is owned by the account of the current user.
   Provided wallet must be USD and have sufficient balance to cover amount specified in mutation request.

--- a/src/graphql/root/mutation/ln-usd-invoice-create-on-behalf-of-recipient.ts
+++ b/src/graphql/root/mutation/ln-usd-invoice-create-on-behalf-of-recipient.ts
@@ -28,6 +28,9 @@ const LnUsdInvoiceCreateOnBehalfOfRecipientInput = GT.Input({
 })
 
 const LnUsdInvoiceCreateOnBehalfOfRecipientMutation = GT.Field({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(LnInvoicePayload),
   description: dedent`Returns a lightning invoice denominated in satoshis for an associated wallet.
   When invoice is paid the equivalent value at invoice creation will be credited to a USD wallet.

--- a/src/graphql/root/mutation/ln-usd-invoice-create.ts
+++ b/src/graphql/root/mutation/ln-usd-invoice-create.ts
@@ -21,6 +21,9 @@ const LnUsdInvoiceCreateInput = GT.Input({
 })
 
 const LnUsdInvoiceCreateMutation = GT.Field({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(LnInvoicePayload),
   description: dedent`Returns a lightning invoice denominated in satoshis for an associated wallet.
   When invoice is paid the equivalent value at invoice creation will be credited to a USD wallet.

--- a/src/graphql/root/mutation/ln-usd-invoice-fee-probe.ts
+++ b/src/graphql/root/mutation/ln-usd-invoice-fee-probe.ts
@@ -27,6 +27,9 @@ const LnUsdInvoiceFeeProbeMutation = GT.Field<{
     paymentRequest: EncodedPaymentRequest | InputValidationError
   }
 }>({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(CentAmountPayload),
   args: {
     input: { type: GT.NonNull(LnUsdInvoiceFeeProbeInput) },

--- a/src/graphql/root/mutation/on-chain-address-create.ts
+++ b/src/graphql/root/mutation/on-chain-address-create.ts
@@ -13,6 +13,9 @@ const OnChainAddressCreateInput = GT.Input({
 })
 
 const OnChainAddressCreateMutation = GT.Field({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(OnChainAddressPayload),
   args: {
     input: { type: GT.NonNull(OnChainAddressCreateInput) },

--- a/src/graphql/root/mutation/on-chain-address-current.ts
+++ b/src/graphql/root/mutation/on-chain-address-current.ts
@@ -13,6 +13,9 @@ const OnChainAddressCurrentInput = GT.Input({
 })
 
 const OnChainAddressCurrentMutation = GT.Field({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(OnChainAddressPayload),
   args: {
     input: { type: GT.NonNull(OnChainAddressCurrentInput) },

--- a/src/graphql/root/mutation/onchain-payment-send-all.ts
+++ b/src/graphql/root/mutation/onchain-payment-send-all.ts
@@ -30,6 +30,9 @@ const OnChainPaymentSendAllMutation = GT.Field<
   null,
   GraphQLContextForUser
 >({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(PaymentSendPayload),
   args: {
     input: { type: GT.NonNull(OnChainPaymentSendAllInput) },

--- a/src/graphql/root/mutation/onchain-payment-send.ts
+++ b/src/graphql/root/mutation/onchain-payment-send.ts
@@ -33,6 +33,9 @@ const OnChainPaymentSendMutation = GT.Field<
   null,
   GraphQLContextForUser
 >({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(PaymentSendPayload),
   args: {
     input: { type: GT.NonNull(OnChainPaymentSendInput) },

--- a/src/graphql/root/mutation/twofa-delete.ts
+++ b/src/graphql/root/mutation/twofa-delete.ts
@@ -18,6 +18,9 @@ const TwoFADeleteMutation = GT.Field<
   null,
   GraphQLContextForUser
 >({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(SuccessPayload),
   args: {
     input: { type: GT.NonNull(TwoFADeleteInput) },

--- a/src/graphql/root/mutation/twofa-generate.ts
+++ b/src/graphql/root/mutation/twofa-generate.ts
@@ -4,6 +4,9 @@ import TwoFAGeneratePayload from "@graphql/types/payload/twofa-generate"
 import { generate2fa } from "@app/users"
 
 const TwoFAGenerateMutation = GT.Field<null, null, GraphQLContextForUser>({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(TwoFAGeneratePayload),
   resolve: async (_, __, { domainUser }) => {
     const twoFASecret = await generate2fa(domainUser.id)

--- a/src/graphql/root/mutation/twofa-save.ts
+++ b/src/graphql/root/mutation/twofa-save.ts
@@ -21,6 +21,9 @@ const TwoFASaveMutation = GT.Field<
   null,
   GraphQLContextForUser
 >({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(SuccessPayload),
   args: {
     input: { type: GT.NonNull(TwoFASaveInput) },

--- a/src/graphql/root/mutation/user-contact-update-alias.ts
+++ b/src/graphql/root/mutation/user-contact-update-alias.ts
@@ -23,6 +23,9 @@ const UserContactUpdateAliasMutation = GT.Field<
   null,
   GraphQLContextForUser
 >({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(UserContactUpdateAliasPayload),
   args: {
     input: { type: GT.NonNull(UserContactUpdateAliasInput) },

--- a/src/graphql/root/mutation/user-login.ts
+++ b/src/graphql/root/mutation/user-login.ts
@@ -24,6 +24,9 @@ const UserLoginMutation = GT.Field<{
     code: PhoneCode | InputValidationError
   }
 }>({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(AuthTokenPayload),
   args: {
     input: { type: GT.NonNull(UserLoginInput) },

--- a/src/graphql/root/mutation/user-quiz-question-update-completed.ts
+++ b/src/graphql/root/mutation/user-quiz-question-update-completed.ts
@@ -12,6 +12,9 @@ const UserQuizQuestionUpdateCompletedInput = GT.Input({
 })
 
 const UserQuizQuestionUpdateCompletedMutation = GT.Field({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(UserQuizQuestionUpdateCompletedPayload),
   args: {
     input: { type: GT.NonNull(UserQuizQuestionUpdateCompletedInput) },

--- a/src/graphql/root/mutation/user-request-auth-code.ts
+++ b/src/graphql/root/mutation/user-request-auth-code.ts
@@ -16,6 +16,9 @@ const UserRequestAuthCodeInput = GT.Input({
 })
 
 const UserRequestAuthCodeMutation = GT.Field({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(SuccessPayload),
   args: {
     input: { type: GT.NonNull(UserRequestAuthCodeInput) },

--- a/src/graphql/root/mutation/user-update-language.ts
+++ b/src/graphql/root/mutation/user-update-language.ts
@@ -13,6 +13,9 @@ const UserUpdateLanguageInput = GT.Input({
 })
 
 const UserUpdateLanguageMutation = GT.Field({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(UserUpdateLanguagePayload),
   args: {
     input: { type: GT.NonNull(UserUpdateLanguageInput) },

--- a/src/graphql/root/mutation/user-update-username.ts
+++ b/src/graphql/root/mutation/user-update-username.ts
@@ -14,6 +14,9 @@ const UserUpdateUsernameInput = GT.Input({
 })
 
 const UserUpdateUsernameMutation = GT.Field({
+  extensions: {
+    complexity: 120,
+  },
   type: GT.NonNull(UserUpdateUsernamePayload),
   args: {
     input: { type: GT.NonNull(UserUpdateUsernameInput) },

--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -1,5 +1,5 @@
-import { createServer } from "http"
 import crypto from "crypto"
+import { createServer } from "http"
 
 import { Accounts, Users } from "@app"
 import { getApolloConfig, getGeetestConfig, isDev, isProd, JWT_SECRET } from "@config"
@@ -31,15 +31,19 @@ import {
   SubscriptionServer,
 } from "subscriptions-transport-ws"
 
-import { mapError } from "@graphql/error-map"
 import { AuthenticationError, AuthorizationError } from "@graphql/error"
+import { mapError } from "@graphql/error-map"
 
 import { parseIps } from "@domain/users-ips"
 
+import { fieldExtensionsEstimator, simpleEstimator } from "graphql-query-complexity"
+
+import { createComplexityPlugin } from "graphql-query-complexity-apollo-plugin"
+
 import { playgroundTabs } from "../graphql/playground"
 
-import healthzHandler from "./middlewares/healthz"
 import authRouter from "./auth-router"
+import healthzHandler from "./middlewares/healthz"
 
 const graphqlLogger = baseLogger.child({
   module: "graphql",
@@ -133,6 +137,14 @@ export const startApolloServer = async ({
   const httpServer = createServer(app)
 
   const apolloPlugins = [
+    createComplexityPlugin({
+      schema,
+      estimators: [fieldExtensionsEstimator(), simpleEstimator({ defaultComplexity: 1 })],
+      maximumComplexity: 200,
+      onComplete: (complexity) => {
+        baseLogger.debug({ complexity }, "queryComplexity")
+      },
+    }),
     ApolloServerPluginDrainHttpServer({ httpServer }),
     apolloConfig.playground
       ? ApolloServerPluginLandingPageGraphQLPlayground({

--- a/yarn.lock
+++ b/yarn.lock
@@ -6429,6 +6429,18 @@ graphql-middleware@^6.1.32:
     "@graphql-tools/delegate" "^8.8.1"
     "@graphql-tools/schema" "^8.5.1"
 
+graphql-query-complexity-apollo-plugin@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/graphql-query-complexity-apollo-plugin/-/graphql-query-complexity-apollo-plugin-1.0.2.tgz#1eff2eb4ea455a3577c9a2f3580561a5e19b394a"
+  integrity sha512-TjDzIuAILNI0+wemtTpl47Vj/wCi8TGhq8tVcJQOsHUkiflrVhrHwKHiBX7V5KC5rgUAJtnsqSgVBDJqsAvwjg==
+
+graphql-query-complexity@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/graphql-query-complexity/-/graphql-query-complexity-0.12.0.tgz#5f636ccc54da82225f31e898e7f27192fe074b4c"
+  integrity sha512-fWEyuSL6g/+nSiIRgIipfI6UXTI7bAxrpPlCY1c0+V3pAEUo1ybaKmSBgNr1ed2r+agm1plJww8Loig9y6s2dw==
+  dependencies:
+    lodash.get "^4.4.2"
+
 graphql-redis-subscriptions@^2.4.2:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/graphql-redis-subscriptions/-/graphql-redis-subscriptions-2.5.0.tgz#edc50d46122bc1491e37cd29b484f15c73653764"


### PR DESCRIPTION
currently, with the current settings, it would not be possible to run multiple mutation in the same HTTP request

if we see a usecase for it, we can lower the complexity of mutation

with a difficulty of 200, it will also make a cap on query, such that only 200 fields can be requested on an HTTP requests (a query like me query should be be in the 100-ish)