### PR TITLE
chore: map new mongo connection errors

### DIFF
--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -16,6 +16,9 @@ export class CouldNotFindError extends RepositoryError {}
 export class CannotConnectToDbError extends RepositoryError {
   level = ErrorLevel.Critical
 }
+export class DbConnectionClosedError extends RepositoryError {
+  level = ErrorLevel.Critical
+}
 
 export class CouldNotFindWalletInvoiceError extends CouldNotFindError {}
 

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -303,6 +303,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       return new RebalanceNeededError({ logger: baseLogger })
 
     case "CannotConnectToDbError":
+    case "DbConnectionClosedError":
       message =
         "Service offline, please try again in a few minutes. If the problem persists, please contact support."
       return new DbError({ message, logger: baseLogger })

--- a/src/services/mongoose/utils.ts
+++ b/src/services/mongoose/utils.ts
@@ -1,4 +1,8 @@
-import { CannotConnectToDbError, UnknownRepositoryError } from "@domain/errors"
+import {
+  CannotConnectToDbError,
+  DbConnectionClosedError,
+  UnknownRepositoryError,
+} from "@domain/errors"
 import { Types } from "mongoose"
 
 export const toObjectId = <T extends string>(id: T): Types.ObjectId => {
@@ -13,7 +17,11 @@ export const parseRepositoryError = (err: Error) => {
   switch (true) {
     case err.message.includes("MongoNetworkTimeoutError: connection timed out"):
     case err.message.includes("MongooseServerSelectionError: connection timed out"):
+    case err.message.includes("MongooseServerSelectionError: getaddrinfo ENOTFOUND"):
+    case err.message.includes("MongooseServerSelectionError: connect ECONNREFUSED"):
       return new CannotConnectToDbError()
+    case /connection .+ to .+ closed/.test(err.message):
+      return new DbConnectionClosedError()
     default:
       return new UnknownRepositoryError(err.message)
   }


### PR DESCRIPTION
## Description

Maps all except "cursor id" errors in [these traces](https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/5zSEGbD2au4?hideMarkers).