### PR TITLE
chore: make logs more meaningful

### DIFF
--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -292,9 +292,30 @@ export const startApolloServer = async ({
   app.use(
     PinoHttp({
       logger: graphqlLogger,
-      wrapSerializers: false,
+      wrapSerializers: true,
+      customProps: (req) => ({
+        /* eslint @typescript-eslint/ban-ts-comment: "off" */
+        // @ts-ignore-next-line no-implicit-any error
+        "body": req["body"],
+        // @ts-ignore-next-line no-implicit-any error
+        "token.sub": req["token"]?.sub,
+        // @ts-ignore-next-line no-implicit-any error
+        "gqlContext.user": req["gqlContext"]?.user,
+        // @ts-ignore-next-line no-implicit-any error
+        "gqlContext.domainAccount:": req["gqlContext"]?.domainAccount,
+      }),
       autoLogging: {
         ignore: (req) => req.url === "/healthz",
+      },
+      serializers: {
+        res: (res) => ({ statusCode: res.statusCode }),
+        req: (req) => ({
+          id: req.id,
+          method: req.method,
+          url: req.url,
+          remoteAddress: req.remoteAddress,
+          // headers: req.headers,
+        }),
       },
     }),
   )


### PR DESCRIPTION
currently I'm using the logs when doing local development.

I don't believe we have any meaningful use of logs in prod (given we rely on honeycomb), so local dev is probably the most relevat

with `wrapSerializers: false`, the logs are very long.

really the things that matter for me is to get the body query+variables requests

this PR is reducing drastically the number of output and just show the relevant outputs