### PR TITLE
test: add routed payment tests

### DIFF
--- a/src/domain/payments/ln-fees.ts
+++ b/src/domain/payments/ln-fees.ts
@@ -39,7 +39,7 @@ export const LnFees = (
   }
 
   const feeFromRawRoute = (rawRoute: RawRoute): BtcPaymentAmount | ValidationError => {
-    const amount = Math.ceil(rawRoute.fee)
+    const amount = Math.ceil(rawRoute.safe_fee)
     return paymentAmountFromNumber({ amount, currency: WalletCurrency.Btc })
   }
 

--- a/test/helpers/lightning.ts
+++ b/test/helpers/lightning.ts
@@ -243,7 +243,7 @@ export const closeAllChannels = async ({ lnd }) => {
   }
 }
 
-export const setChannelFees = async ({ lnd, channel, base = 1, rate = 1 }) => {
+export const setChannelFees = async ({ lnd, channel, base, rate }) => {
   const input = {
     fee_rate: rate,
     base_fee_mtokens: `${base * 1000}`,

--- a/test/integration/01-setup/01-lightning-channels.spec.ts
+++ b/test/integration/01-setup/01-lightning-channels.spec.ts
@@ -33,8 +33,7 @@ afterEach(async () => {
 })
 
 // Setup the next network
-// lnd2 <- lnd1 <-> lndOutside1
-// lnd2 <- lnd1 -> lndOutside2
+// lnd2 <- lnd1 <-> lndOutside1 -> lndOutside2
 // this setup avoids close channels for routing fees tests
 describe("Lightning channels", () => {
   it("opens channel from lnd1 to lnd2", async () => {
@@ -89,28 +88,7 @@ describe("Lightning channels", () => {
     await setChannelFees({ lnd: lndOutside1, channel, base: 1, rate: 0 })
   })
 
-  it("opens channel from lnd1 to lndOutside2", async () => {
-    const socket = `lnd-outside-2:9735`
-
-    const initFeeInLedger = await ledgerAdmin.getBankOwnerBalance()
-
-    const { lndNewChannel: channel } = await openChannelTesting({
-      lnd: lnd1,
-      lndPartner: lndOutside2,
-      socket,
-    })
-
-    const { channels } = await getChannels({ lnd: lnd1 })
-    expect(channels.length).toEqual(channelLengthMain + 1)
-
-    const finalFeeInLedger = await ledgerAdmin.getBankOwnerBalance()
-    expect(finalFeeInLedger - initFeeInLedger).toBe(channelFee * -1)
-
-    await setChannelFees({ lnd: lnd1, channel, base: 1, rate: 0 })
-    await setChannelFees({ lnd: lndOutside2, channel, base: 1, rate: 0 })
-  })
-
-  it.skip("opens private channel from lndOutside1 to lndOutside2", async () => {
+  it("opens private channel from lndOutside1 to lndOutside2", async () => {
     const socket = `lnd-outside-2:9735`
 
     const { lndNewChannel: channel } = await openChannelTesting({

--- a/test/integration/01-setup/01-lightning-channels.spec.ts
+++ b/test/integration/01-setup/01-lightning-channels.spec.ts
@@ -102,8 +102,8 @@ describe("Lightning channels", () => {
     expect(channels.length).toEqual(channelLengthOutside1 + 1)
     expect(channels.some((e) => e.is_private)).toBe(true)
 
-    await setChannelFees({ lnd: lndOutside1, channel, base: 1, rate: 0 })
-    await setChannelFees({ lnd: lndOutside2, channel, base: 1, rate: 0 })
+    await setChannelFees({ lnd: lndOutside1, channel, base: 0, rate: 5000 })
+    await setChannelFees({ lnd: lndOutside2, channel, base: 0, rate: 5000 })
   })
 
   // FIXME: we need a way to calculate the closing fee

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -1088,6 +1088,7 @@ describe("UserWallet - Lightning Pay", () => {
       })
 
       it("pay invoice routed to lnd outside2", async () => {
+        const amountInvoice = 199
         const { request } = await createInvoice({
           lnd: lndOutside2,
           tokens: amountInvoice,

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -69,6 +69,8 @@ import {
   getAccountByTestUserRef,
   getAccountRecordByTestUserRef,
   getBalanceHelper,
+  getChannel,
+  getChannels,
   getDefaultWalletIdByTestUserRef,
   getHash,
   getInvoice,
@@ -1085,7 +1087,7 @@ describe("UserWallet - Lightning Pay", () => {
         )
       })
 
-      it("pay invoice to lnd outside2", async () => {
+      it("pay invoice routed to lnd outside2", async () => {
         const { request } = await createInvoice({
           lnd: lndOutside2,
           tokens: amountInvoice,
@@ -1107,9 +1109,19 @@ describe("UserWallet - Lightning Pay", () => {
         expect(result).toBe(PaymentSendStatus.Success)
         const finalBalance = await getBalanceHelper(walletIdB)
 
-        // TODO: have a way to do this more programmatically?
-        // base rate: 1, fee Rate: 1
-        const fee = 0
+        // Calculate fee from routed payment
+        const { channels } = await getChannels({ lnd: lndOutside2 })
+        expect(channels && channels.length).toBeGreaterThan(0)
+        const { id } = channels[0]
+        const {
+          policies: [{ base_fee_mtokens: baseMilliSats, fee_rate: feeRatePpm }],
+        } = await getChannel({ id, lnd: lndOutside2 })
+        if (baseMilliSats === undefined || feeRatePpm === undefined) {
+          throw new Error("Undefined baseMilliSats or feeRatePpm")
+        }
+        const baseSats = Math.ceil(parseInt(baseMilliSats, 10) / 1000)
+        const feeRate = feeRatePpm / 1_000_000
+        const fee = baseSats + Math.ceil(amountInvoice * feeRate)
 
         expect(finalBalance).toBe(initialBalance - amountInvoice - fee)
       })

--- a/test/unit/domain/payments/ln-fees.spec.ts
+++ b/test/unit/domain/payments/ln-fees.spec.ts
@@ -36,4 +36,14 @@ describe("LnFees", () => {
       })
     })
   })
+
+  describe("feeFromRawRoute", () => {
+    it("returns the feeFromRawRoute", () => {
+      const rawRoute = { total_mtokens: "21000000", safe_fee: 210 } as RawRoute
+      expect(LnFees().feeFromRawRoute(rawRoute)).toEqual({
+        amount: 210n,
+        currency: WalletCurrency.Btc,
+      })
+    })
+  })
 })

--- a/test/unit/payments/payment-flow-builder.spec.ts
+++ b/test/unit/payments/payment-flow-builder.spec.ts
@@ -50,7 +50,7 @@ describe("LightningPaymentFlowBuilder", () => {
     userId: "recipientUserId" as UserId,
   }
   const pubkey = "pubkey" as Pubkey
-  const rawRoute = { total_mtokens: "21000000", fee: 210 } as RawRoute
+  const rawRoute = { total_mtokens: "21000000", safe_fee: 210 } as RawRoute
 
   // 0.02 ratio (0.02 cents/sat, or $20,000 USD/BTC)
   const midPriceRatio = 0.02


### PR DESCRIPTION
## Description

This PR reworks our integration tests to have a node available 1 hop away from the instance node to test hop fees against.