### PR TITLE
fix: staging, following kratos refactoring PR

### DIFF
--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -675,7 +675,7 @@ type Mutation {
   userUpdateLanguage(input: UserUpdateLanguageInput!): UserUpdateLanguagePayload!
   userUpdateUsername(input: UserUpdateUsernameInput!): UserUpdateUsernamePayload!
     @deprecated(
-      reason: "Username will be moved to @Handle in Accounts. Also SetUsername should be used instead of UpdateUsername to reflect the idempotency of Handles"
+      reason: "Username will be moved to @Handle in Accounts. Also SetUsername naming should be used instead of UpdateUsername to reflect the idempotency of Handles"
     )
 }
 

--- a/src/services/twilio.ts
+++ b/src/services/twilio.ts
@@ -67,7 +67,18 @@ export const TwilioClient = (): IPhoneProviderService => {
       //   countryCode: result.countryCode,
       // }
 
-      return result
+      const phoneMetadata: PhoneMetadata = {
+        carrier: {
+          error_code: result.carrier.error_code,
+          mobile_country_code: result.carrier.mobile_country_code,
+          mobile_network_code: result.carrier.mobile_network_code,
+          name: result.carrier.name,
+          type: result.carrier.type,
+        },
+        countryCode: result.countryCode,
+      }
+
+      return phoneMetadata
     } catch (err) {
       return new UnknownPhoneProviderServiceError(err)
     }


### PR DESCRIPTION
the issue came from the fact twilio have an _version property that was creating issue for mongoose who also have a _version property on it's object.

this was creating an infinite loop

recreating the PhoneMetadata object with just the necessary property avoid the issue.

a good reason for the proper boundaries between services