### PR TITLE
chore: bounded cache

### DIFF
--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -172,6 +172,7 @@ export const startApolloServer = async ({
 
   const apolloServer = new ApolloServer({
     schema,
+    cache: "bounded",
     introspection: apolloConfig.playground,
     plugins: apolloPlugins,
     context: async (context) => {


### PR DESCRIPTION
following log provided by apollo server:

Persisted queries are enabled and are using an unbounded cache. Your server is vulnerable to denial of service attacks via memory exhaustion. Set `cache: "bounded"` or `persistedQueries: false` in your ApolloServer constructor, or see https://go.apollo.dev/s/cache-backends for other alternatives.