### PR TITLE
feat: combine both admin and public endpoint in the same server

### DIFF
--- a/src/servers/graphql-main-server.ts
+++ b/src/servers/graphql-main-server.ts
@@ -13,6 +13,7 @@ import { gqlMainSchema, mutationFields, queryFields } from "@graphql/main"
 
 import { isAuthenticated, startApolloServer } from "./graphql-server"
 import { walletIdMiddleware } from "./middlewares/wallet-id"
+import { startApolloServerForAdminSchema } from "./graphql-admin-server"
 
 const graphqlLogger = baseLogger.child({ module: "graphql" })
 
@@ -56,7 +57,10 @@ if (require.main === module) {
   setupMongoConnection(true)
     .then(async () => {
       activateLndHealthCheck()
-      await startApolloServerForCoreSchema()
+      await Promise.race([
+        startApolloServerForCoreSchema(),
+        startApolloServerForAdminSchema(),
+      ])
     })
     .catch((err) => graphqlLogger.error(err, "server error"))
 }


### PR DESCRIPTION
there is no reason to launch a dedicated admin server. it makes local dev more memory/cpu heavy.

this is what kratos is doing and I think this is a preferrable approach - the only downside is that if there is a crash on the admin, currently it won't affect public users. but it will with this refactoring

right now this is just a test, we have to do some work on the CI before doing a broader refactoring of the /server files.