### PR TITLE
chore: add function arg redaction in spans

### DIFF
--- a/src/services/cache/redis-cache.ts
+++ b/src/services/cache/redis-cache.ts
@@ -69,5 +69,6 @@ export const RedisCacheService = (): ICacheService => {
   return wrapAsyncFunctionsToRunInSpan({
     namespace: "services.cache.redis",
     fns: { set, get, getOrSet, clear },
+    redactFnArgs: true,
   })
 }


### PR DESCRIPTION
- enable redaction of function arguments when creating span wrapped functions