### PR TITLE
refactor: change isAuthenticated and validateWalletId to be deterministic

### DIFF
--- a/src/graphql/admin/index.ts
+++ b/src/graphql/admin/index.ts
@@ -2,9 +2,12 @@ import { GraphQLSchema, lexicographicSortSchema, printSchema } from "graphql"
 
 import { isDev, isRunningJest } from "@config"
 
-import QueryType from "./queries"
-import MutationType from "./mutations"
+import { QueryType } from "./queries"
+import { MutationType } from "./mutations"
 import { ALL_INTERFACE_TYPES } from "./types"
+
+export { queryFields as adminQueryFields } from "./queries"
+export { mutationFields as adminMutationFields } from "./mutations"
 
 if (isDev && !isRunningJest) {
   import("@services/fs").then(({ writeSDLFile }) => {

--- a/src/graphql/admin/mutations.ts
+++ b/src/graphql/admin/mutations.ts
@@ -19,12 +19,11 @@ export const mutationFields = {
 
     captchaCreateChallenge: CaptchaCreateChallengeMutation,
     captchaRequestAuthCode: CaptchaRequestAuthCodeMutation,
-
-    accountsAddUsdWallet: AccountsAddUsdWalletMutation,
   },
   authed: {
     accountUpdateLevel: AccountUpdateLevelMutation,
     accountUpdateStatus: AccountUpdateStatusMutation,
+    accountsAddUsdWallet: AccountsAddUsdWalletMutation,
     businessUpdateMapInfo: BusinessUpdateMapInfoMutation,
     coldStorageRebalanceToHotWallet: ColdStorageRebalanceToHotWalletMutation,
   },

--- a/src/graphql/admin/mutations.ts
+++ b/src/graphql/admin/mutations.ts
@@ -12,23 +12,25 @@ import ColdStorageRebalanceToHotWalletMutation from "@graphql/admin/root/mutatio
 
 import AccountsAddUsdWalletMutation from "./root/mutation/account-add-usd-wallet"
 
-const MutationType = GT.Object({
-  name: "Mutation",
-  fields: () => ({
+export const mutationFields = {
+  unauthed: {
     userRequestAuthCode: UserRequestAuthCodeMutation,
     userLogin: UserLoginMutation,
 
     captchaCreateChallenge: CaptchaCreateChallengeMutation,
     captchaRequestAuthCode: CaptchaRequestAuthCodeMutation,
 
+    accountsAddUsdWallet: AccountsAddUsdWalletMutation,
+  },
+  authed: {
     accountUpdateLevel: AccountUpdateLevelMutation,
     accountUpdateStatus: AccountUpdateStatusMutation,
-    accountsAddUsdWallet: AccountsAddUsdWalletMutation,
-
     businessUpdateMapInfo: BusinessUpdateMapInfoMutation,
-
     coldStorageRebalanceToHotWallet: ColdStorageRebalanceToHotWalletMutation,
-  }),
-})
+  },
+}
 
-export default MutationType
+export const MutationType = GT.Object({
+  name: "Mutation",
+  fields: () => ({ ...mutationFields.unauthed, ...mutationFields.authed }),
+})

--- a/src/graphql/admin/queries.ts
+++ b/src/graphql/admin/queries.ts
@@ -10,9 +10,9 @@ import AccountDetailsByUsernameQuery from "./root/query/account-details-by-usern
 import ListWalletIdsQuery from "./root/query/all-walletids"
 import WalletQuery from "./root/query/wallet"
 
-const QueryType = GT.Object({
-  name: "Query",
-  fields: () => ({
+export const queryFields = {
+  unauthed: {},
+  authed: {
     allLevels: AllLevelsQuery,
     accountDetailsByUserPhone: AccountDetailsByUserPhoneQuery,
     accountDetailsByUsername: AccountDetailsByUsernameQuery,
@@ -22,7 +22,10 @@ const QueryType = GT.Object({
     lightningPayment: LightningPaymentQuery,
     listWalletIds: ListWalletIdsQuery,
     wallet: WalletQuery,
-  }),
-})
+  },
+}
 
-export default QueryType
+export const QueryType = GT.Object({
+  name: "Query",
+  fields: () => ({ ...queryFields.unauthed, ...queryFields.authed }),
+})

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -88,6 +88,3 @@ export const GT: GTType = {
 
   Kind,
 }
-
-export * from "./main/index"
-export * from "./admin/index"

--- a/src/graphql/main/index.ts
+++ b/src/graphql/main/index.ts
@@ -4,9 +4,12 @@ import { ALL_INTERFACE_TYPES } from "@graphql/types"
 
 import { isDev, isRunningJest } from "@config"
 
-import QueryType from "./queries"
-import MutationType from "./mutations"
-import SubscriptionType from "./subscriptions"
+import { QueryType } from "./queries"
+import { MutationType } from "./mutations"
+import { SubscriptionType } from "./subscriptions"
+
+export { queryFields } from "./queries"
+export { mutationFields } from "./mutations"
 
 if (isDev && !isRunningJest) {
   import("@services/fs").then(({ writeSDLFile }) => {

--- a/src/graphql/main/mutations.ts
+++ b/src/graphql/main/mutations.ts
@@ -48,7 +48,7 @@ export const mutationFields = {
   },
 
   authed: {
-    noWalletId: {
+    atAccountLevel: {
       userQuizQuestionUpdateCompleted: UserQuizQuestionUpdateCompletedMutation,
       deviceNotificationTokenCreate: DeviceNotificationTokenCreateMutation,
 
@@ -59,7 +59,7 @@ export const mutationFields = {
       userContactUpdateAlias: UserContactUpdateAliasMutation,
     },
 
-    withWalletId: {
+    atWalletLevel: {
       intraLedgerPaymentSend: IntraLedgerPaymentSendMutation,
       intraLedgerUsdPaymentSend: IntraLedgerUsdPaymentSendMutation,
 
@@ -89,7 +89,7 @@ export const MutationType = GT.Object({
   name: "Mutation",
   fields: {
     ...mutationFields.unauthed,
-    ...mutationFields.authed.noWalletId,
-    ...mutationFields.authed.withWalletId,
+    ...mutationFields.authed.atAccountLevel,
+    ...mutationFields.authed.atWalletLevel,
   },
 })

--- a/src/graphql/main/mutations.ts
+++ b/src/graphql/main/mutations.ts
@@ -33,55 +33,55 @@ import CaptchaRequestAuthCodeMutation from "@graphql/root/mutation/captcha-reque
 import CaptchaCreateChallengeMutation from "@graphql/root/mutation/captcha-create-challenge"
 
 // TODO: // const fields: { [key: string]: GraphQLFieldConfig<any, GraphQLContext> }
-const fields = {
-  // unauthed
-  userRequestAuthCode: UserRequestAuthCodeMutation,
-  userLogin: UserLoginMutation,
+export const mutationFields = {
+  unauthed: {
+    userRequestAuthCode: UserRequestAuthCodeMutation,
+    userLogin: UserLoginMutation,
 
-  captchaCreateChallenge: CaptchaCreateChallengeMutation,
-  captchaRequestAuthCode: CaptchaRequestAuthCodeMutation,
+    captchaCreateChallenge: CaptchaCreateChallengeMutation,
+    captchaRequestAuthCode: CaptchaRequestAuthCodeMutation,
 
-  lnInvoiceCreateOnBehalfOfRecipient: LnInvoiceCreateOnBehalfOfRecipientMutation,
-  lnUsdInvoiceCreateOnBehalfOfRecipient: LnUsdInvoiceCreateOnBehalfOfRecipientMutation,
-  lnNoAmountInvoiceCreateOnBehalfOfRecipient:
-    LnNoAmountInvoiceCreateOnBehalfOfRecipientMutation,
+    lnInvoiceCreateOnBehalfOfRecipient: LnInvoiceCreateOnBehalfOfRecipientMutation,
+    lnUsdInvoiceCreateOnBehalfOfRecipient: LnUsdInvoiceCreateOnBehalfOfRecipientMutation,
+    lnNoAmountInvoiceCreateOnBehalfOfRecipient:
+      LnNoAmountInvoiceCreateOnBehalfOfRecipientMutation,
+  },
 
-  // authed
-  userQuizQuestionUpdateCompleted: UserQuizQuestionUpdateCompletedMutation,
-  deviceNotificationTokenCreate: DeviceNotificationTokenCreateMutation,
+  authed: {
+    userQuizQuestionUpdateCompleted: UserQuizQuestionUpdateCompletedMutation,
+    deviceNotificationTokenCreate: DeviceNotificationTokenCreateMutation,
 
-  userUpdateLanguage: UserUpdateLanguageMutation,
-  userUpdateUsername: UserUpdateUsernameMutation,
-  accountUpdateDefaultWalletId: AccountUpdateDefaultWalletIdMutation,
-  accountUpdateDisplayCurrency: AccountUpdateDisplayCurrencyMutation,
-  userContactUpdateAlias: UserContactUpdateAliasMutation,
+    userUpdateLanguage: UserUpdateLanguageMutation,
+    userUpdateUsername: UserUpdateUsernameMutation,
+    accountUpdateDefaultWalletId: AccountUpdateDefaultWalletIdMutation,
+    accountUpdateDisplayCurrency: AccountUpdateDisplayCurrencyMutation,
+    userContactUpdateAlias: UserContactUpdateAliasMutation,
 
-  lnInvoiceFeeProbe: LnInvoiceFeeProbeMutation,
-  lnUsdInvoiceFeeProbe: LnUsdInvoiceFeeProbeMutation,
-  lnNoAmountInvoiceFeeProbe: LnNoAmountInvoiceFeeProbeMutation,
-  lnNoAmountUsdInvoiceFeeProbe: LnNoAmountUsdInvoiceFeeProbeMutation,
+    lnInvoiceFeeProbe: LnInvoiceFeeProbeMutation,
+    lnUsdInvoiceFeeProbe: LnUsdInvoiceFeeProbeMutation,
+    lnNoAmountInvoiceFeeProbe: LnNoAmountInvoiceFeeProbeMutation,
+    lnNoAmountUsdInvoiceFeeProbe: LnNoAmountUsdInvoiceFeeProbeMutation,
 
-  lnInvoiceCreate: LnInvoiceCreateMutation,
-  lnUsdInvoiceCreate: LnUsdInvoiceCreateMutation,
-  lnNoAmountInvoiceCreate: LnNoAmountInvoiceCreateMutation,
+    lnInvoiceCreate: LnInvoiceCreateMutation,
+    lnUsdInvoiceCreate: LnUsdInvoiceCreateMutation,
+    lnNoAmountInvoiceCreate: LnNoAmountInvoiceCreateMutation,
 
-  lnInvoicePaymentSend: LnInvoicePaymentSendMutation,
-  lnNoAmountInvoicePaymentSend: LnNoAmountInvoicePaymentSendMutation,
-  lnNoAmountUsdInvoicePaymentSend: LnNoAmountUsdInvoicePaymentSendMutation,
+    lnInvoicePaymentSend: LnInvoicePaymentSendMutation,
+    lnNoAmountInvoicePaymentSend: LnNoAmountInvoicePaymentSendMutation,
+    lnNoAmountUsdInvoicePaymentSend: LnNoAmountUsdInvoicePaymentSendMutation,
 
-  intraLedgerPaymentSend: IntraLedgerPaymentSendMutation,
-  intraLedgerUsdPaymentSend: IntraLedgerUsdPaymentSendMutation,
+    intraLedgerPaymentSend: IntraLedgerPaymentSendMutation,
+    intraLedgerUsdPaymentSend: IntraLedgerUsdPaymentSendMutation,
 
-  onChainAddressCreate: OnChainAddressCreateMutation,
-  onChainAddressCurrent: OnChainAddressCurrentMutation,
-  onChainPaymentSend: OnChainPaymentSendMutation,
-  onChainUsdPaymentSend: OnChainUsdPaymentSendMutation,
-  onChainPaymentSendAll: OnChainPaymentSendAllMutation,
+    onChainAddressCreate: OnChainAddressCreateMutation,
+    onChainAddressCurrent: OnChainAddressCurrentMutation,
+    onChainPaymentSend: OnChainPaymentSendMutation,
+    onChainUsdPaymentSend: OnChainUsdPaymentSendMutation,
+    onChainPaymentSendAll: OnChainPaymentSendAllMutation,
+  },
 }
 
-const MutationType = GT.Object({
+export const MutationType = GT.Object({
   name: "Mutation",
-  fields,
+  fields: { ...mutationFields.unauthed, ...mutationFields.authed },
 })
-
-export default MutationType

--- a/src/graphql/main/mutations.ts
+++ b/src/graphql/main/mutations.ts
@@ -48,40 +48,48 @@ export const mutationFields = {
   },
 
   authed: {
-    userQuizQuestionUpdateCompleted: UserQuizQuestionUpdateCompletedMutation,
-    deviceNotificationTokenCreate: DeviceNotificationTokenCreateMutation,
+    noWalletId: {
+      userQuizQuestionUpdateCompleted: UserQuizQuestionUpdateCompletedMutation,
+      deviceNotificationTokenCreate: DeviceNotificationTokenCreateMutation,
 
-    userUpdateLanguage: UserUpdateLanguageMutation,
-    userUpdateUsername: UserUpdateUsernameMutation,
-    accountUpdateDefaultWalletId: AccountUpdateDefaultWalletIdMutation,
-    accountUpdateDisplayCurrency: AccountUpdateDisplayCurrencyMutation,
-    userContactUpdateAlias: UserContactUpdateAliasMutation,
+      userUpdateLanguage: UserUpdateLanguageMutation,
+      userUpdateUsername: UserUpdateUsernameMutation,
+      accountUpdateDefaultWalletId: AccountUpdateDefaultWalletIdMutation,
+      accountUpdateDisplayCurrency: AccountUpdateDisplayCurrencyMutation,
+      userContactUpdateAlias: UserContactUpdateAliasMutation,
+    },
 
-    lnInvoiceFeeProbe: LnInvoiceFeeProbeMutation,
-    lnUsdInvoiceFeeProbe: LnUsdInvoiceFeeProbeMutation,
-    lnNoAmountInvoiceFeeProbe: LnNoAmountInvoiceFeeProbeMutation,
-    lnNoAmountUsdInvoiceFeeProbe: LnNoAmountUsdInvoiceFeeProbeMutation,
+    withWalletId: {
+      intraLedgerPaymentSend: IntraLedgerPaymentSendMutation,
+      intraLedgerUsdPaymentSend: IntraLedgerUsdPaymentSendMutation,
 
-    lnInvoiceCreate: LnInvoiceCreateMutation,
-    lnUsdInvoiceCreate: LnUsdInvoiceCreateMutation,
-    lnNoAmountInvoiceCreate: LnNoAmountInvoiceCreateMutation,
+      lnInvoiceFeeProbe: LnInvoiceFeeProbeMutation,
+      lnUsdInvoiceFeeProbe: LnUsdInvoiceFeeProbeMutation,
+      lnNoAmountInvoiceFeeProbe: LnNoAmountInvoiceFeeProbeMutation,
+      lnNoAmountUsdInvoiceFeeProbe: LnNoAmountUsdInvoiceFeeProbeMutation,
 
-    lnInvoicePaymentSend: LnInvoicePaymentSendMutation,
-    lnNoAmountInvoicePaymentSend: LnNoAmountInvoicePaymentSendMutation,
-    lnNoAmountUsdInvoicePaymentSend: LnNoAmountUsdInvoicePaymentSendMutation,
+      lnInvoiceCreate: LnInvoiceCreateMutation,
+      lnUsdInvoiceCreate: LnUsdInvoiceCreateMutation,
+      lnNoAmountInvoiceCreate: LnNoAmountInvoiceCreateMutation,
 
-    intraLedgerPaymentSend: IntraLedgerPaymentSendMutation,
-    intraLedgerUsdPaymentSend: IntraLedgerUsdPaymentSendMutation,
+      lnInvoicePaymentSend: LnInvoicePaymentSendMutation,
+      lnNoAmountInvoicePaymentSend: LnNoAmountInvoicePaymentSendMutation,
+      lnNoAmountUsdInvoicePaymentSend: LnNoAmountUsdInvoicePaymentSendMutation,
 
-    onChainAddressCreate: OnChainAddressCreateMutation,
-    onChainAddressCurrent: OnChainAddressCurrentMutation,
-    onChainPaymentSend: OnChainPaymentSendMutation,
-    onChainUsdPaymentSend: OnChainUsdPaymentSendMutation,
-    onChainPaymentSendAll: OnChainPaymentSendAllMutation,
+      onChainAddressCreate: OnChainAddressCreateMutation,
+      onChainAddressCurrent: OnChainAddressCurrentMutation,
+      onChainPaymentSend: OnChainPaymentSendMutation,
+      onChainUsdPaymentSend: OnChainUsdPaymentSendMutation,
+      onChainPaymentSendAll: OnChainPaymentSendAllMutation,
+    },
   },
 }
 
 export const MutationType = GT.Object({
   name: "Mutation",
-  fields: { ...mutationFields.unauthed, ...mutationFields.authed },
+  fields: {
+    ...mutationFields.unauthed,
+    ...mutationFields.authed.noWalletId,
+    ...mutationFields.authed.withWalletId,
+  },
 })

--- a/src/graphql/main/queries.ts
+++ b/src/graphql/main/queries.ts
@@ -30,13 +30,21 @@ export const queryFields = {
     lnInvoicePaymentStatus: LnInvoicePaymentStatusQuery,
   },
   authed: {
-    me: MeQuery,
-    onChainTxFee: OnChainTxFeeQuery,
-    onChainUsdTxFee: OnChainUsdTxFeeQuery,
+    noWalletId: {
+      me: MeQuery,
+    },
+    withWalletId: {
+      onChainTxFee: OnChainTxFeeQuery,
+      onChainUsdTxFee: OnChainUsdTxFeeQuery,
+    },
   },
 } as const
 
 export const QueryType = GT.Object({
   name: "Query",
-  fields: { ...queryFields.unauthed, ...queryFields.authed },
+  fields: {
+    ...queryFields.unauthed,
+    ...queryFields.authed.noWalletId,
+    ...queryFields.authed.withWalletId,
+  },
 })

--- a/src/graphql/main/queries.ts
+++ b/src/graphql/main/queries.ts
@@ -15,26 +15,28 @@ import AccountDefaultWalletQuery from "@graphql/root/query/account-default-walle
 import AccountDefaultWalletIdQuery from "@graphql/root/query/account-default-wallet-id"
 import LnInvoicePaymentStatusQuery from "@graphql/root/query/ln-invoice-payment-status"
 
-const fields = {
-  globals: GlobalsQuery,
-  me: MeQuery,
-  usernameAvailable: UsernameAvailableQuery,
-  userDefaultWalletId: AccountDefaultWalletIdQuery, // FIXME: migrate to AccountDefaultWalletId
-  accountDefaultWallet: AccountDefaultWalletQuery,
-  businessMapMarkers: BusinessMapMarkersQuery,
-  currencyList: CurrencyListQuery,
-  mobileVersions: MobileVersionsQuery,
-  quizQuestions: QuizQuestionsQuery,
-  btcPrice: BtcPriceQuery,
-  btcPriceList: BtcPriceListQuery,
-  onChainTxFee: OnChainTxFeeQuery,
-  onChainUsdTxFee: OnChainUsdTxFeeQuery,
-  lnInvoicePaymentStatus: LnInvoicePaymentStatusQuery,
+export const queryFields = {
+  unauthed: {
+    globals: GlobalsQuery,
+    usernameAvailable: UsernameAvailableQuery,
+    userDefaultWalletId: AccountDefaultWalletIdQuery, // FIXME: migrate to AccountDefaultWalletId
+    accountDefaultWallet: AccountDefaultWalletQuery,
+    businessMapMarkers: BusinessMapMarkersQuery,
+    currencyList: CurrencyListQuery,
+    mobileVersions: MobileVersionsQuery,
+    quizQuestions: QuizQuestionsQuery,
+    btcPrice: BtcPriceQuery,
+    btcPriceList: BtcPriceListQuery,
+    lnInvoicePaymentStatus: LnInvoicePaymentStatusQuery,
+  },
+  authed: {
+    me: MeQuery,
+    onChainTxFee: OnChainTxFeeQuery,
+    onChainUsdTxFee: OnChainUsdTxFeeQuery,
+  },
 } as const
 
-const QueryType = GT.Object({
+export const QueryType = GT.Object({
   name: "Query",
-  fields,
+  fields: { ...queryFields.unauthed, ...queryFields.authed },
 })
-
-export default QueryType

--- a/src/graphql/main/queries.ts
+++ b/src/graphql/main/queries.ts
@@ -30,10 +30,10 @@ export const queryFields = {
     lnInvoicePaymentStatus: LnInvoicePaymentStatusQuery,
   },
   authed: {
-    noWalletId: {
+    atAccountLevel: {
       me: MeQuery,
     },
-    withWalletId: {
+    atWalletLevel: {
       onChainTxFee: OnChainTxFeeQuery,
       onChainUsdTxFee: OnChainUsdTxFeeQuery,
     },
@@ -44,7 +44,7 @@ export const QueryType = GT.Object({
   name: "Query",
   fields: {
     ...queryFields.unauthed,
-    ...queryFields.authed.noWalletId,
-    ...queryFields.authed.withWalletId,
+    ...queryFields.authed.atAccountLevel,
+    ...queryFields.authed.atWalletLevel,
   },
 })

--- a/src/graphql/main/subscriptions.ts
+++ b/src/graphql/main/subscriptions.ts
@@ -34,9 +34,7 @@ const addTracing = () => {
   return fields
 }
 
-const SubscriptionType = GT.Object({
+export const SubscriptionType = GT.Object({
   name: "Subscription",
   fields: addTracing(),
 })
-
-export default SubscriptionType

--- a/src/servers/graphql-admin-server.ts
+++ b/src/servers/graphql-admin-server.ts
@@ -1,6 +1,7 @@
 import dotenv from "dotenv"
 import { applyMiddleware } from "graphql-middleware"
 import { and, shield } from "graphql-shield"
+import { RuleAnd } from "graphql-shield/typings/rules"
 
 import { baseLogger } from "@services/logger"
 import { setupMongoConnection } from "@services/mongodb"
@@ -17,12 +18,12 @@ dotenv.config()
 const graphqlLogger = baseLogger.child({ module: "graphql" })
 
 export async function startApolloServerForAdminSchema() {
-  const authedQueryFields = {}
+  const authedQueryFields: { [key: string]: RuleAnd } = {}
   for (const key of Object.keys(adminQueryFields.authed)) {
     authedQueryFields[key] = and(isAuthenticated, isEditor)
   }
 
-  const authedMutationFields = {}
+  const authedMutationFields: { [key: string]: RuleAnd } = {}
   for (const key of Object.keys(adminMutationFields.authed)) {
     authedMutationFields[key] = and(isAuthenticated, isEditor)
   }

--- a/src/servers/graphql-admin-server.ts
+++ b/src/servers/graphql-admin-server.ts
@@ -8,9 +8,7 @@ import { setupMongoConnection } from "@services/mongodb"
 import { activateLndHealthCheck } from "@services/lnd/health"
 
 import { GALOY_ADMIN_PORT } from "@config"
-import { adminMutationFields, adminQueryFields } from "@graphql/admin"
-
-import { gqlAdminSchema } from "../graphql"
+import { gqlAdminSchema, adminMutationFields, adminQueryFields } from "@graphql/admin"
 
 import { startApolloServer, isAuthenticated, isEditor } from "./graphql-server"
 

--- a/src/servers/graphql-main-server.ts
+++ b/src/servers/graphql-main-server.ts
@@ -1,6 +1,7 @@
 import dotenv from "dotenv"
 import { applyMiddleware } from "graphql-middleware"
 import { shield } from "graphql-shield"
+import { Rule } from "graphql-shield/typings/rules"
 
 import { setupMongoConnection } from "@services/mongodb"
 import { activateLndHealthCheck } from "@services/lnd/health"
@@ -18,7 +19,7 @@ const graphqlLogger = baseLogger.child({ module: "graphql" })
 dotenv.config()
 
 export async function startApolloServerForCoreSchema() {
-  const authedQueryFields = {}
+  const authedQueryFields: { [key: string]: Rule } = {}
   for (const key of Object.keys({
     ...queryFields.authed.noWalletId,
     ...queryFields.authed.withWalletId,
@@ -26,7 +27,7 @@ export async function startApolloServerForCoreSchema() {
     authedQueryFields[key] = isAuthenticated
   }
 
-  const authedMutationFields = {}
+  const authedMutationFields: { [key: string]: Rule } = {}
   for (const key of Object.keys({
     ...mutationFields.authed.noWalletId,
     ...mutationFields.authed.withWalletId,

--- a/src/servers/graphql-main-server.ts
+++ b/src/servers/graphql-main-server.ts
@@ -8,7 +8,7 @@ import { baseLogger } from "@services/logger"
 
 import { GALOY_API_PORT } from "@config"
 
-import { gqlMainSchema, mutationFields, queryFields } from "../graphql"
+import { gqlMainSchema, mutationFields, queryFields } from "@graphql/main"
 
 import { isAuthenticated, startApolloServer } from "./graphql-server"
 import { walletIdMiddleware } from "./middlewares/wallet-id"

--- a/src/servers/graphql-main-server.ts
+++ b/src/servers/graphql-main-server.ts
@@ -8,7 +8,7 @@ import { baseLogger } from "@services/logger"
 
 import { GALOY_API_PORT } from "@config"
 
-import { gqlMainSchema } from "../graphql"
+import { gqlMainSchema, mutationFields, queryFields } from "../graphql"
 
 import { isAuthenticated, startApolloServer } from "./graphql-server"
 import { walletIdMiddleware } from "./middlewares/wallet-id"
@@ -18,43 +18,20 @@ const graphqlLogger = baseLogger.child({ module: "graphql" })
 dotenv.config()
 
 export async function startApolloServerForCoreSchema() {
+  const authedQueryFields = {}
+  for (const key of Object.keys(queryFields.authed)) {
+    authedQueryFields[key] = isAuthenticated
+  }
+
+  const authedMutationFields = {}
+  for (const key of Object.keys(mutationFields.authed)) {
+    authedMutationFields[key] = isAuthenticated
+  }
+
   const permissions = shield(
     {
-      Query: {
-        me: isAuthenticated,
-        onChainTxFee: isAuthenticated,
-        onChainUsdTxFee: isAuthenticated,
-      },
-      Mutation: {
-        userQuizQuestionUpdateCompleted: isAuthenticated,
-        deviceNotificationTokenCreate: isAuthenticated,
-
-        userUpdateUsername: isAuthenticated,
-        userUpdateLanguage: isAuthenticated,
-        accountUpdateDefaultWalletId: isAuthenticated,
-        accountUpdateDisplayCurrency: isAuthenticated,
-        userContactUpdateAlias: isAuthenticated,
-
-        lnInvoiceFeeProbe: isAuthenticated,
-        lnNoAmountInvoiceFeeProbe: isAuthenticated,
-
-        lnInvoiceCreate: isAuthenticated,
-        lnUsdInvoiceCreate: isAuthenticated,
-        lnNoAmountInvoiceCreate: isAuthenticated,
-
-        lnInvoicePaymentSend: isAuthenticated,
-        lnNoAmountInvoicePaymentSend: isAuthenticated,
-        lnNoAmountUsdInvoicePaymentSend: isAuthenticated,
-
-        intraLedgerPaymentSend: isAuthenticated,
-        intraLedgerUsdPaymentSend: isAuthenticated,
-
-        onChainAddressCreate: isAuthenticated,
-        onChainAddressCurrent: isAuthenticated,
-        onChainPaymentSend: isAuthenticated,
-        onChainUsdPaymentSend: isAuthenticated,
-        onChainPaymentSendAll: isAuthenticated,
-      },
+      Query: authedQueryFields,
+      Mutation: authedMutationFields,
     },
     { allowExternalErrors: true },
   )

--- a/src/servers/graphql-main-server.ts
+++ b/src/servers/graphql-main-server.ts
@@ -21,16 +21,16 @@ dotenv.config()
 export async function startApolloServerForCoreSchema() {
   const authedQueryFields: { [key: string]: Rule } = {}
   for (const key of Object.keys({
-    ...queryFields.authed.noWalletId,
-    ...queryFields.authed.withWalletId,
+    ...queryFields.authed.atAccountLevel,
+    ...queryFields.authed.atWalletLevel,
   })) {
     authedQueryFields[key] = isAuthenticated
   }
 
   const authedMutationFields: { [key: string]: Rule } = {}
   for (const key of Object.keys({
-    ...mutationFields.authed.noWalletId,
-    ...mutationFields.authed.withWalletId,
+    ...mutationFields.authed.atAccountLevel,
+    ...mutationFields.authed.atWalletLevel,
   })) {
     authedMutationFields[key] = isAuthenticated
   }

--- a/src/servers/graphql-main-server.ts
+++ b/src/servers/graphql-main-server.ts
@@ -19,12 +19,18 @@ dotenv.config()
 
 export async function startApolloServerForCoreSchema() {
   const authedQueryFields = {}
-  for (const key of Object.keys(queryFields.authed)) {
+  for (const key of Object.keys({
+    ...queryFields.authed.noWalletId,
+    ...queryFields.authed.withWalletId,
+  })) {
     authedQueryFields[key] = isAuthenticated
   }
 
   const authedMutationFields = {}
-  for (const key of Object.keys(mutationFields.authed)) {
+  for (const key of Object.keys({
+    ...mutationFields.authed.noWalletId,
+    ...mutationFields.authed.withWalletId,
+  })) {
     authedMutationFields[key] = isAuthenticated
   }
 

--- a/src/servers/middlewares/wallet-id.ts
+++ b/src/servers/middlewares/wallet-id.ts
@@ -2,6 +2,7 @@ import { GraphQLResolveInfo, GraphQLFieldResolver } from "graphql"
 
 import { Accounts } from "@app"
 import { mapError } from "@graphql/error-map"
+import { mutationFields, queryFields } from "@graphql/main"
 
 type InputArgs = Record<"input", Record<string, unknown>>
 
@@ -54,26 +55,17 @@ const validateWalletIdMutation = async (
   return result
 }
 
+const walletIdQueryFields = {}
+for (const key of Object.keys(queryFields.authed.withWalletId)) {
+  walletIdQueryFields[key] = validateWalletIdQuery
+}
+
+const walletIdMutationFields = {}
+for (const key of Object.keys(mutationFields.authed.withWalletId)) {
+  walletIdMutationFields[key] = validateWalletIdMutation
+}
+
 export const walletIdMiddleware = {
-  Query: {
-    onChainTxFee: validateWalletIdQuery,
-    onChainUsdTxFee: validateWalletIdQuery,
-  },
-  Mutation: {
-    intraLedgerPaymentSend: validateWalletIdMutation,
-    intraLedgerUsdPaymentSend: validateWalletIdMutation,
-    lnInvoiceFeeProbe: validateWalletIdMutation,
-    lnNoAmountInvoiceFeeProbe: validateWalletIdMutation,
-    lnInvoiceCreate: validateWalletIdMutation,
-    lnUsdInvoiceCreate: validateWalletIdMutation,
-    lnNoAmountInvoiceCreate: validateWalletIdMutation,
-    lnInvoicePaymentSend: validateWalletIdMutation,
-    lnNoAmountInvoicePaymentSend: validateWalletIdMutation,
-    lnNoAmountUsdInvoicePaymentSend: validateWalletIdMutation,
-    onChainAddressCreate: validateWalletIdMutation,
-    onChainAddressCurrent: validateWalletIdMutation,
-    onChainPaymentSend: validateWalletIdMutation,
-    onChainUsdPaymentSend: validateWalletIdMutation,
-    onChainPaymentSendAll: validateWalletIdMutation,
-  },
+  Query: walletIdQueryFields,
+  Mutation: walletIdMutationFields,
 }

--- a/src/servers/middlewares/wallet-id.ts
+++ b/src/servers/middlewares/wallet-id.ts
@@ -61,6 +61,7 @@ export const walletIdMiddleware = {
   },
   Mutation: {
     intraLedgerPaymentSend: validateWalletIdMutation,
+    intraLedgerUsdPaymentSend: validateWalletIdMutation,
     lnInvoiceFeeProbe: validateWalletIdMutation,
     lnNoAmountInvoiceFeeProbe: validateWalletIdMutation,
     lnInvoiceCreate: validateWalletIdMutation,

--- a/src/servers/middlewares/wallet-id.ts
+++ b/src/servers/middlewares/wallet-id.ts
@@ -65,12 +65,12 @@ type ValidateWalletIdFn = (
 ) => Promise<unknown>
 
 const walletIdQueryFields: { [key: string]: ValidateWalletIdFn } = {}
-for (const key of Object.keys(queryFields.authed.withWalletId)) {
+for (const key of Object.keys(queryFields.authed.atWalletLevel)) {
   walletIdQueryFields[key] = validateWalletIdQuery
 }
 
 const walletIdMutationFields: { [key: string]: ValidateWalletIdFn } = {}
-for (const key of Object.keys(mutationFields.authed.withWalletId)) {
+for (const key of Object.keys(mutationFields.authed.atWalletLevel)) {
   walletIdMutationFields[key] = validateWalletIdMutation
 }
 

--- a/src/servers/middlewares/wallet-id.ts
+++ b/src/servers/middlewares/wallet-id.ts
@@ -55,12 +55,21 @@ const validateWalletIdMutation = async (
   return result
 }
 
-const walletIdQueryFields = {}
+// Placed here because 'GraphQLFieldResolver' not working from .d.ts file
+type ValidateWalletIdFn = (
+  resolve: GraphQLFieldResolver<unknown, GraphQLContext | GraphQLContextAuth>,
+  parent: unknown,
+  args: unknown,
+  context: GraphQLContext | GraphQLContextAuth,
+  info: GraphQLResolveInfo,
+) => Promise<unknown>
+
+const walletIdQueryFields: { [key: string]: ValidateWalletIdFn } = {}
 for (const key of Object.keys(queryFields.authed.withWalletId)) {
   walletIdQueryFields[key] = validateWalletIdQuery
 }
 
-const walletIdMutationFields = {}
+const walletIdMutationFields: { [key: string]: ValidateWalletIdFn } = {}
 for (const key of Object.keys(mutationFields.authed.withWalletId)) {
   walletIdMutationFields[key] = validateWalletIdMutation
 }


### PR DESCRIPTION
## Description

This PR organizes the graphql queries and mutation by authentication status and walletId validation before passing into the schema creation method. These same queries/mutations are then used to populate shields and middleware, instead of having to manually maintain these.