### PR TITLE
feat: add onchain stablesats send 🎉 

### DIFF
--- a/src/app/wallets/send-on-chain.ts
+++ b/src/app/wallets/send-on-chain.ts
@@ -22,7 +22,7 @@ import {
   InsufficientOnChainFundsError,
   TxDecoder,
 } from "@domain/bitcoin/onchain"
-import { CouldNotFindError, NotImplementedError } from "@domain/errors"
+import { CouldNotFindError } from "@domain/errors"
 import { DisplayCurrency } from "@domain/fiat"
 import { NewDisplayCurrencyConverter } from "@domain/fiat/display-currency"
 import { ResourceExpiredLockServiceError } from "@domain/lock"
@@ -211,16 +211,6 @@ const executePaymentViaIntraledger = async <
 
   const recipientWallet = await WalletsRepository().findById(recipientWalletId)
   if (recipientWallet instanceof Error) return recipientWallet
-
-  // TODO Usd use case
-  if (
-    !(
-      recipientWallet.currency === WalletCurrency.Btc &&
-      senderWallet.currency === WalletCurrency.Btc
-    )
-  ) {
-    return new NotImplementedError("USD intraledger")
-  }
 
   // Limit check
   const priceRatioForLimits = await getPriceRatioForLimits(paymentFlow.paymentAmounts())

--- a/src/app/wallets/send-on-chain.ts
+++ b/src/app/wallets/send-on-chain.ts
@@ -22,7 +22,7 @@ import {
   InsufficientOnChainFundsError,
   TxDecoder,
 } from "@domain/bitcoin/onchain"
-import { CouldNotFindError } from "@domain/errors"
+import { CouldNotFindError, InsufficientBalanceError } from "@domain/errors"
 import { DisplayCurrency } from "@domain/fiat"
 import { NewDisplayCurrencyConverter } from "@domain/fiat/display-currency"
 import { ResourceExpiredLockServiceError } from "@domain/lock"
