### PR TITLE
fix: handle undefined 'source' arg in subscription resolver

### DIFF
--- a/src/graphql/root/subscription/my-updates.ts
+++ b/src/graphql/root/subscription/my-updates.ts
@@ -118,7 +118,11 @@ const userPayload = (domainUser: User | null) => (updateData: MeResolveUpdate) =
 
 const MeSubscription = {
   type: GT.NonNull(MyUpdatesPayload),
-  resolve: (source: MeResolveSource, _args: unknown, ctx: GraphQLContextForUser) => {
+  resolve: (
+    source: MeResolveSource | undefined,
+    _args: unknown,
+    ctx: GraphQLContextForUser,
+  ) => {
     if (!ctx.domainUser) {
       throw new AuthenticationError({
         message: "Not Authenticated for subscription",
@@ -128,7 +132,8 @@ const MeSubscription = {
 
     if (source === undefined) {
       throw new UnknownClientError({
-        message: "Got 'undefined' payload",
+        message:
+          "Got 'undefined' payload. Check url used to ensure right websocket endpoint was used for subscription.",
         level: "fatal",
         logger: baseLogger,
       })

--- a/src/graphql/root/subscription/price.ts
+++ b/src/graphql/root/subscription/price.ts
@@ -47,12 +47,13 @@ const PriceSubscription = {
     input: { type: GT.NonNull(PriceInput) },
   },
   resolve: (
-    source: { errors: IError[]; satUsdCentPrice?: number },
+    source: { errors: IError[]; satUsdCentPrice?: number } | undefined,
     args: PriceResolveArgs,
   ) => {
     if (source === undefined) {
       throw new UnknownClientError({
-        message: "Got 'undefined' payload",
+        message:
+          "Got 'undefined' payload. Check url used to ensure right websocket endpoint was used for subscription.",
         level: "fatal",
         logger: baseLogger,
       })


### PR DESCRIPTION
## Description

This fixes the latest `missing-code` alert triggered (https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/91QbcxJCxi2) by handling a potential `undefined` argument.

In this case, the root cause was making a subscription request against the normal query/mutation endpoint so that the subscription resolver was triggered directly with an `undefined` value for its `source` argument.