### PR TITLE
fix: Prevent adding self as contact

### DIFF
--- a/src/app/payments/send-intraledger.ts
+++ b/src/app/payments/send-intraledger.ts
@@ -119,12 +119,14 @@ export const intraledgerPaymentSendWalletId = async ({
   })
   if (paymentSendStatus instanceof Error) return paymentSendStatus
 
-  const addContactResult = await addContactsAfterSend({
-    senderAccount,
-    recipientAccount,
-  })
-  if (addContactResult instanceof Error) {
-    recordExceptionInCurrentSpan({ error: addContactResult, level: ErrorLevel.Warn })
+  if (senderAccount?.id !== recipientAccount?.id) {
+    const addContactResult = await addContactsAfterSend({
+      senderAccount,
+      recipientAccount,
+    })
+    if (addContactResult instanceof Error) {
+      recordExceptionInCurrentSpan({ error: addContactResult, level: ErrorLevel.Warn })
+    }
   }
 
   return paymentSendStatus

--- a/src/app/payments/send-intraledger.ts
+++ b/src/app/payments/send-intraledger.ts
@@ -119,7 +119,7 @@ export const intraledgerPaymentSendWalletId = async ({
   })
   if (paymentSendStatus instanceof Error) return paymentSendStatus
 
-  if (senderAccount?.id !== recipientAccount?.id) {
+  if (senderAccount.id !== recipientAccount.id) {
     const addContactResult = await addContactsAfterSend({
       senderAccount,
       recipientAccount,


### PR DESCRIPTION
I found that your own account is added as a contact when you do a conversion from USD -> BTC or vice versa.
This change will prevent that from happening in the future.