### PR TITLE
refactor: unify twilio err msgs and add new one

### DIFF
--- a/src/services/twilio.ts
+++ b/src/services/twilio.ts
@@ -134,6 +134,7 @@ const handleCommonErrors = (err: Error | string) => {
       return new PhoneProviderConnectionError(errMsg)
 
     case match(KnownTwilioErrorMessages.RateLimitsExceeded):
+    case match(KnownTwilioErrorMessages.TooManyConcurrentRequests):
       return new PhoneProviderRateLimitExceededError(errMsg)
 
     case match(KnownTwilioErrorMessages.FraudulentActivityBlock):
@@ -153,6 +154,7 @@ export const KnownTwilioErrorMessages: { [key: string]: RegExp } = {
   BlockedRegion:
     /The destination phone number has been blocked by Verify Geo-Permissions. .* is blocked for sms channel for all services/,
   RateLimitsExceeded: /Max.*attempts reached/,
+  TooManyConcurrentRequests: /Too many concurrent requests/,
   FraudulentActivityBlock:
     /The destination phone number has been temporarily blocked by Twilio due to fraudulent activities/,
 } as const

--- a/src/services/twilio.ts
+++ b/src/services/twilio.ts
@@ -35,32 +35,7 @@ export const TwilioClient = (): IPhoneProviderService => {
       await verify.verifications.create({ to, channel })
     } catch (err) {
       baseLogger.error({ err }, "impossible to send text")
-      const match = (knownErrDetail: RegExp): boolean => knownErrDetail.test(err.message)
-
-      switch (true) {
-        case match(KnownTwilioErrorMessages.InvalidPhoneNumber):
-        case match(KnownTwilioErrorMessages.InvalidMobileNumber):
-          return new InvalidPhoneNumberPhoneProviderError(err.message || err)
-
-        case match(KnownTwilioErrorMessages.RestrictedRegion):
-        case match(KnownTwilioErrorMessages.BlockedRegion):
-          return new RestrictedRegionPhoneProviderError(err.message || err)
-
-        case match(KnownTwilioErrorMessages.UnsubscribedRecipient):
-          return new UnsubscribedRecipientPhoneProviderError(err.message || err)
-
-        case match(KnownTwilioErrorMessages.BadPhoneProviderConnection):
-          return new PhoneProviderConnectionError(err.message || err)
-
-        case match(KnownTwilioErrorMessages.RateLimitsExceeded):
-          return new PhoneProviderRateLimitExceededError(err.message || err)
-
-        case match(KnownTwilioErrorMessages.FraudulentActivityBlock):
-          return new RestrictedRecipientPhoneNumberError(err.message || err)
-
-        default:
-          return new UnknownPhoneProviderServiceError(err.message || err)
-      }
+      return handleCommonErrors(err)
     }
 
     return true
@@ -79,23 +54,13 @@ export const TwilioClient = (): IPhoneProviderService => {
       verification = await verify.verificationChecks.create({ to, code })
     } catch (err) {
       baseLogger.error({ err }, "impossible to verify phone and code")
-      const match = (knownErrDetail: RegExp): boolean => knownErrDetail.test(err.message)
 
       switch (true) {
-        case match(KnownTwilioErrorMessages.InvalidPhoneNumberParameter):
-          return new InvalidPhoneNumberPhoneProviderError(err.message || err)
-
-        case match(KnownTwilioErrorMessages.BadPhoneProviderConnection):
-          return new PhoneProviderConnectionError(err.message || err)
-
-        case match(KnownTwilioErrorMessages.RateLimitsExceeded):
-          return new PhoneProviderRateLimitExceededError(err.message || err)
-
         case err.status === 404:
           return new ExpiredOrNonExistentPhoneNumberError(err.message || err)
 
         default:
-          return new UnknownPhoneProviderServiceError(err.message || err)
+          return handleCommonErrors(err)
       }
     }
 
@@ -147,6 +112,37 @@ export const TwilioClient = (): IPhoneProviderService => {
   })
 }
 
+const handleCommonErrors = (err: Error | string) => {
+  const errMsg = typeof err === "string" ? err : err.message
+
+  const match = (knownErrDetail: RegExp): boolean => knownErrDetail.test(errMsg)
+
+  switch (true) {
+    case match(KnownTwilioErrorMessages.InvalidPhoneNumber):
+    case match(KnownTwilioErrorMessages.InvalidMobileNumber):
+    case match(KnownTwilioErrorMessages.InvalidPhoneNumberParameter):
+      return new InvalidPhoneNumberPhoneProviderError(errMsg)
+
+    case match(KnownTwilioErrorMessages.RestrictedRegion):
+    case match(KnownTwilioErrorMessages.BlockedRegion):
+      return new RestrictedRegionPhoneProviderError(errMsg)
+
+    case match(KnownTwilioErrorMessages.UnsubscribedRecipient):
+      return new UnsubscribedRecipientPhoneProviderError(errMsg)
+
+    case match(KnownTwilioErrorMessages.BadPhoneProviderConnection):
+      return new PhoneProviderConnectionError(errMsg)
+
+    case match(KnownTwilioErrorMessages.RateLimitsExceeded):
+      return new PhoneProviderRateLimitExceededError(errMsg)
+
+    case match(KnownTwilioErrorMessages.FraudulentActivityBlock):
+      return new RestrictedRecipientPhoneNumberError(errMsg)
+
+    default:
+      return new UnknownPhoneProviderServiceError(errMsg)
+  }
+}
 export const KnownTwilioErrorMessages: { [key: string]: RegExp } = {
   InvalidPhoneNumber: /not a valid phone number/,
   InvalidMobileNumber: /not a mobile number/,


### PR DESCRIPTION
## Description

Unifies error handling across Twilio methods since we've observed common errors popping up in both.

---

**Details on new TooManyConcurrentRequests error**

"Possible causes: Your application is initiating many verifications in a short period of time for the same phone number." https://www.twilio.com/docs/api/errors/60212