### PR TITLE
refactor: rename limits to remove 'new' prefix

### DIFF
--- a/src/app/payments/get-protocol-fee.ts
+++ b/src/app/payments/get-protocol-fee.ts
@@ -19,9 +19,9 @@ import { PartialResult } from "../partial-result"
 
 import {
   constructPaymentFlowBuilder,
-  newCheckIntraledgerLimits,
-  newCheckTradeIntraAccountLimits,
-  newCheckWithdrawalLimits,
+  checkIntraledgerLimits,
+  checkTradeIntraAccountLimits,
+  checkWithdrawalLimits,
 } from "./helpers"
 
 const getLightningFeeEstimation = async ({
@@ -172,7 +172,7 @@ const estimateLightningFee = async ({
 
   let paymentFlow: PaymentFlow<WalletCurrency, WalletCurrency> | ApplicationError
   if (await builder.isTradeIntraAccount()) {
-    const limitCheck = await newCheckTradeIntraAccountLimits({
+    const limitCheck = await checkTradeIntraAccountLimits({
       amount: usdPaymentAmount,
       accountId: senderWallet.accountId,
       priceRatio,
@@ -181,7 +181,7 @@ const estimateLightningFee = async ({
 
     paymentFlow = await builder.withoutRoute()
   } else if (await builder.isIntraLedger()) {
-    const limitCheck = await newCheckIntraledgerLimits({
+    const limitCheck = await checkIntraledgerLimits({
       amount: usdPaymentAmount,
       accountId: senderWallet.accountId,
       priceRatio,
@@ -190,7 +190,7 @@ const estimateLightningFee = async ({
 
     paymentFlow = await builder.withoutRoute()
   } else {
-    const limitCheck = await newCheckWithdrawalLimits({
+    const limitCheck = await checkWithdrawalLimits({
       amount: usdPaymentAmount,
       accountId: senderWallet.accountId,
       priceRatio,

--- a/src/app/payments/helpers.ts
+++ b/src/app/payments/helpers.ts
@@ -189,7 +189,7 @@ const volumesAndLimitsForAccountId = async ({
   }
 }
 
-export const newCheckIntraledgerLimits = async ({
+export const checkIntraledgerLimits = async ({
   amount,
   accountId,
   priceRatio,
@@ -214,7 +214,7 @@ export const newCheckIntraledgerLimits = async ({
   })
 }
 
-export const newCheckTradeIntraAccountLimits = async ({
+export const checkTradeIntraAccountLimits = async ({
   amount,
   accountId,
   priceRatio,
@@ -239,7 +239,7 @@ export const newCheckTradeIntraAccountLimits = async ({
   })
 }
 
-export const newCheckWithdrawalLimits = async ({
+export const checkWithdrawalLimits = async ({
   amount,
   accountId,
   priceRatio,

--- a/src/app/payments/send-intraledger.ts
+++ b/src/app/payments/send-intraledger.ts
@@ -36,8 +36,8 @@ import { validateIsBtcWallet, validateIsUsdWallet } from "@app/wallets"
 
 import {
   getPriceRatioForLimits,
-  newCheckIntraledgerLimits,
-  newCheckTradeIntraAccountLimits,
+  checkIntraledgerLimits,
+  checkTradeIntraAccountLimits,
 } from "./helpers"
 
 const dealer = DealerPriceService()
@@ -226,8 +226,8 @@ const executePaymentViaIntraledger = async <
 
   const checkLimits =
     senderWallet.accountId === recipientWallet.accountId
-      ? newCheckTradeIntraAccountLimits
-      : newCheckIntraledgerLimits
+      ? checkTradeIntraAccountLimits
+      : checkIntraledgerLimits
   const limitCheck = await checkLimits({
     amount: paymentFlow.usdPaymentAmount,
     accountId: senderWallet.accountId,

--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -49,9 +49,9 @@ import { ResourceExpiredLockServiceError } from "@domain/lock"
 import {
   constructPaymentFlowBuilder,
   getPriceRatioForLimits,
-  newCheckIntraledgerLimits,
-  newCheckTradeIntraAccountLimits,
-  newCheckWithdrawalLimits,
+  checkIntraledgerLimits,
+  checkTradeIntraAccountLimits,
+  checkWithdrawalLimits,
 } from "./helpers"
 
 const dealer = DealerPriceService()
@@ -353,8 +353,8 @@ const executePaymentViaIntraledger = async <
 
   const checkLimits =
     senderWallet.accountId === recipientWallet.accountId
-      ? newCheckTradeIntraAccountLimits
-      : newCheckIntraledgerLimits
+      ? checkTradeIntraAccountLimits
+      : checkIntraledgerLimits
   const limitCheck = await checkLimits({
     amount: paymentFlow.usdPaymentAmount,
     accountId: senderWallet.accountId,
@@ -487,7 +487,7 @@ const executePaymentViaLn = async ({
   const priceRatioForLimits = await getPriceRatioForLimits(paymentFlow.paymentAmounts())
   if (priceRatioForLimits instanceof Error) return priceRatioForLimits
 
-  const limitCheck = await newCheckWithdrawalLimits({
+  const limitCheck = await checkWithdrawalLimits({
     amount: paymentFlow.usdPaymentAmount,
     accountId: senderWallet.accountId,
     priceRatio: priceRatioForLimits,

--- a/src/app/wallets/send-on-chain.ts
+++ b/src/app/wallets/send-on-chain.ts
@@ -5,9 +5,9 @@ import { BTC_NETWORK, getOnChainWalletConfig, ONCHAIN_SCAN_DEPTH_OUTGOING } from
 import { btcFromUsdMidPriceFn, usdFromBtcMidPriceFn } from "@app/shared"
 import {
   getPriceRatioForLimits,
-  newCheckIntraledgerLimits,
-  newCheckTradeIntraAccountLimits,
-  newCheckWithdrawalLimits,
+  checkIntraledgerLimits,
+  checkTradeIntraAccountLimits,
+  checkWithdrawalLimits,
 } from "@app/payments/helpers"
 
 import { checkedToTargetConfs, toSats } from "@domain/bitcoin"
@@ -242,8 +242,8 @@ const executePaymentViaIntraledger = async <
 
   const checkLimits =
     senderWallet.accountId === recipientWallet.accountId
-      ? newCheckTradeIntraAccountLimits
-      : newCheckIntraledgerLimits
+      ? checkTradeIntraAccountLimits
+      : checkIntraledgerLimits
   const limitCheck = await checkLimits({
     amount: paymentFlow.usdPaymentAmount,
     accountId: senderWallet.accountId,
@@ -378,7 +378,7 @@ const executePaymentViaOnChain = async <
   const priceRatioForLimits = await getPriceRatioForLimits(proposedAmounts)
   if (priceRatioForLimits instanceof Error) return priceRatioForLimits
 
-  const limitCheck = await newCheckWithdrawalLimits({
+  const limitCheck = await checkWithdrawalLimits({
     amount: proposedAmounts.usd,
     accountId: senderWalletDescriptor.accountId,
     priceRatio: priceRatioForLimits,


### PR DESCRIPTION
## Description

Renames lingering `new...LimitCheck` function to drop the `new` prefix.