### PR TITLE
feat: admin api proxy thru oathkeeper in dev

### DIFF
--- a/dev/ory/oathkeeper_rules.yaml
+++ b/dev/ory/oathkeeper_rules.yaml
@@ -42,7 +42,7 @@
         claims: '{"sub": "{{ print .Subject }}"}'
 - id: admin-backend
   upstream:
-    url: "http://e2e-tests:4001"
+    url: "http://e2e-tests:4011"
     strip_path: /admin
   match:
     url: "<(http|https)>://<.*><[0-9]+>/admin<.*>"
@@ -50,7 +50,7 @@
   authenticators:
     - handler: bearer_token
       config:
-        check_session_url: "http://e2e-tests:4001/auth/validatetoken"
+        check_session_url: "http://e2e-tests:4011/auth/validatetoken"
         preserve_path: true
         preserve_query: true
         subject_from: sub

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -56,6 +56,7 @@ services:
       - "e2e-tests:host-gateway"
     ports:
       - "4002:4455"
+      - "4001:4455"
       - "4456:4456"
   kratos:
     extra_hosts:
@@ -66,7 +67,7 @@ services:
   e2e-tests:
     ports:
       - "4012:4012"
-      - "4001:4001"
+      - "4011:4011"
   mailslurper:
     ports:
       - "4436:4436"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "trigger": "yarn build && node lib/servers/trigger.js | pino-pretty -c -l",
     "watch": "nodemon -V -e ts,graphql -w ./src -x yarn run start",
     "watch-trigger": "nodemon -V -e ts,graphql -w ./src -x yarn trigger",
-    "kill-graphql": "kill $(lsof -t -i:4001) & kill $(lsof -t -i:4012) & kill $(lsof -t -i:4011)",
+    "kill-graphql": "kill $(lsof -t -i:4012) & kill $(lsof -t -i:4011)",
     "cron": ". ./.envrc && yarn build && node lib/servers/cron.js",
     "exporter": "yarn build && node lib/servers/exporter.js",
     "daily-notif": "yarn build && node lib/servers/daily-balance-notification.js",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "trigger": "yarn build && node lib/servers/trigger.js | pino-pretty -c -l",
     "watch": "nodemon -V -e ts,graphql -w ./src -x yarn run start",
     "watch-trigger": "nodemon -V -e ts,graphql -w ./src -x yarn trigger",
-    "kill-graphql": "kill $(lsof -t -i:4001) & kill $(lsof -t -i:4012)",
+    "kill-graphql": "kill $(lsof -t -i:4001) & kill $(lsof -t -i:4012) & kill $(lsof -t -i:4011)",
     "cron": ". ./.envrc && yarn build && node lib/servers/cron.js",
     "exporter": "yarn build && node lib/servers/exporter.js",
     "daily-notif": "yarn build && node lib/servers/daily-balance-notification.js",

--- a/src/config/process.ts
+++ b/src/config/process.ts
@@ -9,7 +9,7 @@ type TwilioConfig = {
 }
 
 export const GALOY_API_PORT = process.env.GALOY_API_PORT || 4012
-export const GALOY_ADMIN_PORT = process.env.GALOY_ADMIN_PORT || 4001
+export const GALOY_ADMIN_PORT = process.env.GALOY_ADMIN_PORT || 4011
 
 const jwtSecret = process.env.JWT_SECRET
 if (!jwtSecret) {


### PR DESCRIPTION
Hey @dolcalmi  i noticed the admin api in dev was not being proxied thru oathkeeper so it was getting a 401 when hitting http://localhost:4001/graphql. I followed what we did for the graphql api 4002=>4012 This should fix that 4001=>4011