### PR TITLE
feat: map new unknown lnd errors

### DIFF
--- a/src/domain/bitcoin/lightning/errors.ts
+++ b/src/domain/bitcoin/lightning/errors.ts
@@ -30,6 +30,7 @@ export class NoValidNodeForPubkeyError extends LightningServiceError {
 export class PaymentNotFoundError extends LightningServiceError {}
 export class RouteNotFoundError extends LightningServiceError {}
 export class InsufficientBalanceForRoutingError extends LightningServiceError {}
+export class InsufficientBalanceForLnPaymentError extends LightningServiceError {}
 export class InvoiceExpiredOrBadPaymentHashError extends LightningServiceError {}
 export class PaymentAttemptsTimedOutError extends LightningServiceError {}
 export class ProbeForRouteTimedOutError extends LightningServiceError {}

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -404,6 +404,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "InvalidOnChainAddress":
     case "InvalidScanDepthAmount":
     case "InsufficientBalanceForRoutingError":
+    case "InsufficientBalanceForLnPaymentError":
     case "InvalidLanguageError":
     case "InvalidAccountLevelError":
     case "InvalidWithdrawFeeError":

--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -730,6 +730,7 @@ export const KnownLndErrorDetails: { [key: string]: RegExp } = {
   ConnectionDropped: /Connection dropped/,
   TemporaryChannelFailure: /TemporaryChannelFailure/,
   InvoiceAlreadySettled: /invoice already settled/,
+  NoConnectionEstablished: /No connection established/,
 } as const
 
 /* eslint @typescript-eslint/ban-ts-comment: "off" */
@@ -859,6 +860,7 @@ const handleCommonLightningServiceErrors = (err: Error) => {
   const match = (knownErrDetail: RegExp): boolean => knownErrDetail.test(errDetails)
   switch (true) {
     case match(KnownLndErrorDetails.ConnectionDropped):
+    case match(KnownLndErrorDetails.NoConnectionEstablished):
       return new OffChainServiceUnavailableError()
     default:
       return new UnknownLightningServiceError(msgForUnknown(err))
@@ -870,6 +872,7 @@ const handleCommonRouteNotFoundErrors = (err: Error) => {
   const match = (knownErrDetail: RegExp): boolean => knownErrDetail.test(errDetails)
   switch (true) {
     case match(KnownLndErrorDetails.ConnectionDropped):
+    case match(KnownLndErrorDetails.NoConnectionEstablished):
       return new OffChainServiceUnavailableError()
     default:
       return new UnknownRouteNotFoundError(msgForUnknown(err))

--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -31,6 +31,7 @@ import {
   CorruptLndDbError,
   CouldNotDecodeReturnedPaymentRequest,
   decodeInvoice,
+  InsufficientBalanceForLnPaymentError,
   InsufficientBalanceForRoutingError,
   InvoiceExpiredOrBadPaymentHashError,
   InvoiceNotFoundError,
@@ -715,6 +716,7 @@ const lookupPaymentByPubkeyAndHash = async ({
 
 export const KnownLndErrorDetails: { [key: string]: RegExp } = {
   InsufficientBalance: /insufficient local balance/,
+  InsufficientBalanceToAttemptPayment: /InsufficientBalanceToAttemptPayment/,
   InvoiceNotFound: /unable to locate invoice/,
   InvoiceAlreadyPaid: /invoice is already paid/,
   UnableToFindRoute: /PaymentPathfindingFailedToFindPossibleRoute/,
@@ -850,6 +852,9 @@ const handleSendPaymentLndErrors = ({
       return new PaymentInTransitionError(paymentHash)
     case match(KnownLndErrorDetails.TemporaryChannelFailure):
       return new TemporaryChannelFailureError(paymentHash)
+    case match(KnownLndErrorDetails.InsufficientBalanceToAttemptPayment):
+      return new InsufficientBalanceForLnPaymentError()
+
     default:
       return handleCommonLightningServiceErrors(err)
   }

--- a/src/services/lnd/onchain-service.ts
+++ b/src/services/lnd/onchain-service.ts
@@ -217,6 +217,7 @@ const KnownLndErrorDetails = {
   ConnectionDropped: /Connection dropped/,
   CPFPAncestorLimitReached:
     /unmatched backend error: -26: too-long-mempool-chain, too many .* \[limit: \d+\]/,
+  NoConnectionEstablished: /No connection established/,
 } as const
 
 export const extractIncomingTransactions = ({
@@ -270,6 +271,7 @@ const handleCommonOnChainServiceErrors = (err: Error) => {
   const match = (knownErrDetail: RegExp): boolean => knownErrDetail.test(errDetails)
   switch (true) {
     case match(KnownLndErrorDetails.ConnectionDropped):
+    case match(KnownLndErrorDetails.NoConnectionEstablished):
       return new OnChainServiceUnavailableError()
     default:
       return new UnknownOnChainServiceError(msgForUnknown(err))


### PR DESCRIPTION
## Description

- Maps "insufficient balance" errors ([trace](https://ui.honeycomb.io/galoy/datasets/galoy-staging/result/otZJhTGR9xs/trace/cVyR9K87qvu?fields[]=c_name&fields[]=c_service.name&span=c737e4c5a92b93d1))
  I didn't set a level for this because we'd likely get a rebalance alert well before this might trigger. I only discovered it while testing on staging with very large amounts.

- Maps "no connection established" error ([traces](https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/rQaiT3siacA))