### PR TITLE
chore: add lnd dust error to parser

### DIFF
--- a/src/domain/bitcoin/onchain/errors.ts
+++ b/src/domain/bitcoin/onchain/errors.ts
@@ -11,6 +11,9 @@ export class CPFPAncestorLimitReachedError extends OnChainServiceError {
 export class InsufficientOnChainFundsError extends OnChainServiceError {
   level = ErrorLevel.Critical
 }
+export class UnexpectedDustAmountError extends OnChainServiceError {
+  level = ErrorLevel.Critical
+}
 export class UnknownOnChainServiceError extends OnChainServiceError {
   level = ErrorLevel.Critical
 }

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -240,6 +240,10 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
         "Onchain withdrawals halted while we replenish the hot wallet. Withdrawals will be resumed shortly, and Lightning withdrawals are still available."
       return new InsufficientLiquidityError({ message, logger: baseLogger })
 
+    case "UnexpectedDustAmountError":
+      message = "Use lightning to very small dust amounts."
+      return new OnChainPaymentError({ message, logger: baseLogger })
+
     case "CPFPAncestorLimitReachedError":
       message =
         "Onchain payments temporarily unavailable because of busy mempool queue. Withdraw via Lightning until queue is cleared."

--- a/src/services/lnd/onchain-service.ts
+++ b/src/services/lnd/onchain-service.ts
@@ -7,6 +7,7 @@ import {
   InsufficientOnChainFundsError,
   OnChainServiceUnavailableError,
   OutgoingOnChainTransaction,
+  UnexpectedDustAmountError,
   UnknownOnChainServiceError,
 } from "@domain/bitcoin/onchain"
 import {
@@ -174,6 +175,8 @@ export const OnChainService = (
       switch (true) {
         case match(KnownLndErrorDetails.InsufficientFunds):
           return new InsufficientOnChainFundsError()
+        case match(KnownLndErrorDetails.DustAmount):
+          return new UnexpectedDustAmountError()
         default:
           return handleCommonOnChainServiceErrors(err)
       }
@@ -203,6 +206,8 @@ export const OnChainService = (
       switch (true) {
         case match(KnownLndErrorDetails.InsufficientFunds):
           return new InsufficientOnChainFundsError()
+        case match(KnownLndErrorDetails.DustAmount):
+          return new UnexpectedDustAmountError()
         case match(KnownLndErrorDetails.CPFPAncestorLimitReached):
           return new CPFPAncestorLimitReachedError()
         default:
@@ -232,6 +237,7 @@ const KnownLndErrorDetails = {
   ConnectionDropped: /Connection dropped/,
   CPFPAncestorLimitReached:
     /unmatched backend error: -26: too-long-mempool-chain, too many .* \[limit: \d+\]/,
+  DustAmount: /transaction output is dust/,
   NoConnectionEstablished: /No connection established/,
 } as const
 


### PR DESCRIPTION
## Description

Adds a new error type for lnd dust error (see [traces](https://ui.honeycomb.io/galoy/datasets/galoy-bbw?query=%7B%22time_range%22%3A7200%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22service.name%22%2C%22name%22%2C%22error.name%22%2C%22error.message%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22COUNT%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22error%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3Atrue%7D%2C%7B%22column%22%3A%22error.level%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22critical%22%7D%2C%7B%22column%22%3A%22service.name%22%2C%22op%22%3A%22!%3D%22%2C%22value%22%3A%22galoy-bbw-dealer%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22op%22%3A%22COUNT%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A1000%7D))