### PR TITLE
chore: add error catch for multiple pending payments for single hash

### DIFF
--- a/src/domain/ledger/errors.ts
+++ b/src/domain/ledger/errors.ts
@@ -7,6 +7,9 @@ export class FeeDifferenceError extends LedgerError {}
 export class NoTransactionToSettleError extends LedgerServiceError {}
 export class InvalidPaginationArgumentsError extends LedgerServiceError {}
 export class MismatchedResultForTransactionMetadataQuery extends LedgerServiceError {}
+export class MultiplePendingPaymentsForHashError extends LedgerServiceError {
+  level = ErrorLevel.Critical
+}
 export class UnknownLedgerError extends LedgerServiceError {
   level = ErrorLevel.Critical
 }

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -414,6 +414,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "InvalidDocumentIdForDbError":
     case "MismatchedResultForTransactionMetadataQuery":
     case "InvalidLedgerTransactionId":
+    case "MultiplePendingPaymentsForHashError":
     case "CacheError":
     case "CacheNotAvailableError":
     case "CacheServiceError":


### PR DESCRIPTION
## Description

See #2151, there are some critical assumptions that depend on there being only 1 pending payment for a payment hash at any given time:
- having only 1 ledger transaction be debited for user for a single lnd payment (failure mode is user gets over-debited)
- accounting for fees correctly if a route changes and fees increase in lnd payment out