### PR TITLE
chore: add migration for 'usd' prop in existing onchain sends

### DIFF
--- a/src/migrations/20230106142545-fix-onchain-send-usd.ts
+++ b/src/migrations/20230106142545-fix-onchain-send-usd.ts
@@ -1,0 +1,28 @@
+module.exports = {
+  async up(db) {
+    const collection = db.collection("medici_transactions")
+    const newUsd = {
+      $round: [
+        {
+          $divide: [{ $add: ["$centsAmount", "$centsFee"] }, 100],
+        },
+        2,
+      ],
+    }
+
+    try {
+      const result = await collection.update(
+        {
+          type: "onchain_payment",
+          centsAmount: { $exists: true },
+          centsFee: { $exists: true },
+        },
+        [{ $set: { usd: newUsd } }],
+        { multi: true },
+      )
+      console.log({ result }, "update 'usd' property")
+    } catch (error) {
+      console.log({ result: error }, "Couldn't update 'usd' property")
+    }
+  },
+}


### PR DESCRIPTION
## Description

**_Supports #2129_**

This migration only targets onchain sends (BTC & USD) that have the new centsAmount & centsFee properties. These would have started with the new onchain-payment-builder flow.

**This will only be merged and deployed after #2129 has been deployed.**