### PR TITLE
chore: add global attributes to spans

### DIFF
--- a/src/graphql/main/mutations.ts
+++ b/src/graphql/main/mutations.ts
@@ -30,12 +30,6 @@ import OnChainPaymentSendAllMutation from "@graphql/root/mutation/onchain-paymen
 import CaptchaRequestAuthCodeMutation from "@graphql/root/mutation/captcha-request-auth-code"
 import CaptchaCreateChallengeMutation from "@graphql/root/mutation/captcha-create-challenge"
 
-import {
-  addAttributesToCurrentSpanAndPropagate,
-  SemanticAttributes,
-  ACCOUNT_USERNAME,
-} from "@services/tracing"
-
 // TODO: // const fields: { [key: string]: GraphQLFieldConfig<any, GraphQLContext> }
 const fields = {
   // unauthed
@@ -81,30 +75,9 @@ const fields = {
   onChainPaymentSendAll: OnChainPaymentSendAllMutation,
 }
 
-const addTracing = () => {
-  for (const key in fields) {
-    // @ts-ignore-next-line no-implicit-any error
-    const original = fields[key].resolve
-    /* eslint @typescript-eslint/ban-ts-comment: "off" */
-    // @ts-ignore-next-line no-implicit-any error
-    fields[key].resolve = (source, args, context: GraphQLContextForUser, info) => {
-      const { ip, domainAccount } = context
-      return addAttributesToCurrentSpanAndPropagate(
-        {
-          [SemanticAttributes.ENDUSER_ID]: domainAccount?.id,
-          [ACCOUNT_USERNAME]: domainAccount?.username,
-          [SemanticAttributes.HTTP_CLIENT_IP]: ip,
-        },
-        () => original(source, args, context, info),
-      )
-    }
-  }
-  return fields
-}
-
 const MutationType = GT.Object({
   name: "Mutation",
-  fields: () => addTracing(),
+  fields,
 })
 
 export default MutationType

--- a/src/graphql/main/subscriptions.ts
+++ b/src/graphql/main/subscriptions.ts
@@ -3,14 +3,40 @@ import { GT } from "@graphql/index"
 import PriceSubscription from "@graphql/root/subscription/price"
 import LnInvoicePaymentStatusSubscription from "@graphql/root/subscription/ln-invoice-payment-status"
 import MyUpdatesSubscription from "@graphql/root/subscription/my-updates"
+import {
+  ACCOUNT_USERNAME,
+  addAttributesToCurrentSpan,
+  SemanticAttributes,
+} from "@services/tracing"
+
+const fields = {
+  myUpdates: MyUpdatesSubscription,
+  price: PriceSubscription,
+  lnInvoicePaymentStatus: LnInvoicePaymentStatusSubscription,
+}
+
+const addTracing = () => {
+  for (const key in fields) {
+    // @ts-ignore-next-line no-implicit-any error
+    const original = fields[key].resolve
+    /* eslint @typescript-eslint/ban-ts-comment: "off" */
+    // @ts-ignore-next-line no-implicit-any error
+    fields[key].resolve = (source, args, context: GraphQLContextForUser, info) => {
+      const { ip, domainAccount } = context
+      addAttributesToCurrentSpan({
+        [SemanticAttributes.ENDUSER_ID]: domainAccount?.id,
+        [ACCOUNT_USERNAME]: domainAccount?.username,
+        [SemanticAttributes.HTTP_CLIENT_IP]: ip,
+      })
+      return original(source, args, context, info)
+    }
+  }
+  return fields
+}
 
 const SubscriptionType = GT.Object({
   name: "Subscription",
-  fields: () => ({
-    myUpdates: MyUpdatesSubscription,
-    price: PriceSubscription,
-    lnInvoicePaymentStatus: LnInvoicePaymentStatusSubscription,
-  }),
+  fields: addTracing(),
 })
 
 export default SubscriptionType


### PR DESCRIPTION
- moves session context logic out of ApolloServer and into middleware so that all graphql spans will be descendants that inherit session context attributes
- add session attributes to top level subscription fields because they do not execute as children of the express middleware spans