### PR TITLE
fix: update fee calc rounding in tests

### DIFF
--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -1194,9 +1194,9 @@ describe("UserWallet - Lightning Pay", () => {
         if (baseMilliSats === undefined || feeRatePpm === undefined) {
           throw new Error("Undefined baseMilliSats or feeRatePpm")
         }
-        const baseFee = parseInt(baseMilliSats, 10) / 1000
-        const feeRate = (amountInvoice * feeRatePpm) / 1_000_000
-        const fee = Math.ceil(baseFee + feeRate)
+        const baseFee = BigInt(baseMilliSats) / BigInt(1000)
+        const feeRate = (BigInt(amountInvoice) * BigInt(feeRatePpm)) / BigInt(1_000_000)
+        const fee = Number(baseFee + feeRate)
 
         expect(finalBalance).toBe(initialBalance - amountInvoice - fee)
       })


### PR DESCRIPTION
attempt to fix 1 sat (rounding) issue in tests using same strategy used in lightning library for safe tokens https://github.com/alexbosworth/lightning/blob/master/bolt00/safe_tokens.js

purpose: reduce dev, github actions and CI errors produced by millisat fee rounding issue