### PR TITLE
chore!: migrate users collection to account

### DIFF
--- a/src/migrations/2022110622030802-users-to-account.ts
+++ b/src/migrations/2022110622030802-users-to-account.ts
@@ -1,0 +1,13 @@
+module.exports = {
+  async up(db) {
+    try {
+      await db.renameCollection("users", "accounts")
+      console.log(`migration of users to accounts successful`)
+    } catch (error) {
+      console.log({ result: error }, `Couldn't rename user collection`)
+    }
+  },
+  down() {
+    return true
+  },
+}

--- a/src/services/mongoose/schema.ts
+++ b/src/services/mongoose/schema.ts
@@ -297,7 +297,7 @@ const UserSchema = new Schema<UserRecord>(
           },
           updatedByUserId: {
             type: Schema.Types.ObjectId,
-            ref: "User",
+            ref: "Account",
             required: false,
           },
           comment: {
@@ -324,7 +324,7 @@ UserSchema.index({
   coordinates: 1,
 })
 
-export const User = mongoose.model<UserRecord>("User", UserSchema)
+export const User = mongoose.model<UserRecord>("Account", UserSchema)
 
 // TODO: this DB should be capped.
 const PhoneCodeSchema = new Schema({


### PR DESCRIPTION
TODO before #1861

now that we're separating `users` and `accounts`, and will introduce a new `user` collection in #1861, it's a good time to remove potential confusion and rename the current `user` collection to `account`