### PR TITLE
feat: whatsapp as an alternative way of receiving code

### DIFF
--- a/src/app/auth/request-phone-code.ts
+++ b/src/app/auth/request-phone-code.ts
@@ -14,6 +14,7 @@ export const requestPhoneCodeWithCaptcha = async ({
   geetestSeccode,
   logger,
   ip,
+  channel,
 }: {
   phone: PhoneNumber
   geetest: GeetestType
@@ -22,6 +23,7 @@ export const requestPhoneCodeWithCaptcha = async ({
   geetestSeccode: string
   logger: Logger
   ip: IpAddress
+  channel: ChannelType
 }): Promise<true | ApplicationError> => {
   logger.info({ phone, ip }, "RequestPhoneCodeGeetest called")
 
@@ -36,6 +38,7 @@ export const requestPhoneCodeWithCaptcha = async ({
     phone,
     logger,
     ip,
+    channel,
   })
 }
 
@@ -43,10 +46,12 @@ export const requestPhoneCode = async ({
   phone,
   logger,
   ip,
+  channel,
 }: {
   phone: PhoneNumber
   logger: Logger
   ip: IpAddress
+  channel: ChannelType
 }): Promise<true | PhoneProviderServiceError> => {
   logger.info({ phone, ip }, "RequestPhoneCode called")
 
@@ -74,7 +79,7 @@ export const requestPhoneCode = async ({
     return new NotImplementedError("use test account for local dev and tests")
   }
 
-  return TwilioClient().initiateVerify(phone)
+  return TwilioClient().initiateVerify({ to: phone, channel })
 }
 
 const checkPhoneCodeAttemptPerIpLimits = async (

--- a/src/domain/phone-provider/index.ts
+++ b/src/domain/phone-provider/index.ts
@@ -5,3 +5,8 @@ export const CarrierType = {
   Void: "voip",
   Mobile: "mobile",
 } as const
+
+export const ChannelType = {
+  sms: "sms",
+  whatsapp: "whatsapp",
+} as const

--- a/src/domain/phone-provider/index.ts
+++ b/src/domain/phone-provider/index.ts
@@ -7,6 +7,6 @@ export const CarrierType = {
 } as const
 
 export const ChannelType = {
-  sms: "sms",
-  whatsapp: "whatsapp",
+  Sms: "sms",
+  Whatsapp: "whatsapp",
 } as const

--- a/src/domain/phone-provider/index.types.d.ts
+++ b/src/domain/phone-provider/index.types.d.ts
@@ -5,7 +5,13 @@ type PhoneCodeInvalidError = import("./errors").PhoneCodeInvalidError
 
 interface IPhoneProviderService {
   getCarrier(phone: PhoneNumber): Promise<PhoneMetadata | PhoneProviderServiceError>
-  initiateVerify(to: PhoneNumber): Promise<true | PhoneProviderServiceError>
+  initiateVerify({
+    to,
+    channel,
+  }: {
+    to: PhoneNumber
+    channel: ChannelType
+  }): Promise<true | PhoneProviderServiceError>
   validateVerify({
     to,
     code,

--- a/src/domain/users/index.types.d.ts
+++ b/src/domain/users/index.types.d.ts
@@ -11,6 +11,9 @@ type DeviceToken = string & { readonly brand: unique symbol }
 type CarrierType =
   typeof import("../phone-provider/index").CarrierType[keyof typeof import("../phone-provider/index").CarrierType]
 
+type ChannelType =
+  typeof import("../phone-provider/index").ChannelType[keyof typeof import("../phone-provider/index").ChannelType]
+
 type PhoneMetadata = {
   // from twilio
   carrier: {

--- a/src/graphql/admin/schema.graphql
+++ b/src/graphql/admin/schema.graphql
@@ -149,6 +149,7 @@ type CaptchaCreateChallengeResult {
 
 input CaptchaRequestAuthCodeInput {
   challengeCode: String!
+  channel: PhoneCodeChannelType
   phone: Phone!
   secCode: String!
   validationCode: String!
@@ -300,6 +301,11 @@ scalar PaymentHash
 Phone number which includes country code
 """
 scalar Phone
+
+enum PhoneCodeChannelType {
+  SMS
+  WHATSAPP
+}
 
 """
 Price amount expressed in base/offset. To calculate, use: `base / 10^offset`
@@ -543,6 +549,7 @@ input UserLoginInput {
 }
 
 input UserRequestAuthCodeInput {
+  channel: PhoneCodeChannelType
   phone: Phone!
 }
 

--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -136,6 +136,7 @@ type CaptchaCreateChallengeResult {
 
 input CaptchaRequestAuthCodeInput {
   challengeCode: String!
+  channel: PhoneCodeChannelType
   phone: Phone!
   secCode: String!
   validationCode: String!
@@ -790,6 +791,11 @@ Phone number which includes country code
 """
 scalar Phone
 
+enum PhoneCodeChannelType {
+  SMS
+  WHATSAPP
+}
+
 """
 Price amount expressed in base/offset. To calculate, use: `base / 10^offset`
 """
@@ -1197,6 +1203,7 @@ type UserQuizQuestionUpdateCompletedPayload {
 }
 
 input UserRequestAuthCodeInput {
+  channel: PhoneCodeChannelType
   phone: Phone!
 }
 

--- a/src/graphql/root/mutation/captcha-request-auth-code.ts
+++ b/src/graphql/root/mutation/captcha-request-auth-code.ts
@@ -58,8 +58,8 @@ const CaptchaRequestAuthCodeMutation = GT.Field<{
       return { errors: [{ message: "ip is undefined" }] }
     }
 
-    let channel: ChannelType = ChannelType.sms
-    if (channelInput === "WHATSAPP") channel = ChannelType.whatsapp
+    let channel: ChannelType = ChannelType.Sms
+    if (channelInput === "WHATSAPP") channel = ChannelType.Whatsapp
 
     const result = await Auth.requestPhoneCodeWithCaptcha({
       phone,

--- a/src/graphql/root/mutation/captcha-request-auth-code.ts
+++ b/src/graphql/root/mutation/captcha-request-auth-code.ts
@@ -4,6 +4,9 @@ import Phone from "@graphql/types/scalar/phone"
 import SuccessPayload from "@graphql/types/payload/success-payload"
 import { Auth } from "@app"
 import { mapAndParseErrorForGqlResponse } from "@graphql/error-map"
+import { ChannelType } from "@domain/phone-provider"
+import PhoneCodeChannelType from "@graphql/types/scalar/phone-code-channel-type"
+import { InputValidationError } from "@graphql/error"
 
 const CaptchaRequestAuthCodeInput = GT.Input({
   name: "CaptchaRequestAuthCodeInput",
@@ -12,10 +15,19 @@ const CaptchaRequestAuthCodeInput = GT.Input({
     challengeCode: { type: GT.NonNull(GT.String) },
     validationCode: { type: GT.NonNull(GT.String) },
     secCode: { type: GT.NonNull(GT.String) },
+    channel: { type: PhoneCodeChannelType },
   }),
 })
 
-const CaptchaRequestAuthCodeMutation = GT.Field({
+const CaptchaRequestAuthCodeMutation = GT.Field<{
+  input: {
+    phone: PhoneNumber | InputValidationError
+    challengeCode: string | InputValidationError
+    validationCode: string | InputValidationError
+    secCode: string | InputValidationError
+    channel: string | InputValidationError
+  }
+}>({
   extensions: {
     complexity: 120,
   },
@@ -29,17 +41,25 @@ const CaptchaRequestAuthCodeMutation = GT.Field({
       challengeCode: geetestChallenge,
       validationCode: geetestValidate,
       secCode: geetestSeccode,
+      channel: channelInput,
     } = args.input
 
-    for (const input of [phone, geetestChallenge, geetestValidate, geetestSeccode]) {
-      if (input instanceof Error) {
-        return { errors: [{ message: input.message }] }
-      }
-    }
+    if (phone instanceof Error) return { errors: [{ message: phone.message }] }
+    if (geetestChallenge instanceof Error)
+      return { errors: [{ message: geetestChallenge.message }] }
+    if (geetestValidate instanceof Error)
+      return { errors: [{ message: geetestValidate.message }] }
+    if (geetestSeccode instanceof Error)
+      return { errors: [{ message: geetestSeccode.message }] }
+    if (channelInput instanceof Error)
+      return { errors: [{ message: channelInput.message }] }
 
     if (ip === undefined) {
       return { errors: [{ message: "ip is undefined" }] }
     }
+
+    let channel: ChannelType = ChannelType.sms
+    if (channelInput === "WHATSAPP") channel = ChannelType.whatsapp
 
     const result = await Auth.requestPhoneCodeWithCaptcha({
       phone,
@@ -49,6 +69,7 @@ const CaptchaRequestAuthCodeMutation = GT.Field({
       geetestSeccode,
       logger,
       ip,
+      channel,
     })
 
     if (result instanceof Error) {

--- a/src/graphql/root/mutation/user-request-auth-code.ts
+++ b/src/graphql/root/mutation/user-request-auth-code.ts
@@ -36,12 +36,15 @@ const UserRequestAuthCodeMutation = GT.Field({
       return { errors: [{ message: phone.message }] }
     }
 
+    if (channelInput instanceof Error)
+      return { errors: [{ message: channelInput.message }] }
+
     if (ip === undefined) {
       return { errors: [{ message: "ip is undefined" }] }
     }
 
-    let channel: ChannelType = ChannelType.sms
-    if (channelInput === "WHATSAPP") channel = ChannelType.whatsapp
+    let channel: ChannelType = ChannelType.Sms
+    if (channelInput === "WHATSAPP") channel = ChannelType.Whatsapp
 
     const status = await Auth.requestPhoneCode({
       phone,

--- a/src/graphql/root/mutation/user-request-auth-code.ts
+++ b/src/graphql/root/mutation/user-request-auth-code.ts
@@ -5,13 +5,14 @@ import SuccessPayload from "@graphql/types/payload/success-payload"
 import { Auth } from "@app"
 import { mapAndParseErrorForGqlResponse } from "@graphql/error-map"
 import { getCaptcha } from "@config"
+import { ChannelType } from "@domain/phone-provider"
+import PhoneCodeChannelType from "@graphql/types/scalar/phone-code-channel-type"
 
 const UserRequestAuthCodeInput = GT.Input({
   name: "UserRequestAuthCodeInput",
   fields: () => ({
-    phone: {
-      type: GT.NonNull(Phone),
-    },
+    phone: { type: GT.NonNull(Phone) },
+    channel: { type: PhoneCodeChannelType },
   }),
 })
 
@@ -29,7 +30,7 @@ const UserRequestAuthCodeMutation = GT.Field({
       return { errors: [{ message: "use captcha endpoint to request auth code" }] }
     }
 
-    const { phone } = args.input
+    const { phone, channel: channelInput } = args.input
 
     if (phone instanceof Error) {
       return { errors: [{ message: phone.message }] }
@@ -39,7 +40,15 @@ const UserRequestAuthCodeMutation = GT.Field({
       return { errors: [{ message: "ip is undefined" }] }
     }
 
-    const status = await Auth.requestPhoneCode({ phone, logger, ip })
+    let channel: ChannelType = ChannelType.sms
+    if (channelInput === "WHATSAPP") channel = ChannelType.whatsapp
+
+    const status = await Auth.requestPhoneCode({
+      phone,
+      logger,
+      ip,
+      channel,
+    })
 
     if (status instanceof Error) {
       return { errors: [mapAndParseErrorForGqlResponse(status)] }

--- a/src/graphql/types/scalar/phone-code-channel-type.ts
+++ b/src/graphql/types/scalar/phone-code-channel-type.ts
@@ -1,0 +1,11 @@
+import { GT } from "@graphql/index"
+
+const PhoneCodeChannelType = GT.Enum({
+  name: "PhoneCodeChannelType",
+  values: {
+    SMS: {},
+    WHATSAPP: {},
+  },
+})
+
+export default PhoneCodeChannelType

--- a/src/services/twilio.ts
+++ b/src/services/twilio.ts
@@ -22,11 +22,15 @@ export const TwilioClient = (): IPhoneProviderService => {
   const client = twilio(accountSid, authToken)
   const verify = client.verify.v2.services(verifyService)
 
-  const initiateVerify = async (
-    to: PhoneNumber,
-  ): Promise<true | PhoneProviderServiceError> => {
+  const initiateVerify = async ({
+    to,
+    channel,
+  }: {
+    to: PhoneNumber
+    channel: ChannelType
+  }): Promise<true | PhoneProviderServiceError> => {
     try {
-      await verify.verifications.create({ to, channel: "sms" })
+      await verify.verifications.create({ to, channel })
     } catch (err) {
       baseLogger.error({ err }, "impossible to send text")
 


### PR DESCRIPTION
a new optional channel argument has been added to UserRequestAuthCodeInput and UserRequestAuthCodeInput

when channel is not set, it defaulted to SMS, otherwise WHATSAPP can be used and set. 

~~there are now 2 different mutations:~~
~~- `captchaRequestAuthViaSmsCode`~~
~~- `captchaRequestAuthViaWhatsappCode`~~
~~`captchaRequestAuthCode` is still available but deprecated~~
~~as `userRequestAuthCode` is only used for dev (bypassing captcha), I didn't created two endpoints for this one, as it's also meant to bypass the twilio integration with the use of test codes.~~