### PR TITLE
feat: otel oathkeeper tracing

### DIFF
--- a/dev/ory/oathkeeper.yml
+++ b/dev/ory/oathkeeper.yml
@@ -2,6 +2,12 @@ log:
   level: debug
   format: json
 
+tracing:
+  provider: jaeger
+  providers:
+    jaeger:
+      local_agent_address: otel-agent:6831
+
 authenticators:
   bearer_token:
     enabled: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -283,7 +283,7 @@ services:
     volumes:
       - ./:/repo
   oathkeeper:
-    image: oryd/oathkeeper:v0.40
+    image: ntheile/oathkeeper:v0.40.1
     command: serve -c /home/ory/oathkeeper.yml --sqa-opt-out
     volumes:
       - type: bind


### PR DESCRIPTION
@krtk6160 ,

Today the oathkeeper codebase got a PR to fix OTEL tracing here https://github.com/ory/oathkeeper/pull/1049 . I compiled the source and tested it locally and was able to see tracing flowing thru honeycomb!

<img width="405" alt="210886687-f4fc7ab9-34b6-4699-9edd-69b1548c3909" src="https://user-images.githubusercontent.com/1273575/210913942-bc6d2b24-a659-40b6-8565-5a9a8f8f27d6.png">
<img width="1514" alt="210886695-c7212655-5012-4585-8873-9bc1764252a7" src="https://user-images.githubusercontent.com/1273575/210913951-33de5398-d9ce-4d24-ae9a-d75db258014a.png">

I pushed a docker image here: https://hub.docker.com/layers/ntheile/oathkeeper/v0.40.1/images/sha256-2aced8081b5fc8648bf9d48affb59fe4245c64b449ca82a81e10f93474331f14?context=explore 

@nicolasburtey  wanted to test this in staging. can you add this to the staging deployment and see if tracing work?

Thanks,