### PR TITLE
fix: convert onchain receive notification display amount to major unit

### DIFF
--- a/src/app/wallets/update-on-chain-receipt.ts
+++ b/src/app/wallets/update-on-chain-receipt.ts
@@ -225,14 +225,16 @@ const processTxForWallet = async (
           )
           if (recipientUser instanceof Error) return recipientUser
 
+          const displayPaymentAmount = {
+            amount: Number((amountDisplayCurrency / 100).toFixed(2)),
+            currency: displayCurrency,
+          }
+
           await notifications.onChainTxReceived({
             recipientAccountId: wallet.accountId,
             recipientWalletId: wallet.id,
             paymentAmount: { amount: BigInt(sats), currency: wallet.currency },
-            displayPaymentAmount: {
-              amount: amountDisplayCurrency,
-              currency: displayCurrency,
-            },
+            displayPaymentAmount,
             txHash: tx.rawTx.txHash,
             recipientDeviceTokens: recipientUser.deviceTokens,
             recipientLanguage: recipientUser.language,


### PR DESCRIPTION
## Description

Adds a test and fixes the issue.

### Issue

Reported: _"have this problem with formatting in the notifications where the onchain pending notification has the right formatting but not the confirmation notification"_

![image](https://user-images.githubusercontent.com/17693119/218327591-02f95505-aaa9-495a-b146-e28c8ddf031b.png)
