### PR TITLE
feat: ws upgrade (attempt 4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "graphql-relay": "^0.10.0",
     "graphql-shield": "^7.6.4",
     "graphql-tools": "^8.3.14",
+    "graphql-ws": "^5.11.2",
     "gt3-server-node-express-sdk": "https://github.com/GaloyMoney/gt3-server-node-express-bypass#master",
     "helmet": "^6.0.1",
     "i18n": "^0.15.1",
@@ -161,7 +162,7 @@
     "ts-node-dev": "^2.0.0",
     "tsconfig-paths": "^4.1.0",
     "typescript": "^4.9.4",
-    "ws": "^8.10.0"
+    "ws": "^8.11.0"
   },
   "resolutions": {
     "**/**/ws": ">=7.4.6",

--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -1,15 +1,14 @@
 import { createServer } from "http"
 
-import cors from "cors"
 import { Accounts } from "@app"
 import { getApolloConfig, getGeetestConfig, getJwksArgs, isDev } from "@config"
 import Geetest from "@services/geetest"
 import { baseLogger } from "@services/logger"
 import {
   ACCOUNT_USERNAME,
+  SemanticAttributes,
   addAttributesToCurrentSpan,
   addAttributesToCurrentSpanAndPropagate,
-  SemanticAttributes,
 } from "@services/tracing"
 import {
   ApolloServerPluginDrainHttpServer,
@@ -17,18 +16,24 @@ import {
   ApolloServerPluginLandingPageGraphQLPlayground,
 } from "apollo-server-core"
 import { ApolloError, ApolloServer } from "apollo-server-express"
+import cors from "cors"
 import express, { NextFunction, Request, Response } from "express"
-import { expressjwt, GetVerificationKey } from "express-jwt"
-import { execute, GraphQLError, GraphQLSchema, subscribe } from "graphql"
+import { GetVerificationKey, expressjwt } from "express-jwt"
+import { GraphQLError, GraphQLSchema, execute, subscribe } from "graphql"
 import { rule } from "graphql-shield"
+import { useServer } from "graphql-ws/lib/use/ws"
 import helmet from "helmet"
 import jsonwebtoken from "jsonwebtoken"
 import PinoHttp from "pino-http"
 import {
   ExecuteFunction,
+  GRAPHQL_WS,
   SubscribeFunction,
   SubscriptionServer,
 } from "subscriptions-transport-ws"
+import { GRAPHQL_TRANSPORT_WS_PROTOCOL } from "graphql-ws"
+
+import { WebSocketServer } from "ws"
 
 import { AuthenticationError, AuthorizationError } from "@graphql/error"
 import { mapError } from "@graphql/error-map"
@@ -53,10 +58,10 @@ import { validateKratosCookie } from "@services/kratos"
 
 import { playgroundTabs } from "../graphql/playground"
 
-import healthzHandler from "./middlewares/healthz"
 import authRouter from "./middlewares/auth-router"
-import { updateToken } from "./middlewares/update-token"
+import healthzHandler from "./middlewares/healthz"
 import kratosRouter from "./middlewares/kratos-router"
+import { updateToken } from "./middlewares/update-token"
 
 const graphqlLogger = baseLogger.child({
   module: "graphql",
@@ -320,77 +325,167 @@ export const startApolloServer = async ({
 
   apolloServer.applyMiddleware({ app, path: "/graphql" })
 
+  // old legacy ws
+  const onConnect = async (
+    connectionParams: Record<string, unknown>,
+    webSocket: unknown,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    connectionContext: any,
+  ) => {
+    const { request } = connectionContext
+
+    const authz = (connectionParams.authorization || connectionParams.Authorization) as
+      | string
+      | undefined
+
+    // TODO: also manage the case where there is a cookie in the request
+    // https://www.ory.sh/docs/oathkeeper/guides/proxy-websockets#configure-ory-oathkeeper-and-ory-kratos
+    const cookies = request.headers.cookie
+    if (cookies?.includes("ory_kratos_session")) {
+      const kratosCookieRes = await validateKratosCookie(cookies)
+      if (kratosCookieRes instanceof Error) return kratosCookieRes
+      const tokenPayload = {
+        sub: kratosCookieRes.kratosUserId,
+      }
+      return sessionContext({
+        tokenPayload,
+        ip: request?.socket?.remoteAddress,
+        body: null,
+      })
+    }
+
+    // make request to oathkeeper
+    const originalToken = authz?.slice(7) as LegacyJwtToken | SessionToken | undefined
+
+    const newToken = await sendOathkeeperRequest(originalToken)
+    // TODO: see how returning an error affect the websocket connection
+    if (newToken instanceof Error) return newToken
+
+    const keyJwks = await jwksRsa(getJwksArgs()).getSigningKey()
+
+    const tokenPayload = jsonwebtoken.verify(newToken, keyJwks.getPublicKey(), {
+      algorithms: jwtAlgorithms,
+    })
+
+    if (typeof tokenPayload === "string") {
+      throw new Error("tokenPayload should be an object")
+    }
+
+    return sessionContext({
+      tokenPayload,
+      ip: request?.socket?.remoteAddress,
+
+      // TODO: Resolve what's needed here
+      body: null,
+    })
+  }
+
+  // new ws server
+  const context = async (ctx) => {
+    const connectionParams = ctx.connectionParams as Record<string, string>
+
+    // TODO: check if nginx pass the ip to the header
+    // TODO: ip not been used currently for subscription.
+    // implement some rate limiting.
+    const ipString = isDev
+      ? connectionParams?.ip
+      : connectionParams?.["x-real-ip"] || connectionParams?.["x-forwarded-for"]
+
+    const ip = parseIps(ipString)
+
+    const authz = (connectionParams.authorization || connectionParams.Authorization) as
+      | string
+      | undefined
+
+    // TODO: also manage the case where there is a cookie in the request
+    // https://www.ory.sh/docs/oathkeeper/guides/proxy-websockets#configure-ory-oathkeeper-and-ory-kratos
+    // const cookies = request.headers.cookie
+    // if (cookies?.includes("ory_kratos_session")) {
+    //   const kratosCookieRes = await validateKratosCookie(cookies)
+    //   if (kratosCookieRes instanceof Error) return kratosCookieRes
+    //   const tokenPayload = {
+    //     sub: kratosCookieRes.kratosUserId,
+    //   }
+    //   return sessionContext({
+    //     tokenPayload,
+    //     ip: request?.socket?.remoteAddress,
+    //     body: null,
+    //   })
+    // }
+
+    // make request to oathkeeper
+    const originalToken = authz?.slice(7) as LegacyJwtToken | SessionToken | undefined
+
+    const newToken = await sendOathkeeperRequest(originalToken)
+    // TODO: see how returning an error affect the websocket connection
+    if (newToken instanceof Error) return newToken
+
+    const keyJwks = await jwksRsa(getJwksArgs()).getSigningKey()
+
+    const tokenPayload = jsonwebtoken.verify(newToken, keyJwks.getPublicKey(), {
+      algorithms: jwtAlgorithms,
+    })
+
+    if (typeof tokenPayload === "string") {
+      throw new Error("tokenPayload should be an object")
+    }
+
+    return sessionContext({
+      tokenPayload,
+      ip,
+
+      // TODO: Resolve what's needed here
+      body: null,
+    })
+  }
+
   return new Promise((resolve, reject) => {
     httpServer.listen({ port }, () => {
       if (startSubscriptionServer) {
-        const apolloSubscriptionServer = new SubscriptionServer(
+        const graphqlWs = new WebSocketServer({ noServer: true })
+        const serverCleanup = useServer(
+          { schema, execute, subscribe, context },
+          graphqlWs,
+        )
+
+        const subTransWs = new WebSocketServer({ noServer: true })
+        const apolloSubscriptionServer = SubscriptionServer.create(
           {
             execute: execute as unknown as ExecuteFunction,
             subscribe: subscribe as unknown as SubscribeFunction,
             schema,
-            async onConnect(
-              connectionParams: Record<string, unknown>,
-              webSocket: unknown,
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              connectionContext: any,
-            ) {
-              const { request } = connectionContext
-
-              const authz = (connectionParams.authorization ||
-                connectionParams.Authorization) as string | undefined
-
-              // TODO: also manage the case where there is a cookie in the request
-              // https://www.ory.sh/docs/oathkeeper/guides/proxy-websockets#configure-ory-oathkeeper-and-ory-kratos
-              const cookies = request.headers.cookie
-              if (cookies?.includes("ory_kratos_session")) {
-                const kratosCookieRes = await validateKratosCookie(cookies)
-                if (kratosCookieRes instanceof Error) return kratosCookieRes
-                const tokenPayload = {
-                  sub: kratosCookieRes.kratosUserId,
-                }
-                return sessionContext({
-                  tokenPayload,
-                  ip: request?.socket?.remoteAddress,
-                  body: null,
-                })
-              }
-
-              // make request to oathkeeper
-              const originalToken = authz?.slice(7) as
-                | LegacyJwtToken
-                | SessionToken
-                | undefined
-
-              const newToken = await sendOathkeeperRequest(originalToken)
-              // TODO: see how returning an error affect the websocket connection
-              if (newToken instanceof Error) return newToken
-
-              const keyJwks = await jwksRsa(getJwksArgs()).getSigningKey()
-
-              const tokenPayload = jsonwebtoken.verify(newToken, keyJwks.getPublicKey(), {
-                algorithms: jwtAlgorithms,
-              })
-
-              if (typeof tokenPayload === "string") {
-                throw new Error("tokenPayload should be an object")
-              }
-
-              return sessionContext({
-                tokenPayload,
-                ip: request?.socket?.remoteAddress,
-
-                // TODO: Resolve what's needed here
-                body: null,
-              })
-            },
+            onConnect,
           },
-          {
-            server: httpServer,
-            path: apolloServer.graphqlPath,
-          },
+          subTransWs,
         )
         ;["SIGINT", "SIGTERM"].forEach((signal) => {
-          process.on(signal, () => apolloSubscriptionServer.close())
+          process.on(signal, () => {
+            apolloSubscriptionServer.close()
+            serverCleanup.dispose()
+          })
+        })
+
+        httpServer.on("upgrade", (req, socket, head) => {
+          console.log(req, "updade")
+
+          // extract websocket subprotocol from header
+          const protocol = req.headers["sec-websocket-protocol"]
+          const protocols = Array.isArray(protocol)
+            ? protocol
+            : protocol?.split(",").map((p) => p.trim())
+
+          // decide which websocket server to use
+          const wss =
+            protocols?.includes(GRAPHQL_WS) && // subscriptions-transport-ws subprotocol
+            !protocols.includes(GRAPHQL_TRANSPORT_WS_PROTOCOL) // graphql-ws subprotocol
+              ? subTransWs
+              : // graphql-ws will welcome its own subprotocol and
+                // gracefully reject invalid ones. if the client supports
+                // both transports, graphql-ws will prevail
+                graphqlWs
+          wss.handleUpgrade(req, socket, head, (ws) => {
+            wss.emit("connection", ws, req)
+          })
         })
       }
 

--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -381,6 +381,8 @@ export const startApolloServer = async ({
   }
 
   // new ws server
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   const context = async (ctx) => {
     const connectionParams = ctx.connectionParams as Record<string, string>
 
@@ -466,8 +468,6 @@ export const startApolloServer = async ({
         })
 
         httpServer.on("upgrade", (req, socket, head) => {
-          console.log(req, "updade")
-
           // extract websocket subprotocol from header
           const protocol = req.headers["sec-websocket-protocol"]
           const protocols = Array.isArray(protocol)

--- a/test/helpers/apollo-client.ts
+++ b/test/helpers/apollo-client.ts
@@ -1,19 +1,20 @@
 import {
   ApolloClient,
+  InMemoryCache,
   ApolloLink,
   from,
   HttpLink,
-  InMemoryCache,
-  NormalizedCacheObject,
   split,
+  NormalizedCacheObject,
 } from "@apollo/client/core"
-import { WebSocketLink } from "@apollo/client/link/ws"
 import { getMainDefinition } from "@apollo/client/utilities"
-import { SubscriptionClient } from "subscriptions-transport-ws"
-import ws from "ws"
 
 import { onError } from "@apollo/client/link/error"
 import { baseLogger } from "@services/logger"
+
+import { createClient } from "graphql-ws"
+import { GraphQLWsLink } from "@apollo/client/link/subscriptions"
+import WebSocket from "ws"
 
 export const localIpAddress = "127.0.0.1" as IpAddress
 
@@ -55,15 +56,13 @@ export const createApolloClient = (
 
   const httpLink = new HttpLink({ uri: graphqlUrl })
 
-  const subscriptionClient = new SubscriptionClient(
-    graphqlSubscriptionUrl,
-    {
-      connectionParams: authToken ? { Authorization: `Bearer ${authToken}` } : undefined,
-    },
-    ws,
-  )
+  const subscriptionClient = createClient({
+    url: graphqlSubscriptionUrl,
+    connectionParams: authToken ? { Authorization: `Bearer ${authToken}` } : undefined,
+    webSocketImpl: WebSocket,
+  })
 
-  const wsLink = new WebSocketLink(subscriptionClient)
+  const wsLink = new GraphQLWsLink(subscriptionClient)
 
   const errorLink = onError(({ graphQLErrors, networkError }) => {
     if (graphQLErrors)
@@ -106,7 +105,7 @@ export const createApolloClient = (
   const disposeClient = () => {
     apolloClient.clearStore()
     apolloClient.stop()
-    subscriptionClient.close()
+    subscriptionClient.terminate()
   }
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6668,6 +6668,11 @@ graphql-tools@^8.3.14:
   optionalDependencies:
     "@apollo/client" "~3.2.5 || ~3.3.0 || ~3.4.0 || ~3.5.0 || ~3.6.0 || ~3.7.0"
 
+graphql-ws@^5.11.2:
+  version "5.11.2"
+  resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.11.2.tgz#d5e0acae8b4d4a4cf7be410a24135cfcefd7ddc0"
+  integrity sha512-4EiZ3/UXYcjm+xFGP544/yW1+DVI8ZpKASFbzrV5EDTFWJp0ZvLl4Dy2fSZAzz9imKp5pZMIcjB0x/H69Pv/6w==
+
 graphql@^16.3.0, graphql@^16.6.0:
   version "16.6.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
@@ -12328,7 +12333,7 @@ write-file-atomic@^4.0.1:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
-ws@8.10.0, ws@8.11.0, ws@8.8.1, ws@>=7.4.6, ws@^3.2.0, "ws@^5.2.0 || ^6.0.0 || ^7.0.0", ws@^8.10.0:
+ws@8.10.0, ws@8.11.0, ws@8.8.1, ws@>=7.4.6, ws@^3.2.0, "ws@^5.2.0 || ^6.0.0 || ^7.0.0", ws@^8.11.0:
   version "8.11.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.11.0.tgz#6a0d36b8edfd9f96d8b25683db2f8d7de6e8e143"
   integrity sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==


### PR DESCRIPTION
previous attempt (https://github.com/GaloyMoney/galoy/pull/1780) was trying to both upgrade the ws socket library to `graphql-ws` and also segregates the ws socket server from the main server (a recommended best practice to get apollo federation to work). 

the second part is the harder part (more code/graphql schema moving around, more to do on the infra side to keep things to map the backend code), and is the reason this PS has not been completed yet.

I instead go with this PR with [this code snippet](https://github.com/enisdenjo/graphql-ws#ws-backwards-compat) that let run both the old and new websocket protocol simultaneously. the goal of this PR is now to only upgrade the websocket library. 

the seggregation of the HTTP server and ws server can be done in another PR later. 