### PR TITLE
feat: kratos userLogout mutation

### DIFF
--- a/src/app/auth/index.ts
+++ b/src/app/auth/index.ts
@@ -1,4 +1,5 @@
 export * from "./login"
+export * from "./logout"
 export * from "./request-phone-code"
 
 import { ErrorLevel } from "@domain/shared"

--- a/src/app/auth/logout.ts
+++ b/src/app/auth/logout.ts
@@ -1,0 +1,12 @@
+import { AuthWithPhonePasswordlessService } from "@services/kratos"
+
+export const logout = async (
+  authToken: SessionToken,
+): Promise<boolean | ApplicationError> => {
+  const authService = AuthWithPhonePasswordlessService()
+  const kratosResult = await authService.logout(authToken)
+  if (kratosResult instanceof Error) {
+    return kratosResult
+  }
+  return true
+}

--- a/src/domain/authentication/index.types.d.ts
+++ b/src/domain/authentication/index.types.d.ts
@@ -30,7 +30,7 @@ interface IAuthWithPhonePasswordlessService {
   login(
     phone: PhoneNumber,
   ): Promise<LoginWithPhoneNoPasswordSchemaResponse | AuthenticationError>
-  logout(token: string): Promise<void | AuthenticationError>
+  logout(token: SessionToken): Promise<void | AuthenticationError>
   createIdentityWithSession(
     phone: PhoneNumber,
   ): Promise<CreateKratosUserForPhoneNoPasswordSchemaResponse | AuthenticationError>

--- a/src/domain/authentication/index.types.d.ts
+++ b/src/domain/authentication/index.types.d.ts
@@ -30,6 +30,7 @@ interface IAuthWithPhonePasswordlessService {
   login(
     phone: PhoneNumber,
   ): Promise<LoginWithPhoneNoPasswordSchemaResponse | AuthenticationError>
+  logout(token: string): Promise<void | AuthenticationError>
   createIdentityWithSession(
     phone: PhoneNumber,
   ): Promise<CreateKratosUserForPhoneNoPasswordSchemaResponse | AuthenticationError>

--- a/src/graphql/main/mutations.ts
+++ b/src/graphql/main/mutations.ts
@@ -19,6 +19,7 @@ import LnNoAmountUsdInvoicePaymentSendMutation from "@graphql/root/mutation/ln-n
 import OnChainAddressCreateMutation from "@graphql/root/mutation/on-chain-address-create"
 import OnChainAddressCurrentMutation from "@graphql/root/mutation/on-chain-address-current"
 import UserLoginMutation from "@graphql/root/mutation/user-login"
+import UserLogoutMutation from "@graphql/root/mutation/user-logout"
 import UserRequestAuthCodeMutation from "@graphql/root/mutation/user-request-auth-code"
 import UserUpdateLanguageMutation from "@graphql/root/mutation/user-update-language"
 import UserUpdateUsernameMutation from "@graphql/root/mutation/user-update-username"
@@ -37,6 +38,7 @@ export const mutationFields = {
   unauthed: {
     userRequestAuthCode: UserRequestAuthCodeMutation,
     userLogin: UserLoginMutation,
+    userLogout: UserLogoutMutation,
 
     captchaCreateChallenge: CaptchaCreateChallengeMutation,
     captchaRequestAuthCode: CaptchaRequestAuthCodeMutation,

--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -732,6 +732,7 @@ type Mutation {
     input: UserContactUpdateAliasInput!
   ): UserContactUpdateAliasPayload! @deprecated(reason: "will be moved to AccountContact")
   userLogin(input: UserLoginInput!): AuthTokenPayload!
+  userLogout(input: UserLogoutInput!): AuthTokenPayload!
   userQuizQuestionUpdateCompleted(
     input: UserQuizQuestionUpdateCompletedInput!
   ): UserQuizQuestionUpdateCompletedPayload!
@@ -1291,6 +1292,10 @@ type UserContactUpdateAliasPayload {
 input UserLoginInput {
   code: OneTimeAuthCode!
   phone: Phone!
+}
+
+input UserLogoutInput {
+  authToken: AuthToken!
 }
 
 type UserQuizQuestion {

--- a/src/graphql/root/mutation/user-logout.ts
+++ b/src/graphql/root/mutation/user-logout.ts
@@ -8,7 +8,7 @@ import { mapAndParseErrorForGqlResponse } from "@graphql/error-map"
 const UserLogoutInput = GT.Input({
   name: "UserLogoutInput",
   fields: () => ({
-    token: {
+    authToken: {
       type: GT.NonNull(AuthToken),
     },
   }),
@@ -16,7 +16,7 @@ const UserLogoutInput = GT.Input({
 
 const UserLogoutMutation = GT.Field<{
   input: {
-    token: string | InputValidationError
+    authToken: string | InputValidationError
   }
 }>({
   extensions: {
@@ -27,10 +27,10 @@ const UserLogoutMutation = GT.Field<{
     input: { type: GT.NonNull(UserLogoutInput) },
   },
   resolve: async (_, args) => {
-    const { token } = args.input
-    if (token instanceof Error) return
+    const { authToken } = args.input
+    if (authToken instanceof Error) return
     const authService = AuthWithPhonePasswordlessService()
-    const logoutResp = await authService.logout(token)
+    const logoutResp = await authService.logout(authToken)
     if (logoutResp instanceof Error)
       return { errors: [mapAndParseErrorForGqlResponse(logoutResp)] }
     return { errors: [] }

--- a/src/graphql/root/mutation/user-logout.ts
+++ b/src/graphql/root/mutation/user-logout.ts
@@ -1,0 +1,40 @@
+import { GT } from "@graphql/index"
+
+import AuthToken from "@graphql/types/scalar/auth-token"
+import AuthTokenPayload from "@graphql/types/payload/auth-token"
+import { AuthWithPhonePasswordlessService } from "@services/kratos"
+import { mapAndParseErrorForGqlResponse } from "@graphql/error-map"
+
+const UserLogoutInput = GT.Input({
+  name: "UserLogoutInput",
+  fields: () => ({
+    token: {
+      type: GT.NonNull(AuthToken),
+    },
+  }),
+})
+
+const UserLogoutMutation = GT.Field<{
+  input: {
+    token: string | InputValidationError
+  }
+}>({
+  extensions: {
+    complexity: 120,
+  },
+  type: GT.NonNull(AuthTokenPayload),
+  args: {
+    input: { type: GT.NonNull(UserLogoutInput) },
+  },
+  resolve: async (_, args) => {
+    const { token } = args.input
+    if (token instanceof Error) return
+    const authService = AuthWithPhonePasswordlessService()
+    const logoutResp = await authService.logout(token)
+    if (logoutResp instanceof Error)
+      return { errors: [mapAndParseErrorForGqlResponse(logoutResp)] }
+    return { errors: [] }
+  },
+})
+
+export default UserLogoutMutation

--- a/src/graphql/root/mutation/user-logout.ts
+++ b/src/graphql/root/mutation/user-logout.ts
@@ -2,7 +2,7 @@ import { GT } from "@graphql/index"
 
 import AuthToken from "@graphql/types/scalar/auth-token"
 import AuthTokenPayload from "@graphql/types/payload/auth-token"
-import { AuthWithPhonePasswordlessService } from "@services/kratos"
+import { logout } from "@app/auth"
 import { mapAndParseErrorForGqlResponse } from "@graphql/error-map"
 
 const UserLogoutInput = GT.Input({
@@ -16,7 +16,7 @@ const UserLogoutInput = GT.Input({
 
 const UserLogoutMutation = GT.Field<{
   input: {
-    authToken: string | InputValidationError
+    authToken: SessionToken | InputValidationError
   }
 }>({
   extensions: {
@@ -29,8 +29,7 @@ const UserLogoutMutation = GT.Field<{
   resolve: async (_, args) => {
     const { authToken } = args.input
     if (authToken instanceof Error) return
-    const authService = AuthWithPhonePasswordlessService()
-    const logoutResp = await authService.logout(authToken)
+    const logoutResp = await logout(authToken)
     if (logoutResp instanceof Error)
       return { errors: [mapAndParseErrorForGqlResponse(logoutResp)] }
     return { errors: [] }

--- a/src/services/kratos/auth-phone-no-password.ts
+++ b/src/services/kratos/auth-phone-no-password.ts
@@ -67,6 +67,18 @@ export const AuthWithPhonePasswordlessService = (): IAuthWithPhonePasswordlessSe
     return { sessionToken, kratosUserId }
   }
 
+  const logout = async (token: string): Promise<void | KratosError> => {
+    try {
+      await kratosPublic.performNativeLogout({
+        performNativeLogoutBody: {
+          session_token: token,
+        },
+      })
+    } catch (err) {
+      return new UnknownKratosError(err)
+    }
+  }
+
   const createIdentityWithSession = async (
     phone: PhoneNumber,
   ): Promise<CreateKratosUserForPhoneNoPasswordSchemaResponse | KratosError> => {
@@ -174,6 +186,7 @@ export const AuthWithPhonePasswordlessService = (): IAuthWithPhonePasswordlessSe
 
   return {
     login,
+    logout,
     createIdentityWithSession,
     createIdentityNoSession,
     upgradeToPhoneAndEmailSchema,


### PR DESCRIPTION
New graphql mutation for user logout. It only logs the user out of the current session. If a user is logged in on two devices the other device will remain logged in.

```gql
mutation {
  userLogout( input: {
    authToken: "AUTH_TOKEN"
  }) { 
  errors {
    message
  }
    authToken
  }
}
```