### PR TITLE
fix: ip check fallback following axios regression

### DIFF
--- a/galoy.yaml
+++ b/galoy.yaml
@@ -143,9 +143,9 @@ spamLimits:
   memoSharingSatsThreshold: 1000
   memoSharingCentsThreshold: 50
 ipRecording:
-  enabled: true
+  enabled: false
   proxyChecking:
-    enabled: true
+    enabled: false
 fees:
   withdraw:
     method: flat

--- a/src/app/accounts/update-account-ip.ts
+++ b/src/app/accounts/update-account-ip.ts
@@ -1,9 +1,15 @@
 import { getIpConfig } from "@config"
 import { RepositoryError } from "@domain/errors"
 import { IpFetcherServiceError } from "@domain/ipfetcher"
+import { ErrorLevel } from "@domain/shared"
 import { IpFetcher } from "@services/ipfetcher"
 import { AccountsIpRepository } from "@services/mongoose/accounts-ips"
-import { asyncRunInSpan, SemanticAttributes } from "@services/tracing"
+import {
+  addAttributesToCurrentSpan,
+  asyncRunInSpan,
+  recordExceptionInCurrentSpan,
+  SemanticAttributes,
+} from "@services/tracing"
 
 const accountsIp = AccountsIpRepository()
 
@@ -17,11 +23,11 @@ export const updateAccountIPsInfo = async ({
   logger: Logger
 }): Promise<void | RepositoryError> =>
   asyncRunInSpan(
-    "app.users.updateAccountIPsInfo",
+    "app.accounts.updateAccountIPsInfo",
     {
       attributes: {
         [SemanticAttributes.CODE_FUNCTION]: "updateAccountIPsInfo",
-        [SemanticAttributes.CODE_NAMESPACE]: "app.users",
+        [SemanticAttributes.CODE_NAMESPACE]: "app.accounts",
       },
     },
     async () => {
@@ -29,16 +35,16 @@ export const updateAccountIPsInfo = async ({
 
       const lastConnection = new Date()
 
-      const userIP = await accountsIp.findById(accountId)
-      if (userIP instanceof RepositoryError) return userIP
+      const accountIP = await accountsIp.findById(accountId)
+      if (accountIP instanceof RepositoryError) return accountIP
 
       if (!ip || !ipConfig.ipRecordingEnabled) {
-        const result = await accountsIp.update(userIP)
+        const result = await accountsIp.update(accountIP)
 
         if (result instanceof Error) {
           logger.error(
             { result, accountId, ip },
-            "impossible to update user last connection",
+            "impossible to update account last connection",
           )
 
           return result
@@ -47,31 +53,80 @@ export const updateAccountIPsInfo = async ({
         return
       }
 
-      const lastIP = userIP.lastIPs.find((ipObject) => ipObject.ip === ip)
+      let ipInfo: IPType
 
-      if (lastIP) {
-        lastIP.lastConnection = lastConnection
+      const ipFromDb = accountIP.lastIPs.find((ipObject) => ipObject.ip === ip)
+
+      if (ipFromDb) {
+        ipInfo = ipFromDb
+        ipInfo.lastConnection = lastConnection
       } else {
-        let ipInfo: IPType = {
+        ipInfo = {
           ip,
           firstConnection: lastConnection,
           lastConnection: lastConnection,
         }
-
-        if (ipConfig.proxyCheckingEnabled) {
-          const ipFetcher = IpFetcher()
-          const ipFetcherInfo = await ipFetcher.fetchIPInfo(ip)
-
-          if (ipFetcherInfo instanceof IpFetcherServiceError) {
-            logger.error({ accountId, ip }, "impossible to get ip detail")
-            return ipFetcherInfo
-          }
-
-          ipInfo = { ...ipInfo, ...ipFetcherInfo }
-        }
-        userIP.lastIPs.push(ipInfo)
       }
-      const result = await accountsIp.update(userIP)
+
+      if (
+        ipConfig.proxyCheckingEnabled &&
+        (ipInfo.isoCode === undefined ||
+          ipInfo.proxy === undefined ||
+          ipInfo.asn === undefined)
+      ) {
+        const ipFetcher = IpFetcher()
+        const ipFetcherInfo = await ipFetcher.fetchIPInfo(ip)
+
+        if (ipFetcherInfo instanceof IpFetcherServiceError) {
+          recordExceptionInCurrentSpan({
+            error: ipFetcherInfo.message,
+            level: ErrorLevel.Warn,
+            attributes: {
+              ip,
+              accountId,
+            },
+          })
+
+          logger.error({ accountId, ip }, "impossible to get ip detail")
+          return ipFetcherInfo
+        }
+
+        // deep copy
+        const ipFetcherInfoForOtel = JSON.parse(JSON.stringify(ipFetcherInfo))
+
+        for (const key in ipFetcherInfoForOtel) {
+          ipFetcherInfoForOtel["proxycheck." + key] = ipFetcherInfoForOtel[key]
+          delete ipFetcherInfoForOtel[key]
+        }
+
+        addAttributesToCurrentSpan(ipFetcherInfoForOtel)
+
+        if (
+          ipFetcherInfo.isoCode === undefined ||
+          ipFetcherInfo.proxy === undefined ||
+          ipFetcherInfo.asn === undefined
+        ) {
+          const error = `missing mandatory fields. isoCode: ${ipFetcherInfo.isoCode}, proxy: ${ipFetcherInfo.proxy}, asn: ${ipFetcherInfo.asn}`
+          recordExceptionInCurrentSpan({
+            error,
+            level: ErrorLevel.Warn,
+            attributes: {
+              ip,
+              accountId,
+            },
+          })
+        } else {
+          // using Object.assign instead of ... because of conflict with mongoose hidden properties
+          ipInfo = Object.assign(ipInfo, ipFetcherInfo)
+
+          // removing current ip from lastIPs - if it exists
+          accountIP.lastIPs = accountIP.lastIPs.filter((ipDb) => ipDb.ip !== ip)
+
+          // adding it back with the correct info
+          accountIP.lastIPs.push(ipInfo)
+        }
+      }
+      const result = await accountsIp.update(accountIP)
 
       if (result instanceof Error) {
         logger.error({ result, accountId, ip }, "impossible to update ip")

--- a/src/app/auth/request-phone-code.ts
+++ b/src/app/auth/request-phone-code.ts
@@ -1,5 +1,6 @@
-import { getTestAccounts } from "@config"
+import { getTestAccounts, getTwilioConfig } from "@config"
 import { TestAccountsChecker } from "@domain/accounts/test-accounts-checker"
+import { NotImplementedError } from "@domain/errors"
 import { RateLimitConfig } from "@domain/rate-limit"
 import { RateLimiterExceededError } from "@domain/rate-limit/errors"
 import { consumeLimiter } from "@services/rate-limit"
@@ -67,6 +68,10 @@ export const requestPhoneCode = async ({
   const testAccounts = getTestAccounts()
   if (TestAccountsChecker(testAccounts).isPhoneValid(phone)) {
     return true
+  }
+
+  if (getTwilioConfig().accountSid === "AC_twilio_id") {
+    return new NotImplementedError("use test account for local dev and tests")
   }
 
   return TwilioClient().initiateVerify(phone)

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -452,9 +452,9 @@ export const configSchema = {
       required: ["enabled"],
       additionalProperties: false,
       default: {
-        enabled: true,
+        enabled: false,
         proxyChecking: {
-          enabled: true,
+          enabled: false,
         },
       },
     },

--- a/src/config/yaml.ts
+++ b/src/config/yaml.ts
@@ -264,9 +264,8 @@ export const getBuildVersions = (): {
 export const PROXY_CHECK_APIKEY = yamlConfig?.PROXY_CHECK_APIKEY
 
 export const getIpConfig = (config = yamlConfig): IpConfig => ({
-  ipRecordingEnabled:
-    process.env.NODE_ENV === "test" ? false : config.ipRecording?.enabled,
-  proxyCheckingEnabled: config.ipRecording?.proxyChecking?.enabled,
+  ipRecordingEnabled: config.ipRecording.enabled,
+  proxyCheckingEnabled: config.ipRecording.proxyChecking.enabled,
 })
 
 export const getApolloConfig = (config = yamlConfig): ApolloConfig => config.apollo

--- a/src/services/ipfetcher/index.ts
+++ b/src/services/ipfetcher/index.ts
@@ -1,23 +1,28 @@
 import axios from "axios"
 import { UnknownIpFetcherServiceError } from "@domain/ipfetcher"
 import { PROXY_CHECK_APIKEY } from "@config"
-import { addAttributesToCurrentSpan } from "@services/tracing"
 
 export const IpFetcher = (): IIpFetcherService => {
   const fetchIPInfo = async (ip: string): Promise<IPInfo | IpFetcherServiceError> => {
     try {
-      const { data } = await axios.get(
-        `https://proxycheck.io/v2/${ip}?key=${PROXY_CHECK_APIKEY}&vpn=1&asn=1`,
-      )
+      const params: { [id: string]: string } = {
+        vpn: "1",
+        asn: "1",
+        time: "1",
+        risk: "1",
+      }
+
+      if (PROXY_CHECK_APIKEY) {
+        params["key"] = PROXY_CHECK_APIKEY
+      }
+
+      const { data } = await axios.request({
+        url: `https://proxycheck.io/v2/${ip}`,
+        params,
+      })
+
       const proxy = !!(data[ip] && data[ip].proxy && data[ip].proxy === "yes")
       const isoCode = data[ip] && data[ip].isocode
-
-      addAttributesToCurrentSpan({
-        ...data[ip],
-        isoCode,
-        proxy,
-        status: data.status,
-      })
 
       return { ...data[ip], isoCode, proxy, status: data.status }
     } catch (err) {


### PR DESCRIPTION
axios had a regression that made proxycheck call failed: https://github.com/axios/axios/pull/5306
 
this prior PR fixes the proxycheck issue: https://github.com/GaloyMoney/galoy/commit/eca59ab0833c09d6d53d3aa3600ce162d683944a

now most `IPType` are not populated with the correct info, so as a result the rewards are not working.

this PR will make a call back to proxychecker if the relevant info is not present.

also, it adds proper open telemetry info