### PR TITLE
chore: add missing amount metadata props

### DIFF
--- a/src/app/payments/send-intraledger.ts
+++ b/src/app/payments/send-intraledger.ts
@@ -269,7 +269,7 @@ const executePaymentViaIntraledger = async <
     let additionalDebitMetadata: { [key: string]: Username | undefined } = {}
     if (senderWallet.accountId === recipientWallet.accountId) {
       metadata = LedgerFacade.WalletIdTradeIntraAccountLedgerMetadata({
-        paymentFlow,
+        paymentAmounts: paymentFlow,
 
         amountDisplayCurrency: converter.fromUsdAmount(paymentFlow.usdPaymentAmount),
         feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
@@ -280,7 +280,7 @@ const executePaymentViaIntraledger = async <
     } else {
       ;({ metadata, debitAccountAdditionalMetadata: additionalDebitMetadata } =
         LedgerFacade.WalletIdIntraledgerLedgerMetadata({
-          paymentFlow,
+          paymentAmounts: paymentFlow,
 
           amountDisplayCurrency: converter.fromUsdAmount(paymentFlow.usdPaymentAmount),
           feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,

--- a/src/app/payments/send-intraledger.ts
+++ b/src/app/payments/send-intraledger.ts
@@ -264,8 +264,8 @@ const executePaymentViaIntraledger = async <
     }
 
     let metadata:
-      | NewAddWalletIdIntraledgerSendLedgerMetadata
-      | NewAddWalletIdTradeIntraAccountLedgerMetadata
+      | AddWalletIdIntraledgerSendLedgerMetadata
+      | AddWalletIdTradeIntraAccountLedgerMetadata
     let additionalDebitMetadata: { [key: string]: Username | undefined } = {}
     if (senderWallet.accountId === recipientWallet.accountId) {
       metadata = LedgerFacade.WalletIdTradeIntraAccountLedgerMetadata({

--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -389,8 +389,8 @@ const executePaymentViaIntraledger = async <
     }
 
     let metadata:
-      | NewAddLnIntraledgerSendLedgerMetadata
-      | NewAddLnTradeIntraAccountLedgerMetadata
+      | AddLnIntraledgerSendLedgerMetadata
+      | AddLnTradeIntraAccountLedgerMetadata
     let additionalDebitMetadata: { [key: string]: string | undefined } = {}
     if (senderWallet.accountId === recipientWallet.accountId) {
       ;({ metadata, debitAccountAdditionalMetadata: additionalDebitMetadata } =

--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -397,7 +397,7 @@ const executePaymentViaIntraledger = async <
         LedgerFacade.LnTradeIntraAccountLedgerMetadata({
           paymentHash,
           pubkey: recipientPubkey,
-          paymentFlow,
+          paymentAmounts: paymentFlow,
 
           amountDisplayCurrency: converter.fromUsdAmount(paymentFlow.usdPaymentAmount),
           feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
@@ -410,7 +410,7 @@ const executePaymentViaIntraledger = async <
         LedgerFacade.LnIntraledgerLedgerMetadata({
           paymentHash,
           pubkey: recipientPubkey,
-          paymentFlow,
+          paymentAmounts: paymentFlow,
 
           amountDisplayCurrency: converter.fromUsdAmount(paymentFlow.usdPaymentAmount),
           feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
@@ -532,7 +532,7 @@ const executePaymentViaLn = async ({
       feeDisplayCurrency: converter.fromUsdAmount(paymentFlow.usdProtocolFee),
       displayCurrency: DisplayCurrency.Usd,
 
-      paymentFlow,
+      paymentAmounts: paymentFlow,
       pubkey: outgoingNodePubkey || lndService.defaultPubkey(),
       paymentHash,
       feeKnownInAdvance: !!rawRoute,

--- a/src/app/wallets/send-on-chain.ts
+++ b/src/app/wallets/send-on-chain.ts
@@ -278,8 +278,8 @@ const executePaymentViaIntraledger = async <
     const converter = NewDisplayCurrencyConverter(displayCentsPerSat)
 
     let metadata:
-      | NewAddOnChainIntraledgerSendLedgerMetadata
-      | NewAddOnChainTradeIntraAccountLedgerMetadata
+      | AddOnChainIntraledgerSendLedgerMetadata
+      | AddOnChainTradeIntraAccountLedgerMetadata
     let additionalDebitMetadata: { [key: string]: string | undefined } = {}
     if (senderWallet.accountId === recipientWallet.accountId) {
       ;({ metadata, debitAccountAdditionalMetadata: additionalDebitMetadata } =

--- a/src/app/wallets/send-on-chain.ts
+++ b/src/app/wallets/send-on-chain.ts
@@ -286,7 +286,7 @@ const executePaymentViaIntraledger = async <
         LedgerFacade.OnChainTradeIntraAccountLedgerMetadata({
           payeeAddresses,
           sendAll,
-          paymentFlow,
+          paymentAmounts: paymentFlow,
 
           amountDisplayCurrency: converter.fromUsdAmount(paymentFlow.usdPaymentAmount),
           feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
@@ -299,7 +299,7 @@ const executePaymentViaIntraledger = async <
         LedgerFacade.OnChainIntraledgerLedgerMetadata({
           payeeAddresses,
           sendAll,
-          paymentFlow,
+          paymentAmounts: paymentFlow,
 
           amountDisplayCurrency: converter.fromUsdAmount(paymentFlow.usdPaymentAmount),
           feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
@@ -453,7 +453,7 @@ const executePaymentViaOnChain = async <
     const metadata = LedgerFacade.OnChainSendLedgerMetadata({
       // we need a temporary hash to be able to search in admin panel
       onChainTxHash: crypto.randomBytes(32).toString("hex") as OnChainTxHash,
-      paymentFlow,
+      paymentAmounts: paymentFlow,
 
       amountDisplayCurrency: converter.fromUsdAmount(paymentFlow.usdPaymentAmount),
       feeDisplayCurrency: converter.fromUsdAmount(paymentFlow.usdProtocolFee),

--- a/src/app/wallets/update-on-chain-receipt.ts
+++ b/src/app/wallets/update-on-chain-receipt.ts
@@ -112,7 +112,7 @@ export const updateOnChainReceipt = async ({
   return onChainTxs.length
 }
 
-const processTxForWallet = async (
+const processTxForWallet = async <S extends WalletCurrency, R extends WalletCurrency>(
   wallet: Wallet,
   tx: IncomingOnChainTransaction,
   logger: Logger,
@@ -179,11 +179,20 @@ const processTxForWallet = async (
             walletAddressReceiver.usdToCreditReceiver.amount,
           ) as DisplayCurrencyBaseAmount
 
+          const displayCurrency = DisplayCurrency.Usd
+
           const metadata = LedgerFacade.OnChainReceiveLedgerMetadata({
             onChainTxHash: tx.rawTx.txHash,
-            fee: walletAddressReceiver.btcBankFee,
+            paymentFlow: {
+              btcPaymentAmount: walletAddressReceiver.btcToCreditReceiver,
+              usdPaymentAmount: walletAddressReceiver.usdToCreditReceiver,
+              btcProtocolFee: walletAddressReceiver.btcBankFee,
+              usdProtocolFee: walletAddressReceiver.usdBankFee,
+            } as OnChainPaymentFlowState<S, R>,
             feeDisplayCurrency,
             amountDisplayCurrency,
+            displayCurrency,
+
             payeeAddresses: [address],
           })
 
@@ -220,7 +229,7 @@ const processTxForWallet = async (
             paymentAmount: { amount: BigInt(sats), currency: wallet.currency },
             displayPaymentAmount: {
               amount: amountDisplayCurrency,
-              currency: DisplayCurrency.Usd,
+              currency: displayCurrency,
             },
             txHash: tx.rawTx.txHash,
             recipientDeviceTokens: recipientUser.deviceTokens,

--- a/src/app/wallets/update-on-chain-receipt.ts
+++ b/src/app/wallets/update-on-chain-receipt.ts
@@ -112,7 +112,7 @@ export const updateOnChainReceipt = async ({
   return onChainTxs.length
 }
 
-const processTxForWallet = async <S extends WalletCurrency, R extends WalletCurrency>(
+const processTxForWallet = async (
   wallet: Wallet,
   tx: IncomingOnChainTransaction,
   logger: Logger,
@@ -183,12 +183,12 @@ const processTxForWallet = async <S extends WalletCurrency, R extends WalletCurr
 
           const metadata = LedgerFacade.OnChainReceiveLedgerMetadata({
             onChainTxHash: tx.rawTx.txHash,
-            paymentFlow: {
+            paymentAmounts: {
               btcPaymentAmount: walletAddressReceiver.btcToCreditReceiver,
               usdPaymentAmount: walletAddressReceiver.usdToCreditReceiver,
               btcProtocolFee: walletAddressReceiver.btcBankFee,
               usdProtocolFee: walletAddressReceiver.usdBankFee,
-            } as OnChainPaymentFlowState<S, R>,
+            },
             feeDisplayCurrency,
             amountDisplayCurrency,
             displayCurrency,

--- a/src/app/wallets/update-pending-invoices.ts
+++ b/src/app/wallets/update-pending-invoices.ts
@@ -81,10 +81,7 @@ export const updatePendingInvoiceByPaymentHash = async ({
 
 const dealer = NewDealerPriceService()
 
-const updatePendingInvoiceBeforeFinally = async <
-  S extends WalletCurrency,
-  R extends WalletCurrency,
->({
+const updatePendingInvoiceBeforeFinally = async ({
   walletInvoice,
   logger,
 }: {
@@ -197,12 +194,12 @@ const updatePendingInvoiceBeforeFinally = async <
     const metadata = LedgerFacade.LnReceiveLedgerMetadata({
       paymentHash,
       pubkey: walletInvoice.pubkey,
-      paymentFlow: {
+      paymentAmounts: {
         btcPaymentAmount: walletInvoiceReceiver.btcToCreditReceiver,
         usdPaymentAmount: walletInvoiceReceiver.usdToCreditReceiver,
         btcProtocolFee: walletInvoiceReceiver.btcBankFee,
         usdProtocolFee: walletInvoiceReceiver.usdBankFee,
-      } as PaymentFlowState<S, R>,
+      },
 
       feeDisplayCurrency: Number(
         walletInvoiceReceiver.usdBankFee.amount,

--- a/src/domain/payments/index.types.d.ts
+++ b/src/domain/payments/index.types.d.ts
@@ -11,7 +11,18 @@ type XorPaymentHashProperty = XOR<
   { intraLedgerHash: IntraLedgerHash }
 >
 
-type PaymentFlowCommonState<S extends WalletCurrency, R extends WalletCurrency> = {
+type AmountsAndFees = {
+  btcPaymentAmount: BtcPaymentAmount
+  btcProtocolFee: BtcPaymentAmount
+
+  usdPaymentAmount: UsdPaymentAmount
+  usdProtocolFee: UsdPaymentAmount
+}
+
+type PaymentFlowCommonState<
+  S extends WalletCurrency,
+  R extends WalletCurrency,
+> = AmountsAndFees & {
   senderWalletId: WalletId
   senderWalletCurrency: S
   senderAccountId: AccountId
@@ -20,12 +31,7 @@ type PaymentFlowCommonState<S extends WalletCurrency, R extends WalletCurrency> 
   createdAt: Date
   paymentSentAndPending: boolean
 
-  btcPaymentAmount: BtcPaymentAmount
-  usdPaymentAmount: UsdPaymentAmount
   inputAmount: bigint
-
-  btcProtocolFee: BtcPaymentAmount
-  usdProtocolFee: UsdPaymentAmount
 
   recipientWalletId?: WalletId
   recipientWalletCurrency?: R

--- a/src/domain/wallet-invoices/index.types.d.ts
+++ b/src/domain/wallet-invoices/index.types.d.ts
@@ -99,6 +99,7 @@ type WalletAddressReceiver = {
 
 type WalletReceiverArgs = {
   receivedBtc: BtcPaymentAmount
+  feeBtc?: BtcPaymentAmount
   usdFromBtc(
     amount: BtcPaymentAmount,
   ): Promise<UsdPaymentAmount | DealerPriceServiceError>
@@ -113,7 +114,6 @@ type WalletInvoiceReceiverArgs = WalletReceiverArgs & {
 
 type WalletAddressReceiverArgs<S extends WalletCurrency> = WalletReceiverArgs & {
   walletAddress: WalletAddress<S>
-  feeBtc: BtcPaymentAmount
 }
 
 type WalletInvoiceValidator = {

--- a/src/domain/wallet-invoices/wallet-invoice-receiver.ts
+++ b/src/domain/wallet-invoices/wallet-invoice-receiver.ts
@@ -18,15 +18,15 @@ export const WalletInvoiceReceiver = async ({
 
     const priceRatio = PriceRatio({ usd: receivedUsd, btc: receivedBtc })
     if (priceRatio instanceof Error) return priceRatio
-    const bankFee = {
-      usdBankFee: priceRatio.convertFromBtcToCeil(feeBtc),
-      btcBankFee: feeBtc,
-    }
+
+    const btcBankFee = feeBtc
+    const usdBankFee = priceRatio.convertFromBtcToCeil(btcBankFee)
 
     return {
-      btcToCreditReceiver: calc.sub(receivedBtc, feeBtc),
-      usdToCreditReceiver: calc.sub(receivedUsd, bankFee.usdBankFee),
-      ...bankFee,
+      btcToCreditReceiver: calc.sub(receivedBtc, btcBankFee),
+      usdToCreditReceiver: calc.sub(receivedUsd, usdBankFee),
+      usdBankFee,
+      btcBankFee,
       receivedAmount: () =>
         walletInvoice.recipientWalletDescriptor.currency === WalletCurrency.Btc
           ? receivedBtc
@@ -39,15 +39,15 @@ export const WalletInvoiceReceiver = async ({
 
     const priceRatio = PriceRatio({ usd: receivedUsd, btc: receivedBtc })
     if (priceRatio instanceof Error) return priceRatio
-    const bankFee = {
-      usdBankFee: priceRatio.convertFromBtcToCeil(feeBtc),
-      btcBankFee: feeBtc,
-    }
+
+    const btcBankFee = feeBtc
+    const usdBankFee = priceRatio.convertFromBtcToCeil(btcBankFee)
 
     return {
-      btcToCreditReceiver: calc.sub(receivedBtc, feeBtc),
-      usdToCreditReceiver: calc.sub(receivedUsd, bankFee.usdBankFee),
-      ...bankFee,
+      btcToCreditReceiver: calc.sub(receivedBtc, btcBankFee),
+      usdToCreditReceiver: calc.sub(receivedUsd, usdBankFee),
+      usdBankFee,
+      btcBankFee,
       receivedAmount: () =>
         walletInvoice.recipientWalletDescriptor.currency === WalletCurrency.Btc
           ? receivedBtc
@@ -60,15 +60,15 @@ export const WalletInvoiceReceiver = async ({
 
   const priceRatio = PriceRatio({ usd: receivedUsd, btc: receivedBtc })
   if (priceRatio instanceof Error) return priceRatio
-  const bankFee = {
-    usdBankFee: priceRatio.convertFromBtcToCeil(feeBtc),
-    btcBankFee: feeBtc,
-  }
+
+  const btcBankFee = feeBtc
+  const usdBankFee = priceRatio.convertFromBtcToCeil(btcBankFee)
 
   return {
-    btcToCreditReceiver: calc.sub(receivedBtc, feeBtc),
-    usdToCreditReceiver: calc.sub(receivedUsd, bankFee.usdBankFee),
-    ...bankFee,
+    btcToCreditReceiver: calc.sub(receivedBtc, btcBankFee),
+    usdToCreditReceiver: calc.sub(receivedUsd, usdBankFee),
+    usdBankFee,
+    btcBankFee,
     receivedAmount: () =>
       walletInvoice.recipientWalletDescriptor.currency === WalletCurrency.Btc
         ? receivedBtc

--- a/src/domain/wallet-invoices/wallet-invoice-receiver.ts
+++ b/src/domain/wallet-invoices/wallet-invoice-receiver.ts
@@ -1,53 +1,77 @@
-import { WalletCurrency, ZERO_BANK_FEE } from "@domain/shared"
+import { PriceRatio } from "@domain/payments"
+import { AmountCalculator, WalletCurrency, ZERO_BANK_FEE } from "@domain/shared"
+
+const calc = AmountCalculator()
 
 export const WalletInvoiceReceiver = async ({
   walletInvoice,
   receivedBtc,
+  feeBtc = ZERO_BANK_FEE.btcBankFee,
   usdFromBtc,
   usdFromBtcMidPrice,
 }: WalletInvoiceReceiverArgs): Promise<
   WalletInvoiceReceiver | DealerPriceServiceError | ValidationError
 > => {
-  const btcToCreditReceiver = receivedBtc
-
   if (walletInvoice.recipientWalletDescriptor.currency === WalletCurrency.Btc) {
-    const usdToCreditReceiver = await usdFromBtcMidPrice(btcToCreditReceiver)
-    if (usdToCreditReceiver instanceof Error) return usdToCreditReceiver
+    const receivedUsd = await usdFromBtcMidPrice(receivedBtc)
+    if (receivedUsd instanceof Error) return receivedUsd
+
+    const priceRatio = PriceRatio({ usd: receivedUsd, btc: receivedBtc })
+    if (priceRatio instanceof Error) return priceRatio
+    const bankFee = {
+      usdBankFee: priceRatio.convertFromBtcToCeil(feeBtc),
+      btcBankFee: feeBtc,
+    }
 
     return {
-      btcToCreditReceiver,
-      usdToCreditReceiver,
-      ...ZERO_BANK_FEE,
+      btcToCreditReceiver: calc.sub(receivedBtc, feeBtc),
+      usdToCreditReceiver: calc.sub(receivedUsd, bankFee.usdBankFee),
+      ...bankFee,
       receivedAmount: () =>
         walletInvoice.recipientWalletDescriptor.currency === WalletCurrency.Btc
-          ? btcToCreditReceiver
-          : usdToCreditReceiver,
+          ? receivedBtc
+          : receivedUsd,
     }
   }
 
   if (walletInvoice.usdAmount) {
-    const usdToCreditReceiver = walletInvoice.usdAmount
+    const receivedUsd = walletInvoice.usdAmount
+
+    const priceRatio = PriceRatio({ usd: receivedUsd, btc: receivedBtc })
+    if (priceRatio instanceof Error) return priceRatio
+    const bankFee = {
+      usdBankFee: priceRatio.convertFromBtcToCeil(feeBtc),
+      btcBankFee: feeBtc,
+    }
+
     return {
-      btcToCreditReceiver,
-      usdToCreditReceiver,
-      ...ZERO_BANK_FEE,
+      btcToCreditReceiver: calc.sub(receivedBtc, feeBtc),
+      usdToCreditReceiver: calc.sub(receivedUsd, bankFee.usdBankFee),
+      ...bankFee,
       receivedAmount: () =>
         walletInvoice.recipientWalletDescriptor.currency === WalletCurrency.Btc
-          ? btcToCreditReceiver
-          : usdToCreditReceiver,
+          ? receivedBtc
+          : receivedUsd,
     }
   }
 
-  const usdToCreditReceiver = await usdFromBtc(btcToCreditReceiver)
-  if (usdToCreditReceiver instanceof Error) return usdToCreditReceiver
+  const receivedUsd = await usdFromBtc(receivedBtc)
+  if (receivedUsd instanceof Error) return receivedUsd
+
+  const priceRatio = PriceRatio({ usd: receivedUsd, btc: receivedBtc })
+  if (priceRatio instanceof Error) return priceRatio
+  const bankFee = {
+    usdBankFee: priceRatio.convertFromBtcToCeil(feeBtc),
+    btcBankFee: feeBtc,
+  }
 
   return {
-    usdToCreditReceiver,
-    btcToCreditReceiver,
-    ...ZERO_BANK_FEE,
+    btcToCreditReceiver: calc.sub(receivedBtc, feeBtc),
+    usdToCreditReceiver: calc.sub(receivedUsd, bankFee.usdBankFee),
+    ...bankFee,
     receivedAmount: () =>
       walletInvoice.recipientWalletDescriptor.currency === WalletCurrency.Btc
-        ? btcToCreditReceiver
-        : usdToCreditReceiver,
+        ? receivedBtc
+        : receivedUsd,
   }
 }

--- a/src/domain/wallet-on-chain-addresses/wallet-address-receiver.ts
+++ b/src/domain/wallet-on-chain-addresses/wallet-address-receiver.ts
@@ -1,12 +1,12 @@
 import { PriceRatio } from "@domain/payments"
-import { AmountCalculator, WalletCurrency } from "@domain/shared"
+import { AmountCalculator, WalletCurrency, ZERO_BANK_FEE } from "@domain/shared"
 
 const calc = AmountCalculator()
 
 export const WalletAddressReceiver = async <S extends WalletCurrency>({
   walletAddress,
   receivedBtc,
-  feeBtc,
+  feeBtc = ZERO_BANK_FEE.btcBankFee,
   usdFromBtc,
   usdFromBtcMidPrice,
 }: WalletAddressReceiverArgs<S>): Promise<

--- a/src/services/ledger/index.types.d.ts
+++ b/src/services/ledger/index.types.d.ts
@@ -53,14 +53,17 @@ type NonIntraledgerLedgerMetadata = LedgerMetadata & {
   feeUsd: number // to be removed when "centFee" takes over
 }
 
-type LnReceiveLedgerMetadata = NonIntraledgerLedgerMetadata & {
-  hash: PaymentHash
-}
+type LnReceiveLedgerMetadata = NonIntraledgerLedgerMetadata &
+  SendAmountsMetadata & {
+    hash: PaymentHash
+    pubkey: Pubkey
+  }
 
-type OnChainReceiveLedgerMetadata = NonIntraledgerLedgerMetadata & {
-  hash: OnChainTxHash
-  payee_addresses: OnChainAddress[]
-}
+type OnChainReceiveLedgerMetadata = NonIntraledgerLedgerMetadata &
+  SendAmountsMetadata & {
+    hash: OnChainTxHash
+    payee_addresses: OnChainAddress[]
+  }
 
 type SendAmountsMetadata = {
   satsAmount: Satoshis

--- a/src/services/ledger/index.types.d.ts
+++ b/src/services/ledger/index.types.d.ts
@@ -106,60 +106,33 @@ type IntraledgerBaseMetadata = LedgerMetadata & {
   username?: Username
 }
 
-type AddLnIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata & {
-  hash: PaymentHash
-  pubkey: Pubkey
-}
+type AddLnIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata &
+  SendAmountsMetadata & {
+    hash: PaymentHash
+    pubkey: Pubkey
+  }
 
 type AddLnTradeIntraAccountLedgerMetadata = Omit<
   AddLnIntraledgerSendLedgerMetadata,
   "username"
 >
 
-type NewAddLnIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata &
+type AddOnChainIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata &
   SendAmountsMetadata & {
-    hash: PaymentHash
-    pubkey: Pubkey
+    payee_addresses: OnChainAddress[]
+    sendAll: boolean
   }
-
-type NewAddLnTradeIntraAccountLedgerMetadata = Omit<
-  NewAddLnIntraledgerSendLedgerMetadata,
-  "username"
->
-
-type AddOnChainIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata & {
-  payee_addresses: OnChainAddress[]
-  sendAll: boolean
-}
 
 type AddOnChainTradeIntraAccountLedgerMetadata = Omit<
   AddOnChainIntraledgerSendLedgerMetadata,
   "username"
 >
 
-type NewAddOnChainIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata &
-  SendAmountsMetadata & {
-    payee_addresses: OnChainAddress[]
-    sendAll: boolean
-  }
-
-type NewAddOnChainTradeIntraAccountLedgerMetadata = Omit<
-  NewAddOnChainIntraledgerSendLedgerMetadata,
-  "username"
->
-
-type AddWalletIdIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata
+type AddWalletIdIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata &
+  SendAmountsMetadata
 
 type AddWalletIdTradeIntraAccountLedgerMetadata = Omit<
   AddWalletIdIntraledgerSendLedgerMetadata,
-  "username"
->
-
-type NewAddWalletIdIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata &
-  SendAmountsMetadata
-
-type NewAddWalletIdTradeIntraAccountLedgerMetadata = Omit<
-  NewAddWalletIdIntraledgerSendLedgerMetadata,
   "username"
 >
 

--- a/src/services/ledger/tx-metadata.ts
+++ b/src/services/ledger/tx-metadata.ts
@@ -147,18 +147,18 @@ export const OnChainReceiveLedgerMetadata = <
 
     fee: toSats(satsFee),
     feeUsd: convertCentsToUsdAsDollars(feeDisplayCurrency),
-    usd: convertCentsToUsdAsDollars(
-      (amountDisplayCurrency + feeDisplayCurrency) as DisplayCurrencyBaseAmount,
-    ),
+    usd: convertCentsToUsdAsDollars(amountDisplayCurrency),
 
-    satsFee: toSats(satsFee),
-    displayFee: feeDisplayCurrency,
+    // Amounts are after fee is deducted
+    satsAmount: toSats(satsAmount),
+    centsAmount: toCents(centsAmount),
     displayAmount: amountDisplayCurrency,
 
-    displayCurrency,
-    centsAmount: toCents(centsAmount),
-    satsAmount: toSats(satsAmount),
+    satsFee: toSats(satsFee),
     centsFee: toCents(centsFee),
+    displayFee: feeDisplayCurrency,
+
+    displayCurrency,
   }
   return metadata
 }
@@ -198,18 +198,18 @@ export const LnReceiveLedgerMetadata = <
 
     fee: toSats(satsFee),
     feeUsd: convertCentsToUsdAsDollars(feeDisplayCurrency),
-    usd: convertCentsToUsdAsDollars(
-      (amountDisplayCurrency + feeDisplayCurrency) as DisplayCurrencyBaseAmount,
-    ),
+    usd: convertCentsToUsdAsDollars(amountDisplayCurrency),
 
-    satsFee: toSats(satsFee),
-    displayFee: feeDisplayCurrency,
+    // Amounts are after fee is deducted
+    satsAmount: toSats(satsAmount),
+    centsAmount: toCents(centsAmount),
     displayAmount: amountDisplayCurrency,
 
-    displayCurrency,
-    centsAmount: toCents(centsAmount),
-    satsAmount: toSats(satsAmount),
+    satsFee: toSats(satsFee),
     centsFee: toCents(centsFee),
+    displayFee: feeDisplayCurrency,
+
+    displayCurrency,
   }
   return metadata
 }

--- a/src/services/ledger/tx-metadata.ts
+++ b/src/services/ledger/tx-metadata.ts
@@ -111,52 +111,105 @@ export const OnChainSendLedgerMetadata = <
   return metadata
 }
 
-export const OnChainReceiveLedgerMetadata = ({
+export const OnChainReceiveLedgerMetadata = <
+  S extends WalletCurrency,
+  R extends WalletCurrency,
+>({
   onChainTxHash,
-  fee,
+  paymentFlow,
   feeDisplayCurrency,
   amountDisplayCurrency,
+  displayCurrency,
+
   payeeAddresses,
 }: {
   onChainTxHash: OnChainTxHash
-  fee: BtcPaymentAmount
+  paymentFlow: OnChainPaymentFlowState<S, R>
+
   feeDisplayCurrency: DisplayCurrencyBaseAmount
   amountDisplayCurrency: DisplayCurrencyBaseAmount
+  displayCurrency: DisplayCurrency
+
   payeeAddresses: OnChainAddress[]
 }) => {
+  const {
+    btcPaymentAmount: { amount: satsAmount },
+    usdPaymentAmount: { amount: centsAmount },
+    btcProtocolFee: { amount: satsFee },
+    usdProtocolFee: { amount: centsFee },
+  } = paymentFlow
+
   const metadata: OnChainReceiveLedgerMetadata = {
     type: LedgerTransactionType.OnchainReceipt,
     pending: false,
     hash: onChainTxHash,
-    fee: Number(fee.amount) as Satoshis,
+    payee_addresses: payeeAddresses,
+
+    fee: toSats(satsFee),
     feeUsd: convertCentsToUsdAsDollars(feeDisplayCurrency),
     usd: convertCentsToUsdAsDollars(
       (amountDisplayCurrency + feeDisplayCurrency) as DisplayCurrencyBaseAmount,
     ),
-    payee_addresses: payeeAddresses,
+
+    satsFee: toSats(satsFee),
+    displayFee: feeDisplayCurrency,
+    displayAmount: amountDisplayCurrency,
+
+    displayCurrency,
+    centsAmount: toCents(centsAmount),
+    satsAmount: toSats(satsAmount),
+    centsFee: toCents(centsFee),
   }
   return metadata
 }
 
-export const LnReceiveLedgerMetadata = ({
+export const LnReceiveLedgerMetadata = <
+  S extends WalletCurrency,
+  R extends WalletCurrency,
+>({
   paymentHash,
-  fee,
+  pubkey,
+  paymentFlow,
+
   feeDisplayCurrency,
   amountDisplayCurrency,
+  displayCurrency,
 }: {
   paymentHash: PaymentHash
-  fee: BtcPaymentAmount
+  pubkey: Pubkey
+  paymentFlow: PaymentFlowState<S, R>
+
   feeDisplayCurrency: DisplayCurrencyBaseAmount
   amountDisplayCurrency: DisplayCurrencyBaseAmount
-  pubkey: Pubkey
+  displayCurrency: DisplayCurrency
 }) => {
+  const {
+    btcPaymentAmount: { amount: satsAmount },
+    usdPaymentAmount: { amount: centsAmount },
+    btcProtocolFee: { amount: satsFee },
+    usdProtocolFee: { amount: centsFee },
+  } = paymentFlow
+
   const metadata: LnReceiveLedgerMetadata = {
     type: LedgerTransactionType.Invoice,
     pending: false,
     hash: paymentHash,
-    fee: Number(fee.amount) as Satoshis,
+    pubkey,
+
+    fee: toSats(satsFee),
     feeUsd: convertCentsToUsdAsDollars(feeDisplayCurrency),
-    usd: convertCentsToUsdAsDollars(amountDisplayCurrency),
+    usd: convertCentsToUsdAsDollars(
+      (amountDisplayCurrency + feeDisplayCurrency) as DisplayCurrencyBaseAmount,
+    ),
+
+    satsFee: toSats(satsFee),
+    displayFee: feeDisplayCurrency,
+    displayAmount: amountDisplayCurrency,
+
+    displayCurrency,
+    centsAmount: toCents(centsAmount),
+    satsAmount: toSats(satsAmount),
+    centsFee: toCents(centsFee),
   }
   return metadata
 }

--- a/src/services/ledger/tx-metadata.ts
+++ b/src/services/ledger/tx-metadata.ts
@@ -5,10 +5,10 @@ import { LedgerTransactionType } from "@domain/ledger"
 const convertCentsToUsdAsDollars = (cents: DisplayCurrencyBaseAmount) =>
   Number((Number(cents) / 100).toFixed(2))
 
-export const LnSendLedgerMetadata = <S extends WalletCurrency, R extends WalletCurrency>({
+export const LnSendLedgerMetadata = ({
   paymentHash,
   pubkey,
-  paymentFlow,
+  paymentAmounts,
   feeDisplayCurrency,
   amountDisplayCurrency,
   displayCurrency,
@@ -16,7 +16,7 @@ export const LnSendLedgerMetadata = <S extends WalletCurrency, R extends WalletC
 }: {
   paymentHash: PaymentHash
   pubkey: Pubkey
-  paymentFlow: PaymentFlowState<S, R>
+  paymentAmounts: AmountsAndFees
 
   feeDisplayCurrency: DisplayCurrencyBaseAmount
   amountDisplayCurrency: DisplayCurrencyBaseAmount
@@ -29,7 +29,7 @@ export const LnSendLedgerMetadata = <S extends WalletCurrency, R extends WalletC
     usdPaymentAmount: { amount: centsAmount },
     btcProtocolFee: { amount: satsFee },
     usdProtocolFee: { amount: centsFee },
-  } = paymentFlow
+  } = paymentAmounts
 
   const metadata: AddLnSendLedgerMetadata = {
     type: LedgerTransactionType.Payment,
@@ -56,12 +56,9 @@ export const LnSendLedgerMetadata = <S extends WalletCurrency, R extends WalletC
   return metadata
 }
 
-export const OnChainSendLedgerMetadata = <
-  S extends WalletCurrency,
-  R extends WalletCurrency,
->({
+export const OnChainSendLedgerMetadata = ({
   onChainTxHash,
-  paymentFlow,
+  paymentAmounts,
   feeDisplayCurrency,
   amountDisplayCurrency,
   displayCurrency,
@@ -69,7 +66,7 @@ export const OnChainSendLedgerMetadata = <
   sendAll,
 }: {
   onChainTxHash: OnChainTxHash
-  paymentFlow: OnChainPaymentFlowState<S, R>
+  paymentAmounts: AmountsAndFees
 
   feeDisplayCurrency: DisplayCurrencyBaseAmount
   amountDisplayCurrency: DisplayCurrencyBaseAmount
@@ -83,7 +80,7 @@ export const OnChainSendLedgerMetadata = <
     usdPaymentAmount: { amount: centsAmount },
     btcProtocolFee: { amount: satsFee },
     usdProtocolFee: { amount: centsFee },
-  } = paymentFlow
+  } = paymentAmounts
 
   const metadata: AddOnchainSendLedgerMetadata = {
     type: LedgerTransactionType.OnchainPayment,
@@ -111,12 +108,9 @@ export const OnChainSendLedgerMetadata = <
   return metadata
 }
 
-export const OnChainReceiveLedgerMetadata = <
-  S extends WalletCurrency,
-  R extends WalletCurrency,
->({
+export const OnChainReceiveLedgerMetadata = ({
   onChainTxHash,
-  paymentFlow,
+  paymentAmounts,
   feeDisplayCurrency,
   amountDisplayCurrency,
   displayCurrency,
@@ -124,7 +118,7 @@ export const OnChainReceiveLedgerMetadata = <
   payeeAddresses,
 }: {
   onChainTxHash: OnChainTxHash
-  paymentFlow: OnChainPaymentFlowState<S, R>
+  paymentAmounts: AmountsAndFees
 
   feeDisplayCurrency: DisplayCurrencyBaseAmount
   amountDisplayCurrency: DisplayCurrencyBaseAmount
@@ -137,7 +131,7 @@ export const OnChainReceiveLedgerMetadata = <
     usdPaymentAmount: { amount: centsAmount },
     btcProtocolFee: { amount: satsFee },
     usdProtocolFee: { amount: centsFee },
-  } = paymentFlow
+  } = paymentAmounts
 
   const metadata: OnChainReceiveLedgerMetadata = {
     type: LedgerTransactionType.OnchainReceipt,
@@ -163,13 +157,10 @@ export const OnChainReceiveLedgerMetadata = <
   return metadata
 }
 
-export const LnReceiveLedgerMetadata = <
-  S extends WalletCurrency,
-  R extends WalletCurrency,
->({
+export const LnReceiveLedgerMetadata = ({
   paymentHash,
   pubkey,
-  paymentFlow,
+  paymentAmounts,
 
   feeDisplayCurrency,
   amountDisplayCurrency,
@@ -177,7 +168,7 @@ export const LnReceiveLedgerMetadata = <
 }: {
   paymentHash: PaymentHash
   pubkey: Pubkey
-  paymentFlow: PaymentFlowState<S, R>
+  paymentAmounts: AmountsAndFees
 
   feeDisplayCurrency: DisplayCurrencyBaseAmount
   amountDisplayCurrency: DisplayCurrencyBaseAmount
@@ -188,7 +179,7 @@ export const LnReceiveLedgerMetadata = <
     usdPaymentAmount: { amount: centsAmount },
     btcProtocolFee: { amount: satsFee },
     usdProtocolFee: { amount: centsFee },
-  } = paymentFlow
+  } = paymentAmounts
 
   const metadata: LnReceiveLedgerMetadata = {
     type: LedgerTransactionType.Invoice,
@@ -214,18 +205,15 @@ export const LnReceiveLedgerMetadata = <
   return metadata
 }
 
-export const LnFeeReimbursementReceiveLedgerMetadata = <
-  S extends WalletCurrency,
-  R extends WalletCurrency,
->({
-  paymentFlow,
+export const LnFeeReimbursementReceiveLedgerMetadata = ({
+  paymentAmounts,
   paymentHash,
   journalId,
   feeDisplayCurrency,
   amountDisplayCurrency,
   displayCurrency,
 }: {
-  paymentFlow: PaymentFlowState<S, R>
+  paymentAmounts: AmountsAndFees
   paymentHash: PaymentHash
   journalId: LedgerJournalId
   feeDisplayCurrency: DisplayCurrencyBaseAmount
@@ -237,7 +225,7 @@ export const LnFeeReimbursementReceiveLedgerMetadata = <
     usdPaymentAmount: { amount: centsAmount },
     btcProtocolFee: { amount: satsFee },
     usdProtocolFee: { amount: centsFee },
-  } = paymentFlow
+  } = paymentAmounts
 
   const metadata: FeeReimbursementLedgerMetadata = {
     type: LedgerTransactionType.LnFeeReimbursement,
@@ -260,13 +248,10 @@ export const LnFeeReimbursementReceiveLedgerMetadata = <
   return metadata
 }
 
-export const OnChainIntraledgerLedgerMetadata = <
-  S extends WalletCurrency,
-  R extends WalletCurrency,
->({
+export const OnChainIntraledgerLedgerMetadata = ({
   payeeAddresses,
   sendAll,
-  paymentFlow,
+  paymentAmounts,
   feeDisplayCurrency,
   amountDisplayCurrency,
   displayCurrency,
@@ -276,7 +261,7 @@ export const OnChainIntraledgerLedgerMetadata = <
 }: {
   payeeAddresses: OnChainAddress[]
   sendAll: boolean
-  paymentFlow: OnChainPaymentFlowState<S, R>
+  paymentAmounts: AmountsAndFees
 
   feeDisplayCurrency: DisplayCurrencyBaseAmount
   amountDisplayCurrency: DisplayCurrencyBaseAmount
@@ -291,7 +276,7 @@ export const OnChainIntraledgerLedgerMetadata = <
     usdPaymentAmount: { amount: centsAmount },
     btcProtocolFee: { amount: satsFee },
     usdProtocolFee: { amount: centsFee },
-  } = paymentFlow
+  } = paymentAmounts
 
   const metadata: NewAddOnChainIntraledgerSendLedgerMetadata = {
     type: LedgerTransactionType.OnchainIntraLedger,
@@ -319,11 +304,8 @@ export const OnChainIntraledgerLedgerMetadata = <
   return { metadata, debitAccountAdditionalMetadata }
 }
 
-export const WalletIdIntraledgerLedgerMetadata = <
-  S extends WalletCurrency,
-  R extends WalletCurrency,
->({
-  paymentFlow,
+export const WalletIdIntraledgerLedgerMetadata = ({
+  paymentAmounts,
   feeDisplayCurrency,
   amountDisplayCurrency,
   displayCurrency,
@@ -331,7 +313,7 @@ export const WalletIdIntraledgerLedgerMetadata = <
   senderUsername,
   recipientUsername,
 }: {
-  paymentFlow: PaymentFlowState<S, R>
+  paymentAmounts: AmountsAndFees
   feeDisplayCurrency: DisplayCurrencyBaseAmount
   amountDisplayCurrency: DisplayCurrencyBaseAmount
   displayCurrency: DisplayCurrency
@@ -344,7 +326,7 @@ export const WalletIdIntraledgerLedgerMetadata = <
     usdPaymentAmount: { amount: centsAmount },
     btcProtocolFee: { amount: satsFee },
     usdProtocolFee: { amount: centsFee },
-  } = paymentFlow
+  } = paymentAmounts
 
   const metadata: NewAddWalletIdIntraledgerSendLedgerMetadata = {
     type: LedgerTransactionType.IntraLedger,
@@ -370,13 +352,10 @@ export const WalletIdIntraledgerLedgerMetadata = <
   return { metadata, debitAccountAdditionalMetadata }
 }
 
-export const LnIntraledgerLedgerMetadata = <
-  S extends WalletCurrency,
-  R extends WalletCurrency,
->({
+export const LnIntraledgerLedgerMetadata = ({
   paymentHash,
   pubkey,
-  paymentFlow,
+  paymentAmounts,
   feeDisplayCurrency,
   amountDisplayCurrency,
   displayCurrency,
@@ -386,7 +365,7 @@ export const LnIntraledgerLedgerMetadata = <
 }: {
   paymentHash: PaymentHash
   pubkey: Pubkey
-  paymentFlow: PaymentFlowState<S, R>
+  paymentAmounts: AmountsAndFees
   feeDisplayCurrency: DisplayCurrencyBaseAmount
   amountDisplayCurrency: DisplayCurrencyBaseAmount
   displayCurrency: DisplayCurrency
@@ -399,7 +378,7 @@ export const LnIntraledgerLedgerMetadata = <
     usdPaymentAmount: { amount: centsAmount },
     btcProtocolFee: { amount: satsFee },
     usdProtocolFee: { amount: centsFee },
-  } = paymentFlow
+  } = paymentAmounts
 
   const metadata: NewAddLnIntraledgerSendLedgerMetadata = {
     type: LedgerTransactionType.LnIntraLedger,
@@ -427,13 +406,10 @@ export const LnIntraledgerLedgerMetadata = <
   return { metadata, debitAccountAdditionalMetadata }
 }
 
-export const OnChainTradeIntraAccountLedgerMetadata = <
-  S extends WalletCurrency,
-  R extends WalletCurrency,
->({
+export const OnChainTradeIntraAccountLedgerMetadata = ({
   payeeAddresses,
   sendAll,
-  paymentFlow,
+  paymentAmounts,
   feeDisplayCurrency,
   amountDisplayCurrency,
   displayCurrency,
@@ -441,7 +417,7 @@ export const OnChainTradeIntraAccountLedgerMetadata = <
 }: {
   payeeAddresses: OnChainAddress[]
   sendAll: boolean
-  paymentFlow: OnChainPaymentFlowState<S, R>
+  paymentAmounts: AmountsAndFees
 
   feeDisplayCurrency: DisplayCurrencyBaseAmount
   amountDisplayCurrency: DisplayCurrencyBaseAmount
@@ -453,7 +429,7 @@ export const OnChainTradeIntraAccountLedgerMetadata = <
     usdPaymentAmount: { amount: centsAmount },
     btcProtocolFee: { amount: satsFee },
     usdProtocolFee: { amount: centsFee },
-  } = paymentFlow
+  } = paymentAmounts
 
   const metadata: NewAddOnChainTradeIntraAccountLedgerMetadata = {
     type: LedgerTransactionType.OnChainTradeIntraAccount,
@@ -479,17 +455,14 @@ export const OnChainTradeIntraAccountLedgerMetadata = <
   return { metadata, debitAccountAdditionalMetadata }
 }
 
-export const WalletIdTradeIntraAccountLedgerMetadata = <
-  S extends WalletCurrency,
-  R extends WalletCurrency,
->({
-  paymentFlow,
+export const WalletIdTradeIntraAccountLedgerMetadata = ({
+  paymentAmounts,
   feeDisplayCurrency,
   amountDisplayCurrency,
   displayCurrency,
   memoOfPayer,
 }: {
-  paymentFlow: PaymentFlowState<S, R>
+  paymentAmounts: AmountsAndFees
   feeDisplayCurrency: DisplayCurrencyBaseAmount
   amountDisplayCurrency: DisplayCurrencyBaseAmount
   displayCurrency: DisplayCurrency
@@ -500,7 +473,7 @@ export const WalletIdTradeIntraAccountLedgerMetadata = <
     usdPaymentAmount: { amount: centsAmount },
     btcProtocolFee: { amount: satsFee },
     usdProtocolFee: { amount: centsFee },
-  } = paymentFlow
+  } = paymentAmounts
 
   const metadata: NewAddWalletIdTradeIntraAccountLedgerMetadata = {
     type: LedgerTransactionType.WalletIdTradeIntraAccount,
@@ -522,13 +495,10 @@ export const WalletIdTradeIntraAccountLedgerMetadata = <
   return metadata
 }
 
-export const LnTradeIntraAccountLedgerMetadata = <
-  S extends WalletCurrency,
-  R extends WalletCurrency,
->({
+export const LnTradeIntraAccountLedgerMetadata = ({
   paymentHash,
   pubkey,
-  paymentFlow,
+  paymentAmounts,
   feeDisplayCurrency,
   amountDisplayCurrency,
   displayCurrency,
@@ -536,7 +506,7 @@ export const LnTradeIntraAccountLedgerMetadata = <
 }: {
   paymentHash: PaymentHash
   pubkey: Pubkey
-  paymentFlow: PaymentFlowState<S, R>
+  paymentAmounts: AmountsAndFees
   feeDisplayCurrency: DisplayCurrencyBaseAmount
   amountDisplayCurrency: DisplayCurrencyBaseAmount
   displayCurrency: DisplayCurrency
@@ -547,7 +517,7 @@ export const LnTradeIntraAccountLedgerMetadata = <
     usdPaymentAmount: { amount: centsAmount },
     btcProtocolFee: { amount: satsFee },
     usdProtocolFee: { amount: centsFee },
-  } = paymentFlow
+  } = paymentAmounts
 
   const metadata: NewAddLnTradeIntraAccountLedgerMetadata = {
     type: LedgerTransactionType.LnTradeIntraAccount,
@@ -572,6 +542,8 @@ export const LnTradeIntraAccountLedgerMetadata = <
   }
   return { metadata, debitAccountAdditionalMetadata }
 }
+
+// Non-LedgerFacade constructors from legacy admin service
 
 export const LnChannelOpenOrClosingFee = ({ txId }: { txId: OnChainTxHash }) => {
   const metadata: LnChannelOpenOrClosingFee = {

--- a/src/services/ledger/tx-metadata.ts
+++ b/src/services/ledger/tx-metadata.ts
@@ -278,7 +278,7 @@ export const OnChainIntraledgerLedgerMetadata = ({
     usdProtocolFee: { amount: centsFee },
   } = paymentAmounts
 
-  const metadata: NewAddOnChainIntraledgerSendLedgerMetadata = {
+  const metadata: AddOnChainIntraledgerSendLedgerMetadata = {
     type: LedgerTransactionType.OnchainIntraLedger,
     pending: false,
     memoPayer: undefined,
@@ -328,7 +328,7 @@ export const WalletIdIntraledgerLedgerMetadata = ({
     usdProtocolFee: { amount: centsFee },
   } = paymentAmounts
 
-  const metadata: NewAddWalletIdIntraledgerSendLedgerMetadata = {
+  const metadata: AddWalletIdIntraledgerSendLedgerMetadata = {
     type: LedgerTransactionType.IntraLedger,
     pending: false,
     memoPayer: memoOfPayer,
@@ -380,7 +380,7 @@ export const LnIntraledgerLedgerMetadata = ({
     usdProtocolFee: { amount: centsFee },
   } = paymentAmounts
 
-  const metadata: NewAddLnIntraledgerSendLedgerMetadata = {
+  const metadata: AddLnIntraledgerSendLedgerMetadata = {
     type: LedgerTransactionType.LnIntraLedger,
     pending: false,
     memoPayer: undefined,
@@ -431,7 +431,7 @@ export const OnChainTradeIntraAccountLedgerMetadata = ({
     usdProtocolFee: { amount: centsFee },
   } = paymentAmounts
 
-  const metadata: NewAddOnChainTradeIntraAccountLedgerMetadata = {
+  const metadata: AddOnChainTradeIntraAccountLedgerMetadata = {
     type: LedgerTransactionType.OnChainTradeIntraAccount,
     pending: false,
     memoPayer: undefined,
@@ -475,7 +475,7 @@ export const WalletIdTradeIntraAccountLedgerMetadata = ({
     usdProtocolFee: { amount: centsFee },
   } = paymentAmounts
 
-  const metadata: NewAddWalletIdTradeIntraAccountLedgerMetadata = {
+  const metadata: AddWalletIdTradeIntraAccountLedgerMetadata = {
     type: LedgerTransactionType.WalletIdTradeIntraAccount,
     pending: false,
     memoPayer: memoOfPayer,
@@ -519,7 +519,7 @@ export const LnTradeIntraAccountLedgerMetadata = ({
     usdProtocolFee: { amount: centsFee },
   } = paymentAmounts
 
-  const metadata: NewAddLnTradeIntraAccountLedgerMetadata = {
+  const metadata: AddLnTradeIntraAccountLedgerMetadata = {
     type: LedgerTransactionType.LnTradeIntraAccount,
     pending: false,
     memoPayer: undefined,

--- a/test/integration/02-user-wallet/02-receive-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-lightning.spec.ts
@@ -1,6 +1,7 @@
 import { MEMO_SHARING_SATS_THRESHOLD, ONE_DAY } from "@config"
 
 import { Lightning } from "@app"
+import { usdFromBtcMidPriceFn } from "@app/shared"
 import * as Wallets from "@app/wallets"
 import { handleHeldInvoices } from "@app/wallets"
 
@@ -23,6 +24,7 @@ import { baseLogger } from "@services/logger"
 import { setupInvoiceSubscribe } from "@servers/trigger"
 
 import { ImbalanceCalculator } from "@domain/ledger/imbalance-calculator"
+import { LedgerTransactionType } from "@domain/ledger"
 
 import { sleep } from "@utils"
 
@@ -181,6 +183,34 @@ describe("UserWallet - Lightning", () => {
     if (imbalance instanceof Error) throw imbalance
 
     expect(Number(imbalance.amount)).toBe(sats)
+
+    // Check ledger transaction metadata for BTC 'LedgerTransactionType.Invoice'
+    // ===
+    const usdPaymentAmount = await usdFromBtcMidPriceFn({
+      amount: BigInt(sats),
+      currency: WalletCurrency.Btc,
+    })
+    if (usdPaymentAmount instanceof Error) throw usdPaymentAmount
+    const centsAmount = Number(usdPaymentAmount.amount)
+
+    const expectedFields = {
+      type: LedgerTransactionType.Invoice,
+
+      debit: 0,
+      credit: sats,
+
+      fee: 0,
+      feeUsd: 0,
+      usd: Number((centsAmount / 100).toFixed(2)),
+
+      satsAmount: sats,
+      satsFee: 0,
+      centsAmount,
+      centsFee: 0,
+      displayAmount: centsAmount,
+      displayFee: 0,
+    }
+    expect(ledgerTx).toEqual(expect.objectContaining(expectedFields))
   })
 
   it("if trigger is missing the USD invoice, then it should be denied", async () => {
@@ -425,9 +455,30 @@ describe("UserWallet - Lightning", () => {
 
     const finalBalance = await getBalanceHelper(walletIdUsdB)
     expect(finalBalance).toBe(initBalanceUsdB + cents)
+
+    // Check ledger transaction metadata for USD 'LedgerTransactionType.Invoice'
+    // ===
+    const expectedFields = {
+      type: LedgerTransactionType.Invoice,
+
+      debit: 0,
+      credit: cents,
+
+      fee: 0,
+      feeUsd: 0,
+      usd: Number((cents / 100).toFixed(2)),
+
+      satsAmount: sats,
+      satsFee: 0,
+      centsAmount: cents,
+      centsFee: 0,
+      displayAmount: cents,
+      displayFee: 0,
+    }
+    expect(ledgerTx).toEqual(expect.objectContaining(expectedFields))
   })
 
-  it("receives payment from outside USD wallet with amountless invoices", async () => {
+  it("receives payment from outside to USD wallet with amountless invoices", async () => {
     const initBalanceUsdB = toCents(await getBalanceHelper(walletIdUsdB))
 
     const sats = toSats(120000)

--- a/test/integration/02-user-wallet/02-receive-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-lightning.spec.ts
@@ -8,7 +8,7 @@ import { handleHeldInvoices } from "@app/wallets"
 import { toSats } from "@domain/bitcoin"
 import { InvoiceNotFoundError } from "@domain/bitcoin/lightning"
 import { defaultTimeToExpiryInSeconds } from "@domain/bitcoin/lightning/invoice-expiration"
-import { toCents } from "@domain/fiat"
+import { DisplayCurrency, toCents } from "@domain/fiat"
 import { PaymentInitiationMethod, WithdrawalFeePriceMethod } from "@domain/wallets"
 import { WalletCurrency } from "@domain/shared"
 import { CouldNotFindWalletInvoiceError } from "@domain/errors"
@@ -209,6 +209,8 @@ describe("UserWallet - Lightning", () => {
       centsFee: 0,
       displayAmount: centsAmount,
       displayFee: 0,
+
+      displayCurrency: DisplayCurrency.Usd,
     }
     expect(ledgerTx).toEqual(expect.objectContaining(expectedFields))
   })
@@ -474,6 +476,8 @@ describe("UserWallet - Lightning", () => {
       centsFee: 0,
       displayAmount: cents,
       displayFee: 0,
+
+      displayCurrency: DisplayCurrency.Usd,
     }
     expect(ledgerTx).toEqual(expect.objectContaining(expectedFields))
   })

--- a/test/integration/02-user-wallet/02-receive-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-onchain.spec.ts
@@ -1,6 +1,9 @@
 import { once } from "events"
 
 import { Prices, Wallets, Accounts } from "@app"
+import { getCurrentPrice } from "@app/prices"
+import { usdFromBtcMidPriceFn } from "@app/shared"
+
 import {
   getAccountLimits,
   getDisplayCurrencyConfig,
@@ -8,23 +11,27 @@ import {
   getLocale,
   getOnChainAddressCreateAttemptLimits,
 } from "@config"
+
 import { sat2btc, toSats } from "@domain/bitcoin"
 import { NotificationType } from "@domain/notifications"
 import { OnChainAddressCreateRateLimiterExceededError } from "@domain/rate-limit/errors"
 import { DepositFeeCalculator, TxStatus } from "@domain/wallets"
+import { WalletCurrency } from "@domain/shared"
+import { LedgerTransactionType } from "@domain/ledger"
+import { toCents } from "@domain/fiat"
+import { PriceRatio } from "@domain/payments"
+
 import { onchainTransactionEventHandler } from "@servers/trigger"
+
 import { getFunderWalletId } from "@services/ledger/caching"
 import { baseLogger } from "@services/logger"
-import { WalletsRepository } from "@services/mongoose"
+import { AccountsRepository, WalletsRepository } from "@services/mongoose"
 import { createPushNotificationContent } from "@services/notifications/create-push-notification-content"
 import * as PushNotificationsServiceImpl from "@services/notifications/push-notifications"
+import { LedgerService } from "@services/ledger"
 import { elapsedSinceTimestamp, ModifiedSet, sleep } from "@utils"
 
 import { DisplayCurrencyConverter } from "@domain/fiat/display-currency"
-
-import { getCurrentPrice } from "@app/prices"
-
-import { WalletCurrency } from "@domain/shared"
 
 import {
   amountAfterFeeDeduction,
@@ -461,6 +468,8 @@ async function sendToWalletTestWrapper({
       }),
     )
     expect(txn.initiationVia.address).toBe(address)
+
+    return txn
   }
 
   // just to improve performance
@@ -470,7 +479,64 @@ async function sendToWalletTestWrapper({
     address,
     amount: sat2btc(amountSats),
   })
-  await checkBalance(blockNumber)
+  const txn = await checkBalance(blockNumber)
+
+  // Check ledger transaction metadata for BTC 'LedgerTransactionType.OnchainReceipt'
+  // ===
+  const ledgerTxs = await LedgerService().getTransactionsByHash(
+    (txn.settlementVia as SettlementViaOnChain).transactionHash,
+  )
+  if (ledgerTxs instanceof Error) throw ledgerTxs
+  const ledgerTx = ledgerTxs.find((tx) => tx.walletId === walletId)
+  expect(ledgerTx).not.toBeUndefined()
+
+  const wallet = await WalletsRepository().findById(walletId)
+  if (wallet instanceof Error) throw wallet
+  const account = await AccountsRepository().findById(wallet.accountId)
+  if (account instanceof Error) throw account
+
+  const fee = DepositFeeCalculator().onChainDepositFee({
+    amount: amountSats,
+    ratio: account.depositFeeRatio,
+  })
+
+  const usdPaymentAmount = await usdFromBtcMidPriceFn({
+    amount: BigInt(amountSats),
+    currency: WalletCurrency.Btc,
+  })
+  if (usdPaymentAmount instanceof Error) throw usdPaymentAmount
+  const centsAmount = Number(usdPaymentAmount.amount)
+
+  const priceRatio = PriceRatio({
+    usd: usdPaymentAmount,
+    btc: { amount: BigInt(amountSats), currency: WalletCurrency.Btc },
+  })
+  if (priceRatio instanceof Error) throw priceRatio
+
+  const feeAmountCents = priceRatio.convertFromBtc({
+    amount: BigInt(fee),
+    currency: WalletCurrency.Btc,
+  })
+  const centsFee = toCents(feeAmountCents.amount)
+
+  const expectedFields = {
+    type: LedgerTransactionType.OnchainReceipt,
+
+    debit: 0,
+    credit: amountSats - fee,
+
+    fee: fee,
+    feeUsd: Number((centsFee / 100).toFixed(2)),
+    usd: Number(((centsAmount - centsFee) / 100).toFixed(2)),
+
+    satsAmount: amountSats - fee,
+    satsFee: fee,
+    centsAmount: centsAmount - centsFee,
+    centsFee,
+    displayAmount: centsAmount - centsFee,
+    displayFee: centsFee,
+  }
+  expect(ledgerTx).toEqual(expect.objectContaining(expectedFields))
 }
 
 async function testTxnsByAddressWrapper({

--- a/test/integration/02-user-wallet/02-receive-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-onchain.spec.ts
@@ -18,7 +18,7 @@ import { OnChainAddressCreateRateLimiterExceededError } from "@domain/rate-limit
 import { DepositFeeCalculator, TxStatus } from "@domain/wallets"
 import { WalletCurrency } from "@domain/shared"
 import { LedgerTransactionType } from "@domain/ledger"
-import { toCents } from "@domain/fiat"
+import { DisplayCurrency, toCents } from "@domain/fiat"
 import { PriceRatio } from "@domain/payments"
 
 import { onchainTransactionEventHandler } from "@servers/trigger"
@@ -535,6 +535,8 @@ async function sendToWalletTestWrapper({
     centsFee,
     displayAmount: centsAmount - centsFee,
     displayFee: centsFee,
+
+    displayCurrency: DisplayCurrency.Usd,
   }
   expect(ledgerTx).toEqual(expect.objectContaining(expectedFields))
 }

--- a/test/integration/02-user-wallet/02-receive-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-onchain.spec.ts
@@ -513,7 +513,7 @@ async function sendToWalletTestWrapper({
   })
   if (priceRatio instanceof Error) throw priceRatio
 
-  const feeAmountCents = priceRatio.convertFromBtc({
+  const feeAmountCents = priceRatio.convertFromBtcToCeil({
     amount: BigInt(fee),
     currency: WalletCurrency.Btc,
   })

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -19,7 +19,7 @@ import {
   InsufficientBalanceError as DomainInsufficientBalanceError,
   SelfPaymentError as DomainSelfPaymentError,
 } from "@domain/errors"
-import { toCents } from "@domain/fiat"
+import { DisplayCurrency, toCents } from "@domain/fiat"
 import { LedgerTransactionType } from "@domain/ledger"
 import { ImbalanceCalculator } from "@domain/ledger/imbalance-calculator"
 import {
@@ -293,6 +293,8 @@ describe("UserWallet - Lightning Pay", () => {
       centsFee: 0,
       displayAmount: centsAmount,
       displayFee: 0,
+
+      displayCurrency: DisplayCurrency.Usd,
     }
     expect(txnPayment).toEqual(expect.objectContaining(expectedFields))
   })
@@ -561,6 +563,8 @@ describe("UserWallet - Lightning Pay", () => {
       centsFee,
       displayAmount: cents,
       displayFee: centsFee,
+
+      displayCurrency: DisplayCurrency.Usd,
     }
     expect(txnPayment).toEqual(expect.objectContaining(expectedFields))
 
@@ -585,6 +589,8 @@ describe("UserWallet - Lightning Pay", () => {
         centsFee: 0,
         displayAmount: centsFee,
         displayFee: 0,
+
+        displayCurrency: DisplayCurrency.Usd,
       }),
     )
 
@@ -1609,6 +1615,8 @@ describe("USD Wallets - Lightning Pay", () => {
         centsFee,
         displayAmount: cents,
         displayFee: centsFee,
+
+        displayCurrency: DisplayCurrency.Usd,
       }
       expect(txnPayment).toEqual(expect.objectContaining(expectedFields))
 
@@ -2153,6 +2161,8 @@ describe("USD Wallets - Lightning Pay", () => {
         centsFee: 0,
         displayAmount: centsAmount,
         displayFee: 0,
+
+        displayCurrency: DisplayCurrency.Usd,
       }
       expect(txnPayment).toEqual(expect.objectContaining(expectedFields))
     }

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -28,7 +28,7 @@ import { LedgerService } from "@services/ledger"
 import { sleep, timestampDaysAgo } from "@utils"
 
 import { getCurrentPrice } from "@app/prices"
-import { usdFromBtcMidPriceFn } from "@app/shared"
+import { btcFromUsdMidPriceFn, usdFromBtcMidPriceFn } from "@app/shared"
 
 import { LedgerTransactionType } from "@domain/ledger"
 import { DisplayCurrencyConverter } from "@domain/fiat/display-currency"
@@ -49,7 +49,7 @@ import {
 } from "@domain/bitcoin/onchain/errors"
 import { TxDecoder } from "@domain/bitcoin/onchain"
 import * as OnChainServiceImpl from "@services/lnd/onchain-service"
-import { DealerPriceService } from "@services/dealer-price"
+import { DealerPriceService, NewDealerPriceService } from "@services/dealer-price"
 
 import { getBalanceHelper, getTransactionsForWalletId } from "test/helpers/wallet"
 import {
@@ -278,7 +278,7 @@ const testExternalSend = async ({
       expect(finalBalance).toBe(initialWalletBalance - amount - fee)
     }
 
-    // Check ledger transaction metadata
+    // Check ledger transaction metadata for USD & BTC 'LedgerTransactionType.OnchainPayment'
     // ===
     const txHash = (settledTx.settlementVia as SettlementViaOnChain).transactionHash
     const txns = await LedgerService().getTransactionsByHash(txHash)
@@ -327,6 +327,8 @@ const testExternalSend = async ({
 
     expect(txnPayment).toEqual(
       expect.objectContaining({
+        type: LedgerTransactionType.OnchainPayment,
+
         debit,
         credit: 0,
 
@@ -387,6 +389,9 @@ const testInternalSend = async ({
   recipientWalletId: WalletId
   senderAmount: Satoshis | UsdCents
 }) => {
+  const sendAll = false
+  const fee = 0
+
   const memo = "this is my onchain memo #" + (Math.random() * 1_000_000).toFixed()
 
   const senderWallet = await WalletsRepository().findById(senderWalletId)
@@ -398,6 +403,7 @@ const testInternalSend = async ({
   const { currency: recipientCurrency } = recipientWallet
 
   const dealerFns = DealerPriceService()
+  const newDealerFns = NewDealerPriceService()
 
   let amountResult: UsdCents | Satoshis | DealerPriceServiceError
   let recipientAmount: UsdCents | Satoshis
@@ -447,7 +453,7 @@ const testInternalSend = async ({
     amount: senderAmount,
     targetConfirmations,
     memo,
-    sendAll: false,
+    sendAll,
   }
   const paid =
     senderWallet.currency === WalletCurrency.Btc
@@ -529,6 +535,88 @@ const testInternalSend = async ({
   const filteredTxsUserD = txsRecipient.slice.filter(matchTx)
   expect(filteredTxsUserD.length).toBe(1)
   expect(filteredTxsUserD[0].memo).not.toBe(memo)
+
+  // Check ledger transaction metadata for USD & BTC 'LedgerTransactionType.OnchainIntraLedger'
+  // ===
+  const txns = await LedgerService().getTransactionsByWalletId(senderWalletId)
+  if (txns instanceof Error) throw txns
+
+  const txnPayment = txns.find(
+    (tx) =>
+      tx.type === LedgerTransactionType.OnchainIntraLedger &&
+      tx.memoFromPayer === memo &&
+      tx.debit,
+  )
+  expect(txnPayment).not.toBeUndefined()
+
+  const amountToSend = senderAmount
+
+  let debit, satsAmount, centsAmount, satsFee, centsFee
+  if (senderWallet.currency === WalletCurrency.Btc) {
+    satsAmount = sendAll ? amountToSend - fee : amountToSend
+    const btcPaymentAmount = {
+      amount: BigInt(satsAmount),
+      currency: WalletCurrency.Btc,
+    }
+    const centsPaymentAmount =
+      senderCurrency === recipientCurrency
+        ? await usdFromBtcMidPriceFn(btcPaymentAmount)
+        : await newDealerFns.getCentsFromSatsForImmediateBuy(btcPaymentAmount)
+
+    if (centsPaymentAmount instanceof Error) throw centsPaymentAmount
+    centsAmount = toCents(centsPaymentAmount.amount)
+
+    satsFee = fee
+
+    const priceRatio = PriceRatio({
+      usd: { amount: BigInt(centsAmount), currency: WalletCurrency.Usd },
+      btc: { amount: BigInt(satsAmount), currency: WalletCurrency.Btc },
+    })
+    if (priceRatio instanceof Error) throw priceRatio
+    const centsFeeAmount = priceRatio.convertFromBtcToCeil({
+      amount: BigInt(satsFee),
+      currency: WalletCurrency.Btc,
+    })
+    centsFee = toCents(centsFeeAmount.amount)
+
+    debit = satsAmount + satsFee
+  } else {
+    centsAmount = sendAll ? amountToSend - fee : amountToSend
+    const usdPaymentAmount = {
+      amount: BigInt(centsAmount),
+      currency: WalletCurrency.Usd,
+    }
+    const satsPaymentAmount =
+      senderCurrency === recipientCurrency
+        ? await btcFromUsdMidPriceFn(usdPaymentAmount)
+        : await newDealerFns.getSatsFromCentsForImmediateSell(usdPaymentAmount)
+    if (satsPaymentAmount instanceof Error) throw satsPaymentAmount
+    satsAmount = toSats(satsPaymentAmount.amount)
+
+    centsFee = fee
+    satsFee = 0
+
+    debit = centsAmount + centsFee
+  }
+
+  const expectedFields = {
+    type: LedgerTransactionType.OnchainIntraLedger,
+
+    debit,
+    credit: 0,
+
+    fee: satsFee,
+    feeUsd: Number((centsFee / 100).toFixed(2)),
+    usd: Number(((centsAmount + centsFee) / 100).toFixed(2)),
+
+    satsAmount,
+    satsFee,
+    centsAmount,
+    centsFee,
+    displayAmount: centsAmount,
+    displayFee: centsFee,
+  }
+  expect(txnPayment).toEqual(expect.objectContaining(expectedFields))
 }
 
 describe("BtcWallet - onChainPay", () => {

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -33,7 +33,7 @@ import { btcFromUsdMidPriceFn, usdFromBtcMidPriceFn } from "@app/shared"
 import { LedgerTransactionType } from "@domain/ledger"
 import { DisplayCurrencyConverter } from "@domain/fiat/display-currency"
 
-import { add, sub, toCents } from "@domain/fiat"
+import { add, DisplayCurrency, sub, toCents } from "@domain/fiat"
 
 import { createPushNotificationContent } from "@services/notifications/create-push-notification-content"
 import { WalletsRepository } from "@services/mongoose"
@@ -342,6 +342,8 @@ const testExternalSend = async ({
         centsFee,
         displayAmount: centsAmount,
         displayFee: centsFee,
+
+        displayCurrency: DisplayCurrency.Usd,
       }),
     )
 
@@ -615,6 +617,8 @@ const testInternalSend = async ({
     centsFee,
     displayAmount: centsAmount,
     displayFee: centsFee,
+
+    displayCurrency: DisplayCurrency.Usd,
   }
   expect(txnPayment).toEqual(expect.objectContaining(expectedFields))
 }

--- a/test/integration/services/ledger/facade.spec.ts
+++ b/test/integration/services/ledger/facade.spec.ts
@@ -22,19 +22,18 @@ describe("Facade", () => {
     usd: { amount: 10n, currency: WalletCurrency.Usd },
     btc: { amount: 20n, currency: WalletCurrency.Btc },
   }
-  const walletDescriptor1 = BtcWalletDescriptor(crypto.randomUUID() as WalletId)
-  const walletDescriptor2 = UsdWalletDescriptor(crypto.randomUUID() as WalletId)
 
   describe("recordReceive", () => {
     it("receives to btc wallet", async () => {
+      const btcWalletDescriptor = BtcWalletDescriptor(crypto.randomUUID() as WalletId)
       await recordReceiveLnPayment({
-        walletDescriptor: walletDescriptor1,
+        walletDescriptor: btcWalletDescriptor,
         paymentAmount: receiveAmount,
         bankFee,
       })
 
       const balance = await LedgerFacade.getLedgerAccountBalanceForWalletId(
-        walletDescriptor1,
+        btcWalletDescriptor,
       )
       if (balance instanceof Error) throw balance
       expect(balance).toEqual(
@@ -48,19 +47,21 @@ describe("Facade", () => {
 
   describe("recordSend", () => {
     it("sends from btc wallet", async () => {
+      const btcWalletDescriptor = BtcWalletDescriptor(crypto.randomUUID() as WalletId)
+
       const startingBalance = await LedgerFacade.getLedgerAccountBalanceForWalletId(
-        walletDescriptor1,
+        btcWalletDescriptor,
       )
       if (startingBalance instanceof Error) throw startingBalance
 
       await recordSendLnPayment({
-        walletDescriptor: walletDescriptor1,
+        walletDescriptor: btcWalletDescriptor,
         paymentAmount: sendAmount,
         bankFee,
       })
 
       const balance = await LedgerFacade.getLedgerAccountBalanceForWalletId(
-        walletDescriptor1,
+        btcWalletDescriptor,
       )
       if (balance instanceof Error) throw balance
       expect(balance).toEqual(
@@ -74,19 +75,22 @@ describe("Facade", () => {
 
   describe("recordIntraledger", () => {
     it("sends from btc wallet to usd wallet", async () => {
+      const btcWalletDescriptor = BtcWalletDescriptor(crypto.randomUUID() as WalletId)
+      const usdWalletDescriptor = UsdWalletDescriptor(crypto.randomUUID() as WalletId)
+
       const startingBalanceSender = await LedgerFacade.getLedgerAccountBalanceForWalletId(
-        walletDescriptor1,
+        btcWalletDescriptor,
       )
       if (startingBalanceSender instanceof Error) throw startingBalanceSender
 
       await recordLnIntraLedgerPayment({
-        senderWalletDescriptor: walletDescriptor1,
-        recipientWalletDescriptor: walletDescriptor2,
+        senderWalletDescriptor: btcWalletDescriptor,
+        recipientWalletDescriptor: usdWalletDescriptor,
         paymentAmount: sendAmount,
       })
 
       const finishBalanceSender = await LedgerFacade.getLedgerAccountBalanceForWalletId(
-        walletDescriptor1,
+        btcWalletDescriptor,
       )
       if (finishBalanceSender instanceof Error) throw finishBalanceSender
       expect(finishBalanceSender).toEqual(
@@ -97,7 +101,7 @@ describe("Facade", () => {
       )
 
       const finishBalanceReceiver = await LedgerFacade.getLedgerAccountBalanceForWalletId(
-        walletDescriptor2,
+        usdWalletDescriptor,
       )
       if (finishBalanceReceiver instanceof Error) throw finishBalanceReceiver
       expect(finishBalanceReceiver).toEqual(

--- a/test/integration/services/ledger/facade.spec.ts
+++ b/test/integration/services/ledger/facade.spec.ts
@@ -1,6 +1,11 @@
 import crypto from "crypto"
 
 import { BtcWalletDescriptor, UsdWalletDescriptor, WalletCurrency } from "@domain/shared"
+import { LedgerTransactionType } from "@domain/ledger"
+import { toSats } from "@domain/bitcoin"
+import { toCents } from "@domain/fiat"
+
+import { LedgerService } from "@services/ledger"
 import * as LedgerFacade from "@services/ledger/facade"
 
 import {
@@ -30,8 +35,62 @@ describe("Facade", () => {
     btc: { amount: 20n, currency: WalletCurrency.Btc },
   }
 
+  const testMetadata = async ({
+    senderWalletDescriptor,
+    metadata,
+    isSend,
+    isIntraLedger = false,
+  }) => {
+    const txns = await LedgerService().getTransactionsByWalletId(
+      senderWalletDescriptor.id,
+    )
+    if (txns instanceof Error) throw txns
+    if (!(txns && txns.length)) throw new Error()
+    const txn = txns[0]
+
+    const satsAmount = toSats(isSend ? sendAmount.btc.amount : receiveAmount.btc.amount)
+    const centsAmount = toCents(isSend ? sendAmount.usd.amount : receiveAmount.usd.amount)
+
+    const satsFee = !isIntraLedger ? toSats(bankFee.btc.amount) : 0
+    const centsFee = !isIntraLedger ? toSats(bankFee.usd.amount) : 0
+
+    const debit = isSend
+      ? senderWalletDescriptor.currency === WalletCurrency.Btc
+        ? satsAmount
+        : centsAmount
+      : 0
+
+    const credit = !isSend
+      ? senderWalletDescriptor.currency === WalletCurrency.Btc
+        ? satsAmount
+        : centsAmount
+      : 0
+
+    const expectedFields = {
+      type: metadata,
+
+      debit,
+      credit,
+
+      fee: satsFee,
+      feeUsd: Number((centsFee / 100).toFixed(2)),
+      usd: isSend
+        ? Number(((centsAmount + centsFee) / 100).toFixed(2))
+        : Number((centsAmount / 100).toFixed(2)),
+
+      satsAmount,
+      centsAmount,
+      displayAmount: centsAmount,
+
+      satsFee,
+      centsFee,
+      displayFee: centsFee,
+    }
+    expect(txn).toEqual(expect.objectContaining(expectedFields))
+  }
+
   describe("recordReceive", () => {
-    const runRecordReceive = (recordFn) => {
+    const runRecordReceive = ({ recordFn, metadata }) => {
       it("receives to btc wallet", async () => {
         const btcWalletDescriptor = BtcWalletDescriptor(crypto.randomUUID() as WalletId)
         await recordFn({
@@ -50,6 +109,12 @@ describe("Facade", () => {
             currency: WalletCurrency.Btc,
           }),
         )
+
+        await testMetadata({
+          senderWalletDescriptor: btcWalletDescriptor,
+          metadata,
+          isSend: false,
+        })
       })
 
       it("receives to usd wallet", async () => {
@@ -70,17 +135,30 @@ describe("Facade", () => {
             currency: WalletCurrency.Usd,
           }),
         )
+
+        await testMetadata({
+          senderWalletDescriptor: usdWalletDescriptor,
+          metadata,
+          isSend: false,
+        })
       })
     }
 
-    describe("recordReceiveLnPayment", () => runRecordReceive(recordReceiveLnPayment))
+    describe("recordReceiveLnPayment", () =>
+      runRecordReceive({
+        recordFn: recordReceiveLnPayment,
+        metadata: LedgerTransactionType.Invoice,
+      }))
 
     describe("recordReceiveOnChainPayment", () =>
-      runRecordReceive(recordReceiveOnChainPayment))
+      runRecordReceive({
+        recordFn: recordReceiveOnChainPayment,
+        metadata: LedgerTransactionType.OnchainReceipt,
+      }))
   })
 
   describe("recordSend", () => {
-    const runRecordSend = (recordFn) => {
+    const runRecordSend = ({ recordFn, metadata }) => {
       it("sends from btc wallet", async () => {
         const btcWalletDescriptor = BtcWalletDescriptor(crypto.randomUUID() as WalletId)
 
@@ -105,6 +183,12 @@ describe("Facade", () => {
             currency: WalletCurrency.Btc,
           }),
         )
+
+        await testMetadata({
+          senderWalletDescriptor: btcWalletDescriptor,
+          metadata,
+          isSend: true,
+        })
       })
 
       it("sends from usd wallet", async () => {
@@ -133,13 +217,21 @@ describe("Facade", () => {
         )
       })
     }
-    describe("recordSendLnPayment", () => runRecordSend(recordSendLnPayment))
+    describe("recordSendLnPayment", () =>
+      runRecordSend({
+        recordFn: recordSendLnPayment,
+        metadata: LedgerTransactionType.Payment,
+      }))
 
-    describe("recordSendOnChainPayment", () => runRecordSend(recordSendOnChainPayment))
+    describe("recordSendOnChainPayment", () =>
+      runRecordSend({
+        recordFn: recordSendOnChainPayment,
+        metadata: LedgerTransactionType.OnchainPayment,
+      }))
   })
 
   describe("recordIntraledger", () => {
-    const itRecordIntraLedger = ({ recordFn, send, receive }) => {
+    const itRecordIntraLedger = ({ recordFn, metadata, send, receive }) => {
       it(`sends from ${send.toLowerCase()} wallet to ${receive.toLowerCase()} wallet`, async () => {
         const btcSendWalletDescriptor = BtcWalletDescriptor(
           crypto.randomUUID() as WalletId,
@@ -200,10 +292,17 @@ describe("Facade", () => {
             currency: receive,
           }),
         )
+
+        await testMetadata({
+          senderWalletDescriptor,
+          metadata,
+          isSend: true,
+          isIntraLedger: true,
+        })
       })
     }
 
-    const runRecordIntraLedger = (recordFn) => {
+    const runRecordIntraLedger = ({ recordFn, metadata }) => {
       const sendReceivePairs = [
         { send: WalletCurrency.Btc, receive: WalletCurrency.Btc },
         { send: WalletCurrency.Btc, receive: WalletCurrency.Usd },
@@ -214,12 +313,13 @@ describe("Facade", () => {
       for (const sendReceivePair of sendReceivePairs) {
         itRecordIntraLedger({
           recordFn,
+          metadata,
           ...sendReceivePair,
         })
       }
     }
 
-    const runRecordTradeIntraAccount = (recordFn) => {
+    const runRecordTradeIntraAccount = ({ recordFn, metadata }) => {
       const sendReceivePairs = [
         { send: WalletCurrency.Btc, receive: WalletCurrency.Usd },
         { send: WalletCurrency.Usd, receive: WalletCurrency.Btc },
@@ -228,27 +328,46 @@ describe("Facade", () => {
       for (const sendReceivePair of sendReceivePairs) {
         itRecordIntraLedger({
           recordFn,
+          metadata,
           ...sendReceivePair,
         })
       }
     }
 
     describe("recordLnIntraLedgerPayment", () =>
-      runRecordIntraLedger(recordLnIntraLedgerPayment))
+      runRecordIntraLedger({
+        recordFn: recordLnIntraLedgerPayment,
+        metadata: LedgerTransactionType.LnIntraLedger,
+      }))
 
     describe("recordWalletIdIntraLedgerPayment", () =>
-      runRecordIntraLedger(recordWalletIdIntraLedgerPayment))
+      runRecordIntraLedger({
+        recordFn: recordWalletIdIntraLedgerPayment,
+        metadata: LedgerTransactionType.IntraLedger,
+      }))
 
     describe("recordOnChainIntraLedgerPayment", () =>
-      runRecordIntraLedger(recordOnChainIntraLedgerPayment))
+      runRecordIntraLedger({
+        recordFn: recordOnChainIntraLedgerPayment,
+        metadata: LedgerTransactionType.OnchainIntraLedger,
+      }))
 
     describe("recordLnTradeIntraAccountTxn", () =>
-      runRecordTradeIntraAccount(recordLnTradeIntraAccountTxn))
+      runRecordTradeIntraAccount({
+        recordFn: recordLnTradeIntraAccountTxn,
+        metadata: LedgerTransactionType.LnTradeIntraAccount,
+      }))
 
     describe("recordWalletIdTradeIntraAccountTxn", () =>
-      runRecordTradeIntraAccount(recordWalletIdTradeIntraAccountTxn))
+      runRecordTradeIntraAccount({
+        recordFn: recordWalletIdTradeIntraAccountTxn,
+        metadata: LedgerTransactionType.WalletIdTradeIntraAccount,
+      }))
 
     describe("recordOnChainTradeIntraAccountTxn", () =>
-      runRecordTradeIntraAccount(recordOnChainTradeIntraAccountTxn))
+      runRecordTradeIntraAccount({
+        recordFn: recordOnChainTradeIntraAccountTxn,
+        metadata: LedgerTransactionType.OnChainTradeIntraAccount,
+      }))
   })
 })

--- a/test/integration/services/ledger/facade.spec.ts
+++ b/test/integration/services/ledger/facade.spec.ts
@@ -5,8 +5,15 @@ import * as LedgerFacade from "@services/ledger/facade"
 
 import {
   recordLnIntraLedgerPayment,
+  recordLnTradeIntraAccountTxn,
+  recordOnChainIntraLedgerPayment,
+  recordOnChainTradeIntraAccountTxn,
   recordReceiveLnPayment,
+  recordReceiveOnChainPayment,
   recordSendLnPayment,
+  recordSendOnChainPayment,
+  recordWalletIdIntraLedgerPayment,
+  recordWalletIdTradeIntraAccountTxn,
 } from "./helpers"
 
 describe("Facade", () => {
@@ -24,92 +31,224 @@ describe("Facade", () => {
   }
 
   describe("recordReceive", () => {
-    it("receives to btc wallet", async () => {
-      const btcWalletDescriptor = BtcWalletDescriptor(crypto.randomUUID() as WalletId)
-      await recordReceiveLnPayment({
-        walletDescriptor: btcWalletDescriptor,
-        paymentAmount: receiveAmount,
-        bankFee,
+    const runRecordReceive = (recordFn) => {
+      it("receives to btc wallet", async () => {
+        const btcWalletDescriptor = BtcWalletDescriptor(crypto.randomUUID() as WalletId)
+        await recordFn({
+          walletDescriptor: btcWalletDescriptor,
+          paymentAmount: receiveAmount,
+          bankFee,
+        })
+
+        const balance = await LedgerFacade.getLedgerAccountBalanceForWalletId(
+          btcWalletDescriptor,
+        )
+        if (balance instanceof Error) throw balance
+        expect(balance).toEqual(
+          expect.objectContaining({
+            amount: receiveAmount.btc.amount,
+            currency: WalletCurrency.Btc,
+          }),
+        )
       })
 
-      const balance = await LedgerFacade.getLedgerAccountBalanceForWalletId(
-        btcWalletDescriptor,
-      )
-      if (balance instanceof Error) throw balance
-      expect(balance).toEqual(
-        expect.objectContaining({
-          amount: receiveAmount.btc.amount,
-          currency: WalletCurrency.Btc,
-        }),
-      )
-    })
+      it("receives to usd wallet", async () => {
+        const usdWalletDescriptor = UsdWalletDescriptor(crypto.randomUUID() as WalletId)
+        await recordFn({
+          walletDescriptor: usdWalletDescriptor,
+          paymentAmount: receiveAmount,
+          bankFee,
+        })
+
+        const balance = await LedgerFacade.getLedgerAccountBalanceForWalletId(
+          usdWalletDescriptor,
+        )
+        if (balance instanceof Error) throw balance
+        expect(balance).toEqual(
+          expect.objectContaining({
+            amount: receiveAmount.usd.amount,
+            currency: WalletCurrency.Usd,
+          }),
+        )
+      })
+    }
+
+    describe("recordReceiveLnPayment", () => runRecordReceive(recordReceiveLnPayment))
+
+    describe("recordReceiveOnChainPayment", () =>
+      runRecordReceive(recordReceiveOnChainPayment))
   })
 
   describe("recordSend", () => {
-    it("sends from btc wallet", async () => {
-      const btcWalletDescriptor = BtcWalletDescriptor(crypto.randomUUID() as WalletId)
+    const runRecordSend = (recordFn) => {
+      it("sends from btc wallet", async () => {
+        const btcWalletDescriptor = BtcWalletDescriptor(crypto.randomUUID() as WalletId)
 
-      const startingBalance = await LedgerFacade.getLedgerAccountBalanceForWalletId(
-        btcWalletDescriptor,
-      )
-      if (startingBalance instanceof Error) throw startingBalance
+        const startingBalance = await LedgerFacade.getLedgerAccountBalanceForWalletId(
+          btcWalletDescriptor,
+        )
+        if (startingBalance instanceof Error) throw startingBalance
 
-      await recordSendLnPayment({
-        walletDescriptor: btcWalletDescriptor,
-        paymentAmount: sendAmount,
-        bankFee,
+        await recordFn({
+          walletDescriptor: btcWalletDescriptor,
+          paymentAmount: sendAmount,
+          bankFee,
+        })
+
+        const balance = await LedgerFacade.getLedgerAccountBalanceForWalletId(
+          btcWalletDescriptor,
+        )
+        if (balance instanceof Error) throw balance
+        expect(balance).toEqual(
+          expect.objectContaining({
+            amount: startingBalance.amount - sendAmount.btc.amount,
+            currency: WalletCurrency.Btc,
+          }),
+        )
       })
 
-      const balance = await LedgerFacade.getLedgerAccountBalanceForWalletId(
-        btcWalletDescriptor,
-      )
-      if (balance instanceof Error) throw balance
-      expect(balance).toEqual(
-        expect.objectContaining({
-          amount: startingBalance.amount - sendAmount.btc.amount,
-          currency: WalletCurrency.Btc,
-        }),
-      )
-    })
+      it("sends from usd wallet", async () => {
+        const usdWalletDescriptor = UsdWalletDescriptor(crypto.randomUUID() as WalletId)
+
+        const startingBalance = await LedgerFacade.getLedgerAccountBalanceForWalletId(
+          usdWalletDescriptor,
+        )
+        if (startingBalance instanceof Error) throw startingBalance
+
+        await recordFn({
+          walletDescriptor: usdWalletDescriptor,
+          paymentAmount: sendAmount,
+          bankFee,
+        })
+
+        const balance = await LedgerFacade.getLedgerAccountBalanceForWalletId(
+          usdWalletDescriptor,
+        )
+        if (balance instanceof Error) throw balance
+        expect(balance).toEqual(
+          expect.objectContaining({
+            amount: startingBalance.amount - sendAmount.usd.amount,
+            currency: WalletCurrency.Usd,
+          }),
+        )
+      })
+    }
+    describe("recordSendLnPayment", () => runRecordSend(recordSendLnPayment))
+
+    describe("recordSendOnChainPayment", () => runRecordSend(recordSendOnChainPayment))
   })
 
   describe("recordIntraledger", () => {
-    it("sends from btc wallet to usd wallet", async () => {
-      const btcWalletDescriptor = BtcWalletDescriptor(crypto.randomUUID() as WalletId)
-      const usdWalletDescriptor = UsdWalletDescriptor(crypto.randomUUID() as WalletId)
+    const itRecordIntraLedger = ({ recordFn, send, receive }) => {
+      it(`sends from ${send.toLowerCase()} wallet to ${receive.toLowerCase()} wallet`, async () => {
+        const btcSendWalletDescriptor = BtcWalletDescriptor(
+          crypto.randomUUID() as WalletId,
+        )
+        const btcReceiveWalletDescriptor = BtcWalletDescriptor(
+          crypto.randomUUID() as WalletId,
+        )
 
-      const startingBalanceSender = await LedgerFacade.getLedgerAccountBalanceForWalletId(
-        btcWalletDescriptor,
-      )
-      if (startingBalanceSender instanceof Error) throw startingBalanceSender
+        const usdSendWalletDescriptor = UsdWalletDescriptor(
+          crypto.randomUUID() as WalletId,
+        )
+        const usdReceiveWalletDescriptor = UsdWalletDescriptor(
+          crypto.randomUUID() as WalletId,
+        )
 
-      await recordLnIntraLedgerPayment({
-        senderWalletDescriptor: btcWalletDescriptor,
-        recipientWalletDescriptor: usdWalletDescriptor,
-        paymentAmount: sendAmount,
+        const senderWalletDescriptor =
+          send === WalletCurrency.Btc ? btcSendWalletDescriptor : usdSendWalletDescriptor
+
+        const recipientWalletDescriptor =
+          receive === WalletCurrency.Btc
+            ? btcReceiveWalletDescriptor
+            : usdReceiveWalletDescriptor
+
+        const startingBalanceSender =
+          await LedgerFacade.getLedgerAccountBalanceForWalletId(senderWalletDescriptor)
+        if (startingBalanceSender instanceof Error) throw startingBalanceSender
+
+        await recordFn({
+          senderWalletDescriptor,
+          recipientWalletDescriptor,
+          paymentAmount: sendAmount,
+        })
+
+        const finishBalanceSender = await LedgerFacade.getLedgerAccountBalanceForWalletId(
+          senderWalletDescriptor,
+        )
+        if (finishBalanceSender instanceof Error) throw finishBalanceSender
+        expect(finishBalanceSender).toEqual(
+          expect.objectContaining({
+            amount:
+              startingBalanceSender.amount -
+              (send === WalletCurrency.Btc
+                ? sendAmount.btc.amount
+                : sendAmount.usd.amount),
+            currency: send,
+          }),
+        )
+
+        const finishBalanceReceiver =
+          await LedgerFacade.getLedgerAccountBalanceForWalletId(recipientWalletDescriptor)
+        if (finishBalanceReceiver instanceof Error) throw finishBalanceReceiver
+        expect(finishBalanceReceiver).toEqual(
+          expect.objectContaining({
+            amount:
+              receive === WalletCurrency.Btc
+                ? sendAmount.btc.amount
+                : sendAmount.usd.amount,
+            currency: receive,
+          }),
+        )
       })
+    }
 
-      const finishBalanceSender = await LedgerFacade.getLedgerAccountBalanceForWalletId(
-        btcWalletDescriptor,
-      )
-      if (finishBalanceSender instanceof Error) throw finishBalanceSender
-      expect(finishBalanceSender).toEqual(
-        expect.objectContaining({
-          amount: startingBalanceSender.amount - sendAmount.btc.amount,
-          currency: WalletCurrency.Btc,
-        }),
-      )
+    const runRecordIntraLedger = (recordFn) => {
+      const sendReceivePairs = [
+        { send: WalletCurrency.Btc, receive: WalletCurrency.Btc },
+        { send: WalletCurrency.Btc, receive: WalletCurrency.Usd },
+        { send: WalletCurrency.Usd, receive: WalletCurrency.Btc },
+        { send: WalletCurrency.Usd, receive: WalletCurrency.Usd },
+      ]
 
-      const finishBalanceReceiver = await LedgerFacade.getLedgerAccountBalanceForWalletId(
-        usdWalletDescriptor,
-      )
-      if (finishBalanceReceiver instanceof Error) throw finishBalanceReceiver
-      expect(finishBalanceReceiver).toEqual(
-        expect.objectContaining({
-          amount: sendAmount.usd.amount,
-          currency: WalletCurrency.Usd,
-        }),
-      )
-    })
+      for (const sendReceivePair of sendReceivePairs) {
+        itRecordIntraLedger({
+          recordFn,
+          ...sendReceivePair,
+        })
+      }
+    }
+
+    const runRecordTradeIntraAccount = (recordFn) => {
+      const sendReceivePairs = [
+        { send: WalletCurrency.Btc, receive: WalletCurrency.Usd },
+        { send: WalletCurrency.Usd, receive: WalletCurrency.Btc },
+      ]
+
+      for (const sendReceivePair of sendReceivePairs) {
+        itRecordIntraLedger({
+          recordFn,
+          ...sendReceivePair,
+        })
+      }
+    }
+
+    describe("recordLnIntraLedgerPayment", () =>
+      runRecordIntraLedger(recordLnIntraLedgerPayment))
+
+    describe("recordWalletIdIntraLedgerPayment", () =>
+      runRecordIntraLedger(recordWalletIdIntraLedgerPayment))
+
+    describe("recordOnChainIntraLedgerPayment", () =>
+      runRecordIntraLedger(recordOnChainIntraLedgerPayment))
+
+    describe("recordLnTradeIntraAccountTxn", () =>
+      runRecordTradeIntraAccount(recordLnTradeIntraAccountTxn))
+
+    describe("recordWalletIdTradeIntraAccountTxn", () =>
+      runRecordTradeIntraAccount(recordWalletIdTradeIntraAccountTxn))
+
+    describe("recordOnChainTradeIntraAccountTxn", () =>
+      runRecordTradeIntraAccount(recordOnChainTradeIntraAccountTxn))
   })
 })

--- a/test/integration/services/ledger/facade.spec.ts
+++ b/test/integration/services/ledger/facade.spec.ts
@@ -3,7 +3,7 @@ import crypto from "crypto"
 import { BtcWalletDescriptor, UsdWalletDescriptor, WalletCurrency } from "@domain/shared"
 import { LedgerTransactionType } from "@domain/ledger"
 import { toSats } from "@domain/bitcoin"
-import { toCents } from "@domain/fiat"
+import { DisplayCurrency, toCents } from "@domain/fiat"
 
 import { LedgerService } from "@services/ledger"
 import * as LedgerFacade from "@services/ledger/facade"
@@ -85,6 +85,8 @@ describe("Facade", () => {
       satsFee,
       centsFee,
       displayFee: centsFee,
+
+      displayCurrency: DisplayCurrency.Usd,
     }
     expect(txn).toEqual(expect.objectContaining(expectedFields))
   }

--- a/test/integration/services/ledger/helpers.ts
+++ b/test/integration/services/ledger/helpers.ts
@@ -17,7 +17,10 @@ import {
 import { translateToLedgerJournal } from "@services/ledger"
 import { toSats } from "@domain/bitcoin"
 
-export const recordReceiveLnPayment = async ({
+export const recordReceiveLnPayment = async <
+  S extends WalletCurrency,
+  R extends WalletCurrency,
+>({
   walletDescriptor,
   paymentAmount,
   bankFee,
@@ -26,10 +29,17 @@ export const recordReceiveLnPayment = async ({
 
   const metadata = LedgerFacade.LnReceiveLedgerMetadata({
     paymentHash,
-    fee: bankFee.btc,
+    pubkey: crypto.randomUUID() as Pubkey,
+    paymentFlow: {
+      btcPaymentAmount: paymentAmount.btc,
+      usdPaymentAmount: paymentAmount.usd,
+      btcProtocolFee: bankFee.btc,
+      usdProtocolFee: bankFee.usd,
+    } as PaymentFlowState<S, R>,
+
     feeDisplayCurrency: Number(bankFee.usd.amount) as DisplayCurrencyBaseAmount,
     amountDisplayCurrency: Number(paymentAmount.usd.amount) as DisplayCurrencyBaseAmount,
-    pubkey: crypto.randomUUID() as Pubkey,
+    displayCurrency: DisplayCurrency.Usd,
   })
 
   return LedgerFacade.recordReceive({
@@ -42,7 +52,10 @@ export const recordReceiveLnPayment = async ({
   })
 }
 
-export const recordReceiveOnChainPayment = async ({
+export const recordReceiveOnChainPayment = async <
+  S extends WalletCurrency,
+  R extends WalletCurrency,
+>({
   walletDescriptor,
   paymentAmount,
   bankFee,
@@ -51,9 +64,17 @@ export const recordReceiveOnChainPayment = async ({
 
   const metadata = LedgerFacade.OnChainReceiveLedgerMetadata({
     onChainTxHash,
-    fee: bankFee.btc,
+    paymentFlow: {
+      btcPaymentAmount: paymentAmount.btc,
+      usdPaymentAmount: paymentAmount.usd,
+      btcProtocolFee: bankFee.btc,
+      usdProtocolFee: bankFee.usd,
+    } as OnChainPaymentFlowState<S, R>,
+
     feeDisplayCurrency: Number(bankFee.usd.amount) as DisplayCurrencyBaseAmount,
     amountDisplayCurrency: Number(paymentAmount.usd.amount) as DisplayCurrencyBaseAmount,
+    displayCurrency: DisplayCurrency.Usd,
+
     payeeAddresses: ["address1" as OnChainAddress],
   })
 

--- a/test/integration/services/ledger/helpers.ts
+++ b/test/integration/services/ledger/helpers.ts
@@ -290,7 +290,10 @@ export const recordOnChainIntraLedgerPayment = async <
   })
 }
 
-export const recordLnTradeIntraAccountTxn = async ({
+export const recordLnTradeIntraAccountTxn = async <
+  S extends WalletCurrency,
+  R extends WalletCurrency,
+>({
   senderWalletDescriptor,
   recipientWalletDescriptor,
   paymentAmount,
@@ -309,7 +312,7 @@ export const recordLnTradeIntraAccountTxn = async ({
         usdPaymentAmount: paymentAmount.usd,
         btcProtocolFee: ZERO_SATS,
         usdProtocolFee: ZERO_CENTS,
-      } as PaymentFlowState<WalletCurrency, WalletCurrency>,
+      } as PaymentFlowState<S, R>,
     })
 
   return LedgerFacade.recordIntraledger({
@@ -322,7 +325,10 @@ export const recordLnTradeIntraAccountTxn = async ({
   })
 }
 
-export const recordWalletIdTradeIntraAccountTxn = async ({
+export const recordWalletIdTradeIntraAccountTxn = async <
+  S extends WalletCurrency,
+  R extends WalletCurrency,
+>({
   senderWalletDescriptor,
   recipientWalletDescriptor,
   paymentAmount,
@@ -336,7 +342,7 @@ export const recordWalletIdTradeIntraAccountTxn = async ({
       usdPaymentAmount: paymentAmount.usd,
       btcProtocolFee: ZERO_SATS,
       usdProtocolFee: ZERO_CENTS,
-    } as PaymentFlowState<WalletCurrency, WalletCurrency>,
+    } as PaymentFlowState<S, R>,
   })
 
   return LedgerFacade.recordIntraledger({
@@ -349,7 +355,10 @@ export const recordWalletIdTradeIntraAccountTxn = async ({
   })
 }
 
-export const recordOnChainTradeIntraAccountTxn = async ({
+export const recordOnChainTradeIntraAccountTxn = async <
+  S extends WalletCurrency,
+  R extends WalletCurrency,
+>({
   senderWalletDescriptor,
   recipientWalletDescriptor,
   paymentAmount,
@@ -368,7 +377,7 @@ export const recordOnChainTradeIntraAccountTxn = async ({
         usdPaymentAmount: paymentAmount.usd,
         btcProtocolFee: ZERO_SATS,
         usdProtocolFee: ZERO_CENTS,
-      } as OnChainPaymentFlowState<WalletCurrency, WalletCurrency>,
+      } as OnChainPaymentFlowState<S, R>,
     })
 
   return LedgerFacade.recordIntraledger({
@@ -380,6 +389,7 @@ export const recordOnChainTradeIntraAccountTxn = async ({
     additionalDebitMetadata: debitAccountAdditionalMetadata,
   })
 }
+
 // Non-LedgerFacade helpers from legacy admin service
 // ======
 

--- a/test/integration/services/ledger/helpers.ts
+++ b/test/integration/services/ledger/helpers.ts
@@ -17,10 +17,7 @@ import {
 import { translateToLedgerJournal } from "@services/ledger"
 import { toSats } from "@domain/bitcoin"
 
-export const recordReceiveLnPayment = async <
-  S extends WalletCurrency,
-  R extends WalletCurrency,
->({
+export const recordReceiveLnPayment = async ({
   walletDescriptor,
   paymentAmount,
   bankFee,
@@ -30,12 +27,12 @@ export const recordReceiveLnPayment = async <
   const metadata = LedgerFacade.LnReceiveLedgerMetadata({
     paymentHash,
     pubkey: crypto.randomUUID() as Pubkey,
-    paymentFlow: {
+    paymentAmounts: {
       btcPaymentAmount: paymentAmount.btc,
       usdPaymentAmount: paymentAmount.usd,
       btcProtocolFee: bankFee.btc,
       usdProtocolFee: bankFee.usd,
-    } as PaymentFlowState<S, R>,
+    },
 
     feeDisplayCurrency: Number(bankFee.usd.amount) as DisplayCurrencyBaseAmount,
     amountDisplayCurrency: Number(paymentAmount.usd.amount) as DisplayCurrencyBaseAmount,
@@ -52,10 +49,7 @@ export const recordReceiveLnPayment = async <
   })
 }
 
-export const recordReceiveOnChainPayment = async <
-  S extends WalletCurrency,
-  R extends WalletCurrency,
->({
+export const recordReceiveOnChainPayment = async ({
   walletDescriptor,
   paymentAmount,
   bankFee,
@@ -64,12 +58,12 @@ export const recordReceiveOnChainPayment = async <
 
   const metadata = LedgerFacade.OnChainReceiveLedgerMetadata({
     onChainTxHash,
-    paymentFlow: {
+    paymentAmounts: {
       btcPaymentAmount: paymentAmount.btc,
       usdPaymentAmount: paymentAmount.usd,
       btcProtocolFee: bankFee.btc,
       usdProtocolFee: bankFee.usd,
-    } as OnChainPaymentFlowState<S, R>,
+    },
 
     feeDisplayCurrency: Number(bankFee.usd.amount) as DisplayCurrencyBaseAmount,
     amountDisplayCurrency: Number(paymentAmount.usd.amount) as DisplayCurrencyBaseAmount,
@@ -87,10 +81,7 @@ export const recordReceiveOnChainPayment = async <
   })
 }
 
-export const recordSendLnPayment = async <
-  S extends WalletCurrency,
-  R extends WalletCurrency,
->({
+export const recordSendLnPayment = async ({
   walletDescriptor,
   paymentAmount,
   bankFee,
@@ -102,12 +93,12 @@ export const recordSendLnPayment = async <
     displayCurrency: getDisplayCurrencyConfig().code,
     pubkey: crypto.randomUUID() as Pubkey,
     feeKnownInAdvance: true,
-    paymentFlow: {
+    paymentAmounts: {
       btcPaymentAmount: paymentAmount.btc,
       usdPaymentAmount: paymentAmount.usd,
       btcProtocolFee: bankFee.btc,
       usdProtocolFee: bankFee.usd,
-    } as PaymentFlowState<S, R>,
+    },
   })
 
   return LedgerFacade.recordSend({
@@ -119,22 +110,19 @@ export const recordSendLnPayment = async <
   })
 }
 
-export const recordSendOnChainPayment = async <
-  S extends WalletCurrency,
-  R extends WalletCurrency,
->({
+export const recordSendOnChainPayment = async ({
   walletDescriptor,
   paymentAmount,
   bankFee,
 }) => {
   const metadata = LedgerFacade.OnChainSendLedgerMetadata({
     onChainTxHash: crypto.randomUUID() as OnChainTxHash,
-    paymentFlow: {
+    paymentAmounts: {
       btcPaymentAmount: paymentAmount.btc,
       usdPaymentAmount: paymentAmount.usd,
       btcProtocolFee: bankFee.btc,
       usdProtocolFee: bankFee.usd,
-    } as OnChainPaymentFlowState<S, R>,
+    },
 
     feeDisplayCurrency: Number(bankFee.usd.amount) as DisplayCurrencyBaseAmount,
     amountDisplayCurrency: Number(paymentAmount.usd.amount) as DisplayCurrencyBaseAmount,
@@ -153,10 +141,7 @@ export const recordSendOnChainPayment = async <
   })
 }
 
-export const recordLnFeeReimbursement = async <
-  S extends WalletCurrency,
-  R extends WalletCurrency,
->({
+export const recordLnFeeReimbursement = async ({
   walletDescriptor,
   paymentAmount,
   bankFee,
@@ -168,12 +153,12 @@ export const recordLnFeeReimbursement = async <
     feeDisplayCurrency: Number(bankFee.usd.amount) as DisplayCurrencyBaseAmount,
     amountDisplayCurrency: Number(paymentAmount.usd.amount) as DisplayCurrencyBaseAmount,
     displayCurrency: getDisplayCurrencyConfig().code,
-    paymentFlow: {
+    paymentAmounts: {
       btcPaymentAmount: paymentAmount.btc,
       usdPaymentAmount: paymentAmount.usd,
       btcProtocolFee: bankFee.btc,
       usdProtocolFee: bankFee.usd,
-    } as PaymentFlowState<S, R>,
+    },
     journalId: "031a419636dbf6d25981d6d2" as LedgerJournalId,
   })
 
@@ -187,10 +172,7 @@ export const recordLnFeeReimbursement = async <
   })
 }
 
-export const recordLnIntraLedgerPayment = async <
-  S extends WalletCurrency,
-  R extends WalletCurrency,
->({
+export const recordLnIntraLedgerPayment = async ({
   senderWalletDescriptor,
   recipientWalletDescriptor,
   paymentAmount,
@@ -204,12 +186,12 @@ export const recordLnIntraLedgerPayment = async <
       feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
       displayCurrency: DisplayCurrency.Usd,
       pubkey: crypto.randomUUID() as Pubkey,
-      paymentFlow: {
+      paymentAmounts: {
         btcPaymentAmount: paymentAmount.btc,
         usdPaymentAmount: paymentAmount.usd,
         btcProtocolFee: ZERO_SATS,
         usdProtocolFee: ZERO_CENTS,
-      } as PaymentFlowState<S, R>,
+      },
     })
 
   return LedgerFacade.recordIntraledger({
@@ -222,10 +204,7 @@ export const recordLnIntraLedgerPayment = async <
   })
 }
 
-export const recordWalletIdIntraLedgerPayment = async <
-  S extends WalletCurrency,
-  R extends WalletCurrency,
->({
+export const recordWalletIdIntraLedgerPayment = async ({
   senderWalletDescriptor,
   recipientWalletDescriptor,
   paymentAmount,
@@ -237,12 +216,12 @@ export const recordWalletIdIntraLedgerPayment = async <
       ) as DisplayCurrencyBaseAmount,
       feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
       displayCurrency: DisplayCurrency.Usd,
-      paymentFlow: {
+      paymentAmounts: {
         btcPaymentAmount: paymentAmount.btc,
         usdPaymentAmount: paymentAmount.usd,
         btcProtocolFee: ZERO_SATS,
         usdProtocolFee: ZERO_CENTS,
-      } as PaymentFlowState<S, R>,
+      },
     })
 
   return LedgerFacade.recordIntraledger({
@@ -255,10 +234,7 @@ export const recordWalletIdIntraLedgerPayment = async <
   })
 }
 
-export const recordOnChainIntraLedgerPayment = async <
-  S extends WalletCurrency,
-  R extends WalletCurrency,
->({
+export const recordOnChainIntraLedgerPayment = async ({
   senderWalletDescriptor,
   recipientWalletDescriptor,
   paymentAmount,
@@ -272,12 +248,12 @@ export const recordOnChainIntraLedgerPayment = async <
       displayCurrency: DisplayCurrency.Usd,
       sendAll: false,
       payeeAddresses: ["address1" as OnChainAddress],
-      paymentFlow: {
+      paymentAmounts: {
         btcPaymentAmount: paymentAmount.btc,
         usdPaymentAmount: paymentAmount.usd,
         btcProtocolFee: ZERO_SATS,
         usdProtocolFee: ZERO_CENTS,
-      } as OnChainPaymentFlowState<S, R>,
+      },
     })
 
   return LedgerFacade.recordIntraledger({
@@ -290,10 +266,7 @@ export const recordOnChainIntraLedgerPayment = async <
   })
 }
 
-export const recordLnTradeIntraAccountTxn = async <
-  S extends WalletCurrency,
-  R extends WalletCurrency,
->({
+export const recordLnTradeIntraAccountTxn = async ({
   senderWalletDescriptor,
   recipientWalletDescriptor,
   paymentAmount,
@@ -307,12 +280,12 @@ export const recordLnTradeIntraAccountTxn = async <
       feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
       displayCurrency: DisplayCurrency.Usd,
       pubkey: crypto.randomUUID() as Pubkey,
-      paymentFlow: {
+      paymentAmounts: {
         btcPaymentAmount: paymentAmount.btc,
         usdPaymentAmount: paymentAmount.usd,
         btcProtocolFee: ZERO_SATS,
         usdProtocolFee: ZERO_CENTS,
-      } as PaymentFlowState<S, R>,
+      },
     })
 
   return LedgerFacade.recordIntraledger({
@@ -325,10 +298,7 @@ export const recordLnTradeIntraAccountTxn = async <
   })
 }
 
-export const recordWalletIdTradeIntraAccountTxn = async <
-  S extends WalletCurrency,
-  R extends WalletCurrency,
->({
+export const recordWalletIdTradeIntraAccountTxn = async ({
   senderWalletDescriptor,
   recipientWalletDescriptor,
   paymentAmount,
@@ -337,12 +307,12 @@ export const recordWalletIdTradeIntraAccountTxn = async <
     amountDisplayCurrency: Number(paymentAmount.usd.amount) as DisplayCurrencyBaseAmount,
     feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
     displayCurrency: DisplayCurrency.Usd,
-    paymentFlow: {
+    paymentAmounts: {
       btcPaymentAmount: paymentAmount.btc,
       usdPaymentAmount: paymentAmount.usd,
       btcProtocolFee: ZERO_SATS,
       usdProtocolFee: ZERO_CENTS,
-    } as PaymentFlowState<S, R>,
+    },
   })
 
   return LedgerFacade.recordIntraledger({
@@ -355,10 +325,7 @@ export const recordWalletIdTradeIntraAccountTxn = async <
   })
 }
 
-export const recordOnChainTradeIntraAccountTxn = async <
-  S extends WalletCurrency,
-  R extends WalletCurrency,
->({
+export const recordOnChainTradeIntraAccountTxn = async ({
   senderWalletDescriptor,
   recipientWalletDescriptor,
   paymentAmount,
@@ -372,12 +339,12 @@ export const recordOnChainTradeIntraAccountTxn = async <
       displayCurrency: DisplayCurrency.Usd,
       sendAll: false,
       payeeAddresses: ["address1" as OnChainAddress],
-      paymentFlow: {
+      paymentAmounts: {
         btcPaymentAmount: paymentAmount.btc,
         usdPaymentAmount: paymentAmount.usd,
         btcProtocolFee: ZERO_SATS,
         usdProtocolFee: ZERO_CENTS,
-      } as OnChainPaymentFlowState<S, R>,
+      },
     })
 
   return LedgerFacade.recordIntraledger({

--- a/test/unit/services/ledger/domain/tx-metadata.spec.ts
+++ b/test/unit/services/ledger/domain/tx-metadata.spec.ts
@@ -26,19 +26,19 @@ describe("Tx metadata", () => {
     usd: { amount: 10n, currency: WalletCurrency.Usd },
     btc: { amount: 2000n, currency: WalletCurrency.Btc },
   }
-  const paymentFlow = {
+  const paymentAmounts = {
     btcPaymentAmount: receiveAmount.btc,
     usdPaymentAmount: receiveAmount.usd,
     btcProtocolFee: ZERO_SATS,
     usdProtocolFee: ZERO_CENTS,
-  } as PaymentFlowState<WalletCurrency, WalletCurrency>
+  }
 
-  const onChainPaymentFlow = {
+  const onChainPaymentAmounts = {
     btcPaymentAmount: receiveAmount.btc,
     usdPaymentAmount: receiveAmount.usd,
     btcProtocolFee: ZERO_SATS,
     usdProtocolFee: ZERO_CENTS,
-  } as OnChainPaymentFlowState<WalletCurrency, WalletCurrency>
+  }
 
   describe("intraledger", () => {
     it("onchain", () => {
@@ -46,7 +46,7 @@ describe("Tx metadata", () => {
         OnChainIntraledgerLedgerMetadata({
           payeeAddresses,
           sendAll: true,
-          paymentFlow: onChainPaymentFlow,
+          paymentAmounts: onChainPaymentAmounts,
 
           amountDisplayCurrency,
           feeDisplayCurrency,
@@ -76,7 +76,7 @@ describe("Tx metadata", () => {
         OnChainTradeIntraAccountLedgerMetadata({
           payeeAddresses,
           sendAll: true,
-          paymentFlow: onChainPaymentFlow,
+          paymentAmounts: onChainPaymentAmounts,
 
           amountDisplayCurrency,
           feeDisplayCurrency,
@@ -102,7 +102,7 @@ describe("Tx metadata", () => {
       const { metadata, debitAccountAdditionalMetadata } = LnIntraledgerLedgerMetadata({
         paymentHash,
         pubkey,
-        paymentFlow,
+        paymentAmounts,
 
         amountDisplayCurrency,
         feeDisplayCurrency,
@@ -144,7 +144,7 @@ describe("Tx metadata", () => {
         LnTradeIntraAccountLedgerMetadata({
           paymentHash,
           pubkey,
-          paymentFlow,
+          paymentAmounts,
 
           amountDisplayCurrency,
           feeDisplayCurrency,
@@ -180,7 +180,7 @@ describe("Tx metadata", () => {
     it("wallet id", () => {
       const { metadata, debitAccountAdditionalMetadata } =
         WalletIdIntraledgerLedgerMetadata({
-          paymentFlow,
+          paymentAmounts,
 
           feeDisplayCurrency,
           amountDisplayCurrency,
@@ -218,7 +218,7 @@ describe("Tx metadata", () => {
 
     it("wallet id trade", () => {
       const metadata = WalletIdTradeIntraAccountLedgerMetadata({
-        paymentFlow,
+        paymentAmounts,
 
         feeDisplayCurrency,
         amountDisplayCurrency,


### PR DESCRIPTION
## Description

This PR adds the `satsAmount` set of properties to the transaction types that currently don't have it, and it adds tests for metadata on all non-admin transaction types.

The intention is to eventually rely on these and to remove the `fee`, `feeUsd` and `usd` properties from transactions.