### PR TITLE
chore: migrate remaining intraledger types to self trade

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -162,6 +162,28 @@ When developing migrations the best way to test them on a clean database is:
 make test-migrate
 ```
 
+#### Create a new migration
+
+Create the migration file
+
+```bash
+npx migrate-mongo create <migration-name> \
+  -f src/migrations/migrate-mongo-config.js
+```
+
+Write the migration in the newly created migration file and then test/run with the following:
+```bash
+# Migrate
+npx migrate-mongo up \
+  -f src/migrations/migrate-mongo-config.js
+
+# Rollback
+npx migrate-mongo down \
+  -f src/migrations/migrate-mongo-config.js
+```
+
+When testing, to isolate just the current migration being worked on in local dev you can temporarily move the other migrations to another dir.
+
 ### Known issues
 
 * **Test suite timeouts**: increase jest timeout value. Example:

--- a/src/migrations/20221010162913-add-self-trade-type.ts
+++ b/src/migrations/20221010162913-add-self-trade-type.ts
@@ -1,5 +1,4 @@
 /* eslint @typescript-eslint/no-var-requires: "off" */
-
 const { Types } = require("mongoose")
 
 const toWalletId = (walletIdPath) => {
@@ -27,7 +26,6 @@ const getNonUserWalletIds = async ({ usersCollection, walletsCollection }) => {
   for await (const wallet of walletsCursor) {
     nonUserWalletIds.push(wallet.id)
   }
-  console.log("HERE 0:", nonUserWalletIds)
   return nonUserWalletIds
 }
 
@@ -78,7 +76,6 @@ module.exports = {
 
       // Check that we have txns with valid walletIds
       if (txns && txns.length === 0) return false
-      console.log("\nHERE 1:", { [txnAgg._id]: txns })
 
       // Check if we have exactly 2 txns
       if (txns.length !== 2) return false
@@ -88,12 +85,10 @@ module.exports = {
 
       // Compare accountIds to see if self-trade
       const accountIdsSet = new Set(txns.map((txn) => txn.accountId))
-      console.log("HERE 2:", { accountIdsSet })
       if (accountIdsSet.size > 1) return false
 
       // RETURN SELF-TRADE TYPE
       // =====
-      console.log("HERE 3:", txnAgg.type)
       switch (txnAgg.type) {
         case "on_us":
           return "self_trade"
@@ -124,7 +119,6 @@ module.exports = {
       const selfTradeType = await getSelfTradeType(txn)
       if (!selfTradeType) continue
 
-      console.log("HERE 4:", _journal)
       const result = await txnsCollection.updateMany(
         { _journal },
         [
@@ -139,18 +133,10 @@ module.exports = {
           multi: true,
         },
       )
-      console.log("HERE 5:", result)
       const { modifiedCount, matchedCount } = result
       console.log(
         `changed txn type from ${type} to ${selfTradeType} for ${modifiedCount} of ${matchedCount} transactions for journalId: ${_journal.toString()}`,
       )
     }
-  },
-
-  async down(db) {
-    console.log(db)
-    // TODO write the statements to rollback your migration (if possible)
-    // Example:
-    // await db.collection('albums').updateOne({artist: 'The Beatles'}, {$set: {blacklisted: false}});
   },
 }

--- a/src/migrations/20221010162913-add-self-trade-type.ts
+++ b/src/migrations/20221010162913-add-self-trade-type.ts
@@ -1,3 +1,6 @@
+/* eslint @typescript-eslint/ban-ts-comment: "off" */
+// @ts-nocheck
+
 /* eslint @typescript-eslint/no-var-requires: "off" */
 const { Types } = require("mongoose")
 

--- a/src/migrations/20221010162913-add-self-trade-type.ts
+++ b/src/migrations/20221010162913-add-self-trade-type.ts
@@ -139,4 +139,28 @@ module.exports = {
       )
     }
   },
+
+  async down(db) {
+    try {
+      const result = await db.collection("medici_transactions").updateMany(
+        {
+          type: { $in: ["self_trade", "ln_self_trade", "onchain_self_trade"] },
+          type_old: { $exists: true },
+        },
+        [
+          {
+            $set: {
+              type: "$type_old",
+            },
+          },
+          {
+            $unset: "type_old",
+          },
+        ],
+      )
+      console.log({ result }, "revert '..self_trade' types back to '..on_us'")
+    } catch (error) {
+      console.log({ result: error }, "Couldn't revert '..self_trade' medici_transactions")
+    }
+  },
 }

--- a/src/migrations/20221010162913-add-self-trade-type.ts
+++ b/src/migrations/20221010162913-add-self-trade-type.ts
@@ -1,0 +1,156 @@
+/* eslint @typescript-eslint/no-var-requires: "off" */
+
+const { Types } = require("mongoose")
+
+const toWalletId = (walletIdPath) => {
+  const path = walletIdPath.split(":")
+  return Array.isArray(path) && path.length === 2 && path[0] === "Liabilities" && path[1]
+    ? path[1]
+    : undefined
+}
+
+const getNonUserWalletIds = async ({ usersCollection, walletsCollection }) => {
+  const accountIds = []
+  const usersCursor = usersCollection.find({
+    role: { $in: ["funder", "dealer", "bankowner"] },
+  })
+  for await (const user of usersCursor) {
+    const accountId = user._id.toString()
+    accountIds.push(accountId)
+  }
+  const accountObjectIds = accountIds.map((id) => new Types.ObjectId(id))
+
+  const nonUserWalletIds = []
+  const walletsCursor = walletsCollection.find({
+    _accountId: { $in: accountObjectIds },
+  })
+  for await (const wallet of walletsCursor) {
+    nonUserWalletIds.push(wallet.id)
+  }
+  console.log("HERE 0:", nonUserWalletIds)
+  return nonUserWalletIds
+}
+
+module.exports = {
+  async up(db) {
+    const usersCollection = db.collection("users")
+    const walletsCollection = db.collection("wallets")
+    const txnsCollection = db.collection("medici_transactions")
+
+    const nonUserWalletIds = await getNonUserWalletIds({
+      usersCollection,
+      walletsCollection,
+    })
+
+    const accountIdsByWalletId = {}
+    const getSelfTradeType = async (txnAgg) => {
+      // BUILD 'txns' FOR JOURNALID
+      // =====
+      const txns = []
+      const txnsCursor = txnsCollection.find({ _journal: txnAgg._id })
+      for await (const txn of txnsCursor) {
+        // Filter internal wallet IDs
+        if (nonUserWalletIds.includes(toWalletId(txn.accounts))) continue
+
+        // Filter non-user walletIds
+        const walletId = toWalletId(txn.accounts)
+        if (!walletId) continue
+
+        // Fetch accountId locally
+        let accountId = accountIdsByWalletId[walletId]
+        if (accountId) {
+          txns.push({ walletId, currency: txn.currency, accountId })
+          continue
+        }
+
+        // Fetch accountId from db if not cached
+        const wallet = await walletsCollection.findOne({ id: walletId })
+        if (!wallet) continue
+        accountId = wallet._accountId.toString()
+        if (!accountId) continue
+
+        accountIdsByWalletId[walletId] = accountId
+        txns.push({ walletId, currency: txn.currency, accountId })
+      }
+
+      // CHECK 'txns' TO DETERMINE IF SELF-TRADE
+      // =====
+
+      // Check that we have txns with valid walletIds
+      if (txns && txns.length === 0) return false
+      console.log("\nHERE 1:", { [txnAgg._id]: txns })
+
+      // Check if we have exactly 2 txns
+      if (txns.length !== 2) return false
+
+      // Check if txns have different currencies
+      if (txns[0].currency === txns[1].currency) return false
+
+      // Compare accountIds to see if self-trade
+      const accountIdsSet = new Set(txns.map((txn) => txn.accountId))
+      console.log("HERE 2:", { accountIdsSet })
+      if (accountIdsSet.size > 1) return false
+
+      // RETURN SELF-TRADE TYPE
+      // =====
+      console.log("HERE 3:", txnAgg.type)
+      switch (txnAgg.type) {
+        case "on_us":
+          return "self_trade"
+        case "ln_on_us":
+          return "ln_self_trade"
+        case "onchain_on_us":
+          return "onchain_self_trade"
+        default:
+          return false
+      }
+    }
+
+    // FETCH INTRALEDGER TXNS AND UPDATE TYPE FOR SELF-TRADES
+    // =====
+    const journalCursor = txnsCollection.aggregate([
+      { $match: { type: { $regex: "on_us" }, currency: "USD" } },
+      {
+        $group: {
+          _id: "$_journal",
+          createdAt: { $first: "$timestamp" },
+          type: { $first: "$type" },
+        },
+      },
+      { $sort: { createdAt: -1 } },
+    ])
+    for await (const txn of journalCursor) {
+      const { _id: _journal, type } = txn
+      const selfTradeType = await getSelfTradeType(txn)
+      if (!selfTradeType) continue
+
+      console.log("HERE 4:", _journal)
+      const result = await txnsCollection.updateMany(
+        { _journal },
+        [
+          {
+            $set: {
+              type: selfTradeType,
+              type_old: "$type",
+            },
+          },
+        ],
+        {
+          multi: true,
+        },
+      )
+      console.log("HERE 5:", result)
+      const { modifiedCount, matchedCount } = result
+      console.log(
+        `changed txn type from ${type} to ${selfTradeType} for ${modifiedCount} of ${matchedCount} transactions for journalId: ${_journal.toString()}`,
+      )
+    }
+  },
+
+  async down(db) {
+    console.log(db)
+    // TODO write the statements to rollback your migration (if possible)
+    // Example:
+    // await db.collection('albums').updateOne({artist: 'The Beatles'}, {$set: {blacklisted: false}});
+  },
+}

--- a/src/migrations/migrate-mongo-config.js
+++ b/src/migrations/migrate-mongo-config.js
@@ -28,6 +28,9 @@ const config = {
   // Enable the algorithm to create a checksum of the file contents and use that in the comparison to determine
   // if the file should be run.  Requires that scripts are coded to be run multiple times.
   useFileHash: false,
+
+  // Can be 'commonjs' or 'esm'
+  moduleSystem: "commonjs",
 }
 
 // Return the config as a promise


### PR DESCRIPTION
## Discussion

This PR is to follow #1750. It executes the migration for intraledger transactions that were self trades but did not get tagged with this new type before we implemented the self-trade code.

### Rollout process

We should do a check of which transactions are currently on the old type and should be the new type pre-migration, and then confirm that these types change as expected post-migration. I've added a rollback migration step as well for in case anything goes wrong from this check.

I can work with Jose maybe to execute this check before we roll out.
