### PR TITLE
chore: migrate receipts-related sats amounts properties

### DIFF
--- a/src/migrations/20230116132109-add-sats-amounts-onchain-payments.ts
+++ b/src/migrations/20230116132109-add-sats-amounts-onchain-payments.ts
@@ -1,7 +1,7 @@
-const txTypes = ["onchain_payment"]
-
 module.exports = {
   async up(db) {
+    const txTypes = ["onchain_payment"]
+
     const collection = db.collection("medici_transactions")
 
     try {
@@ -66,6 +66,8 @@ module.exports = {
   },
 
   async down(db) {
+    const txTypes = ["onchain_payment"]
+
     try {
       const result = await db.collection("medici_transactions").update(
         { type: { $in: txTypes }, satsAmountMigration: true },

--- a/src/migrations/20230116162612-add-sats-amounts-to-receipts.ts
+++ b/src/migrations/20230116162612-add-sats-amounts-to-receipts.ts
@@ -1,0 +1,91 @@
+const txTypes = ["onchain_payment"]
+
+module.exports = {
+  async up(db) {
+    const collection = db.collection("medici_transactions")
+
+    try {
+      const allTxns = await collection.aggregate([
+        {
+          $match: {
+            type: { $in: txTypes },
+            satsAmount: { $exists: false },
+            currency: "BTC",
+          },
+        },
+        {
+          $group: {
+            _id: "$hash",
+            // For payments, 'currency: "BTC"' filter applies above:
+            // - for USD: max sat debit comes from dealer BTC wallet
+            // - for BTC: max sat debit comes from sender BTC wallet
+            debit: { $max: "$debit" },
+            fee: { $first: "$fee" },
+            usd: { $first: "$usd" },
+            feeUsd: { $first: "$feeUsd" },
+          },
+        },
+      ])
+      for await (const { _id: hash, debit, fee, usd, feeUsd } of allTxns) {
+        if (!hash) continue
+        const satsAmount = Math.round(debit - fee)
+        const centsAmount = Math.round((usd - feeUsd) * 100)
+        const centsFee = Math.round(feeUsd * 100)
+
+        const resultRest = await collection.update(
+          { hash },
+          [
+            {
+              $set: {
+                satsAmount,
+                satsFee: fee,
+                centsAmount,
+                centsFee,
+                displayAmount: centsAmount,
+                displayFee: centsFee,
+                displayCurrency: "USD",
+                satsAmountMigration: true,
+              },
+            },
+          ],
+          {
+            multi: true,
+          },
+        )
+        const { matchedCount: n, modifiedCount: nModified } = resultRest
+        console.log(
+          `added new props to ${nModified} of ${n}  transactions for hash: ${hash}`,
+        )
+      }
+    } catch (error) {
+      console.log(
+        { result: error },
+        "Couldn't add new props to rest of medici_transactions",
+      )
+    }
+  },
+
+  async down(db) {
+    try {
+      const result = await db.collection("medici_transactions").update(
+        { type: { $in: txTypes }, satsAmountMigration: true },
+        {
+          $unset: {
+            satsAmount: "",
+            satsFee: "",
+            centsAmount: "",
+            centsFee: "",
+            displayAmount: "",
+            displayFee: "",
+            displayCurrency: "",
+            satsAmountMigration: "",
+          },
+        },
+        { multi: true },
+      )
+      console.log({ result }, "removed new props from medici_transactions")
+    } catch (error) {
+      console.log({ result: error }, "Couldn't remove new props from medici_transactions")
+    }
+  },
+}

--- a/src/migrations/20230116162612-add-sats-amounts-to-receipts.ts
+++ b/src/migrations/20230116162612-add-sats-amounts-to-receipts.ts
@@ -1,7 +1,7 @@
-const txTypes = ["invoice", "onchain_receipt"]
-
 module.exports = {
   async up(db) {
+    const txTypes = ["invoice", "onchain_receipt"]
+
     const collection = db.collection("medici_transactions")
 
     try {
@@ -64,6 +64,8 @@ module.exports = {
   },
 
   async down(db) {
+    const txTypes = ["invoice", "onchain_receipt"]
+
     try {
       const result = await db.collection("medici_transactions").update(
         { type: { $in: txTypes }, satsAmountMigration: true },


### PR DESCRIPTION
## Description

This PR migrates the satsAmounts-related properties to older `invoice` and `onchain_receipt` type transactions that don't have these as yet. The migration follows the same logic as the one in #2182.


## Notes on transactions changes

There are currently 3 states of transactions in the system for onchain receipts (receipts with fees):
1. No `satsAmount` props, wrong `usd` prop

2. Correct `satsAmount` props, wrong `usd` value
   (introduced #2148)

3. Correct `satsAmount` props, correct `usd` value
  (introduced #2157)

The two new states were introduced with recent changes, where new `satsAmount` properties were added and general logic across transactions was cleaned up. The following is an account of where we started from and how we moved through the 2 transitions.

- Before the `satsAmount` changes, we would record the full amount received ([`sats`](https://github.com/GaloyMoney/galoy/blob/495314de78135748d58d4a6b08e989fc6859b65f/src/app/wallets/update-on-chain-receipt.ts#L136) full amount received in lnd, converted to [`amountDisplayCurrency`](https://github.com/GaloyMoney/galoy/blob/495314de78135748d58d4a6b08e989fc6859b65f/src/app/wallets/update-on-chain-receipt.ts#L144), passed through [here](https://github.com/GaloyMoney/galoy/blob/495314de78135748d58d4a6b08e989fc6859b65f/src/app/wallets/update-on-chain-receipt.ts#L153), and eventually written to [`usd`](https://github.com/GaloyMoney/galoy/blob/495314de78135748d58d4a6b08e989fc6859b65f/src/services/ledger/receive.ts#L36))

- This was continued in the #2148 refactor where [`amountDisplayCurrency`](https://github.com/GaloyMoney/galoy/blob/353e643bb61deae8ba0a4941190d12394a00b08f/src/app/wallets/update-on-chain-receipt.ts#L178) is set as the amount after fees where fees are deducted in [`WalletAddressReceiver`](https://github.com/GaloyMoney/galoy/blob/353e643bb61deae8ba0a4941190d12394a00b08f/src/domain/wallet-on-chain-addresses/wallet-address-receiver.ts#L32). `amountDisplayCurrency` is [passed to metadata](amountDisplayCurrency) where it then [gets added to fees and written to `usd`](https://github.com/GaloyMoney/galoy/blob/353e643bb61deae8ba0a4941190d12394a00b08f/src/services/ledger/tx-metadata.ts#L133)

- This was then changed/fixed [here](https://github.com/GaloyMoney/galoy/pull/2157/commits/5c23bef8c91699a6f78b1dc6e40a5dfecc685706) so that `usd` is the final amount after fees received by recipient since this is [what is matched](https://github.com/GaloyMoney/galoy/blob/be8f505814ce56ba69ed3f838eb124aadfe8f5ec/src/domain/wallets/tx-history.ts#L87) against the final received sats amount in the API

### Scope

This PR is to **only** correct the "1." set of transaction by adding all missing `satsAmount` props. The wrong `usd` values will be left as-is for transaction sets "1." and "2." since:
- it is difficult to differentiate between "2." and "3." for a migration
- we will be deprecating the `usd` property and relying solely on `satsAmount` properties for returning price to the API once this migration is complete

After this migration we will only have states "2." and "3." where state "1." would have been converted to state "3.", and where both "2." and "3." will have the correct values for `satsAmount` related properties.