### PR TITLE
fix: add user memo to ln send metadata

### DIFF
--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -91,7 +91,7 @@ export const payInvoiceByWalletId = async ({
         senderUsername: senderAccount.username,
         memo,
       })
-    : executePaymentViaLn({ decodedInvoice, paymentFlow, senderWallet })
+    : executePaymentViaLn({ decodedInvoice, paymentFlow, senderWallet, memo })
 }
 
 const payNoAmountInvoiceByWalletId = async ({
@@ -130,7 +130,7 @@ const payNoAmountInvoiceByWalletId = async ({
         senderUsername: senderAccount.username,
         memo,
       })
-    : executePaymentViaLn({ decodedInvoice, paymentFlow, senderWallet })
+    : executePaymentViaLn({ decodedInvoice, paymentFlow, senderWallet, memo })
 }
 
 export const payNoAmountInvoiceByWalletIdForBtcWallet = async (
@@ -478,10 +478,12 @@ const executePaymentViaLn = async ({
   decodedInvoice,
   paymentFlow,
   senderWallet,
+  memo,
 }: {
   decodedInvoice: LnInvoice
   paymentFlow: PaymentFlow<WalletCurrency, WalletCurrency>
   senderWallet: Wallet
+  memo: string | null
 }): Promise<PaymentSendStatus | ApplicationError> => {
   addAttributesToCurrentSpan({
     "payment.settlement_method": SettlementMethod.Lightning,
@@ -540,10 +542,12 @@ const executePaymentViaLn = async ({
       pubkey: outgoingNodePubkey || lndService.defaultPubkey(),
       paymentHash,
       feeKnownInAdvance: !!rawRoute,
+
+      memoOfPayer: memo || paymentFlow.descriptionFromInvoice,
     })
 
     const journal = await LedgerFacade.recordSend({
-      description: paymentFlow.descriptionFromInvoice,
+      description: paymentFlow.descriptionFromInvoice || memo || "",
       amountToDebitSender: {
         btc: {
           currency: paymentFlow.btcPaymentAmount.currency,

--- a/src/app/wallets/send-on-chain.ts
+++ b/src/app/wallets/send-on-chain.ts
@@ -465,6 +465,7 @@ const executePaymentViaOnChain = async <
 
       payeeAddresses: [paymentFlow.address],
       sendAll,
+      memoOfPayer: memo || undefined,
     })
 
     // Record transaction

--- a/src/services/ledger/index.types.d.ts
+++ b/src/services/ledger/index.types.d.ts
@@ -48,6 +48,10 @@ type LedgerMetadata = {
   pending: boolean
 }
 
+type LedgerSendMetadata = {
+  memoPayer?: string
+}
+
 type LnReceiveLedgerMetadata = LedgerMetadata &
   SendAmountsMetadata & {
     hash: PaymentHash
@@ -72,6 +76,7 @@ type SendAmountsMetadata = {
 }
 
 type AddLnSendLedgerMetadata = LedgerMetadata &
+  LedgerSendMetadata &
   SendAmountsMetadata & {
     hash: PaymentHash
     pubkey: Pubkey
@@ -79,6 +84,7 @@ type AddLnSendLedgerMetadata = LedgerMetadata &
   }
 
 type AddOnchainSendLedgerMetadata = LedgerMetadata &
+  LedgerSendMetadata &
   SendAmountsMetadata & {
     hash: OnChainTxHash
     payee_addresses: OnChainAddress[]
@@ -101,13 +107,13 @@ type AddColdStorageReceiveLedgerMetadata = AddColdStorageLedgerMetadata
 
 type AddColdStorageSendLedgerMetadata = AddColdStorageLedgerMetadata
 
-type IntraledgerBaseMetadata = LedgerMetadata & {
-  usd: DisplayCurrencyBaseAmount // to be renamed amountDisplayCurrency
-  memoPayer?: string
-  username?: Username
-}
+type IntraledgerSendBaseMetadata = LedgerMetadata &
+  LedgerSendMetadata & {
+    usd: DisplayCurrencyBaseAmount // to be renamed amountDisplayCurrency
+    username?: Username
+  }
 
-type AddLnIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata &
+type AddLnIntraledgerSendLedgerMetadata = IntraledgerSendBaseMetadata &
   SendAmountsMetadata & {
     hash: PaymentHash
     pubkey: Pubkey
@@ -118,7 +124,7 @@ type AddLnTradeIntraAccountLedgerMetadata = Omit<
   "username"
 >
 
-type AddOnChainIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata &
+type AddOnChainIntraledgerSendLedgerMetadata = IntraledgerSendBaseMetadata &
   SendAmountsMetadata & {
     payee_addresses: OnChainAddress[]
     sendAll: boolean
@@ -129,7 +135,7 @@ type AddOnChainTradeIntraAccountLedgerMetadata = Omit<
   "username"
 >
 
-type AddWalletIdIntraledgerSendLedgerMetadata = IntraledgerBaseMetadata &
+type AddWalletIdIntraledgerSendLedgerMetadata = IntraledgerSendBaseMetadata &
   SendAmountsMetadata
 
 type AddWalletIdTradeIntraAccountLedgerMetadata = Omit<

--- a/src/services/ledger/tx-metadata.ts
+++ b/src/services/ledger/tx-metadata.ts
@@ -10,6 +10,7 @@ export const LnSendLedgerMetadata = ({
   amountDisplayCurrency,
   displayCurrency,
   feeKnownInAdvance,
+  memoOfPayer,
 }: {
   paymentHash: PaymentHash
   pubkey: Pubkey
@@ -20,6 +21,7 @@ export const LnSendLedgerMetadata = ({
   displayCurrency: DisplayCurrency
 
   feeKnownInAdvance: boolean
+  memoOfPayer?: string
 }) => {
   const {
     btcPaymentAmount: { amount: satsAmount },
@@ -34,6 +36,7 @@ export const LnSendLedgerMetadata = ({
     hash: paymentHash,
     pubkey,
     feeKnownInAdvance,
+    memoPayer: memoOfPayer,
 
     satsFee: toSats(satsFee),
     displayFee: feeDisplayCurrency,
@@ -55,6 +58,7 @@ export const OnChainSendLedgerMetadata = ({
   displayCurrency,
   payeeAddresses,
   sendAll,
+  memoOfPayer,
 }: {
   onChainTxHash: OnChainTxHash
   paymentAmounts: AmountsAndFees
@@ -65,6 +69,7 @@ export const OnChainSendLedgerMetadata = ({
 
   payeeAddresses: OnChainAddress[]
   sendAll: boolean
+  memoOfPayer?: string
 }) => {
   const {
     btcPaymentAmount: { amount: satsAmount },
@@ -79,6 +84,7 @@ export const OnChainSendLedgerMetadata = ({
     hash: onChainTxHash,
     payee_addresses: payeeAddresses,
     sendAll,
+    memoPayer: memoOfPayer,
 
     satsFee: toSats(satsFee),
     displayFee: feeDisplayCurrency,

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -620,16 +620,6 @@ describe("UserWallet - Lightning Pay", () => {
   })
 
   it("pay zero amount invoice with amount less than 1 cent", async () => {
-    const imbalanceCalc = ImbalanceCalculator({
-      method: WithdrawalFeePriceMethod.proportionalOnImbalance,
-      sinceDaysAgo: ONE_DAY,
-      volumeLightningFn: LedgerService().lightningTxBaseVolumeSince,
-      volumeOnChainFn: LedgerService().onChainTxBaseVolumeSince,
-    })
-
-    const imbalanceInit = await imbalanceCalc.getSwapOutImbalanceAmount(walletDescriptorB)
-    if (imbalanceInit instanceof Error) throw imbalanceInit
-
     const { request } = await createInvoice({ lnd: lndOutside1 })
 
     // Test payment is successful


### PR DESCRIPTION
## Description

Add memo provided to ln send metadata:
- prioritize user memo over payment request
- store user memo in `memoPayer` property first, fallback to payment request description
- store payment request description in `memo` first, fallback to user memo