@@ -63,6 +63,10 @@ export const payOnChainByWalletId = async <R extends WalletCurrency>({
     ? await LedgerService().getWalletBalance(senderWalletId)
     : amountRaw
   if (amountToSendRaw instanceof Error) return amountToSendRaw
+
+  if (sendAll && amountToSendRaw === 0) {
+    return new InsufficientBalanceError(`No balance left to send.`)
+  }
 
   const validator = PaymentInputValidator(WalletsRepository().findById)
   const validationResult = await validator.validatePaymentInput({

--- a/src/domain/payments/onchain-payment-flow-builder.ts
+++ b/src/domain/payments/onchain-payment-flow-builder.ts
@@ -320,7 +320,7 @@ const OPFBWithConversion = <S extends WalletCurrency, R extends WalletCurrency>(
       btcPaymentAmount.amount < state.dustThreshold
     ) {
       return new LessThanDustThresholdError(
-        `Use lightning to send amounts less than ${state.dustThreshold}`,
+        `Use lightning to send amounts less than ${state.dustThreshold} sats`,
       )
     }
 

--- a/src/graphql/error.ts
+++ b/src/graphql/error.ts
@@ -153,7 +153,7 @@ export class DustAmountError extends CustomApolloError {
   constructor(errData: CustomApolloErrorData) {
     super({
       code: "ENTERED_DUST_AMOUNT",
-      message: `Use lightning to send amounts less than ${onChainWalletConfig.dustThreshold}`,
+      message: `Use lightning to send amounts less than ${onChainWalletConfig.dustThreshold} sats`,
       forwardToClient: true,
       ...errData,
     })

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -48,7 +48,19 @@ export const validateIsBtcWalletForQuery = async (
   const wallet = await WalletsRepository().findById(walletId)
   if (wallet instanceof Error) return mapError(wallet)
 
-  if (wallet.currency === WalletCurrency.Usd) {
+  if (wallet.currency !== WalletCurrency.Btc) {
+    return QueryDoesNotMatchWalletCurrencyError
+  }
+  return true
+}
+
+export const validateIsUsdWalletForQuery = async (
+  walletId: WalletId,
+): Promise<true | CustomApolloError> => {
+  const wallet = await WalletsRepository().findById(walletId)
+  if (wallet instanceof Error) return mapError(wallet)
+
+  if (wallet.currency !== WalletCurrency.Usd) {
     return QueryDoesNotMatchWalletCurrencyError
   }
   return true

--- a/src/graphql/main/mutations.ts
+++ b/src/graphql/main/mutations.ts
@@ -26,6 +26,7 @@ import AccountUpdateDefaultWalletIdMutation from "@graphql/root/mutation/account
 import UserContactUpdateAliasMutation from "@graphql/root/mutation/user-contact-update-alias"
 import UserQuizQuestionUpdateCompletedMutation from "@graphql/root/mutation/user-quiz-question-update-completed"
 import OnChainPaymentSendMutation from "@graphql/root/mutation/onchain-payment-send"
+import OnChainUsdPaymentSendMutation from "@graphql/root/mutation/onchain-usd-payment-send"
 import OnChainPaymentSendAllMutation from "@graphql/root/mutation/onchain-payment-send-all"
 import CaptchaRequestAuthCodeMutation from "@graphql/root/mutation/captcha-request-auth-code"
 import CaptchaCreateChallengeMutation from "@graphql/root/mutation/captcha-create-challenge"
@@ -72,6 +73,7 @@ const fields = {
   onChainAddressCreate: OnChainAddressCreateMutation,
   onChainAddressCurrent: OnChainAddressCurrentMutation,
   onChainPaymentSend: OnChainPaymentSendMutation,
+  onChainUsdPaymentSend: OnChainUsdPaymentSendMutation,
   onChainPaymentSendAll: OnChainPaymentSendAllMutation,
 }
 

--- a/src/graphql/main/queries.ts
+++ b/src/graphql/main/queries.ts
@@ -8,6 +8,7 @@ import BtcPriceListQuery from "@graphql/root/query/btc-price-list"
 import QuizQuestionsQuery from "@graphql/root/query/quiz-questions"
 import MobileVersionsQuery from "@graphql/root/query/mobile-versions"
 import OnChainTxFeeQuery from "@graphql/root/query/on-chain-tx-fee-query"
+import OnChainUsdTxFeeQuery from "@graphql/root/query/on-chain-usd-tx-fee-query"
 import UsernameAvailableQuery from "@graphql/root/query/username-available"
 import BusinessMapMarkersQuery from "@graphql/root/query/business-map-markers"
 import AccountDefaultWalletQuery from "@graphql/root/query/account-default-wallet"
@@ -27,6 +28,7 @@ const fields = {
   btcPrice: BtcPriceQuery,
   btcPriceList: BtcPriceListQuery,
   onChainTxFee: OnChainTxFeeQuery,
+  onChainUsdTxFee: OnChainUsdTxFeeQuery,
   lnInvoicePaymentStatus: LnInvoicePaymentStatusQuery,
 } as const
 

--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -708,6 +708,7 @@ type Mutation {
   onChainAddressCurrent(input: OnChainAddressCurrentInput!): OnChainAddressPayload!
   onChainPaymentSend(input: OnChainPaymentSendInput!): PaymentSendPayload!
   onChainPaymentSendAll(input: OnChainPaymentSendAllInput!): PaymentSendPayload!
+  onChainUsdPaymentSend(input: OnChainUsdPaymentSendInput!): PaymentSendPayload!
   userContactUpdateAlias(
     input: UserContactUpdateAliasInput!
   ): UserContactUpdateAliasPayload! @deprecated(reason: "will be moved to AccountContact")
@@ -782,6 +783,14 @@ type OnChainUpdate {
   txHash: OnChainTxHash!
   txNotificationType: TxNotificationType!
   usdPerSat: Float! @deprecated(reason: "updated over displayCurrencyPerSat")
+  walletId: WalletId!
+}
+
+input OnChainUsdPaymentSendInput {
+  address: OnChainAddress!
+  amount: CentAmount!
+  memo: Memo
+  targetConfirmations: TargetConfirmations = 1
   walletId: WalletId!
 }
 

--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -923,6 +923,12 @@ type Query {
     targetConfirmations: TargetConfirmations = 1
     walletId: WalletId!
   ): OnChainTxFee!
+  onChainUsdTxFee(
+    address: OnChainAddress!
+    amount: CentAmount!
+    targetConfirmations: TargetConfirmations = 1
+    walletId: WalletId!
+  ): OnChainTxFee!
   quizQuestions: [QuizQuestion]
   userDefaultWalletId(username: Username!): WalletId!
     @deprecated(reason: "will be migrated to AccountDefaultWalletId")

--- a/src/graphql/root/mutation/onchain-payment-send-all.ts
+++ b/src/graphql/root/mutation/onchain-payment-send-all.ts
@@ -5,7 +5,6 @@ import WalletId from "@graphql/types/scalar/wallet-id"
 import OnChainAddress from "@graphql/types/scalar/on-chain-address"
 import PaymentSendPayload from "@graphql/types/payload/payment-send"
 import TargetConfirmations from "@graphql/types/scalar/target-confirmations"
-import { validateIsBtcWalletForMutation } from "@graphql/helpers"
 import { Wallets } from "@app"
 
 const OnChainPaymentSendAllInput = GT.Input({
@@ -55,9 +54,6 @@ const OnChainPaymentSendAllMutation = GT.Field<
     if (targetConfirmations instanceof Error) {
       return { errors: [{ message: targetConfirmations.message }] }
     }
-
-    const btcWalletValidated = await validateIsBtcWalletForMutation(walletId)
-    if (btcWalletValidated != true) return btcWalletValidated
 
     const status = await Wallets.payOnChainByWalletId({
       senderAccount: domainAccount,

--- a/src/graphql/root/mutation/onchain-usd-payment-send.ts
+++ b/src/graphql/root/mutation/onchain-usd-payment-send.ts
@@ -1,0 +1,86 @@
+import { GT } from "@graphql/index"
+import Memo from "@graphql/types/scalar/memo"
+import { mapAndParseErrorForGqlResponse } from "@graphql/error-map"
+import WalletId from "@graphql/types/scalar/wallet-id"
+import CentAmount from "@graphql/types/scalar/cent-amount"
+import OnChainAddress from "@graphql/types/scalar/on-chain-address"
+import PaymentSendPayload from "@graphql/types/payload/payment-send"
+import TargetConfirmations from "@graphql/types/scalar/target-confirmations"
+import { validateIsUsdWalletForMutation } from "@graphql/helpers"
+import { Wallets } from "@app"
+
+const OnChainUsdPaymentSendInput = GT.Input({
+  name: "OnChainUsdPaymentSendInput",
+  fields: () => ({
+    walletId: { type: GT.NonNull(WalletId) },
+    address: { type: GT.NonNull(OnChainAddress) },
+    amount: { type: GT.NonNull(CentAmount) },
+    memo: { type: Memo },
+    targetConfirmations: { type: TargetConfirmations, defaultValue: 1 },
+  }),
+})
+
+const OnChainUsdPaymentSendMutation = GT.Field<
+  {
+    input: {
+      walletId: WalletId | InputValidationError
+      address: OnChainAddress | InputValidationError
+      amount: number
+      memo: Memo | InputValidationError | null
+      targetConfirmations: TargetConfirmations | InputValidationError
+    }
+  },
+  null,
+  GraphQLContextAuth
+>({
+  extensions: {
+    complexity: 120,
+  },
+  type: GT.NonNull(PaymentSendPayload),
+  args: {
+    input: { type: GT.NonNull(OnChainUsdPaymentSendInput) },
+  },
+  resolve: async (_, args, { domainAccount }) => {
+    const { walletId, address, amount, memo, targetConfirmations } = args.input
+
+    if (walletId instanceof Error) {
+      return { errors: [{ message: walletId.message }] }
+    }
+
+    if (address instanceof Error) {
+      return { errors: [{ message: address.message }] }
+    }
+
+    if (memo instanceof Error) {
+      return { errors: [{ message: memo.message }] }
+    }
+
+    if (targetConfirmations instanceof Error) {
+      return { errors: [{ message: targetConfirmations.message }] }
+    }
+
+    const usdWalletValidated = await validateIsUsdWalletForMutation(walletId)
+    if (usdWalletValidated != true) return usdWalletValidated
+
+    const status = await Wallets.payOnChainByWalletId({
+      senderAccount: domainAccount,
+      senderWalletId: walletId,
+      amount,
+      address,
+      targetConfirmations,
+      memo,
+      sendAll: false,
+    })
+
+    if (status instanceof Error) {
+      return { status: "failed", errors: [mapAndParseErrorForGqlResponse(status)] }
+    }
+
+    return {
+      errors: [],
+      status: status.value,
+    }
+  },
+})
+
+export default OnChainUsdPaymentSendMutation

--- a/src/graphql/root/query/on-chain-tx-fee-query.ts
+++ b/src/graphql/root/query/on-chain-tx-fee-query.ts
@@ -11,6 +11,8 @@ import TargetConfirmations from "@graphql/types/scalar/target-confirmations"
 
 import OnChainTxFee from "@graphql/types/object/onchain-tx-fee"
 
+import { normalizePaymentAmount } from "../mutation"
+
 const OnChainTxFeeQuery = GT.Field({
   type: GT.NonNull(OnChainTxFee),
   args: {
@@ -39,7 +41,7 @@ const OnChainTxFeeQuery = GT.Field({
     if (fee instanceof Error) throw mapError(fee)
 
     return {
-      amount: fee,
+      amount: normalizePaymentAmount(fee).amount,
       targetConfirmations,
     }
   },

--- a/src/graphql/root/query/on-chain-usd-tx-fee-query.ts
+++ b/src/graphql/root/query/on-chain-usd-tx-fee-query.ts
@@ -9,10 +9,12 @@ import CentAmount from "@graphql/types/scalar/cent-amount"
 import OnChainAddress from "@graphql/types/scalar/on-chain-address"
 import TargetConfirmations from "@graphql/types/scalar/target-confirmations"
 
-import OnChainTxFee from "@graphql/types/object/onchain-tx-fee"
+import OnChainUsdTxFee from "@graphql/types/object/onchain-usd-tx-fee"
+
+import { normalizePaymentAmount } from "../mutation"
 
 const OnChainUsdTxFeeQuery = GT.Field({
-  type: GT.NonNull(OnChainTxFee),
+  type: GT.NonNull(OnChainUsdTxFee),
   args: {
     walletId: { type: GT.NonNull(WalletId) },
     address: { type: GT.NonNull(OnChainAddress) },
@@ -39,7 +41,7 @@ const OnChainUsdTxFeeQuery = GT.Field({
     if (fee instanceof Error) throw mapError(fee)
 
     return {
-      amount: fee,
+      amount: normalizePaymentAmount(fee).amount,
       targetConfirmations,
     }
   },

--- a/src/graphql/root/query/on-chain-usd-tx-fee-query.ts
+++ b/src/graphql/root/query/on-chain-usd-tx-fee-query.ts
@@ -1,0 +1,48 @@
+import { Wallets } from "@app"
+
+import { GT } from "@graphql/index"
+import { mapError } from "@graphql/error-map"
+import { validateIsUsdWalletForQuery } from "@graphql/helpers"
+
+import WalletId from "@graphql/types/scalar/wallet-id"
+import CentAmount from "@graphql/types/scalar/cent-amount"
+import OnChainAddress from "@graphql/types/scalar/on-chain-address"
+import TargetConfirmations from "@graphql/types/scalar/target-confirmations"
+
+import OnChainTxFee from "@graphql/types/object/onchain-tx-fee"
+
+const OnChainUsdTxFeeQuery = GT.Field({
+  type: GT.NonNull(OnChainTxFee),
+  args: {
+    walletId: { type: GT.NonNull(WalletId) },
+    address: { type: GT.NonNull(OnChainAddress) },
+    amount: { type: GT.NonNull(CentAmount) },
+    targetConfirmations: { type: TargetConfirmations, defaultValue: 1 },
+  },
+  resolve: async (_, args, { domainAccount }) => {
+    const { walletId, address, amount, targetConfirmations } = args
+
+    for (const input of [walletId, address, amount, targetConfirmations]) {
+      if (input instanceof Error) throw input
+    }
+
+    const usdWalletValidated = await validateIsUsdWalletForQuery(walletId)
+    if (usdWalletValidated instanceof Error) throw usdWalletValidated
+
+    const fee = await Wallets.getOnChainFee({
+      walletId,
+      account: domainAccount as Account,
+      amount,
+      address,
+      targetConfirmations,
+    })
+    if (fee instanceof Error) throw mapError(fee)
+
+    return {
+      amount: fee,
+      targetConfirmations,
+    }
+  },
+})
+
+export default OnChainUsdTxFeeQuery

--- a/src/graphql/types/object/onchain-usd-tx-fee.ts
+++ b/src/graphql/types/object/onchain-usd-tx-fee.ts
@@ -1,0 +1,14 @@
+import { GT } from "@graphql/index"
+
+import CentAmount from "../scalar/cent-amount"
+import TargetConfirmations from "../scalar/target-confirmations"
+
+const OnChainUsdTxFee = GT.Object({
+  name: "OnChainUsdTxFee",
+  fields: () => ({
+    amount: { type: GT.NonNull(CentAmount) },
+    targetConfirmations: { type: GT.NonNull(TargetConfirmations) },
+  }),
+})
+
+export default OnChainUsdTxFee

--- a/src/servers/graphql-main-server.ts
+++ b/src/servers/graphql-main-server.ts
@@ -23,6 +23,7 @@ export async function startApolloServerForCoreSchema() {
       Query: {
         me: isAuthenticated,
         onChainTxFee: isAuthenticated,
+        onChainUsdTxFee: isAuthenticated,
       },
       Mutation: {
         userQuizQuestionUpdateCompleted: isAuthenticated,
@@ -50,6 +51,7 @@ export async function startApolloServerForCoreSchema() {
         onChainAddressCreate: isAuthenticated,
         onChainAddressCurrent: isAuthenticated,
         onChainPaymentSend: isAuthenticated,
+        onChainUsdPaymentSend: isAuthenticated,
         onChainPaymentSendAll: isAuthenticated,
       },
     },

--- a/src/servers/middlewares/wallet-id.ts
+++ b/src/servers/middlewares/wallet-id.ts
@@ -57,6 +57,7 @@ const validateWalletIdMutation = async (
 export const walletIdMiddleware = {
   Query: {
     onChainTxFee: validateWalletIdQuery,
+    onChainUsdTxFee: validateWalletIdQuery,
   },
   Mutation: {
     intraLedgerPaymentSend: validateWalletIdMutation,
@@ -71,6 +72,7 @@ export const walletIdMiddleware = {
     onChainAddressCreate: validateWalletIdMutation,
     onChainAddressCurrent: validateWalletIdMutation,
     onChainPaymentSend: validateWalletIdMutation,
+    onChainUsdPaymentSend: validateWalletIdMutation,
     onChainPaymentSendAll: validateWalletIdMutation,
   },
 }

--- a/test/integration/02-user-wallet/02-receive-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-lightning.spec.ts
@@ -433,7 +433,7 @@ describe("UserWallet - Lightning", () => {
   it("receives payment from outside USD wallet with amountless invoices", async () => {
     const initBalanceUsdB = toCents(await getBalanceHelper(walletIdUsdB))
 
-    const sats = toSats(120)
+    const sats = toSats(120000)
     const memo = "myMemo"
 
     const lnInvoice = await Wallets.addInvoiceNoAmountForSelf({

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -59,7 +59,6 @@ import {
   createUserAndWalletFromUserRef,
   getAccountByTestUserRef,
   getDefaultWalletIdByTestUserRef,
-  getAccountRecordByTestUserRef,
   lndonchain,
   lndOutside1,
   mineBlockAndSync,
@@ -67,8 +66,6 @@ import {
   subscribeToTransactions,
   getUsdWalletIdByTestUserRef,
 } from "test/helpers"
-
-let accountRecordA: AccountRecord
 
 let accountA: Account
 let accountB: Account
@@ -96,7 +93,6 @@ beforeAll(async () => {
   await createUserAndWalletFromUserRef("E")
   await createUserAndWalletFromUserRef("F")
 
-  accountRecordA = await getAccountRecordByTestUserRef("A")
   walletIdA = await getDefaultWalletIdByTestUserRef("A")
   walletIdUsdA = await getUsdWalletIdByTestUserRef("A")
   accountA = await getAccountByTestUserRef("A")
@@ -308,7 +304,7 @@ const testInternalSend = async ({
   recipientWalletId: WalletId
   senderAmount: Satoshis | UsdCents
 }) => {
-  const memo = "this is my onchain usd memo #" + (Math.random() * 1_000_000).toFixed()
+  const memo = "this is my onchain memo #" + (Math.random() * 1_000_000).toFixed()
 
   const senderWallet = await WalletsRepository().findById(senderWalletId)
   if (senderWallet instanceof Error) return senderWallet
@@ -447,7 +443,7 @@ const testInternalSend = async ({
   expect(filteredTxsUserD[0].memo).not.toBe(memo)
 }
 
-describe("UserWallet - onChainPay", () => {
+describe("BtcWallet - onChainPay", () => {
   it("sends a successful payment", async () => {
     const res = await testExternalSend({
       senderAccount: accountA,
@@ -835,8 +831,6 @@ describe("UserWallet - onChainPay", () => {
     if (walletVolume instanceof Error) return walletVolume
 
     const { outgoingBaseAmount } = walletVolume
-
-    if (!accountRecordA.level) throw new Error("Invalid or non existent user level")
 
     const withdrawalLimit = getAccountLimits({ level: accountA.level }).withdrawalLimit
 

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -33,6 +33,7 @@ import { DisplayCurrencyConverter } from "@domain/fiat/display-currency"
 import { add, sub, toCents } from "@domain/fiat"
 
 import { createPushNotificationContent } from "@services/notifications/create-push-notification-content"
+import { WalletsRepository } from "@services/mongoose"
 import * as PushNotificationsServiceImpl from "@services/notifications/push-notifications"
 
 import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
@@ -138,10 +139,12 @@ const payOnChainForPromiseAll = async (args: PayOnChainByWalletIdArgs) => {
 const testExternalSend = async ({
   senderAccount,
   senderWalletId,
+  amount,
   sendAll,
 }: {
   senderAccount: Account
   senderWalletId: WalletId
+  amount: Satoshis | UsdCents
   sendAll: boolean
 }) => {
   const initialWalletBalance = await getBalanceHelper(senderWalletId)
@@ -216,13 +219,16 @@ const testExternalSend = async ({
 
   expect(sendNotification.mock.calls.length).toBe(1)
 
+  const senderWallet = await WalletsRepository().findById(senderWalletId)
+  if (senderWallet instanceof Error) throw senderWallet
+
   if (!sendAll) {
     const satsPrice = await Prices.getCurrentPrice()
     if (satsPrice instanceof Error) throw satsPrice
 
-    const paymentAmount = { amount: BigInt(amount), currency: WalletCurrency.Btc }
+    const paymentAmount = { amount: BigInt(amount), currency: senderWallet.currency }
     const displayPaymentAmount = {
-      amount: amount * satsPrice,
+      amount: senderWallet.currency === WalletCurrency.Btc ? amount * satsPrice : amount,
       currency: DefaultDisplayCurrency,
     }
 
@@ -259,7 +265,16 @@ const testExternalSend = async ({
     const settledTx = settledTxs[0] as WalletTransaction
 
     const feeRates = getFeesConfig()
-    const fee = feeRates.withdrawDefaultMin + 7050
+    let fee: number
+    if (senderWallet.currency === WalletCurrency.Btc) {
+      fee = feeRates.withdrawDefaultMin + 7050
+    } else {
+      const feeSats = toSats(feeRates.withdrawDefaultMin + 7050)
+      const dealerFns = DealerPriceService()
+      const feeResult = await dealerFns.getCentsFromSatsForImmediateSell(feeSats)
+      if (feeResult instanceof Error) throw feeResult
+      fee = feeResult
+    }
 
     expect(settledTx.settlementFee).toBe(fee)
     expect(settledTx.displayCurrencyPerSettlementCurrencyUnit).toBeGreaterThan(0)
@@ -283,6 +298,7 @@ describe("UserWallet - onChainPay", () => {
     testExternalSend({
       senderAccount: accountA,
       senderWalletId: walletIdA,
+      amount,
       sendAll: false,
     }))
 
@@ -290,6 +306,7 @@ describe("UserWallet - onChainPay", () => {
     testExternalSend({
       senderAccount: accountE,
       senderWalletId: walletIdE,
+      amount,
       sendAll: true,
     }))
 
@@ -883,125 +900,13 @@ describe("UserWallet - onChainPay", () => {
 })
 
 describe("UsdWallet - onChainPay", () => {
-  it("send to external address from usd wallet", async () => {
-    const initialUsdBalanceUserB = await getBalanceHelper(walletIdUsdB)
-    const sendNotification = jest.fn()
-    jest
-      .spyOn(PushNotificationsServiceImpl, "PushNotificationsService")
-      .mockImplementation(() => ({ sendNotification }))
-    const { address } = await createChainAddress({
-      format: "p2wpkh",
-      lnd: lndOutside1,
-    })
-
-    const sub = subscribeToTransactions({ lnd: lndonchain })
-    sub.on("chain_transaction", onchainTransactionEventHandler)
-
-    const results = await Promise.all([
-      once(sub, "chain_transaction"),
-      payOnChainForPromiseAll({
-        senderAccount: accountB,
-        senderWalletId: walletIdUsdB,
-        address,
-        amount: usdAmount,
-        targetConfirmations,
-        memo: null,
-        sendAll: false,
-      }),
-    ])
-
-    expect(results[1]).toBe(PaymentSendStatus.Success)
-    await onchainTransactionEventHandler(results[0][0])
-
-    let pendingTxHash: OnChainTxHash
-
-    {
-      const txResult = await Wallets.getTransactionsForWalletId({
-        walletId: walletIdUsdB,
-      })
-      if (txResult.error instanceof Error || txResult.result === null) {
-        throw txResult.error
-      }
-      const pendingTxs = txResult.result.filter(
-        ({ status }) => status === TxStatus.Pending,
-      )
-
-      expect(pendingTxs.length).toBe(1)
-
-      const pendingTx = pendingTxs[0]
-
-      expect(pendingTx.settlementAmount).toBe(-usdAmount - pendingTx.settlementFee)
-      pendingTxHash = pendingTx.id as OnChainTxHash
-
-      const interimBalance = await getBalanceHelper(walletIdUsdB)
-      expect(interimBalance).toBe(
-        initialUsdBalanceUserB - usdAmount - pendingTx.settlementFee,
-      )
-      await checkIsBalanced()
-    }
-
-    await Promise.all([once(sub, "chain_transaction"), mineBlockAndSyncAll()])
-
-    await sleep(3000)
-
-    const satsPrice = await Prices.getCurrentPrice()
-    if (satsPrice instanceof Error) throw satsPrice
-
-    const paymentAmount = { amount: BigInt(usdAmount), currency: WalletCurrency.Usd }
-    const displayPaymentAmount = {
+  it("send to external address from usd wallet", async () =>
+    testExternalSend({
+      senderAccount: accountB,
+      senderWalletId: walletIdUsdB,
       amount: usdAmount,
-      currency: DefaultDisplayCurrency,
-    }
-
-    const { title, body } = createPushNotificationContent({
-      type: NotificationType.OnchainPayment,
-      userLanguage: locale as UserLanguage,
-      amount: paymentAmount,
-      displayAmount: displayPaymentAmount,
-    })
-
-    expect(sendNotification.mock.calls.length).toBe(1)
-    expect(sendNotification.mock.calls[0][0].title).toBe(title)
-    expect(sendNotification.mock.calls[0][0].body).toBe(body)
-
-    {
-      const txResult = await Wallets.getTransactionsForWalletId({
-        walletId: walletIdUsdB,
-      })
-      if (txResult.error instanceof Error || txResult.result === null) {
-        throw txResult.error
-      }
-      const pendingTxs = txResult.result.filter(
-        ({ status }) => status === TxStatus.Pending,
-      )
-      expect(pendingTxs.length).toBe(0)
-
-      const settledTxs = txResult.result.filter(
-        ({ status, initiationVia, id }) =>
-          status === TxStatus.Success &&
-          initiationVia.type === PaymentInitiationMethod.OnChain &&
-          id === pendingTxHash,
-      )
-      expect(settledTxs.length).toBe(1)
-      const settledTx = settledTxs[0] as WalletTransaction
-
-      const feeRates = getFeesConfig()
-      const feeSats = toSats(feeRates.withdrawDefaultMin + 7050)
-      const dealerFns = DealerPriceService()
-      const fee = await dealerFns.getCentsFromSatsForImmediateSell(feeSats)
-      if (fee instanceof Error) throw fee
-
-      expect(settledTx.settlementFee).toBe(fee)
-      expect(settledTx.settlementAmount).toBe(-usdAmount - fee)
-
-      expect(settledTx.displayCurrencyPerSettlementCurrencyUnit).toBeGreaterThan(0)
-
-      const finalBalance = await getBalanceHelper(walletIdUsdB)
-      expect(finalBalance).toBe(initialUsdBalanceUserB - usdAmount - fee)
-    }
-
-    sub.removeAllListeners()
-  })
+      sendAll: false,
+    }))
 
   // it("sends to internal address from usd wallet to usd wallet", async () => {})
 

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -156,18 +156,23 @@ const testExternalSend = async ({
   const sub = subscribeToTransactions({ lnd: lndonchain })
   sub.on("chain_transaction", onchainTransactionEventHandler)
 
-  const results = await Promise.all([
-    once(sub, "chain_transaction"),
-    payOnChainForPromiseAll({
-      senderAccount,
-      senderWalletId,
-      address,
-      amount,
-      targetConfirmations,
-      memo: null,
-      sendAll,
-    }),
-  ])
+  let results
+  try {
+    results = await Promise.all([
+      once(sub, "chain_transaction"),
+      payOnChainForPromiseAll({
+        senderAccount,
+        senderWalletId,
+        address,
+        amount,
+        targetConfirmations,
+        memo: null,
+        sendAll,
+      }),
+    ])
+  } catch (err) {
+    return err
+  }
 
   expect(results[1]).toBe(PaymentSendStatus.Success)
   await onchainTransactionEventHandler(results[0][0])
@@ -184,7 +189,7 @@ const testExternalSend = async ({
       walletId: senderWalletId,
     })
     if (txResult.error instanceof Error || txResult.result === null) {
-      throw txResult.error
+      return txResult.error
     }
     const pendingTxs = txResult.result.slice.filter(
       ({ status }) => status === TxStatus.Pending,
@@ -218,11 +223,11 @@ const testExternalSend = async ({
   expect(sendNotification.mock.calls.length).toBe(1)
 
   const senderWallet = await WalletsRepository().findById(senderWalletId)
-  if (senderWallet instanceof Error) throw senderWallet
+  if (senderWallet instanceof Error) return senderWallet
 
   if (!sendAll) {
     const satsPrice = await Prices.getCurrentPrice()
-    if (satsPrice instanceof Error) throw satsPrice
+    if (satsPrice instanceof Error) return satsPrice
 
     const paymentAmount = { amount: BigInt(amount), currency: senderWallet.currency }
     const displayPaymentAmount = {
@@ -246,7 +251,7 @@ const testExternalSend = async ({
       walletId: senderWalletId,
     })
     if (txResult.error instanceof Error || txResult.result === null) {
-      throw txResult.error
+      return txResult.error
     }
     const pendingTxs = txResult.result.slice.filter(
       ({ status }) => status === TxStatus.Pending,
@@ -270,7 +275,7 @@ const testExternalSend = async ({
       const feeSats = toSats(feeRates.withdrawDefaultMin + 7050)
       const dealerFns = DealerPriceService()
       const feeResult = await dealerFns.getCentsFromSatsForImmediateSell(feeSats)
-      if (feeResult instanceof Error) throw feeResult
+      if (feeResult instanceof Error) return feeResult
       fee = feeResult
     }
 
@@ -442,21 +447,25 @@ const testInternalSend = async ({
 }
 
 describe("UserWallet - onChainPay", () => {
-  it("sends a successful payment", async () =>
-    testExternalSend({
+  it("sends a successful payment", async () => {
+    const res = await testExternalSend({
       senderAccount: accountA,
       senderWalletId: walletIdA,
       amount,
       sendAll: false,
-    }))
+    })
+    if (res instanceof Error) throw res
+  })
 
-  it("sends all in a successful payment", async () =>
-    testExternalSend({
+  it("sends all in a successful payment", async () => {
+    const res = await testExternalSend({
       senderAccount: accountE,
       senderWalletId: walletIdE,
       amount,
       sendAll: true,
-    }))
+    })
+    if (res instanceof Error) throw res
+  })
 
   it("sends a successful payment with memo", async () => {
     const memo = "this is my onchain memo"
@@ -982,20 +991,24 @@ describe("UsdWallet - onChainPay", () => {
       expect(onChainFee).toBeInstanceOf(LessThanDustThresholdError)
     })
 
-    it("send from usd wallet", async () =>
-      testExternalSend({
+    it("send from usd wallet", async () => {
+      const res = await testExternalSend({
         senderAccount: accountB,
         senderWalletId: walletIdUsdB,
         amount: usdAmount,
         sendAll: false,
-      }))
+      })
+      if (res instanceof Error) throw res
+    })
 
-    it("send all from usd wallet", async () =>
-      testExternalSend({
+    it("send all from usd wallet", async () => {
+      const res = await testExternalSend({
         senderAccount: accountB,
         senderWalletId: walletIdUsdB,
         amount: usdAmount,
         sendAll: true,
-      }))
+      })
+      if (res instanceof Error) throw res
+    })
   })
 })

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -119,6 +119,12 @@ const amount = toSats(10040)
 const amountBelowDustThreshold = getOnChainWalletConfig().dustThreshold - 1
 const targetConfirmations = toTargetConfs(1)
 
+const payOnChainForPromiseAll = async (args: PayOnChainByWalletIdArgs) => {
+  const res = await Wallets.payOnChainByWalletId(args)
+  if (res instanceof Error) throw res
+  return res
+}
+
 describe("UserWallet - onChainPay", () => {
   it("sends a successful payment", async () => {
     const sendNotification = jest.fn()
@@ -132,7 +138,7 @@ describe("UserWallet - onChainPay", () => {
 
     const results = await Promise.all([
       once(sub, "chain_transaction"),
-      Wallets.payOnChainByWalletId({
+      payOnChainForPromiseAll({
         senderAccount: accountA,
         senderWalletId: walletIdA,
         address,
@@ -250,7 +256,7 @@ describe("UserWallet - onChainPay", () => {
 
     const results = await Promise.all([
       once(sub, "chain_transaction"),
-      Wallets.payOnChainByWalletId({
+      payOnChainForPromiseAll({
         senderAccount,
         senderWalletId: walletIdE,
         address,

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -20,6 +20,7 @@ import {
   RebalanceNeededError,
   SelfPaymentError,
 } from "@domain/errors"
+import { InvalidZeroAmountPriceRatioInputError } from "@domain/payments"
 import { NotificationType } from "@domain/notifications"
 import { PaymentInitiationMethod, SettlementMethod, TxStatus } from "@domain/wallets"
 import { onchainTransactionEventHandler } from "@servers/trigger"
@@ -76,6 +77,7 @@ let accountE: Account
 let accountG: Account
 
 let walletIdA: WalletId
+let walletIdUsdA: WalletId
 let walletIdUsdB: WalletId
 let walletIdD: WalletId
 let walletIdG: WalletId
@@ -97,6 +99,7 @@ beforeAll(async () => {
 
   accountRecordA = await getAccountRecordByTestUserRef("A")
   walletIdA = await getDefaultWalletIdByTestUserRef("A")
+  walletIdUsdA = await getUsdWalletIdByTestUserRef("A")
   accountA = await getAccountByTestUserRef("A")
 
   walletIdUsdB = await getUsdWalletIdByTestUserRef("B")
@@ -291,6 +294,154 @@ const testExternalSend = async ({
   }
 
   sub.removeAllListeners()
+}
+
+const testInternalSend = async ({
+  senderAccount,
+  senderWalletId,
+  recipientWalletId,
+  senderAmount,
+}: {
+  senderAccount: Account
+  senderWalletId: WalletId
+  recipientWalletId: WalletId
+  senderAmount: Satoshis | UsdCents
+}) => {
+  const memo = "this is my onchain usd memo #" + (Math.random() * 1_000_000).toFixed()
+
+  const senderWallet = await WalletsRepository().findById(senderWalletId)
+  if (senderWallet instanceof Error) return senderWallet
+  const { currency: senderCurrency } = senderWallet
+
+  const recipientWallet = await WalletsRepository().findById(recipientWalletId)
+  if (recipientWallet instanceof Error) return recipientWallet
+  const { currency: recipientCurrency } = recipientWallet
+
+  const dealerFns = DealerPriceService()
+
+  let amountResult: UsdCents | Satoshis | DealerPriceServiceError
+  let recipientAmount: UsdCents | Satoshis
+  switch (true) {
+    case senderCurrency === recipientCurrency:
+      recipientAmount = senderAmount
+      break
+
+    case senderCurrency === WalletCurrency.Usd &&
+      recipientCurrency === WalletCurrency.Btc:
+      amountResult = await dealerFns.getSatsFromCentsForImmediateSell(
+        senderAmount as unknown as UsdCents,
+      )
+      if (amountResult instanceof Error) return amountResult
+
+      recipientAmount = amountResult
+      break
+
+    case senderCurrency === WalletCurrency.Btc &&
+      recipientCurrency === WalletCurrency.Usd:
+      amountResult = await dealerFns.getCentsFromSatsForImmediateBuy(
+        senderAmount as unknown as Satoshis,
+      )
+      if (amountResult instanceof Error) return amountResult
+
+      recipientAmount = amountResult
+      break
+
+    default:
+      return new Error("Not possible")
+  }
+
+  const initialSenderBalance = await getBalanceHelper(senderWalletId)
+  const initialRecipientBalance = await getBalanceHelper(recipientWalletId)
+
+  const address = await Wallets.createOnChainAddress(recipientWalletId)
+  if (address instanceof Error) return address
+
+  const paid = await Wallets.payOnChainByWalletId({
+    senderAccount: senderAccount,
+    senderWalletId: senderWalletId,
+    address,
+    amount: senderAmount,
+    targetConfirmations,
+    memo,
+    sendAll: false,
+  })
+  if (paid instanceof Error) return paid
+
+  // Check balances for both wallets
+  // ===
+  const finalSenderBalance = await getBalanceHelper(senderWalletId)
+  const finalRecipient = await getBalanceHelper(recipientWalletId)
+
+  expect(paid).toBe(PaymentSendStatus.Success)
+  expect(finalSenderBalance).toBe(initialSenderBalance - senderAmount)
+  expect(finalRecipient).toBe(initialRecipientBalance + recipientAmount)
+
+  // Check txn details for sent wallet
+  // ===
+  const { result: txsSender, error } = await Wallets.getTransactionsForWalletId({
+    walletId: senderWalletId,
+  })
+  if (error instanceof Error || txsSender === null) {
+    return error
+  }
+  const pendingTxsSender = txsSender.filter(({ status }) => status === TxStatus.Pending)
+  expect(pendingTxsSender.length).toBe(0)
+
+  const settledTxsSender = txsSender.filter(
+    ({ status, initiationVia, settlementVia, memo: txMemo }) =>
+      status === TxStatus.Success &&
+      initiationVia.type === PaymentInitiationMethod.OnChain &&
+      settlementVia.type === SettlementMethod.IntraLedger &&
+      txMemo === memo,
+  )
+  expect(settledTxsSender.length).toBe(1)
+  const senderSettledTx = settledTxsSender[0] as WalletTransaction
+
+  expect(senderSettledTx.settlementFee).toBe(0)
+  expect(senderSettledTx.settlementAmount).toBe(-senderAmount)
+  expect(senderSettledTx.displayCurrencyPerSettlementCurrencyUnit).toBeGreaterThan(0)
+
+  // Check txn details for received wallet
+  // ===
+  const { result: txsRecipient, error: errorUserA } =
+    await Wallets.getTransactionsForWalletId({
+      walletId: recipientWalletId,
+    })
+  if (errorUserA instanceof Error || txsRecipient === null) {
+    return errorUserA
+  }
+  const pendingTxsRecipient = txsRecipient.filter(
+    ({ status }) => status === TxStatus.Pending,
+  )
+  expect(pendingTxsRecipient.length).toBe(0)
+
+  const settledTxsRecipient = txsRecipient.filter(
+    ({ status, initiationVia, settlementVia }) =>
+      status === TxStatus.Success &&
+      initiationVia.type === PaymentInitiationMethod.OnChain &&
+      settlementVia.type === SettlementMethod.IntraLedger,
+  )
+  const recipientSettledTx = settledTxsRecipient[0] as WalletTransaction
+
+  expect(recipientSettledTx.settlementFee).toBe(0)
+  expect(recipientSettledTx.settlementAmount).toBe(recipientAmount)
+  expect(recipientSettledTx.displayCurrencyPerSettlementCurrencyUnit).toBeGreaterThan(0)
+
+  // Check memos
+  // ===
+  const matchTx = (tx: WalletTransaction) =>
+    tx.initiationVia.type === PaymentInitiationMethod.OnChain &&
+    tx.initiationVia.address === address
+
+  // sender should know memo
+  const filteredTxs = txsSender.filter(matchTx)
+  expect(filteredTxs.length).toBe(1)
+  expect(filteredTxs[0].memo).toBe(memo)
+
+  // receiver should not know memo from sender
+  const filteredTxsUserD = txsRecipient.filter(matchTx)
+  expect(filteredTxsUserD.length).toBe(1)
+  expect(filteredTxsUserD[0].memo).not.toBe(memo)
 }
 
 describe("UserWallet - onChainPay", () => {
@@ -900,27 +1051,63 @@ describe("UserWallet - onChainPay", () => {
 })
 
 describe("UsdWallet - onChainPay", () => {
-  it("send to an external address from usd wallet", async () =>
-    testExternalSend({
-      senderAccount: accountB,
-      senderWalletId: walletIdUsdB,
-      amount: usdAmount,
-      sendAll: false,
-    }))
+  describe("to an internal address", () => {
+    it("sends from usd wallet to usd wallet", async () => {
+      const res = await testInternalSend({
+        senderAccount: accountB,
+        senderWalletId: walletIdUsdB,
+        recipientWalletId: walletIdUsdA,
+        senderAmount: usdAmount,
+      })
+      if (res instanceof Error) throw res
+    })
 
-  it("send all to an external address from usd wallet", async () =>
-    testExternalSend({
-      senderAccount: accountB,
-      senderWalletId: walletIdUsdB,
-      amount: usdAmount,
-      sendAll: true,
-    }))
+    it("sends from usd wallet to btc wallet", async () => {
+      const res = await testInternalSend({
+        senderAccount: accountB,
+        senderWalletId: walletIdUsdB,
+        recipientWalletId: walletIdA,
+        senderAmount: usdAmount,
+      })
+      if (res instanceof Error) throw res
+    })
 
-  // it("sends to internal address from usd wallet to usd wallet", async () => {})
+    it("sends from btc wallet to usd wallet", async () => {
+      const res = await testInternalSend({
+        senderAccount: accountA,
+        senderWalletId: walletIdA,
+        recipientWalletId: walletIdUsdB,
+        senderAmount: amount,
+      })
+      if (res instanceof Error) throw res
+    })
 
-  // it("sends to internal address from usd wallet to btc wallet", async () => {})
+    it("fails to send with less-than-1-cent amount from btc wallet to usd wallet", async () => {
+      const res = await testInternalSend({
+        senderAccount: accountA,
+        senderWalletId: walletIdA,
+        recipientWalletId: walletIdUsdB,
+        senderAmount: toSats(1),
+      })
+      expect(res).toBeInstanceOf(InvalidZeroAmountPriceRatioInputError)
+    })
+  })
 
-  // it("sends to internal address from btc wallet to usd wallet", async () => {})
+  describe("to an external address", () => {
+    it("send from usd wallet", async () =>
+      testExternalSend({
+        senderAccount: accountB,
+        senderWalletId: walletIdUsdB,
+        amount: usdAmount,
+        sendAll: false,
+      }))
 
-  // it("fails to send to internal address with less-than-1-cent amount from btc wallet to usd wallet", async () => {})
+    it("send all from usd wallet", async () =>
+      testExternalSend({
+        senderAccount: accountB,
+        senderWalletId: walletIdUsdB,
+        amount: usdAmount,
+        sendAll: true,
+      }))
+  })
 })

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -171,7 +171,8 @@ const testExternalSend = async ({
       }),
     ])
   } catch (err) {
-    return err
+    sub.removeAllListeners()
+    return err as ApplicationError
   }
 
   expect(results[1]).toBe(PaymentSendStatus.Success)
@@ -465,6 +466,18 @@ describe("UserWallet - onChainPay", () => {
       sendAll: true,
     })
     if (res instanceof Error) throw res
+  })
+
+  it("fails to send all from empty wallet", async () => {
+    const res = await testExternalSend({
+      senderAccount: accountE,
+      senderWalletId: walletIdE,
+      amount,
+      sendAll: true,
+    })
+
+    expect(res).toBeInstanceOf(InsufficientBalanceError)
+    expect(res && res.message).toEqual(`No balance left to send.`)
   })
 
   it("sends a successful payment with memo", async () => {
@@ -1011,16 +1024,16 @@ describe("UsdWallet - onChainPay", () => {
       if (res instanceof Error) throw res
     })
 
-    it.skip("fails to send all from empty usd wallet", async () => {
-      // TODO: Fix "openHandles" issue before unskipping
+    it("fails to send all from empty usd wallet", async () => {
       const res = await testExternalSend({
         senderAccount: accountB,
         senderWalletId: walletIdUsdB,
         amount: usdAmount,
         sendAll: true,
       })
+
       expect(res).toBeInstanceOf(InsufficientBalanceError)
-      expect(res.message).toEqual(`No balance left to send.`)
+      expect(res && res.message).toEqual(`No balance left to send.`)
     })
   })
 })

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -865,32 +865,6 @@ describe("UserWallet - onChainPay", () => {
     expect(status).toBeInstanceOf(LimitsExceededError)
   })
 
-  it("fee probe fails if the amount is less than on chain dust amount", async () => {
-    const address = (await bitcoindOutside.getNewAddress()) as OnChainAddress
-
-    const status = await Wallets.getOnChainFee({
-      account: accountA,
-      walletId: walletIdA,
-      address,
-      amount: amountBelowDustThreshold,
-      targetConfirmations,
-    })
-    expect(status).toBeInstanceOf(LessThanDustThresholdError)
-  })
-
-  it("fee probe fails if the amount is less than lnd on-chain dust amount", async () => {
-    const address = (await bitcoindOutside.getNewAddress()) as OnChainAddress
-
-    const status = await Wallets.getOnChainFee({
-      account: accountA,
-      walletId: walletIdA,
-      address,
-      amount: 1,
-      targetConfirmations,
-    })
-    expect(status).toBeInstanceOf(LessThanDustThresholdError)
-  })
-
   it("fails if the amount is less than on chain dust amount", async () => {
     const address = await bitcoindOutside.getNewAddress()
 
@@ -974,36 +948,6 @@ describe("UsdWallet - onChainPay", () => {
   })
 
   describe("to an external address", () => {
-    it("fee probe from usd wallet", async () => {
-      const address = (await bitcoindOutside.getNewAddress()) as OnChainAddress
-
-      const onChainFee = await Wallets.getOnChainFee({
-        account: accountB,
-        walletId: walletIdUsdB,
-        address,
-        amount: usdAmount,
-        targetConfirmations,
-      })
-      if (onChainFee instanceof Error) throw onChainFee
-
-      const feeRates = getFeesConfig()
-      const fee = feeRates.withdrawDefaultMin + 7050
-      expect(fee).toEqual(onChainFee)
-    })
-
-    it("fee probe fails if the amount is less than on chain dust amount", async () => {
-      const address = (await bitcoindOutside.getNewAddress()) as OnChainAddress
-
-      const onChainFee = await Wallets.getOnChainFee({
-        account: accountB,
-        walletId: walletIdUsdB,
-        address,
-        amount: toCents(1),
-        targetConfirmations,
-      })
-      expect(onChainFee).toBeInstanceOf(LessThanDustThresholdError)
-    })
-
     it("send from usd wallet", async () => {
       const res = await testExternalSend({
         senderAccount: accountB,

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -262,7 +262,7 @@ const testExternalSend = async ({
         id === pendingTxHash,
     )
     expect(settledTxs.length).toBe(1)
-    const settledTx = settledTxs[0] as WalletTransaction
+    const settledTx = settledTxs[0]
 
     const feeRates = getFeesConfig()
     let fee: number
@@ -394,7 +394,7 @@ const testInternalSend = async ({
       txMemo === memo,
   )
   expect(settledTxsSender.length).toBe(1)
-  const senderSettledTx = settledTxsSender[0] as WalletTransaction
+  const senderSettledTx = settledTxsSender[0]
 
   expect(senderSettledTx.settlementFee).toBe(0)
   expect(senderSettledTx.settlementAmount).toBe(-senderAmount)
@@ -420,7 +420,7 @@ const testInternalSend = async ({
       initiationVia.type === PaymentInitiationMethod.OnChain &&
       settlementVia.type === SettlementMethod.IntraLedger,
   )
-  const recipientSettledTx = settledTxsRecipient[0] as WalletTransaction
+  const recipientSettledTx = settledTxsRecipient[0]
 
   expect(recipientSettledTx.settlementFee).toBe(0)
   expect(recipientSettledTx.settlementAmount).toBe(recipientAmount)

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -900,12 +900,20 @@ describe("UserWallet - onChainPay", () => {
 })
 
 describe("UsdWallet - onChainPay", () => {
-  it("send to external address from usd wallet", async () =>
+  it("send to an external address from usd wallet", async () =>
     testExternalSend({
       senderAccount: accountB,
       senderWalletId: walletIdUsdB,
       amount: usdAmount,
       sendAll: false,
+    }))
+
+  it("send all to an external address from usd wallet", async () =>
+    testExternalSend({
+      senderAccount: accountB,
+      senderWalletId: walletIdUsdB,
+      amount: usdAmount,
+      sendAll: true,
     }))
 
   // it("sends to internal address from usd wallet to usd wallet", async () => {})

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -1010,5 +1010,17 @@ describe("UsdWallet - onChainPay", () => {
       })
       if (res instanceof Error) throw res
     })
+
+    it.skip("fails to send all from empty usd wallet", async () => {
+      // TODO: Fix "openHandles" issue before unskipping
+      const res = await testExternalSend({
+        senderAccount: accountB,
+        senderWalletId: walletIdUsdB,
+        amount: usdAmount,
+        sendAll: true,
+      })
+      expect(res).toBeInstanceOf(InsufficientBalanceError)
+      expect(res.message).toEqual(`No balance left to send.`)
+    })
   })
 })

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -952,6 +952,36 @@ describe("UsdWallet - onChainPay", () => {
   })
 
   describe("to an external address", () => {
+    it("fee probe from usd wallet", async () => {
+      const address = (await bitcoindOutside.getNewAddress()) as OnChainAddress
+
+      const onChainFee = await Wallets.getOnChainFee({
+        account: accountB,
+        walletId: walletIdUsdB,
+        address,
+        amount: usdAmount,
+        targetConfirmations,
+      })
+      if (onChainFee instanceof Error) throw onChainFee
+
+      const feeRates = getFeesConfig()
+      const fee = feeRates.withdrawDefaultMin + 7050
+      expect(fee).toEqual(onChainFee)
+    })
+
+    it("fee probe fails if the amount is less than on chain dust amount", async () => {
+      const address = (await bitcoindOutside.getNewAddress()) as OnChainAddress
+
+      const onChainFee = await Wallets.getOnChainFee({
+        account: accountB,
+        walletId: walletIdUsdB,
+        address,
+        amount: toCents(1),
+        targetConfirmations,
+      })
+      expect(onChainFee).toBeInstanceOf(LessThanDustThresholdError)
+    })
+
     it("send from usd wallet", async () =>
       testExternalSend({
         senderAccount: accountB,

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -68,7 +68,6 @@ import {
   getUsdWalletIdByTestUserRef,
 } from "test/helpers"
 
-let initialBalanceUserA: Satoshis
 let accountRecordA: AccountRecord
 
 let accountA: Account
@@ -113,10 +112,6 @@ beforeAll(async () => {
   accountG = await getAccountByTestUserRef("G")
 
   await bitcoindClient.loadWallet({ filename: "outside" })
-})
-
-beforeEach(async () => {
-  initialBalanceUserA = toSats(await getBalanceHelper(walletIdA))
 })
 
 afterEach(async () => {
@@ -384,10 +379,12 @@ const testInternalSend = async ({
   if (error instanceof Error || txsSender === null) {
     return error
   }
-  const pendingTxsSender = txsSender.filter(({ status }) => status === TxStatus.Pending)
+  const pendingTxsSender = txsSender.slice.filter(
+    ({ status }) => status === TxStatus.Pending,
+  )
   expect(pendingTxsSender.length).toBe(0)
 
-  const settledTxsSender = txsSender.filter(
+  const settledTxsSender = txsSender.slice.filter(
     ({ status, initiationVia, settlementVia, memo: txMemo }) =>
       status === TxStatus.Success &&
       initiationVia.type === PaymentInitiationMethod.OnChain &&
@@ -410,12 +407,12 @@ const testInternalSend = async ({
   if (errorUserA instanceof Error || txsRecipient === null) {
     return errorUserA
   }
-  const pendingTxsRecipient = txsRecipient.filter(
+  const pendingTxsRecipient = txsRecipient.slice.filter(
     ({ status }) => status === TxStatus.Pending,
   )
   expect(pendingTxsRecipient.length).toBe(0)
 
-  const settledTxsRecipient = txsRecipient.filter(
+  const settledTxsRecipient = txsRecipient.slice.filter(
     ({ status, initiationVia, settlementVia }) =>
       status === TxStatus.Success &&
       initiationVia.type === PaymentInitiationMethod.OnChain &&
@@ -434,12 +431,12 @@ const testInternalSend = async ({
     tx.initiationVia.address === address
 
   // sender should know memo
-  const filteredTxs = txsSender.filter(matchTx)
+  const filteredTxs = txsSender.slice.filter(matchTx)
   expect(filteredTxs.length).toBe(1)
   expect(filteredTxs[0].memo).toBe(memo)
 
   // receiver should not know memo from sender
-  const filteredTxsUserD = txsRecipient.filter(matchTx)
+  const filteredTxsUserD = txsRecipient.slice.filter(matchTx)
   expect(filteredTxsUserD.length).toBe(1)
   expect(filteredTxsUserD[0].memo).not.toBe(memo)
 }
@@ -529,155 +526,23 @@ describe("UserWallet - onChainPay", () => {
   })
 
   it("sends an on us transaction", async () => {
-    const address = await Wallets.createOnChainAddress(walletIdD)
-    if (address instanceof Error) throw address
-
-    const initialBalanceUserD = await getBalanceHelper(walletIdD)
-
-    const paid = await Wallets.payOnChainByWalletId({
+    const res = await testInternalSend({
       senderAccount: accountA,
       senderWalletId: walletIdA,
-      address,
-      amount,
-      targetConfirmations,
-      memo: null,
-      sendAll: false,
+      recipientWalletId: walletIdD,
+      senderAmount: amount,
     })
-
-    const finalBalanceUserA = await getBalanceHelper(walletIdA)
-    const finalBalanceUserD = await getBalanceHelper(walletIdD)
-
-    expect(paid).toBe(PaymentSendStatus.Success)
-    expect(finalBalanceUserA).toBe(initialBalanceUserA - amount)
-    expect(finalBalanceUserD).toBe(initialBalanceUserD + amount)
-
-    {
-      const txResult = await Wallets.getTransactionsForWalletId({
-        walletId: walletIdA,
-      })
-      if (txResult.error instanceof Error || txResult.result === null) {
-        throw txResult.error
-      }
-      const pendingTxs = txResult.result.slice.filter(
-        ({ status }) => status === TxStatus.Pending,
-      )
-      expect(pendingTxs.length).toBe(0)
-
-      const settledTxs = txResult.result.slice.filter(
-        ({ status, initiationVia, settlementVia }) =>
-          status === TxStatus.Success &&
-          initiationVia.type === PaymentInitiationMethod.OnChain &&
-          settlementVia.type === SettlementMethod.IntraLedger,
-      )
-      expect(settledTxs.length).toBe(1)
-      const settledTx = settledTxs[0] as WalletTransaction
-
-      expect(settledTx.settlementFee).toBe(0)
-      expect(settledTx.settlementAmount).toBe(-amount)
-      expect(settledTx.displayCurrencyPerSettlementCurrencyUnit).toBeGreaterThan(0)
-
-      const finalBalance = await getBalanceHelper(walletIdA)
-      expect(finalBalance).toBe(initialBalanceUserA - amount)
-    }
-  })
-
-  it("sends an on us transaction with memo", async () => {
-    const memo = "this is my onchain memo"
-
-    const address = await Wallets.createOnChainAddress(walletIdD)
-    if (address instanceof Error) throw address
-
-    const paid = await Wallets.payOnChainByWalletId({
-      senderAccount: accountA,
-      senderWalletId: walletIdA,
-      address,
-      amount,
-      targetConfirmations,
-      memo,
-      sendAll: false,
-    })
-
-    expect(paid).toBe(PaymentSendStatus.Success)
-
-    const matchTx = (tx: WalletTransaction) =>
-      tx.initiationVia.type === PaymentInitiationMethod.OnChain &&
-      tx.initiationVia.address === address
-
-    const { result: txs, error } = await Wallets.getTransactionsForWalletId({
-      walletId: walletIdA,
-    })
-    if (error instanceof Error || txs === null) {
-      throw error
-    }
-    const filteredTxs = txs.slice.filter(matchTx)
-    expect(filteredTxs.length).toBe(1)
-    expect(filteredTxs[0].memo).toBe(memo)
-
-    // receiver should not know memo from sender
-    const { result: txsUserD, error: error2 } = await Wallets.getTransactionsForWalletId({
-      walletId: walletIdD,
-    })
-    if (error2 instanceof Error || txsUserD === null) {
-      throw error2
-    }
-    const filteredTxsUserD = txsUserD.slice.filter(matchTx)
-    expect(filteredTxsUserD.length).toBe(1)
-    expect(filteredTxsUserD[0].memo).not.toBe(memo)
+    if (res instanceof Error) throw res
   })
 
   it("sends an on us transaction below dust limit", async () => {
-    const address = await Wallets.createOnChainAddress(walletIdD)
-    if (address instanceof Error) throw address
-
-    const amount = amountBelowDustThreshold
-
-    const initialBalanceUserD = await getBalanceHelper(walletIdD)
-
-    const paid = await Wallets.payOnChainByWalletId({
+    const res = await testInternalSend({
       senderAccount: accountA,
       senderWalletId: walletIdA,
-      address,
-      amount,
-      targetConfirmations,
-      memo: null,
-      sendAll: false,
+      recipientWalletId: walletIdD,
+      senderAmount: toSats(amountBelowDustThreshold),
     })
-
-    const finalBalanceUserA = await getBalanceHelper(walletIdA)
-    const finalBalanceUserD = await getBalanceHelper(walletIdD)
-
-    expect(paid).toBe(PaymentSendStatus.Success)
-    expect(finalBalanceUserA).toBe(initialBalanceUserA - amount)
-    expect(finalBalanceUserD).toBe(initialBalanceUserD + amount)
-
-    {
-      const txResult = await Wallets.getTransactionsForWalletId({
-        walletId: walletIdA,
-      })
-      if (txResult.error instanceof Error || txResult.result === null) {
-        throw txResult.error
-      }
-      const pendingTxs = txResult.result.slice.filter(
-        ({ status }) => status === TxStatus.Pending,
-      )
-      expect(pendingTxs.length).toBe(0)
-
-      const settledTxs = txResult.result.slice.filter(
-        ({ status, initiationVia, settlementVia }) =>
-          status === TxStatus.Success &&
-          initiationVia.type === PaymentInitiationMethod.OnChain &&
-          settlementVia.type === SettlementMethod.IntraLedger,
-      )
-
-      const settledTx = settledTxs[0] as WalletTransaction
-
-      expect(settledTx.settlementFee).toBe(0)
-      expect(settledTx.settlementAmount).toBe(-amount)
-      expect(settledTx.displayCurrencyPerSettlementCurrencyUnit).toBeGreaterThan(0)
-
-      const finalBalance = await getBalanceHelper(walletIdA)
-      expect(finalBalance).toBe(initialBalanceUserA - amount)
-    }
+    if (res instanceof Error) throw res
   })
 
   it("sends all with an on us transaction", async () => {
@@ -842,38 +707,23 @@ describe("UserWallet - onChainPay", () => {
   )
 
   it("fails if try to send a transaction to self", async () => {
-    const address = await Wallets.createOnChainAddress(walletIdA)
-    if (address instanceof Error) throw address
-
-    const status = await Wallets.payOnChainByWalletId({
+    const res = await testInternalSend({
       senderAccount: accountA,
       senderWalletId: walletIdA,
-      address,
-      amount,
-      targetConfirmations,
-      memo: null,
-      sendAll: false,
+      recipientWalletId: walletIdA,
+      senderAmount: amount,
     })
-    expect(status).toBeInstanceOf(SelfPaymentError)
+    expect(res).toBeInstanceOf(SelfPaymentError)
   })
 
   it("fails if an on us payment has insufficient balance", async () => {
-    const address = await Wallets.createOnChainAddress(walletIdD)
-    if (address instanceof Error) throw address
-
-    const initialBalanceUserE = await getBalanceHelper(walletIdE)
-    const senderAccount = await getAccountByTestUserRef("E")
-
-    const status = await Wallets.payOnChainByWalletId({
-      senderAccount,
+    const res = await testInternalSend({
+      senderAccount: accountE,
       senderWalletId: walletIdE,
-      address,
-      amount: initialBalanceUserE + 1,
-      targetConfirmations,
-      memo: null,
-      sendAll: false,
+      recipientWalletId: walletIdD,
+      senderAmount: amount,
     })
-    expect(status).toBeInstanceOf(InsufficientBalanceError)
+    expect(res).toBeInstanceOf(InsufficientBalanceError)
   })
 
   it("fails if has insufficient balance", async () => {
@@ -1083,11 +933,19 @@ describe("UsdWallet - onChainPay", () => {
     })
 
     it("fails to send with less-than-1-cent amount from btc wallet to usd wallet", async () => {
+      const dealerFns = DealerPriceService()
+
+      const btcSendAmount = toSats(10)
+      const btcSendAmountInUsd = await dealerFns.getCentsFromSatsForImmediateBuy(
+        toSats(btcSendAmount),
+      )
+      expect(btcSendAmountInUsd).toBe(0)
+
       const res = await testInternalSend({
         senderAccount: accountA,
         senderWalletId: walletIdA,
         recipientWalletId: walletIdUsdB,
-        senderAmount: toSats(1),
+        senderAmount: btcSendAmount,
       })
       expect(res).toBeInstanceOf(InvalidZeroAmountPriceRatioInputError)
     })

--- a/test/integration/02-user-wallet/02-tx-onchain-fees.spec.ts
+++ b/test/integration/02-user-wallet/02-tx-onchain-fees.spec.ts
@@ -1,7 +1,10 @@
-import { Wallets } from "@app"
-import { getOnChainWalletConfig } from "@config"
+import { Wallets, Payments } from "@app"
+import { getFeesConfig, getOnChainWalletConfig } from "@config"
 import { toSats, toTargetConfs } from "@domain/bitcoin"
 import { InsufficientBalanceError, LessThanDustThresholdError } from "@domain/errors"
+import { toCents } from "@domain/fiat"
+import { WalletCurrency } from "@domain/shared"
+import { DealerPriceService } from "@services/dealer-price"
 import { AccountsRepository, WalletsRepository } from "@services/mongoose"
 
 import {
@@ -10,12 +13,14 @@ import {
   createUserAndWalletFromUserRef,
   getAccountByTestUserRef,
   getDefaultWalletIdByTestUserRef,
+  getUsdWalletIdByTestUserRef,
 } from "test/helpers"
 
 const defaultAmount = toSats(6000)
+const defaultUsdAmount = toSats(105)
 const defaultTarget = toTargetConfs(3)
 const { dustThreshold } = getOnChainWalletConfig()
-let walletIdA: WalletId, walletIdB: WalletId, accountA: Account
+let walletIdA: WalletId, walletIdB: WalletId, walletIdUsdA: WalletId, accountA: Account
 
 beforeAll(async () => {
   await bitcoindClient.loadWallet({ filename: "outside" })
@@ -24,6 +29,7 @@ beforeAll(async () => {
   await createUserAndWalletFromUserRef("B")
 
   walletIdA = await getDefaultWalletIdByTestUserRef("A")
+  walletIdUsdA = await getUsdWalletIdByTestUserRef("A")
   accountA = await getAccountByTestUserRef("A")
   walletIdB = await getDefaultWalletIdByTestUserRef("B")
 })
@@ -33,72 +39,214 @@ afterAll(async () => {
 })
 
 describe("UserWallet - getOnchainFee", () => {
-  it("returns a fee greater than zero for an external address", async () => {
-    const address = (await bitcoindOutside.getNewAddress()) as OnChainAddress
-    const fee = await Wallets.getOnChainFee({
-      walletId: walletIdA,
-      account: accountA,
-      amount: defaultAmount,
-      address,
-      targetConfirmations: defaultTarget,
+  describe("from btc wallet", () => {
+    it("returns a fee greater than zero for an external address", async () => {
+      const address = (await bitcoindOutside.getNewAddress()) as OnChainAddress
+      const feeAmount = await Wallets.getOnChainFee({
+        walletId: walletIdA,
+        account: accountA,
+        amount: defaultAmount,
+        address,
+        targetConfirmations: defaultTarget,
+      })
+      if (feeAmount instanceof Error) throw feeAmount
+      expect(feeAmount.currency === WalletCurrency.Btc)
+      const fee = Number(feeAmount.amount)
+      expect(fee).toBeGreaterThan(0)
+
+      const wallet = await WalletsRepository().findById(walletIdA)
+      if (wallet instanceof Error) throw wallet
+
+      const account = await AccountsRepository().findById(wallet.accountId)
+      if (account instanceof Error) throw account
+
+      expect(fee).toBeGreaterThan(account.withdrawFee)
     })
-    expect(fee).not.toBeInstanceOf(Error)
-    expect(fee).toBeGreaterThan(0)
 
-    const wallet = await WalletsRepository().findById(walletIdA)
-    if (wallet instanceof Error) throw wallet
+    it("returns zero for an on us address", async () => {
+      const address = await Wallets.createOnChainAddress(walletIdB)
+      if (address instanceof Error) throw address
+      const feeAmount = await Wallets.getOnChainFee({
+        walletId: walletIdA,
+        account: accountA,
+        amount: defaultAmount,
+        address,
+        targetConfirmations: defaultTarget,
+      })
+      if (feeAmount instanceof Error) throw feeAmount
+      const fee = Number(feeAmount.amount)
+      expect(fee).toBe(0)
+    })
 
-    const account = await AccountsRepository().findById(wallet.accountId)
-    if (account instanceof Error) throw account
+    it("returns error for dust amount", async () => {
+      const address = (await bitcoindOutside.getNewAddress()) as OnChainAddress
+      const amount = toSats(dustThreshold - 1)
+      const fee = await Wallets.getOnChainFee({
+        walletId: walletIdA,
+        account: accountA,
+        amount,
+        address,
+        targetConfirmations: defaultTarget,
+      })
+      expect(fee).toBeInstanceOf(LessThanDustThresholdError)
+      expect(fee).toHaveProperty(
+        "message",
+        `Use lightning to send amounts less than ${dustThreshold} sats`,
+      )
+    })
 
-    expect(fee).toBeGreaterThan(account.withdrawFee)
+    it("returns error for minimum amount", async () => {
+      const address = (await bitcoindOutside.getNewAddress()) as OnChainAddress
+      const amount = toSats(1)
+      const fee = await Wallets.getOnChainFee({
+        walletId: walletIdA,
+        account: accountA,
+        amount,
+        address,
+        targetConfirmations: defaultTarget,
+      })
+      expect(fee).toBeInstanceOf(LessThanDustThresholdError)
+      expect(fee).toHaveProperty(
+        "message",
+        `Use lightning to send amounts less than ${dustThreshold} sats`,
+      )
+    })
+
+    it("returns error for balance too low", async () => {
+      const address = (await bitcoindOutside.getNewAddress()) as OnChainAddress
+      const amount = toSats(1_000_000_000)
+      const fee = await Wallets.getOnChainFee({
+        walletId: walletIdA,
+        account: accountA,
+        amount,
+        address,
+        targetConfirmations: defaultTarget,
+      })
+      expect(fee).toBeInstanceOf(InsufficientBalanceError)
+      expect(fee).toHaveProperty(
+        "message",
+        expect.stringMatching(/Payment amount '\d+' sats exceeds balance '\d+'/),
+      )
+    })
   })
 
-  it("returns zero for an on us address", async () => {
-    const address = await Wallets.createOnChainAddress(walletIdB)
-    if (address instanceof Error) throw address
-    const fee = await Wallets.getOnChainFee({
-      walletId: walletIdA,
-      account: accountA,
-      amount: defaultAmount,
-      address,
-      targetConfirmations: defaultTarget,
-    })
-    expect(fee).not.toBeInstanceOf(Error)
-    expect(fee).toBe(0)
-  })
+  describe("from usd wallet", () => {
+    it("returns a fee greater than zero for an external address", async () => {
+      const feeRates = getFeesConfig()
+      const feeSats = toSats(feeRates.withdrawDefaultMin + 7050)
 
-  it("returns error for dust amount", async () => {
-    const address = (await bitcoindOutside.getNewAddress()) as OnChainAddress
-    const amount = toSats(dustThreshold - 1)
-    const fee = await Wallets.getOnChainFee({
-      walletId: walletIdA,
-      account: accountA,
-      amount,
-      address,
-      targetConfirmations: defaultTarget,
-    })
-    expect(fee).toBeInstanceOf(LessThanDustThresholdError)
-    expect(fee).toHaveProperty(
-      "message",
-      `Use lightning to send amounts less than ${dustThreshold} sats`,
-    )
-  })
+      // Fund empty USD wallet
+      const payResult = await Payments.intraledgerPaymentSendWalletId({
+        recipientWalletId: walletIdUsdA,
+        memo: "",
+        amount: defaultAmount + feeSats,
+        senderWalletId: walletIdA,
+        senderAccount: accountA,
+      })
+      if (payResult instanceof Error) throw payResult
 
-  it("returns error for balance too low", async () => {
-    const address = (await bitcoindOutside.getNewAddress()) as OnChainAddress
-    const amount = toSats(1_000_000_000)
-    const fee = await Wallets.getOnChainFee({
-      walletId: walletIdA,
-      account: accountA,
-      amount,
-      address,
-      targetConfirmations: defaultTarget,
+      const address = (await bitcoindOutside.getNewAddress()) as OnChainAddress
+      const feeAmount = await Wallets.getOnChainFee({
+        walletId: walletIdUsdA,
+        account: accountA,
+        amount: defaultUsdAmount,
+        address,
+        targetConfirmations: defaultTarget,
+      })
+      if (feeAmount instanceof Error) throw feeAmount
+      expect(feeAmount.currency === WalletCurrency.Usd)
+      const fee = Number(feeAmount.amount)
+      expect(fee).toBeGreaterThan(0)
+
+      const wallet = await WalletsRepository().findById(walletIdUsdA)
+      if (wallet instanceof Error) throw wallet
+
+      const account = await AccountsRepository().findById(wallet.accountId)
+      if (account instanceof Error) throw account
+
+      const withdrawFeeAsUsd =
+        await DealerPriceService().getCentsFromSatsForImmediateSell(account.withdrawFee)
+      if (withdrawFeeAsUsd instanceof Error) throw withdrawFeeAsUsd
+      expect(fee).toBeGreaterThan(withdrawFeeAsUsd)
+
+      const expectedFee = await DealerPriceService().getCentsFromSatsForImmediateSell(
+        feeSats,
+      )
+      if (expectedFee instanceof Error) throw expectedFee
+      expect(expectedFee).toEqual(fee)
     })
-    expect(fee).toBeInstanceOf(InsufficientBalanceError)
-    expect(fee).toHaveProperty(
-      "message",
-      expect.stringMatching(/Payment amount '\d+' sats exceeds balance '\d+'/),
-    )
+
+    it("returns zero for an on us address", async () => {
+      const address = await Wallets.createOnChainAddress(walletIdB)
+      if (address instanceof Error) throw address
+      const feeAmount = await Wallets.getOnChainFee({
+        walletId: walletIdUsdA,
+        account: accountA,
+        amount: defaultUsdAmount,
+        address,
+        targetConfirmations: defaultTarget,
+      })
+      if (feeAmount instanceof Error) throw feeAmount
+      const fee = Number(feeAmount.amount)
+      expect(fee).toBe(0)
+    })
+
+    it("returns error for dust amount", async () => {
+      const address = (await bitcoindOutside.getNewAddress()) as OnChainAddress
+      const amount = toSats(dustThreshold - 1)
+      const usdAmount = await DealerPriceService().getCentsFromSatsForImmediateBuy(amount)
+      if (usdAmount instanceof Error) throw usdAmount
+
+      const fee = await Wallets.getOnChainFee({
+        walletId: walletIdUsdA,
+        account: accountA,
+        amount: usdAmount,
+        address,
+        targetConfirmations: defaultTarget,
+      })
+      expect(fee).toBeInstanceOf(LessThanDustThresholdError)
+      expect(fee).toHaveProperty(
+        "message",
+        `Use lightning to send amounts less than ${dustThreshold} sats`,
+      )
+    })
+
+    it("returns error for minimum amount", async () => {
+      const address = (await bitcoindOutside.getNewAddress()) as OnChainAddress
+      const usdAmount = toCents(1)
+
+      const fee = await Wallets.getOnChainFee({
+        walletId: walletIdUsdA,
+        account: accountA,
+        amount: usdAmount,
+        address,
+        targetConfirmations: defaultTarget,
+      })
+      expect(fee).toBeInstanceOf(LessThanDustThresholdError)
+      expect(fee).toHaveProperty(
+        "message",
+        `Use lightning to send amounts less than ${dustThreshold} sats`,
+      )
+    })
+
+    it("returns error for balance too low", async () => {
+      const address = (await bitcoindOutside.getNewAddress()) as OnChainAddress
+      const amount = toSats(1_000_000_000)
+      const usdAmount = await DealerPriceService().getCentsFromSatsForImmediateBuy(amount)
+      if (usdAmount instanceof Error) throw usdAmount
+
+      const fee = await Wallets.getOnChainFee({
+        walletId: walletIdUsdA,
+        account: accountA,
+        amount: usdAmount,
+        address,
+        targetConfirmations: defaultTarget,
+      })
+      expect(fee).toBeInstanceOf(InsufficientBalanceError)
+      expect(fee).toHaveProperty(
+        "message",
+        expect.stringMatching(/Payment amount '\d+' cents exceeds balance '\d+'/),
+      )
+    })
   })
 })

--- a/test/integration/02-user-wallet/02-tx-onchain-fees.spec.ts
+++ b/test/integration/02-user-wallet/02-tx-onchain-fees.spec.ts
@@ -81,7 +81,7 @@ describe("UserWallet - getOnchainFee", () => {
     expect(fee).toBeInstanceOf(LessThanDustThresholdError)
     expect(fee).toHaveProperty(
       "message",
-      `Use lightning to send amounts less than ${dustThreshold}`,
+      `Use lightning to send amounts less than ${dustThreshold} sats`,
     )
   })
 


### PR DESCRIPTION
## Description

This PR builds on the work already done in #1408.

It removes the USD code-path blockers, adds new queries/mutations and integration tests for USD use-cases.

### Open `TODO`s
- [x] add tests for fee probe from USD wallet (done: https://github.com/GaloyMoney/galoy/pull/2072/commits/dc44f7b3aa0d94bebffcae2c84bd7e5907827e90)
- [x] add new USD gql mutations and enable existing ones; test

### Follow-up PR
- cherry-pick https://github.com/GaloyMoney/galoy/pull/2094/commits/ff5cca9a708e4bb5c9a8c142b57ccc6e279ef52a for independent PR
- move validate functions to app layer (https://github.com/GaloyMoney/galoy/pull/2072#discussion_r1058588580)
- add hedge cases for onchain where applicable