### PR TITLE
test: remove okex redis mock & use stablesats in-memory internal mock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,26 +9,16 @@ start-deps-integration:
 update-price-history:
 	docker compose run price-history node servers/history/cron.js
 
-start-okex:
-	. ./.envrc && yarn tsnd --respawn --files -r tsconfig-paths/register \
-		test/mocks/okex-server.ts | yarn pino-pretty -c -l
-
-start-main-only:
+start-main:
 	. ./.envrc && yarn tsnd --respawn --files -r tsconfig-paths/register -r src/services/tracing.ts \
 		src/servers/graphql-main-server.ts | yarn pino-pretty -c -l
-
-start-main:
-	make start-okex & make start-main-only
 
 start-main-fast:
 	yarn run watch-main | yarn pino-pretty -c -l
 
-start-admin-only:
+start-admin:
 	. ./.envrc && yarn tsnd --respawn --files -r tsconfig-paths/register -r src/services/tracing.ts \
 		src/servers/graphql-admin-server.ts | yarn pino-pretty -c -l
-
-start-admin:
-	make start-okex & make start-admin-only
 
 start-trigger: start-deps
 	. ./.envrc && yarn tsnd --respawn --files -r tsconfig-paths/register -r src/services/tracing.ts \
@@ -42,7 +32,7 @@ start-loopd:
 	./dev/bin/start-loopd.sh
 
 start: start-deps
-	make start-okex & make start-main-only & make start-admin-only & make start-trigger
+	make start-main & make start-admin & make start-trigger
 
 start-main-ci:
 	node lib/servers/graphql-main-server.js

--- a/dev/stablesats.yml
+++ b/dev/stablesats.yml
@@ -9,9 +9,11 @@ price_server:
     base_fee_rate: 0.0005
     immediate_fee_rate: 0.0005
     delayed_fee_rate: 0.0007
+  price_cache:
+    dev_mock_price_btc_in_usd: 20000
 
 okex_price_feed:
-  dev_mock_price_btc_in_usd: 20000
+  enabled: false
 
 tracing:
   host: "otel-agent"

--- a/dev/stablesats.yml
+++ b/dev/stablesats.yml
@@ -11,7 +11,7 @@ price_server:
     delayed_fee_rate: 0.0007
 
 okex_price_feed:
-  enabled: false
+  dev_mock_price_btc_in_usd: 20000
 
 tracing:
   host: "otel-agent"

--- a/test/e2e/integration-services/stablesats.spec.ts
+++ b/test/e2e/integration-services/stablesats.spec.ts
@@ -12,16 +12,7 @@
 import { WalletCurrency } from "@domain/shared"
 import { NewDealerPriceService } from "@services/dealer-price"
 
-import { cancelOkexPricePublish, publishOkexPrice } from "test/helpers"
-
 const newDealerFns = NewDealerPriceService()
