### PR TITLE
fix: get username from updated account in gql resolver when set

### DIFF
--- a/src/graphql/types/object/graphql-user.ts
+++ b/src/graphql/types/object/graphql-user.ts
@@ -36,7 +36,7 @@ const GraphQLUser = GT.Object({
       type: Username,
       description: "Optional immutable user friendly identifier.",
       resolve: async (source, args, { domainAccount }) => {
-        return domainAccount?.username
+        return source.username || domainAccount?.username
       },
       deprecationReason: "will be moved to @Handle in Account and Wallet",
     },


### PR DESCRIPTION
## Description

When we set the username and return the updated account, this updated account only exists in the `source` variable and hasn't gotten to the `domainAccount` variable as yet.