### PR TITLE
refactor: skip return partial error if error is SkipProbeForPubkeyError

### DIFF
--- a/src/app/payments/get-protocol-fee.ts
+++ b/src/app/payments/get-protocol-fee.ts
@@ -159,10 +159,12 @@ const estimateLightningFee = async ({
       }
 
       PaymentFlowStateRepository(defaultTimeToExpiryInSeconds).persistNew(paymentFlow)
-      return PartialResult.partial(
-        paymentFlow.protocolFeeInSenderWalletCurrency(),
-        routeResult,
-      )
+      return routeResult instanceof SkipProbeForPubkeyError
+        ? PartialResult.ok(paymentFlow.protocolFeeInSenderWalletCurrency())
+        : PartialResult.partial(
+            paymentFlow.protocolFeeInSenderWalletCurrency(),
+            routeResult,
+          )
     }
 
     paymentFlow = await builder.withRoute(routeResult)

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -23,7 +23,6 @@ import {
   LnFees,
   LnPaymentRequestInTransitError,
   PriceRatio,
-  SkipProbeForPubkeyError,
   ZeroAmountForUsdRecipientError,
 } from "@domain/payments"
 import {
@@ -832,7 +831,7 @@ describe("UserWallet - Lightning Pay", () => {
         uncheckedPaymentRequest: muunRequest,
       })
     expect(feeProbeCallCount()).toEqual(feeProbeCallsBefore)
-    expect(errorMuun).toBeInstanceOf(SkipProbeForPubkeyError)
+    expect(errorMuun).toBeUndefined()
     expect(feeMuun).toStrictEqual(LnFees().maxProtocolFee(muunInvoice.paymentAmount))
   })
 


### PR DESCRIPTION
## Description

This is to not return the `SkipProbeForPubkeyError` error if it pops up from the use-case since it is only being used to switch on logic internally to the use-case (is not actually an error).