### PR TITLE
fix: map safe-int errors to apollo error

### DIFF
--- a/src/graphql/types/scalar/safe-int.ts
+++ b/src/graphql/types/scalar/safe-int.ts
@@ -1,4 +1,6 @@
+import { ValidationInternalError } from "@graphql/error"
 import { GT } from "@graphql/index"
+import { baseLogger } from "@services/logger"
 
 const MAX_INT = Number.MAX_SAFE_INTEGER
 const MIN_INT = Number.MIN_SAFE_INTEGER
@@ -22,19 +24,25 @@ const SafeInt = GT.Scalar({
 
 function coerceSafeInt(value: unknown) {
   if (value === "") {
-    throw new Error(
-      "SafeInt cannot represent non 53-bit signed integer value: (empty string)",
-    )
+    throw new ValidationInternalError({
+      message: "SafeInt cannot represent non 53-bit signed integer value: (empty string)",
+      logger: baseLogger,
+    })
   }
   const num = Number(value)
   if (num !== value || num > MAX_INT || num < MIN_INT) {
-    throw new Error(
-      "SafeInt cannot represent non 53-bit signed integer value: " + String(value),
-    )
+    throw new ValidationInternalError({
+      message:
+        "SafeInt cannot represent non 53-bit signed integer value: " + String(value),
+      logger: baseLogger,
+    })
   }
   const int = Math.floor(num)
   if (int !== num) {
-    throw new Error("SafeInt cannot represent non-integer value: " + String(value))
+    throw new ValidationInternalError({
+      message: "SafeInt cannot represent non-integer value: " + String(value),
+      logger: baseLogger,
+    })
   }
   return int
 }


### PR DESCRIPTION
## Discussion

Map safe-int validation errors to `ValidationInternalError` to get the proper `code` attribute in tracing and in API returns, see [traces](https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/tk5E1i8uuva/a/hWwDryEwE7n) from [`galoy-bbw-missing-error-code`](https://ui.honeycomb.io/galoy/datasets/galoy-bbw/triggers/xcLG5xU5eLm) alert.