### PR TITLE
chore: disable internal channel rebalance on signet

### DIFF
--- a/src/servers/cron.ts
+++ b/src/servers/cron.ts
@@ -12,7 +12,8 @@ import { setupMongoConnection } from "@services/mongodb"
 
 import { activateLndHealthCheck } from "@services/lnd/health"
 import { ColdStorage, Lightning, Wallets, Payments, Swap } from "@app"
-import { getCronConfig, TWO_MONTHS_IN_MS } from "@config"
+import { getCronConfig, TWO_MONTHS_IN_MS, BTC_NETWORK } from "@config"
+import { BtcNetwork } from "@domain/bitcoin"
 
 import { rebalancingInternalChannels, reconnectNodes } from "@services/lnd/utils-bos"
 import { extendSessions } from "@app/auth"
@@ -67,7 +68,7 @@ const main = async () => {
   const tasks = [
     // bitcoin related tasks
     reconnectNodes,
-    rebalancingInternalChannels,
+    ...(BTC_NETWORK != BtcNetwork.signet ? [rebalancingInternalChannels] : []),
     updateEscrows,
     updatePendingLightningInvoices,
     updatePendingLightningPayments,


### PR DESCRIPTION
Issue https://github.com/alexbosworth/ln-sync/issues/5 needs resolving before we can use `balanceofsatoshi` on signet - until then the simplest workaround is to disable it.