### PR TITLE
fix: handle missing edge case in phone update

### DIFF
--- a/src/app/admin/update-user-phone.ts
+++ b/src/app/admin/update-user-phone.ts
@@ -66,6 +66,16 @@ export const updateUserPhone = async ({
   }
 
   const usersRepo = UsersRepository()
+
+  const existingUser = await usersRepo.findByPhone(phone)
+  if (!(existingUser instanceof Error)) {
+    const existingUserKratosUserId = existingUser.id
+    const result = await usersRepo.adminUnsetPhoneForUserPreservation(
+      existingUserKratosUserId,
+    )
+    if (result instanceof Error) return result
+  }
+
   const user = await usersRepo.findById(kratosUserId)
   if (user instanceof Error) return user
 


### PR DESCRIPTION
This PR adds handling for an edge case where the phone provided as an arg to the update phone function is associated with a user object, but is absent from the kratos pg, which was making the previous check for user existence fail.