### PR TITLE
test: improve flakiness of setChannelFee call

### DIFF
--- a/test/helpers/lightning.ts
+++ b/test/helpers/lightning.ts
@@ -243,7 +243,7 @@ export const closeAllChannels = async ({ lnd }) => {
   }
 }
 
-export const setChannelFees = async ({ lnd, channel, base, rate }) => {
+export const setChannelFees = async ({ lnd, channel, base, rate }): Promise<boolean> => {
   const input = {
     fee_rate: rate,
     base_fee_mtokens: `${base * 1000}`,
@@ -262,9 +262,13 @@ export const setChannelFees = async ({ lnd, channel, base, rate }) => {
   })
 
   const sub = subscribeToGraph({ lnd })
-  await Promise.all([updateRoutingFeesPromise, once(sub, "channel_updated")])
+  const [updateFeesRes] = await Promise.all([
+    updateRoutingFeesPromise,
+    once(sub, "channel_updated"),
+  ])
 
   sub.removeAllListeners()
+  return updateFeesRes
 }
 
 export const mineBlockAndSync = async ({

--- a/test/helpers/lightning.ts
+++ b/test/helpers/lightning.ts
@@ -243,7 +243,7 @@ export const closeAllChannels = async ({ lnd }) => {
   }
 }
 
-export const setChannelFees = async ({ lnd, channel, base, rate }): Promise<boolean> => {
+export const setChannelFees = async ({ lnd, channel, base, rate }) => {
   const input = {
     fee_rate: rate,
     base_fee_mtokens: `${base * 1000}`,
@@ -253,11 +253,14 @@ export const setChannelFees = async ({ lnd, channel, base, rate }): Promise<bool
 
   const updateRoutingFeesPromise = waitFor(async () => {
     try {
-      await updateRoutingFees({ lnd, ...input })
+      const { failures } = await updateRoutingFees({ lnd, ...input })
+      if (failures && failures.length) {
+        return failures[0].failure
+      }
       return true
     } catch (error) {
       baseLogger.warn({ error }, "updateRoutingFees failed. trying again.")
-      return false
+      return error
     }
   })
 

--- a/test/integration/01-setup/01-lightning-channels.spec.ts
+++ b/test/integration/01-setup/01-lightning-channels.spec.ts
@@ -105,19 +105,30 @@ describe("Lightning channels", () => {
     expect(channels.some((e) => e.is_private)).toBe(true)
 
     // Set fee policy on lndOutside1 as routing node between lnd1 and lndOutside2
-    const setOnLndOutside1 = await setChannelFees({
-      lnd: lndOutside1,
-      channel,
-      base: 0,
-      rate: 5000,
-    })
+    let count = 0
+    let countMax = 3
+    let setOnLndOutside1
+    while (count < countMax && setOnLndOutside1 !== true) {
+      if (count > 0) await sleep(500)
+      count++
+
+      setOnLndOutside1 = await setChannelFees({
+        lnd: lndOutside1,
+        channel,
+        base: 0,
+        rate: 5000,
+      })
+    }
+    expect(count).toBeGreaterThan(0)
+    expect(count).toBeLessThan(countMax)
     expect(setOnLndOutside1).toBe(true)
 
     let policies
     let errMsg: string | undefined = "FullChannelDetailsNotFound"
-    let count = 0
+    count = 0
+    countMax = 8
     // Try to getChannel for up to 2 secs (250ms x 8)
-    while (count < 8 && errMsg === "FullChannelDetailsNotFound") {
+    while (count < countMax && errMsg === "FullChannelDetailsNotFound") {
       count++
       await sleep(250)
       try {
@@ -128,6 +139,7 @@ describe("Lightning channels", () => {
       }
     }
     expect(count).toBeGreaterThan(0)
+    expect(count).toBeLessThan(countMax)
     expect(errMsg).not.toBe("FullChannelDetailsNotFound")
     expect(policies && policies.length).toBeGreaterThan(0)
 

--- a/test/integration/01-setup/01-lightning-channels.spec.ts
+++ b/test/integration/01-setup/01-lightning-channels.spec.ts
@@ -1,9 +1,11 @@
 import { onChannelUpdated, updateEscrows } from "@services/lnd/utils"
 import { ledgerAdmin } from "@services/mongodb"
+import { sleep } from "@utils"
 
 import {
   checkIsBalanced,
   closeChannel,
+  getChannel,
   getChannels,
   lnd1,
   lnd2,
@@ -102,8 +104,37 @@ describe("Lightning channels", () => {
     expect(channels.length).toEqual(channelLengthOutside1 + 1)
     expect(channels.some((e) => e.is_private)).toBe(true)
 
-    await setChannelFees({ lnd: lndOutside1, channel, base: 0, rate: 5000 })
-    await setChannelFees({ lnd: lndOutside2, channel, base: 0, rate: 5000 })
+    // Set fee policy on lndOutside1 as routing node between lnd1 and lndOutside2
+    const setOnLndOutside1 = await setChannelFees({
+      lnd: lndOutside1,
+      channel,
+      base: 0,
+      rate: 5000,
+    })
+    expect(setOnLndOutside1).toBe(true)
+
+    let policies
+    let errMsg: string | undefined = "FullChannelDetailsNotFound"
+    let count = 0
+    // Try to getChannel for up to 2 secs (250ms x 8)
+    while (count < 8 && errMsg === "FullChannelDetailsNotFound") {
+      count++
+      await sleep(250)
+      try {
+        ;({ policies } = await getChannel({ id: channel.id, lnd: lndOutside1 }))
+        errMsg = undefined
+      } catch (err) {
+        errMsg = err[1]
+      }
+    }
+    expect(count).toBeGreaterThan(0)
+    expect(errMsg).not.toBe("FullChannelDetailsNotFound")
+    expect(policies && policies.length).toBeGreaterThan(0)
+
+    const { base_fee_mtokens, fee_rate, public_key } = policies[0]
+    expect(public_key).toBe(process.env.LND_OUTSIDE_1_PUBKEY)
+    expect(base_fee_mtokens).toBe("0")
+    expect(fee_rate).toEqual(5000)
   })
 
   // FIXME: we need a way to calculate the closing fee

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -1190,35 +1190,11 @@ describe("UserWallet - Lightning Pay", () => {
         const { id } = channels[0]
         const { policies } = await getChannel({ id, lnd: lndOutside2 })
 
-        const ownPolicy = policies.find(
-          (pol) => pol.public_key === (process.env.LND_OUTSIDE_2_PUBKEY as Pubkey),
-        )
-        if (ownPolicy === undefined) throw new Error("Undefined 'ownPolicy'")
-
         const partnerPolicy = policies.find(
           (pol) => pol.public_key !== (process.env.LND_OUTSIDE_2_PUBKEY as Pubkey),
         )
         if (partnerPolicy === undefined) throw new Error("Undefined 'partnerPolicy'")
-
-        // FIXME: revert this console.log once we can observe policies from test breaking in CI again
-        console.log(
-          JSON.stringify(
-            {
-              ownPolicy,
-              lndOutside2Pubkey: process.env.LND_OUTSIDE_2_PUBKEY,
-              partnerPolicy,
-              lndOutside1Pubkey: process.env.LND_OUTSIDE_1_PUBKEY,
-            },
-            null,
-            2,
-          ),
-        )
-        expect(ownPolicy.base_fee_mtokens).not.toBe(partnerPolicy.base_fee_mtokens)
-        expect(ownPolicy.base_fee_mtokens).toBe("1000")
         expect(partnerPolicy.base_fee_mtokens).toBe("0")
-
-        expect(ownPolicy.fee_rate).not.toEqual(partnerPolicy.fee_rate)
-        expect(ownPolicy.fee_rate).toEqual(1)
         expect(partnerPolicy.fee_rate).toEqual(5000)
 
         const { base_fee_mtokens: baseMilliSats, fee_rate: feeRatePpm } = partnerPolicy


### PR DESCRIPTION
## Description

This PR moves our testing checks to higher up in the run where channel policies are actually being set. It also removes an unnecessary setChannelFee call.

This is an intermediate PR that could eventually lead to a PR that tightens up how we set fees on the channel we're targeting based on how flakily these new tests perform.