### PR TITLE
fix: kratos extend session cron

### DIFF
--- a/src/app/auth/index.ts
+++ b/src/app/auth/index.ts
@@ -7,11 +7,20 @@ import { extendSession, IdentityRepository } from "@services/kratos"
 
 // TODO: interface/type should be reworked so that it doesn't have to come from private
 import { listSessionsInternal } from "@services/kratos/private"
-import { recordExceptionInCurrentSpan } from "@services/tracing"
+import {
+  recordExceptionInCurrentSpan,
+  addAttributesToCurrentSpan,
+} from "@services/tracing"
 
 export const extendSessions = async (): Promise<void | KratosError> => {
   const users = await IdentityRepository().listIdentities()
   if (users instanceof Error) return users
+
+  const countOfTotalUsers = users.length
+  let countOfTotalSessions = 0
+  let countOfExtendedSessions = 0
+  let countOfExtendedSessionErrors = 0
+  let countOfInactiveSessions = 0
 
   for (const user of users) {
     const sessions = await listSessionsInternal(user.id)
@@ -25,14 +34,27 @@ export const extendSessions = async (): Promise<void | KratosError> => {
     }
 
     for (const session of sessions) {
-      const res = await extendSession({ session })
-      if (res instanceof Error) {
+      countOfTotalSessions++
+      const hasExtended = await extendSession({ session })
+      if (hasExtended instanceof Error) {
+        countOfExtendedSessionErrors++
         recordExceptionInCurrentSpan({
           error: "impossible to extend session",
           level: ErrorLevel.Info,
           attributes: { user: user.id, phone: user.phone },
         })
       }
+      hasExtended ? countOfExtendedSessions++ : countOfInactiveSessions++
     }
   }
+  addAttributesToCurrentSpan({
+    countOfTotalUsers: countOfTotalUsers === 0 ? "none" : countOfTotalUsers, // *0 does not log in honeycomb properly sometimes, so set to none
+    countOfTotalSessions: countOfTotalSessions === 0 ? "none" : countOfTotalSessions,
+    countOfExtendedSessions:
+      countOfExtendedSessions === 0 ? "none" : countOfExtendedSessions,
+    countOfExtendedSessionErrors:
+      countOfExtendedSessionErrors === 0 ? "none" : countOfExtendedSessionErrors,
+    countOfInactiveSessions:
+      countOfInactiveSessions === 0 ? "none" : countOfInactiveSessions,
+  })
 }

--- a/src/services/kratos/cron.ts
+++ b/src/services/kratos/cron.ts
@@ -12,11 +12,14 @@ export const extendSession = async ({
   session,
 }: {
   session: KratosSession
-}): Promise<void | KratosError> => {
+}): Promise<boolean | KratosError> => {
   try {
-    if (!schemaIdsToExtend.includes(session.identity.schema_id)) return
+    if (!schemaIdsToExtend.includes(session.identity.schema_id)) return false
 
-    await kratosAdmin.extendSession({ id: session.id })
+    const res = await kratosAdmin.extendSession({
+      id: session.id,
+    })
+    return res.data?.active ? true : false
   } catch (err) {
     return new UnknownKratosError(err.message || err)
   }

--- a/src/services/kratos/identity.ts
+++ b/src/services/kratos/identity.ts
@@ -63,6 +63,18 @@ export const IdentityRepository = (): IIdentityRepository => {
         hasNext = page !== undefined && totalCount !== 0
       }
 
+      // * fixes bug in kratos res.headers.link not returning last page properly
+      const pageCount = totalCount / perPage
+      const isPageCountWholeNumber = pageCount % 1 // 0 means its a whole number, therefore, we can skip because no partial last page of data exists
+      if (isPageCountWholeNumber !== 0) {
+        const lastPageNum = Math.ceil(totalCount / perPage)
+        const lastPageRes = await kratosAdmin.listIdentities({
+          perPage,
+          page: lastPageNum,
+        })
+        identities.push(...lastPageRes.data)
+      }
+
       // FIXME(nb) function above return duplicated query for the first 2 calls, so removing them here
       const uniqueIdentities = identities.filter(
         (value, index, self) => index === self.findIndex((t) => t.id === value.id),


### PR DESCRIPTION
This PR fixes a bug in kratos `listIdentities` pagination function. The  `response.headers.link` does not return the last page properly. 