### PR TITLE
refactor: demote dealer mid-price error to 'warn'

### DIFF
--- a/src/app/shared/mid-price.ts
+++ b/src/app/shared/mid-price.ts
@@ -104,7 +104,7 @@ export const getMidPriceRatio = async (
     if (priceRatio instanceof Error) {
       recordExceptionInCurrentSpan({
         error: priceRatio,
-        level: ErrorLevel.Critical,
+        level: ErrorLevel.Warn,
       })
       return getCurrentPriceInCentsPerSat()
     }


### PR DESCRIPTION
## Description

This was originally added because at the time we would've eventually liked to switch to using the dealer exclusively. With the 'critical' level though, this error triggers our alerting system even though there is no action to be taken.

The error has been demoted to 'warn' so that when we are ready we can monitor passively how often it has been triggered to decide if/how to remove the fallback price service.