### PR TITLE
fix: validate sats amount after checking status of pending invoice

### DIFF
--- a/src/app/wallets/update-pending-invoices.ts
+++ b/src/app/wallets/update-pending-invoices.ts
@@ -124,6 +124,16 @@ const updatePendingInvoiceBeforeFinally = async ({
     roundedDownReceived: uncheckedRoundedDownReceived,
   } = lnInvoiceLookup
 
+  if (walletInvoice.paid) {
+    pendingInvoiceLogger.info("invoice has already been processed")
+    return true
+  }
+
+  if (!lnInvoiceLookup.isHeld && !lnInvoiceLookup.isSettled) {
+    pendingInvoiceLogger.info("invoice has not been paid yet")
+    return false
+  }
+
   // TODO: validate roundedDownReceived as user input
   const roundedDownReceived = checkedToSats(uncheckedRoundedDownReceived)
   if (roundedDownReceived instanceof Error) {
@@ -136,16 +146,6 @@ const updatePendingInvoiceBeforeFinally = async ({
       paymentHash: walletInvoice.paymentHash,
       logger,
     })
-  }
-
-  if (walletInvoice.paid) {
-    pendingInvoiceLogger.info("invoice has already been processed")
-    return true
-  }
-
-  if (!lnInvoiceLookup.isHeld && !lnInvoiceLookup.isSettled) {
-    pendingInvoiceLogger.info("invoice has not been paid yet")
-    return false
   }
 
   const receivedBtc = paymentAmountFromNumber({


### PR DESCRIPTION
## Description

For no-amount invoices, 0 is a valid amount if the invoice isn't held or settled as yet. This change checks for the invoice status first before validating the sats amount to avoid wrongly erroring for an unpaid/unheld 0-amount invoice.