### PR TITLE
fix: onchain send 'usd' metadata value

### DIFF
--- a/src/services/ledger/tx-metadata.ts
+++ b/src/services/ledger/tx-metadata.ts
@@ -94,7 +94,9 @@ export const OnChainSendLedgerMetadata = <
 
     fee: toSats(satsFee),
     feeUsd: convertCentsToUsdAsDollars(feeDisplayCurrency),
-    usd: convertCentsToUsdAsDollars(amountDisplayCurrency),
+    usd: convertCentsToUsdAsDollars(
+      (amountDisplayCurrency + feeDisplayCurrency) as DisplayCurrencyBaseAmount,
+    ),
 
     satsFee: toSats(satsFee),
     displayFee: feeDisplayCurrency,


### PR DESCRIPTION
## Description

The `usd` property is what we use to return the price to calculate display currencies from for a transaction in the API ([here](https://github.com/GaloyMoney/galoy/blob/7fe52544debec600232333a5bd784d20b4f75782/src/domain/wallets/tx-history.ts#L87)).

This amount has been off since we [pushed](https://github.com/GaloyMoney/galoy/commit/9141102d8ef68a9535e6c67e3b9cb3022e9b1ad2) the onchain-payment-flow-builder. This PR is to correct that for new transactions, and to apply a migration for existing transactions.

### Migration (#2138)

The migration here targets all onchain sends with `centsAmount` properties (only since onchain-payment-flow-builder commit). It was moved to a new PR to be deployed after the new code here deploys. The migratiion is a no-op on new code and will only affect transactions created with the old code.