### PR TITLE
fix: apply dust check for fee estimates as well

### DIFF
--- a/src/domain/payments/index.types.d.ts
+++ b/src/domain/payments/index.types.d.ts
@@ -220,9 +220,15 @@ type OPFBWithConversion<S extends WalletCurrency, R extends WalletCurrency> = {
     OnChainPaymentFlow<S, R> | ValidationError | DealerPriceServiceError
   >
 
-  btcProposedAmount(): Promise<BtcPaymentAmount | DealerPriceServiceError>
-  usdProposedAmount(): Promise<UsdPaymentAmount | DealerPriceServiceError>
-  proposedAmounts(): Promise<PaymentAmountInAllCurrencies | DealerPriceServiceError>
+  btcProposedAmount(): Promise<
+    BtcPaymentAmount | DealerPriceServiceError | ValidationError
+  >
+  usdProposedAmount(): Promise<
+    UsdPaymentAmount | DealerPriceServiceError | ValidationError
+  >
+  proposedAmounts(): Promise<
+    PaymentAmountInAllCurrencies | DealerPriceServiceError | ValidationError
+  >
 
   addressForFlow(): Promise<OnChainAddress | DealerPriceServiceError>
   senderWalletDescriptor(): Promise<WalletDescriptor<S> | DealerPriceServiceError>

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -869,6 +869,32 @@ describe("UserWallet - onChainPay", () => {
     expect(status).toBeInstanceOf(LimitsExceededError)
   })
 
+  it("fee probe fails if the amount is less than on chain dust amount", async () => {
+    const address = (await bitcoindOutside.getNewAddress()) as OnChainAddress
+
+    const status = await Wallets.getOnChainFee({
+      account: accountA,
+      walletId: walletIdA,
+      address,
+      amount: amountBelowDustThreshold,
+      targetConfirmations,
+    })
+    expect(status).toBeInstanceOf(LessThanDustThresholdError)
+  })
+
+  it("fee probe fails if the amount is less than lnd on-chain dust amount", async () => {
+    const address = (await bitcoindOutside.getNewAddress()) as OnChainAddress
+
+    const status = await Wallets.getOnChainFee({
+      account: accountA,
+      walletId: walletIdA,
+      address,
+      amount: 1,
+      targetConfirmations,
+    })
+    expect(status).toBeInstanceOf(LessThanDustThresholdError)
+  })
+
   it("fails if the amount is less than on chain dust amount", async () => {
     const address = await bitcoindOutside.getNewAddress()
 
@@ -877,6 +903,21 @@ describe("UserWallet - onChainPay", () => {
       senderWalletId: walletIdA,
       address,
       amount: amountBelowDustThreshold,
+      targetConfirmations,
+      memo: null,
+      sendAll: false,
+    })
+    expect(status).toBeInstanceOf(LessThanDustThresholdError)
+  })
+
+  it("fails if the amount is less than lnd on-chain dust amount", async () => {
+    const address = await bitcoindOutside.getNewAddress()
+
+    const status = await Wallets.payOnChainByWalletId({
+      senderAccount: accountA,
+      senderWalletId: walletIdA,
+      address,
+      amount: 1,
       targetConfirmations,
       memo: null,
       sendAll: false,


### PR DESCRIPTION
## Description

This PR adds the dust check to other parts of the OPFBWithConversion step where btcPaymentAmounts are accessed.