### PR TITLE
fix: avoid errors if Loop is not enabled

### DIFF
--- a/src/config/process.ts
+++ b/src/config/process.ts
@@ -1,5 +1,6 @@
+import { getCronConfig } from "@config"
+
 import { ConfigError } from "./error"
-import { getCronConfig} from "@config"
 
 type TwilioConfig = {
   accountSid: string
@@ -103,20 +104,22 @@ export const LND_HEALTH_REFRESH_TIME_MS = parseInt(
   10,
 )
 
-export const getLoopConfig = getCronConfig().swapEnabled ? () => {
-  if (!process.env.LND1_LOOP_TLS) throw new ConfigError("Missing LND1_LOOP_TLS config")
-  if (!process.env.LND2_LOOP_TLS) throw new ConfigError("Missing LND2_LOOP_TLS config")
-  if (!process.env.LND1_LOOP_MACAROON)
-    throw new ConfigError("Missing LND1_LOOP_MACAROON config")
-  if (!process.env.LND2_LOOP_MACAROON)
-    throw new ConfigError("Missing LND2_LOOP_MACAROON config")
+export const getLoopConfig = () => {
+  if (getCronConfig().swapEnabled) {
+    if (!process.env.LND1_LOOP_TLS) throw new ConfigError("Missing LND1_LOOP_TLS config")
+    if (!process.env.LND2_LOOP_TLS) throw new ConfigError("Missing LND2_LOOP_TLS config")
+    if (!process.env.LND1_LOOP_MACAROON)
+      throw new ConfigError("Missing LND1_LOOP_MACAROON config")
+    if (!process.env.LND2_LOOP_MACAROON)
+      throw new ConfigError("Missing LND2_LOOP_MACAROON config")
+  }
   return {
     lnd1LoopTls: process.env.LND1_LOOP_TLS,
     lnd1LoopMacaroon: process.env.LND1_LOOP_MACAROON as Macaroon,
     lnd2LoopTls: process.env.LND2_LOOP_TLS,
     lnd2LoopMacaroon: process.env.LND2_LOOP_MACAROON as Macaroon,
   }
-} : null
+}
 
 export const getKratosMasterPhonePassword = () => {
   if (!process.env.KRATOS_MASTER_PHONE_PASSWORD) {

--- a/src/config/process.ts
+++ b/src/config/process.ts
@@ -1,4 +1,5 @@
 import { ConfigError } from "./error"
+import { getCronConfig} from "@config"
 
 type TwilioConfig = {
   accountSid: string
@@ -102,7 +103,7 @@ export const LND_HEALTH_REFRESH_TIME_MS = parseInt(
   10,
 )
 
-export const getLoopConfig = () => {
+export const getLoopConfig = getCronConfig().swapEnabled ? () => {
   if (!process.env.LND1_LOOP_TLS) throw new ConfigError("Missing LND1_LOOP_TLS config")
   if (!process.env.LND2_LOOP_TLS) throw new ConfigError("Missing LND2_LOOP_TLS config")
   if (!process.env.LND1_LOOP_MACAROON)
@@ -115,7 +116,7 @@ export const getLoopConfig = () => {
     lnd2LoopTls: process.env.LND2_LOOP_TLS,
     lnd2LoopMacaroon: process.env.LND2_LOOP_MACAROON as Macaroon,
   }
-}
+} : null
 
 export const getKratosMasterPhonePassword = () => {
   if (!process.env.KRATOS_MASTER_PHONE_PASSWORD) {

--- a/src/domain/swap/index.types.d.ts
+++ b/src/domain/swap/index.types.d.ts
@@ -76,7 +76,7 @@ type SwapConfig = {
 
 type LoopdConfig = {
   macaroon: Macaroon
-  tlsCert: string
+  tlsCert?: string
   grpcEndpoint: string
   btcNetwork: BtcNetwork
   lndInstanceName: string

--- a/src/services/loopd/loop-service.ts
+++ b/src/services/loopd/loop-service.ts
@@ -17,6 +17,8 @@ import { SwapState as DomainSwapState } from "@domain/swap/index"
 
 import { WalletCurrency } from "@domain/shared"
 
+import { ConfigError } from "@config"
+
 import { SwapClientClient } from "./protos/loop_grpc_pb"
 import {
   FailureReason,
@@ -32,8 +34,6 @@ import {
   TermsRequest,
   OutTermsResponse,
 } from "./protos/loop_pb"
-
-import { ConfigError } from "src/config/error"
 
 export const LoopService = ({
   macaroon,

--- a/src/services/loopd/loop-service.ts
+++ b/src/services/loopd/loop-service.ts
@@ -33,6 +33,8 @@ import {
   OutTermsResponse,
 } from "./protos/loop_pb"
 
+import { ConfigError } from "src/config/error"
+
 export const LoopService = ({
   macaroon,
   tlsCert,
@@ -41,6 +43,9 @@ export const LoopService = ({
   lndInstanceName,
 }: LoopdConfig): ISwapService => {
   const mac = Buffer.from(macaroon, "base64").toString("hex") as Macaroon
+  if (!tlsCert) {
+    throw new ConfigError("missing LOOP_TLS")
+  }
   const tls = Buffer.from(tlsCert, "base64")
   const swapClient: ServiceClient = createClient(mac, tls, grpcEndpoint)
 


### PR DESCRIPTION
Currently Loop is  not running on signet https://github.com/lightninglabs/loop/issues/522 so will needed to keep it off in https://github.com/GaloyMoney/charts/pull/1125. 

Fixing the error when deploying on signet with Loop disabled:
```
{"level":30,"time":1666863947270,"pid":1,"hostname":"api-97c4b8f8d-b4j5h","msg":"loading custom.yaml"}
/app/lib/config/process.js:88
        throw new error_1.ConfigError("Missing LND1_LOOP_TLS config");
        ^

ConfigError: Missing LND1_LOOP_TLS config
    at getLoopConfig (/app/lib/config/process.js:88:15)
    at Object.<anonymous> (/app/lib/app/swap/get-active-loopd.js:27:42)
    at Module._compile (node:internal/modules/cjs/loader:1159:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1213:10)
    at Module.load (node:internal/modules/cjs/loader:1037:32)
    at Module._load (node:internal/modules/cjs/loader:878:12)
    at Module.require (node:internal/modules/cjs/loader:1061:19)
    at Hook._require.Module.require (/app/node_modules/require-in-the-middle/index.js:80:39)
    at Hook._require.Module.require (/app/node_modules/require-in-the-middle/index.js:80:39)
    at Hook._require.Module.require (/app/node_modules/require-in-the-middle/index.js:80:39) {
  data: undefined
}

Node.js v18.11.0
k3d@z420:~/charts/dev$ k -n galoy-sig-galoy   logs  api-97c4b8f8d-b4j5h -f
Defaulted container "api" out of: api, wait-for-mongodb-migrate (init)
{"level":30,"time":1666863947270,"pid":1,"hostname":"api-97c4b8f8d-b4j5h","msg":"loading custom.yaml"}
/app/lib/config/process.js:88
        throw new error_1.ConfigError("Missing LND1_LOOP_TLS config");
        ^

ConfigError: Missing LND1_LOOP_TLS config
    at getLoopConfig (/app/lib/config/process.js:88:15)
    at Object.<anonymous> (/app/lib/app/swap/get-active-loopd.js:27:42)
    at Module._compile (node:internal/modules/cjs/loader:1159:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1213:10)
    at Module.load (node:internal/modules/cjs/loader:1037:32)
    at Module._load (node:internal/modules/cjs/loader:878:12)
    at Module.require (node:internal/modules/cjs/loader:1061:19)
    at Hook._require.Module.require (/app/node_modules/require-in-the-middle/index.js:80:39)
    at Hook._require.Module.require (/app/node_modules/require-in-the-middle/index.js:80:39)
    at Hook._require.Module.require (/app/node_modules/require-in-the-middle/index.js:80:39) {
  data: undefined
}

Node.js v18.11.0
```