-beforeAll(async () => {
-  await publishOkexPrice()
-})
-
-afterAll(() => {
-  cancelOkexPricePublish()
-})
 
 const centsFromSats = async (btc: BtcPaymentAmount) => {
   // Conversions with spreads

--- a/test/e2e/servers/graphql-main-server/with-auth-requests.spec.ts
+++ b/test/e2e/servers/graphql-main-server/with-auth-requests.spec.ts
@@ -32,7 +32,6 @@ import TRANSACTIONS_BY_WALLET_IDS from "./queries/transactions-by-wallet-ids.gql
 
 import {
   bitcoindClient,
-  cancelOkexPricePublish,
   clearAccountLocks,
   clearLimiters,
   createApolloClient,
@@ -49,7 +48,6 @@ import {
   lndOutside1,
   lndOutside2,
   pay,
-  publishOkexPrice,
   startServer,
 } from "test/helpers"
 import { loginFromPhoneAndCode } from "test/helpers/account-creation-e2e"
@@ -74,8 +72,6 @@ beforeAll(async () => {
   await initializeTestingState(defaultStateConfig())
   serverPid = await startServer("start-main-ci")
   triggerPid = await startServer("start-trigger-ci")
-
-  await publishOkexPrice()
 })
 
 beforeEach(async () => {
@@ -86,7 +82,6 @@ beforeEach(async () => {
 afterAll(async () => {
   await bitcoindClient.unloadWallet({ walletName: "outside" })
   disposeClient()
-  cancelOkexPricePublish()
   await killServer(serverPid)
   await killServer(triggerPid)
 })

--- a/test/helpers/redis.ts
+++ b/test/helpers/redis.ts
@@ -1,7 +1,3 @@
-import crypto from "crypto"
-
-import Redis from "ioredis"
-
 import { RateLimitPrefix } from "@domain/rate-limit"
 import { redis } from "@services/redis"
 
@@ -23,47 +19,3 @@ export const clearLimitersWithExclusions = async (exclusions: string[]) => {
 }
 
 export const clearLimiters = () => clearLimitersWithExclusions([])
-
-let ioRedis
-let pricePublishInterval
-
-const executePublish = async (ioRedis) => {
-  const timestamp = Math.floor(new Date().getTime() / 1000)
-  const message = {
-    meta: {
-      publishedAt: timestamp,
-      correlationId: crypto.randomUUID(),
-    },
-    payloadType: "OkexBtcUsdSwapPricePayload",
-    payload: {
-      timestamp,
-      exchange: "okex",
-      instrumentId: "BTC-USD-SWAP",
-      askPrice: {
-        numeratorUnit: "USD_CENT",
-        denominatorUnit: "SATOSHI",
-        offset: 12,
-        base: "20000000000",
-      },
-      bidPrice: {
-        numeratorUnit: "USD_CENT",
-        denominatorUnit: "SATOSHI",
-        offset: 12,
-        base: "20000000000",
-      },
-    },
-  }
-  const channel = "galoy.stablesats.price.okex.btc-usd-swap"
-  await ioRedis.publish(channel, JSON.stringify(message))
-}
-
-export const publishOkexPrice = async () => {
-  ioRedis = new Redis(6379, process.env.REDIS_0_INTERNAL_IP || "localhost")
-  await executePublish(ioRedis)
-  pricePublishInterval = setInterval(() => executePublish(ioRedis), 1000)
-}
-
-export const cancelOkexPricePublish = () => {
-  clearInterval(pricePublishInterval)
-  ioRedis.quit()
-}

--- a/test/integration/02-user-wallet/02-receive-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-lightning.spec.ts
@@ -27,7 +27,6 @@ import { ImbalanceCalculator } from "@domain/ledger/imbalance-calculator"
 import { sleep } from "@utils"
 
 import {
-  cancelOkexPricePublish,
   checkIsBalanced,
   createUserAndWalletFromUserRef,
   getAccountByTestUserRef,
@@ -41,7 +40,6 @@ import {
   lnd1,
   lndOutside1,
   pay,
-  publishOkexPrice,
   safePay,
   safePayNoExpect,
   subscribeToInvoices,
@@ -57,7 +55,6 @@ let initBalanceB: Satoshis
 let initBalanceUsdB: UsdCents
 
 beforeAll(async () => {
-  await publishOkexPrice()
   await createUserAndWalletFromUserRef("B")
   await createUserAndWalletFromUserRef("F")
   walletIdB = await getDefaultWalletIdByTestUserRef("B")
@@ -70,10 +67,6 @@ beforeAll(async () => {
   walletIdUsdB = await getUsdWalletIdByTestUserRef("B")
   walletIdF = await getDefaultWalletIdByTestUserRef("F")
   walletIdUsdF = await getUsdWalletIdByTestUserRef("F")
-})
-
-afterAll(async () => {
-  cancelOkexPricePublish()
 })
 
 beforeEach(async () => {

--- a/test/integration/02-user-wallet/02-send-lightning-limits.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning-limits.spec.ts
@@ -12,13 +12,11 @@ import { AccountsRepository } from "@services/mongoose"
 
 import {
   addNewWallet,
-  cancelOkexPricePublish,
   checkIsBalanced,
   createAndFundNewWallet,
   createInvoice,
   randomAccount,
   lndOutside1,
-  publishOkexPrice,
 } from "test/helpers"
 
 const MOCKED_LIMIT = 100 as UsdCents
@@ -60,7 +58,6 @@ let otherBtcWallet: Wallet
 let otherUsdWallet: Wallet // eslint-disable-line @typescript-eslint/no-unused-vars
 
 beforeAll(async () => {
-  await publishOkexPrice()
   otherAccountId = (await randomAccount()).id
 
   const btcWallet = await addNewWallet({
@@ -87,7 +84,6 @@ afterEach(async () => {
 })
 
 afterAll(() => {
-  cancelOkexPricePublish()
   jest.restoreAllMocks()
 })
 

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -61,7 +61,6 @@ import * as PushNotificationsServiceImpl from "@services/notifications/push-noti
 
 import {
   cancelHodlInvoice,
-  cancelOkexPricePublish,
   checkIsBalanced,
   createHodlInvoice,
   createInvoice,
@@ -77,7 +76,6 @@ import {
   getUsdWalletIdByTestUserRef,
   lndOutside1,
   lndOutside2,
-  publishOkexPrice,
   settleHodlInvoice,
   waitFor,
   waitUntilChannelBalanceSyncAll,
@@ -158,7 +156,6 @@ const locale = getLocale()
 const { code: DefaultDisplayCurrency } = getDisplayCurrencyConfig()
 
 beforeAll(async () => {
-  await publishOkexPrice()
   await createUserAndWalletFromUserRef("A")
   await createUserAndWalletFromUserRef("B")
   await createUserAndWalletFromUserRef("C")
@@ -203,7 +200,6 @@ afterEach(async () => {
 })
 
 afterAll(() => {
-  cancelOkexPricePublish()
   jest.restoreAllMocks()
 })
 

--- a/test/integration/app/wallets/invoice.spec.ts
+++ b/test/integration/app/wallets/invoice.spec.ts
@@ -16,12 +16,10 @@ import { WalletInvoicesRepository } from "@services/mongoose"
 import { DealerPriceService } from "@services/dealer-price"
 
 import {
-  cancelOkexPricePublish,
   createUserAndWalletFromUserRef,
   getAccountIdByTestUserRef,
   getDefaultWalletIdByTestUserRef,
   getHash,
-  publishOkexPrice,
 } from "test/helpers"
 import {
   resetRecipientAccountIdLimits,
@@ -35,7 +33,6 @@ let accountIdB: AccountId
 const walletInvoices = WalletInvoicesRepository()
 
 beforeAll(async () => {
-  await publishOkexPrice()
   const userRef = "B"
   await createUserAndWalletFromUserRef(userRef)
 
@@ -52,7 +49,6 @@ beforeAll(async () => {
 })
 
 afterAll(() => {
-  cancelOkexPricePublish()
   jest.restoreAllMocks()
 })
 

--- a/test/integration/services/dealer/hedge-price.spec.ts
+++ b/test/integration/services/dealer/hedge-price.spec.ts
@@ -9,13 +9,7 @@ import { AmountCalculator, paymentAmountFromNumber, WalletCurrency } from "@doma
 import { baseLogger } from "@services/logger"
 import { AccountsRepository } from "@services/mongoose"
 
-import {
-  cancelOkexPricePublish,
-  createAndFundNewWallet,
-  getBalanceHelper,
-  publishOkexPrice,
-  randomAccount,
-} from "test/helpers"
+import { createAndFundNewWallet, getBalanceHelper, randomAccount } from "test/helpers"
 
 jest.mock("@config", () => {
   const config = jest.requireActual("@config")
@@ -348,14 +342,6 @@ const getMinBtcAmountToSpend = async ({
 
   return minBtcAmountToSpend
 }
-
-beforeAll(async () => {
-  await publishOkexPrice()
-})
-
-afterAll(async () => {
-  cancelOkexPricePublish()
-})
 
 describe("arbitrage strategies", () => {
   describe("can pay high sats invoice with $0.01", () => {

--- a/test/integration/services/dealer/mid-price.spec.ts
+++ b/test/integration/services/dealer/mid-price.spec.ts
@@ -2,16 +2,6 @@ import { getCurrentPriceInCentsPerSat, getMidPriceRatio } from "@app/shared"
 
 import { NewDealerPriceService } from "@services/dealer-price"
 
-import { cancelOkexPricePublish, publishOkexPrice } from "test/helpers"
-
-beforeAll(async () => {
-  await publishOkexPrice()
-})
-
-afterAll(() => {
-  cancelOkexPricePublish()
-})
-
 describe("getMidPriceRatio", () => {
   const fetchPrices = async () => {
     const dealerMidPriceRatio =

--- a/test/mocks/okex-server.ts
+++ b/test/mocks/okex-server.ts
@@ -1,6 +1,0 @@
-import { baseLogger } from "@services/logger"
-
-import { publishOkexPrice } from "test/helpers"
-
-publishOkexPrice()
-baseLogger.info("Okex price publish for stablesats started")


### PR DESCRIPTION
## Description

This PR is to configure stablesats to use its new in-memory price feed (mocked) and to remove unused redis price publish mock functions.