### PR TITLE
feat: add intraledger credit metadata

### DIFF
--- a/src/app/payments/send-intraledger.ts
+++ b/src/app/payments/send-intraledger.ts
@@ -306,6 +306,7 @@ const executePaymentViaIntraledger = async <
       recipientWalletDescriptor,
       metadata,
       additionalDebitMetadata,
+      additionalCreditMetadata: {},
     })
     if (journal instanceof Error) return journal
 

--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -432,6 +432,7 @@ const executePaymentViaIntraledger = async <
       recipientWalletDescriptor,
       metadata,
       additionalDebitMetadata,
+      additionalCreditMetadata: {},
     })
     if (journal instanceof Error) return journal
 

--- a/src/app/wallets/send-on-chain.ts
+++ b/src/app/wallets/send-on-chain.ts
@@ -322,6 +322,7 @@ const executePaymentViaIntraledger = async <
       recipientWalletDescriptor,
       metadata,
       additionalDebitMetadata,
+      additionalCreditMetadata: {},
     })
     if (journal instanceof Error) return journal
 

--- a/src/services/ledger/domain/entry-builder.ts
+++ b/src/services/ledger/domain/entry-builder.ts
@@ -135,12 +135,22 @@ const EntryBuilderCredit = <M extends MediciEntry>({
   debitCurrency,
   staticAccountIds,
 }: EntryBuilderCreditState<M>): EntryBuilderCredit<M> => {
-  const creditLnd = () => creditAccount(lndLedgerAccountDescriptor)
-  const creditColdStorage = () => creditAccount(coldStorageAccountDescriptor)
+  const creditLnd = () =>
+    creditAccount({
+      accountDescriptor: lndLedgerAccountDescriptor,
+    })
+  const creditColdStorage = () =>
+    creditAccount({
+      accountDescriptor: coldStorageAccountDescriptor,
+    })
 
-  const creditAccount = <T extends WalletCurrency>(
-    accountDescriptor: LedgerAccountDescriptor<T>,
-  ) => {
+  const creditAccount = <T extends WalletCurrency>({
+    accountDescriptor,
+    additionalMetadata,
+  }: {
+    accountDescriptor: LedgerAccountDescriptor<T>
+    additionalMetadata?: TxMetadata
+  }) => {
     let entryToReturn = entry
     const usdWithOutFee = calc.sub(usdWithFees, usdBankFee)
     const btcWithOutFee = calc.sub(btcWithFees, btcBankFee)
@@ -188,8 +198,12 @@ const EntryBuilderCredit = <M extends MediciEntry>({
     const creditAmount =
       accountDescriptor.currency === WalletCurrency.Usd ? usdWithOutFee : btcWithOutFee
 
+    const creditMetadata = additionalMetadata
+      ? { ...metadata, ...additionalMetadata }
+      : metadata
+
     entryToReturn.credit(accountDescriptor.id, Number(creditAmount.amount), {
-      ...metadata,
+      ...creditMetadata,
       currency: creditAmount.currency,
     })
 

--- a/src/services/ledger/domain/index.types.d.ts
+++ b/src/services/ledger/domain/index.types.d.ts
@@ -90,9 +90,13 @@ type EntryBuilderCreditState<M extends MediciEntry> = {
 type EntryBuilderCredit<M extends MediciEntry> = {
   creditLnd: () => M
   creditColdStorage: () => M
-  creditAccount: <C extends WalletCurrency>(
-    accountDescriptor: LedgerAccountDescriptor<C>,
-  ) => M
+  creditAccount: <C extends WalletCurrency>({
+    accountDescriptor,
+    additionalMetadata,
+  }: {
+    accountDescriptor: LedgerAccountDescriptor<C>
+    additionalMetadata?: TxMetadata
+  }) => M
 }
 
 type BaseLedgerTransactionMetadata = {

--- a/src/services/ledger/facade.ts
+++ b/src/services/ledger/facade.ts
@@ -86,7 +86,9 @@ export const recordReceive = async ({
     .withTotalAmount(amountWithFees)
     .withBankFee({ usdBankFee: actualFee.usd, btcBankFee: actualFee.btc })
     .debitLnd()
-    .creditAccount(toLedgerAccountDescriptor(recipientWalletDescriptor))
+    .creditAccount({
+      accountDescriptor: toLedgerAccountDescriptor(recipientWalletDescriptor),
+    })
 
   return persistAndReturnEntry({ entry, ...txMetadata })
 }
@@ -111,7 +113,8 @@ export const recordIntraledger = async ({
   recipientWalletDescriptor,
   amount,
   metadata,
-  additionalDebitMetadata: additionalMetadata,
+  additionalDebitMetadata,
+  additionalCreditMetadata,
 }: RecordIntraledgerArgs) => {
   let entry = MainBook.entry(description)
   const builder = EntryBuilder({
@@ -125,9 +128,12 @@ export const recordIntraledger = async ({
     .withBankFee(ZERO_BANK_FEE)
     .debitAccount({
       accountDescriptor: toLedgerAccountDescriptor(senderWalletDescriptor),
-      additionalMetadata,
+      additionalMetadata: additionalDebitMetadata,
     })
-    .creditAccount(toLedgerAccountDescriptor(recipientWalletDescriptor))
+    .creditAccount({
+      accountDescriptor: toLedgerAccountDescriptor(recipientWalletDescriptor),
+      additionalMetadata: additionalCreditMetadata,
+    })
 
   return persistAndReturnEntry({
     entry,

--- a/src/services/ledger/index.types.d.ts
+++ b/src/services/ledger/index.types.d.ts
@@ -40,6 +40,7 @@ type RecordIntraledgerArgs = {
   }
   metadata: IntraledgerLedgerMetadata
   additionalDebitMetadata: TxMetadata
+  additionalCreditMetadata: TxMetadata
 }
 
 type LedgerMetadata = {

--- a/test/integration/services/ledger/helpers.ts
+++ b/test/integration/services/ledger/helpers.ts
@@ -201,6 +201,7 @@ export const recordLnIntraLedgerPayment = async ({
     recipientWalletDescriptor,
     metadata,
     additionalDebitMetadata: debitAccountAdditionalMetadata,
+    additionalCreditMetadata: {},
   })
 }
 
@@ -231,6 +232,7 @@ export const recordWalletIdIntraLedgerPayment = async ({
     recipientWalletDescriptor,
     metadata,
     additionalDebitMetadata: debitAccountAdditionalMetadata,
+    additionalCreditMetadata: {},
   })
 }
 
@@ -263,6 +265,7 @@ export const recordOnChainIntraLedgerPayment = async ({
     recipientWalletDescriptor,
     metadata,
     additionalDebitMetadata: debitAccountAdditionalMetadata,
+    additionalCreditMetadata: {},
   })
 }
 
@@ -295,6 +298,7 @@ export const recordLnTradeIntraAccountTxn = async ({
     recipientWalletDescriptor,
     metadata,
     additionalDebitMetadata: debitAccountAdditionalMetadata,
+    additionalCreditMetadata: {},
   })
 }
 
@@ -322,6 +326,7 @@ export const recordWalletIdTradeIntraAccountTxn = async ({
     recipientWalletDescriptor,
     metadata,
     additionalDebitMetadata: {},
+    additionalCreditMetadata: {},
   })
 }
 
@@ -354,6 +359,7 @@ export const recordOnChainTradeIntraAccountTxn = async ({
     recipientWalletDescriptor,
     metadata,
     additionalDebitMetadata: debitAccountAdditionalMetadata,
+    additionalCreditMetadata: {},
   })
 }
 

--- a/test/unit/services/ledger/domain/entry-builder.spec.ts
+++ b/test/unit/services/ledger/domain/entry-builder.spec.ts
@@ -176,7 +176,9 @@ describe("EntryBuilder", () => {
           .withTotalAmount(amount)
           .withBankFee(ZERO_BANK_FEE)
           .debitLnd()
-          .creditAccount(btcCreditorAccountDescriptor)
+          .creditAccount({
+            accountDescriptor: btcCreditorAccountDescriptor,
+          })
 
         const credits = result.transactions.filter((t) => t.credit > 0)
         const debits = result.transactions.filter((t) => t.debit > 0)
@@ -197,7 +199,9 @@ describe("EntryBuilder", () => {
           .withTotalAmount(amount)
           .withBankFee(bankFee)
           .debitLnd()
-          .creditAccount(btcCreditorAccountDescriptor)
+          .creditAccount({
+            accountDescriptor: btcCreditorAccountDescriptor,
+          })
 
         const credits = result.transactions.filter((t) => t.credit > 0)
         const debits = result.transactions.filter((t) => t.debit > 0)
@@ -312,7 +316,9 @@ describe("EntryBuilder", () => {
             .withTotalAmount(amount)
             .withBankFee(ZERO_BANK_FEE)
             .debitLnd()
-            .creditAccount(usdCreditorAccountDescriptor)
+            .creditAccount({
+              accountDescriptor: usdCreditorAccountDescriptor,
+            })
 
           const credits = result.transactions.filter((t) => t.credit > 0)
           const debits = result.transactions.filter((t) => t.debit > 0)
@@ -363,7 +369,9 @@ describe("EntryBuilder", () => {
             .withTotalAmount(amount)
             .withBankFee(ZERO_BANK_FEE)
             .debitLnd()
-            .creditAccount(usdCreditorAccountDescriptor)
+            .creditAccount({
+              accountDescriptor: usdCreditorAccountDescriptor,
+            })
 
           const credits = result.transactions.filter((t) => t.credit > 0)
           const debits = result.transactions.filter((t) => t.debit > 0)
@@ -397,7 +405,9 @@ describe("EntryBuilder", () => {
           .withTotalAmount(amount)
           .withBankFee(bankFee)
           .debitLnd()
-          .creditAccount(usdCreditorAccountDescriptor)
+          .creditAccount({
+            accountDescriptor: usdCreditorAccountDescriptor,
+          })
 
         const credits = result.transactions.filter((t) => t.credit > 0)
         const debits = result.transactions.filter((t) => t.debit > 0)
@@ -441,7 +451,9 @@ describe("EntryBuilder", () => {
           .debitAccount({
             accountDescriptor: btcDebitorAccountDescriptor,
           })
-          .creditAccount(btcCreditorAccountDescriptor)
+          .creditAccount({
+            accountDescriptor: btcCreditorAccountDescriptor,
+          })
 
         const credits = result.transactions.filter((t) => t.credit > 0)
         const debits = result.transactions.filter((t) => t.debit > 0)
@@ -462,7 +474,9 @@ describe("EntryBuilder", () => {
           .debitAccount({
             accountDescriptor: btcDebitorAccountDescriptor,
           })
-          .creditAccount(usdCreditorAccountDescriptor)
+          .creditAccount({
+            accountDescriptor: usdCreditorAccountDescriptor,
+          })
 
         const credits = result.transactions.filter((t) => t.credit > 0)
         const debits = result.transactions.filter((t) => t.debit > 0)
@@ -500,7 +514,9 @@ describe("EntryBuilder", () => {
           .debitAccount({
             accountDescriptor: usdDebitorAccountDescriptor,
           })
-          .creditAccount(btcCreditorAccountDescriptor)
+          .creditAccount({
+            accountDescriptor: btcCreditorAccountDescriptor,
+          })
 
         const credits = result.transactions.filter((t) => t.credit > 0)
         const debits = result.transactions.filter((t) => t.debit > 0)
@@ -537,7 +553,9 @@ describe("EntryBuilder", () => {
           .debitAccount({
             accountDescriptor: usdDebitorAccountDescriptor,
           })
-          .creditAccount(usdCreditorAccountDescriptor)
+          .creditAccount({
+            accountDescriptor: usdCreditorAccountDescriptor,
+          })
 
         const credits = result.transactions.filter((t) => t.credit > 0)
         const debits = result.transactions.filter((t) => t.debit > 0)


### PR DESCRIPTION
This is an split from https://github.com/GaloyMoney/galoy/pull/2190. Allow add additional metadata to receiving account in intra ledger txs (is needed because now the recipient can have a different display currency)