### PR TITLE
chore(deps): downgrade mongodb in compose to v5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
     environment:
       - MONGODB_ADDRESS=mongodb
   mongodb:
-    image: bitnami/mongodb:6.0.3
+    image: bitnami/mongodb:5.0.10-debian-11-r3
     environment:
       - MONGODB_PASSWORD=password
       - MONGODB_USERNAME=testGaloy


### PR DESCRIPTION
This will downgrade mongodb in dev to v5. This is required because the galoy chart is not able to fit in with the latest mongodb chart (`13.6.1`) and will require some debugging to figure out what values need to be changed.