### PR TITLE
chore: improve error message when no token is present

### DIFF
--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -185,8 +185,7 @@ export const startApolloServer = async ({
     introspection: apolloConfig.playground,
     plugins: apolloPlugins,
     context: async (context) => {
-      // @ts-expect-error: TODO
-      const tokenPayload = context.req?.token ?? null
+      const tokenPayload = context.req.token
 
       const body = context.req?.body ?? null
 
@@ -252,7 +251,7 @@ export const startApolloServer = async ({
     expressjwt({
       secret,
       algorithms: jwtAlgorithms,
-      credentialsRequired: false,
+      credentialsRequired: true,
       requestProperty: "token",
     }),
   )

--- a/src/servers/index.files.d.ts
+++ b/src/servers/index.files.d.ts
@@ -16,3 +16,9 @@ type GraphQLContextForUser = {
 
 // globally used types
 type Logger = import("pino").Logger
+
+declare namespace Express {
+  interface Request {
+    token: import("jsonwebtoken").JwtPayload
+  }
+}


### PR DESCRIPTION
previously, a 500 Error was thrown without given indication of what the issue was

after this PR, a `UnauthorizedError: No authorization token was found` will be returned if no JWT is been passsed to the server. 