### PR TITLE
chore: add max-fee-check errors and tests to lnd service

### DIFF
--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -578,6 +578,7 @@ const executePaymentViaLn = async ({
           decodedInvoice,
           btcPaymentAmount: paymentFlow.btcPaymentAmount,
           maxFeeAmount: paymentFlow.btcProtocolAndBankFee,
+          priceRatio,
         })
 
     // Fire-and-forget update to 'lnPayments' collection

--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -579,6 +579,7 @@ const executePaymentViaLn = async ({
           btcPaymentAmount: paymentFlow.btcPaymentAmount,
           maxFeeAmount: paymentFlow.btcProtocolAndBankFee,
           priceRatio,
+          senderWalletCurrency: paymentFlow.senderWalletDescriptor().currency,
         })
 
     // Fire-and-forget update to 'lnPayments' collection

--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -12,6 +12,7 @@ import {
   checkedToBtcPaymentAmount,
   checkedToUsdPaymentAmount,
   InvalidLightningPaymentFlowBuilderStateError,
+  LnFees,
   LnPaymentRequestInTransitError,
   LnPaymentRequestNonZeroAmountRequiredError,
   LnPaymentRequestZeroAmountRequiredError,
@@ -568,19 +569,29 @@ const executePaymentViaLn = async ({
     if (journal instanceof Error) return journal
     const { journalId } = journal
 
-    const payResult = rawRoute
-      ? await lndService.payInvoiceViaRoutes({
-          paymentHash,
-          rawRoute,
-          pubkey: outgoingNodePubkey,
-        })
-      : await lndService.payInvoiceViaPaymentDetails({
-          decodedInvoice,
-          btcPaymentAmount: paymentFlow.btcPaymentAmount,
-          maxFeeAmount: paymentFlow.btcProtocolAndBankFee,
-          priceRatio,
-          senderWalletCurrency: paymentFlow.senderWalletDescriptor().currency,
-        })
+    let payResult: PayInvoiceResult | LightningServiceError
+    if (rawRoute) {
+      payResult = await lndService.payInvoiceViaRoutes({
+        paymentHash,
+        rawRoute,
+        pubkey: outgoingNodePubkey,
+      })
+    } else {
+      const maxFeeCheckArgs = {
+        maxFeeAmount: paymentFlow.btcProtocolAndBankFee,
+        btcPaymentAmount: paymentFlow.btcPaymentAmount,
+        priceRatio,
+        senderWalletCurrency: paymentFlow.senderWalletDescriptor().currency,
+      }
+
+      const maxFeeCheck = LnFees().verifyMaxFee(maxFeeCheckArgs)
+      if (maxFeeCheck instanceof Error) return maxFeeCheck
+
+      payResult = await lndService.payInvoiceViaPaymentDetails({
+        ...maxFeeCheckArgs,
+        decodedInvoice,
+      })
+    }
 
     // Fire-and-forget update to 'lnPayments' collection
     if (!(payResult instanceof LnAlreadyPaidError)) {

--- a/src/domain/bitcoin/lightning/errors.ts
+++ b/src/domain/bitcoin/lightning/errors.ts
@@ -21,6 +21,9 @@ export class SecretDoesNotMatchAnyExistingHodlInvoiceError extends LightningServ
 export class InvoiceNotFoundError extends LightningServiceError {}
 export class LnPaymentPendingError extends LightningServiceError {}
 export class LnAlreadyPaidError extends LightningServiceError {}
+export class MaxFeeTooLargeForRoutelessPaymentError extends LightningServiceError {
+  level = ErrorLevel.Critical
+}
 export class OffChainServiceUnavailableError extends LightningServiceError {
   level = ErrorLevel.Critical
 }

--- a/src/domain/bitcoin/lightning/index.types.d.ts
+++ b/src/domain/bitcoin/lightning/index.types.d.ts
@@ -273,7 +273,7 @@ interface ILightningService {
   }: {
     decodedInvoice: LnInvoice
     btcPaymentAmount: BtcPaymentAmount
-    maxFeeAmount: BtcPaymentAmount
+    maxFeeAmount: BtcPaymentAmount | undefined
   }): Promise<PayInvoiceResult | LightningServiceError>
 }
 

--- a/src/domain/bitcoin/lightning/index.types.d.ts
+++ b/src/domain/bitcoin/lightning/index.types.d.ts
@@ -270,10 +270,12 @@ interface ILightningService {
     decodedInvoice,
     btcPaymentAmount,
     maxFeeAmount,
+    priceRatio,
   }: {
     decodedInvoice: LnInvoice
     btcPaymentAmount: BtcPaymentAmount
     maxFeeAmount: BtcPaymentAmount
+    priceRatio: PriceRatio
   }): Promise<PayInvoiceResult | LightningServiceError>
 }
 

--- a/src/domain/bitcoin/lightning/index.types.d.ts
+++ b/src/domain/bitcoin/lightning/index.types.d.ts
@@ -271,11 +271,13 @@ interface ILightningService {
     btcPaymentAmount,
     maxFeeAmount,
     priceRatio,
+    senderWalletCurrency,
   }: {
     decodedInvoice: LnInvoice
     btcPaymentAmount: BtcPaymentAmount
     maxFeeAmount: BtcPaymentAmount
     priceRatio: PriceRatio
+    senderWalletCurrency: WalletCurrency
   }): Promise<PayInvoiceResult | LightningServiceError>
 }
 

--- a/src/domain/bitcoin/lightning/index.types.d.ts
+++ b/src/domain/bitcoin/lightning/index.types.d.ts
@@ -270,14 +270,10 @@ interface ILightningService {
     decodedInvoice,
     btcPaymentAmount,
     maxFeeAmount,
-    priceRatio,
-    senderWalletCurrency,
   }: {
     decodedInvoice: LnInvoice
     btcPaymentAmount: BtcPaymentAmount
     maxFeeAmount: BtcPaymentAmount
-    priceRatio: PriceRatio
-    senderWalletCurrency: WalletCurrency
   }): Promise<PayInvoiceResult | LightningServiceError>
 }
 

--- a/src/domain/payments/ln-fees.ts
+++ b/src/domain/payments/ln-fees.ts
@@ -10,15 +10,9 @@ import {
 
 const calc = AmountCalculator()
 
-export const LnFees = (
-  {
-    feeCapBasisPoints,
-  }: {
-    feeCapBasisPoints: bigint
-  } = {
-    feeCapBasisPoints: FEECAP_BASIS_POINTS,
-  },
-) => {
+export const LnFees = () => {
+  const feeCapBasisPoints = FEECAP_BASIS_POINTS
+
   const maxProtocolAndBankFee = <T extends WalletCurrency>(amount: PaymentAmount<T>) => {
     if (amount.amount == 0n) {
       return amount

--- a/src/domain/payments/ln-fees.ts
+++ b/src/domain/payments/ln-fees.ts
@@ -35,28 +35,22 @@ export const LnFees = () => {
   }
 
   const verifyMaxFee = ({
-    maxFeeToVerify,
+    maxFeeAmount,
     btcPaymentAmount,
     priceRatio,
     senderWalletCurrency,
   }: {
-    maxFeeToVerify: BtcPaymentAmount
+    maxFeeAmount: BtcPaymentAmount
     btcPaymentAmount: BtcPaymentAmount
     priceRatio: PriceRatio
     senderWalletCurrency: WalletCurrency
   }) => {
-    const maxFeeAmount = maxProtocolAndBankFee(btcPaymentAmount)
-    const minFeeAmount = priceRatio.convertFromUsd(ONE_CENT)
-    console.log("HERE 0:", {
-      maxFeeToVerify,
-      maxFeeAmount,
-      minFeeAmount,
-      senderWalletCurrency,
-    })
+    const calculatedMaxFeeAmount = maxProtocolAndBankFee(btcPaymentAmount)
+    const calculatedMinFeeAmount = priceRatio.convertFromUsd(ONE_CENT)
     if (
       (senderWalletCurrency === WalletCurrency.Btc ||
-        maxFeeToVerify.amount > minFeeAmount.amount) &&
-      maxFeeToVerify.amount > maxFeeAmount.amount
+        maxFeeAmount.amount > calculatedMinFeeAmount.amount) &&
+      maxFeeAmount.amount > calculatedMaxFeeAmount.amount
     ) {
       return new MaxFeeTooLargeForRoutelessPaymentError()
     }

--- a/src/domain/payments/ln-fees.ts
+++ b/src/domain/payments/ln-fees.ts
@@ -5,6 +5,7 @@ import {
   ZERO_CENTS,
   paymentAmountFromNumber,
   AmountCalculator,
+  ONE_CENT,
 } from "@domain/shared"
 
 const calc = AmountCalculator()
@@ -31,6 +32,9 @@ export const LnFees = (
     }
   }
 
+  const minFeeFromPriceRatio = (priceRatio: PriceRatio) =>
+    priceRatio.convertFromUsd(ONE_CENT)
+
   const intraLedgerFees = () => {
     return {
       btc: ZERO_SATS,
@@ -46,6 +50,7 @@ export const LnFees = (
   return {
     intraLedgerFees,
     maxProtocolAndBankFee,
+    minFeeFromPriceRatio,
     feeFromRawRoute,
   }
 }

--- a/src/domain/shared/primitives.ts
+++ b/src/domain/shared/primitives.ts
@@ -21,6 +21,11 @@ export const ZERO_CENTS = {
   amount: 0n,
 }
 
+export const ONE_SAT = {
+  amount: 1n,
+  currency: WalletCurrency.Btc,
+}
+
 export const ONE_CENT = {
   currency: WalletCurrency.Usd,
   amount: 1n,

--- a/src/domain/shared/primitives.ts
+++ b/src/domain/shared/primitives.ts
@@ -21,6 +21,11 @@ export const ZERO_CENTS = {
   amount: 0n,
 }
 
+export const ONE_CENT = {
+  currency: WalletCurrency.Usd,
+  amount: 1n,
+}
+
 export const ZERO_BANK_FEE = {
   usdBankFee: ZERO_CENTS,
   btcBankFee: ZERO_SATS,

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -234,6 +234,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       return new DealerOfflineError({ message, logger: baseLogger })
 
     case "RouteNotFoundError":
+    case "MaxFeeTooLargeForRoutelessPaymentError":
       message = "Unable to find a route for payment."
       return new RouteFindingError({ message, logger: baseLogger })
 

--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -625,23 +625,11 @@ export const LndService = (): ILightningService | LightningServiceError => {
     decodedInvoice,
     btcPaymentAmount,
     maxFeeAmount,
-    priceRatio,
-    senderWalletCurrency,
   }: {
     decodedInvoice: LnInvoice
     btcPaymentAmount: BtcPaymentAmount
     maxFeeAmount: BtcPaymentAmount
-    priceRatio: PriceRatio
-    senderWalletCurrency: WalletCurrency
   }): Promise<PayInvoiceResult | LightningServiceError> => {
-    const maxFeeCheck = LnFees().verifyMaxFee({
-      maxFeeToVerify: maxFeeAmount,
-      btcPaymentAmount,
-      priceRatio,
-      senderWalletCurrency,
-    })
-    if (maxFeeCheck instanceof Error) return maxFeeCheck
-
     const milliSatsAmount = btcPaymentAmount.amount * 1000n
     const maxFee = maxFeeAmount.amount
 

--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -628,10 +628,10 @@ export const LndService = (): ILightningService | LightningServiceError => {
   }: {
     decodedInvoice: LnInvoice
     btcPaymentAmount: BtcPaymentAmount
-    maxFeeAmount: BtcPaymentAmount
+    maxFeeAmount: BtcPaymentAmount | undefined
   }): Promise<PayInvoiceResult | LightningServiceError> => {
     const milliSatsAmount = btcPaymentAmount.amount * 1000n
-    const maxFee = maxFeeAmount.amount
+    const maxFee = maxFeeAmount !== undefined ? Number(maxFeeAmount.amount) : undefined
 
     let routes: RawHopWithStrings[][] = []
     if (decodedInvoice.routeHints) {
@@ -652,7 +652,7 @@ export const LndService = (): ILightningService | LightningServiceError => {
       destination: decodedInvoice.destination,
       mtokens: milliSatsAmount.toString(),
       payment: decodedInvoice.paymentSecret as string,
-      max_fee: Number(maxFee),
+      max_fee: maxFee,
       cltv_delta: decodedInvoice.cltvDelta || undefined,
       features: decodedInvoice.features
         ? decodedInvoice.features.map((f) => ({

--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -222,6 +222,7 @@ export const LndService = (): ILightningService | LightningServiceError => {
     amount,
   }: {
     invoice: LnInvoice
+    // FIXME: remove this optional property, use 'findRouteForNoAmountInvoice' with no-amount invoices instead
     amount?: BtcPaymentAmount
   }): Promise<{ pubkey: Pubkey; rawRoute: RawRoute } | LightningServiceError> => {
     let sats = toSats(0)

--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -627,11 +627,13 @@ export const LndService = (): ILightningService | LightningServiceError => {
     btcPaymentAmount,
     maxFeeAmount,
     priceRatio,
+    senderWalletCurrency,
   }: {
     decodedInvoice: LnInvoice
     btcPaymentAmount: BtcPaymentAmount
     maxFeeAmount: BtcPaymentAmount
     priceRatio: PriceRatio
+    senderWalletCurrency: WalletCurrency
   }): Promise<PayInvoiceResult | LightningServiceError> => {
     const milliSatsAmount = btcPaymentAmount.amount * 1000n
     const maxFee = maxFeeAmount.amount
@@ -639,7 +641,8 @@ export const LndService = (): ILightningService | LightningServiceError => {
     const calculatedMaxFeeAmount = LnFees().maxProtocolAndBankFee(btcPaymentAmount)
     const minFeeAmount = LnFees().minFeeFromPriceRatio(priceRatio)
     if (
-      maxFeeAmount.amount > minFeeAmount.amount &&
+      (senderWalletCurrency === WalletCurrency.Btc ||
+        maxFeeAmount.amount > minFeeAmount.amount) &&
       maxFeeAmount.amount > calculatedMaxFeeAmount.amount
     ) {
       return new MaxFeeTooLargeForRoutelessPaymentError()

--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -626,16 +626,22 @@ export const LndService = (): ILightningService | LightningServiceError => {
     decodedInvoice,
     btcPaymentAmount,
     maxFeeAmount,
+    priceRatio,
   }: {
     decodedInvoice: LnInvoice
     btcPaymentAmount: BtcPaymentAmount
     maxFeeAmount: BtcPaymentAmount
+    priceRatio: PriceRatio
   }): Promise<PayInvoiceResult | LightningServiceError> => {
     const milliSatsAmount = btcPaymentAmount.amount * 1000n
     const maxFee = maxFeeAmount.amount
 
     const calculatedMaxFeeAmount = LnFees().maxProtocolAndBankFee(btcPaymentAmount)
-    if (maxFeeAmount.amount > calculatedMaxFeeAmount.amount) {
+    const minFeeAmount = LnFees().minFeeFromPriceRatio(priceRatio)
+    if (
+      maxFeeAmount.amount > minFeeAmount.amount &&
+      maxFeeAmount.amount > calculatedMaxFeeAmount.amount
+    ) {
       return new MaxFeeTooLargeForRoutelessPaymentError()
     }
 

--- a/test/integration/services/lnd/lnd-service.spec.ts
+++ b/test/integration/services/lnd/lnd-service.spec.ts
@@ -3,6 +3,8 @@ import { createInvoice, getChannel, getChannels, pay } from "lightning"
 import { LndService } from "@services/lnd"
 
 import { decodeInvoice, RouteNotFoundError } from "@domain/bitcoin/lightning"
+import { LnFees } from "@domain/payments"
+import { WalletCurrency } from "@domain/shared"
 
 import { sleep } from "@utils"
 
@@ -12,6 +14,124 @@ const lndService = LndService()
 if (lndService instanceof Error) throw lndService
 
 describe("LndService", () => {
+  const setFeesOnChannel = async ({ localLnd, partnerLnd, base, rate }) => {
+    // Get routing channel details
+    const { channels } = await getChannels({ lnd: partnerLnd })
+    const {
+      id: chanId,
+      remote_balance: remoteBalance,
+      remote_reserve: remoteReserve,
+    } = channels[0]
+
+    // Bump base fee on routing node for disproportionate probe fee
+    const channel = await getChannel({ id: chanId, lnd: partnerLnd })
+    let count = 0
+    const countMax = 3
+    let setOnLndOutside1
+    while (count < countMax && setOnLndOutside1 !== true) {
+      if (count > 0) await sleep(500)
+      count++
+
+      setOnLndOutside1 = await setChannelFees({
+        lnd: localLnd,
+        channel,
+        base,
+        rate,
+      })
+    }
+    expect(count).toBeGreaterThan(0)
+    expect(count).toBeLessThan(countMax)
+    expect(setOnLndOutside1).toBe(true)
+
+    return {
+      chanId,
+      localBalance: remoteBalance,
+      localReserve: remoteReserve,
+    }
+  }
+
+  const fetchChannelReserves = async ({ localPubkey, partnerLnd }) => {
+    const { channels } = await getChannels({ lnd: partnerLnd })
+    const {
+      id: chanId,
+      remote_balance: remoteBalance,
+      remote_reserve: remoteReserve,
+      partner_public_key: localPubkeyForChannel,
+    } = channels[0]
+
+    expect(localPubkey).toBe(localPubkeyForChannel)
+
+    return { chanId, localBalance: remoteBalance, localReserve: remoteReserve }
+  }
+
+  describe("payInvoiceViaPaymentDetails", () => {
+    const btcPaymentAmount = { amount: 1n, currency: WalletCurrency.Btc }
+    const btcAmountAsNumber = Number(btcPaymentAmount.amount)
+
+    const NUM_EXPECTED_PAYMENTS = 2
+    const rebalanceAmount = btcAmountAsNumber * NUM_EXPECTED_PAYMENTS
+
+    it("pays high fee route with no max limit", async () => {
+      const { localBalance, localReserve } = await setFeesOnChannel({
+        localLnd: lndOutside1,
+        partnerLnd: lndOutside3,
+        base: 10,
+        rate: 5000,
+      })
+
+      // Rebalance lndOutside3 route
+      const { request: invoice } = await createInvoice({
+        lnd: lndOutside1,
+        tokens:
+          localBalance < localReserve ? rebalanceAmount + localReserve : rebalanceAmount,
+      })
+      const rebalance = await pay({ lnd: lndOutside3, request: invoice })
+      expect(rebalance.is_confirmed).toBe(true)
+      await sleep(500) // rebalance can take some time to settle even after promise is resolved
+
+      const { localBalance: localBalanceAfter, localReserve: localReserveAfter } =
+        await fetchChannelReserves({
+          localPubkey: process.env.LND_OUTSIDE_1_PUBKEY as Pubkey,
+          partnerLnd: lndOutside3,
+        })
+      expect(localBalanceAfter - localReserveAfter).toBeGreaterThanOrEqual(
+        btcAmountAsNumber,
+      )
+
+      const { request } = await createInvoice({ lnd: lndOutside3 })
+      const decodedInvoice = decodeInvoice(request)
+      if (decodedInvoice instanceof Error) throw decodedInvoice
+
+      const paid = await lndService.payInvoiceViaPaymentDetails({
+        decodedInvoice,
+        btcPaymentAmount,
+        maxFeeAmount: undefined,
+      })
+      if (paid instanceof Error) throw paid
+      const { roundedUpFee } = paid
+      expect(roundedUpFee).toBeGreaterThan(btcAmountAsNumber)
+    })
+
+    it("fails to pay high fee route with max limit set", async () => {
+      const { localBalance, localReserve } = await fetchChannelReserves({
+        localPubkey: process.env.LND_OUTSIDE_1_PUBKEY as Pubkey,
+        partnerLnd: lndOutside3,
+      })
+      expect(localBalance - localReserve).toBeGreaterThanOrEqual(btcAmountAsNumber)
+
+      const { request } = await createInvoice({ lnd: lndOutside3 })
+      const decodedInvoice = decodeInvoice(request)
+      if (decodedInvoice instanceof Error) throw decodedInvoice
+
+      const paid = await lndService.payInvoiceViaPaymentDetails({
+        decodedInvoice,
+        btcPaymentAmount,
+        maxFeeAmount: LnFees().maxProtocolAndBankFee(btcPaymentAmount),
+      })
+      expect(paid).toBeInstanceOf(RouteNotFoundError)
+    })
+  })
+
   describe("findRouteForInvoice", () => {
     const lndService = LndService()
     if (lndService instanceof Error) throw lndService
@@ -19,43 +139,22 @@ describe("LndService", () => {
     it("probes across route with fee higher than payment amount", async () => {
       const amountInvoice = 1
 
-      // Get routing channel details
-      const { channels } = await getChannels({ lnd: lndOutside3 })
-      const {
-        id: chanId,
-        remote_balance: remoteBalance,
-        remote_reserve: remoteReserve,
-      } = channels[0]
+      const { localBalance, localReserve } = await setFeesOnChannel({
+        localLnd: lndOutside1,
+        partnerLnd: lndOutside3,
+        base: 10,
+        rate: 5000,
+      })
 
       // Rebalance lndOutside3 route
       const { request: invoice } = await createInvoice({
         lnd: lndOutside1,
         tokens:
-          remoteBalance < remoteReserve ? amountInvoice + remoteReserve : amountInvoice,
+          localBalance < localReserve ? amountInvoice + localReserve : amountInvoice,
       })
       const rebalance = await pay({ lnd: lndOutside3, request: invoice })
       expect(rebalance.is_confirmed).toBe(true)
       await sleep(500) // rebalance can take some time to settle even after promise is resolved
-
-      // Bump base fee on routing node for disproportionate probe fee
-      const channel = await getChannel({ id: chanId, lnd: lndOutside3 })
-      let count = 0
-      const countMax = 3
-      let setOnLndOutside1
-      while (count < countMax && setOnLndOutside1 !== true) {
-        if (count > 0) await sleep(500)
-        count++
-
-        setOnLndOutside1 = await setChannelFees({
-          lnd: lndOutside1,
-          channel,
-          base: 10,
-          rate: 5000,
-        })
-      }
-      expect(count).toBeGreaterThan(0)
-      expect(count).toBeLessThan(countMax)
-      expect(setOnLndOutside1).toBe(true)
 
       // Execute fee probe
       const { request } = await createInvoice({

--- a/test/integration/services/lnd/lnd-service.spec.ts
+++ b/test/integration/services/lnd/lnd-service.spec.ts
@@ -1,15 +1,18 @@
-import { createInvoice } from "lightning"
+import { createInvoice, getChannel, getChannels, pay } from "lightning"
 
 import { LndService } from "@services/lnd"
 
 import {
   decodeInvoice,
   MaxFeeTooLargeForRoutelessPaymentError,
+  RouteNotFoundError,
 } from "@domain/bitcoin/lightning"
 import { LnFees } from "@domain/payments"
 import { AmountCalculator, WalletCurrency } from "@domain/shared"
 
-import { lndOutside1 } from "test/helpers"
+import { sleep } from "@utils"
+
+import { lndOutside1, lndOutside3, setChannelFees } from "test/helpers"
 
 const calc = AmountCalculator()
 
@@ -47,6 +50,67 @@ describe("LndService", () => {
         maxFeeAmount: calc.add(feeAmount, ONE_SAT),
       })
       expect(paid).toBeInstanceOf(MaxFeeTooLargeForRoutelessPaymentError)
+    })
+  })
+
+  describe("findRouteForInvoice", () => {
+    const lndService = LndService()
+    if (lndService instanceof Error) throw lndService
+
+    it("probes across route with fee higher than payment amount", async () => {
+      const amountInvoice = 1
+
+      // Get routing channel details
+      const { channels } = await getChannels({ lnd: lndOutside3 })
+      const {
+        id: chanId,
+        remote_balance: remoteBalance,
+        remote_reserve: remoteReserve,
+      } = channels[0]
+
+      // Rebalance lndOutside3 route
+      const { request: invoice } = await createInvoice({
+        lnd: lndOutside1,
+        tokens:
+          remoteBalance < remoteReserve ? amountInvoice + remoteReserve : amountInvoice,
+      })
+      const rebalance = await pay({ lnd: lndOutside3, request: invoice })
+      expect(rebalance.is_confirmed).toBe(true)
+      await sleep(500) // rebalance can take some time to settle even after promise is resolved
+
+      // Bump base fee on routing node for disproportionate probe fee
+      const channel = await getChannel({ id: chanId, lnd: lndOutside3 })
+      let count = 0
+      const countMax = 3
+      let setOnLndOutside1
+      while (count < countMax && setOnLndOutside1 !== true) {
+        if (count > 0) await sleep(500)
+        count++
+
+        setOnLndOutside1 = await setChannelFees({
+          lnd: lndOutside1,
+          channel,
+          base: 10,
+          rate: 5000,
+        })
+      }
+      expect(count).toBeGreaterThan(0)
+      expect(count).toBeLessThan(countMax)
+      expect(setOnLndOutside1).toBe(true)
+
+      // Execute fee probe
+      const { request } = await createInvoice({
+        lnd: lndOutside3,
+        tokens: amountInvoice,
+        is_including_private_channels: true,
+      })
+      const decodedInvoice = decodeInvoice(request)
+      if (decodedInvoice instanceof Error) throw decodedInvoice
+
+      const probed = await lndService.findRouteForInvoice({
+        invoice: decodedInvoice,
+      })
+      expect(probed).toBeInstanceOf(RouteNotFoundError)
     })
   })
 })

--- a/test/integration/services/lnd/lnd-service.spec.ts
+++ b/test/integration/services/lnd/lnd-service.spec.ts
@@ -27,7 +27,6 @@ describe("LndService", () => {
       amount: calc.divRound(btcPaymentAmount, FEECAP_BASIS_POINTS).amount,
       currency: WalletCurrency.Usd,
     }
-    const feeAmount = LnFees().maxProtocolAndBankFee(btcPaymentAmount)
 
     const priceRatio = PriceRatio({
       btc: btcPaymentAmount,
@@ -43,23 +42,43 @@ describe("LndService", () => {
       const paid = await lndService.payInvoiceViaPaymentDetails({
         decodedInvoice,
         btcPaymentAmount,
-        maxFeeAmount: feeAmount,
+        maxFeeAmount: LnFees().maxProtocolAndBankFee(btcPaymentAmount),
         priceRatio,
+        senderWalletCurrency: WalletCurrency.Btc,
       })
       expect(paid).not.toBeInstanceOf(Error)
     })
 
-    it("pays 1 sat with fee at the max limit", async () => {
+    it("pays 1 sat with fee at the min limit for USD wallet", async () => {
       const { request } = await createInvoice({ lnd: lndOutside1 })
       const decodedInvoice = decodeInvoice(request)
       if (decodedInvoice instanceof Error) throw decodedInvoice
 
-      const maxFeeAmount = LnFees().minFeeFromPriceRatio(priceRatio)
+      const minFeeAmountForUsd = LnFees().minFeeFromPriceRatio(priceRatio)
+      const maxFeeAmountForBtc = LnFees().maxProtocolAndBankFee(ONE_SAT)
+      expect(minFeeAmountForUsd.amount).toBeGreaterThan(maxFeeAmountForBtc.amount)
+
       const paid = await lndService.payInvoiceViaPaymentDetails({
         decodedInvoice,
         btcPaymentAmount: ONE_SAT,
-        maxFeeAmount,
+        maxFeeAmount: minFeeAmountForUsd,
         priceRatio,
+        senderWalletCurrency: WalletCurrency.Usd,
+      })
+      expect(paid).not.toBeInstanceOf(Error)
+    })
+
+    it("pays 1 sat with fee at the max limit for BTC wallet", async () => {
+      const { request } = await createInvoice({ lnd: lndOutside1 })
+      const decodedInvoice = decodeInvoice(request)
+      if (decodedInvoice instanceof Error) throw decodedInvoice
+
+      const paid = await lndService.payInvoiceViaPaymentDetails({
+        decodedInvoice,
+        btcPaymentAmount: ONE_SAT,
+        maxFeeAmount: LnFees().maxProtocolAndBankFee(ONE_SAT),
+        priceRatio,
+        senderWalletCurrency: WalletCurrency.Usd,
       })
       expect(paid).not.toBeInstanceOf(Error)
     })
@@ -69,11 +88,31 @@ describe("LndService", () => {
       const decodedInvoice = decodeInvoice(request)
       if (decodedInvoice instanceof Error) throw decodedInvoice
 
+      const feeAmount = LnFees().maxProtocolAndBankFee(btcPaymentAmount)
+
       const paid = await lndService.payInvoiceViaPaymentDetails({
         decodedInvoice,
         btcPaymentAmount,
         maxFeeAmount: calc.add(feeAmount, ONE_SAT),
         priceRatio,
+        senderWalletCurrency: WalletCurrency.Btc,
+      })
+      expect(paid).toBeInstanceOf(MaxFeeTooLargeForRoutelessPaymentError)
+    })
+
+    it("fails to pay 1 sat with fee above max limit", async () => {
+      const { request } = await createInvoice({ lnd: lndOutside1 })
+      const decodedInvoice = decodeInvoice(request)
+      if (decodedInvoice instanceof Error) throw decodedInvoice
+
+      const feeAmount = LnFees().maxProtocolAndBankFee(ONE_SAT)
+
+      const paid = await lndService.payInvoiceViaPaymentDetails({
+        decodedInvoice,
+        btcPaymentAmount: ONE_SAT,
+        maxFeeAmount: calc.add(feeAmount, ONE_SAT),
+        priceRatio,
+        senderWalletCurrency: WalletCurrency.Btc,
       })
       expect(paid).toBeInstanceOf(MaxFeeTooLargeForRoutelessPaymentError)
     })

--- a/test/integration/services/lnd/lnd-service.spec.ts
+++ b/test/integration/services/lnd/lnd-service.spec.ts
@@ -1,0 +1,52 @@
+import { createInvoice } from "lightning"
+
+import { LndService } from "@services/lnd"
+
+import {
+  decodeInvoice,
+  MaxFeeTooLargeForRoutelessPaymentError,
+} from "@domain/bitcoin/lightning"
+import { LnFees } from "@domain/payments"
+import { AmountCalculator, WalletCurrency } from "@domain/shared"
+
+import { lndOutside1 } from "test/helpers"
+
+const calc = AmountCalculator()
+
+const ONE_SAT = { amount: 1n, currency: WalletCurrency.Btc }
+
+const lndService = LndService()
+if (lndService instanceof Error) throw lndService
+
+describe("LndService", () => {
+  describe("payInvoiceViaPaymentDetails", () => {
+    const btcPaymentAmount = { amount: 1001n, currency: WalletCurrency.Btc }
+    const feeAmount = LnFees().maxProtocolAndBankFee(btcPaymentAmount)
+
+    it("pays with fee at the max limit", async () => {
+      const { request } = await createInvoice({ lnd: lndOutside1 })
+      const decodedInvoice = decodeInvoice(request)
+      if (decodedInvoice instanceof Error) throw decodedInvoice
+
+      const paid = await lndService.payInvoiceViaPaymentDetails({
+        decodedInvoice,
+        btcPaymentAmount,
+        maxFeeAmount: feeAmount,
+      })
+      expect(paid).not.toBeInstanceOf(Error)
+    })
+
+    it("fails to pay with fee above max limit", async () => {
+      const { request } = await createInvoice({ lnd: lndOutside1 })
+      const decodedInvoice = decodeInvoice(request)
+      if (decodedInvoice instanceof Error) throw decodedInvoice
+
+      const paid = await lndService.payInvoiceViaPaymentDetails({
+        decodedInvoice,
+        btcPaymentAmount,
+        maxFeeAmount: calc.add(feeAmount, ONE_SAT),
+      })
+      expect(paid).toBeInstanceOf(MaxFeeTooLargeForRoutelessPaymentError)
+    })
+  })
+})

--- a/test/unit/domain/payments/ln-fees.spec.ts
+++ b/test/unit/domain/payments/ln-fees.spec.ts
@@ -1,5 +1,5 @@
 import { WalletCurrency } from "@domain/shared"
-import { LnFees } from "@domain/payments"
+import { LnFees, PriceRatio } from "@domain/payments"
 
 describe("LnFees", () => {
   describe("maxProtocolAndBankFee", () => {
@@ -9,6 +9,24 @@ describe("LnFees", () => {
         currency: WalletCurrency.Btc,
       }
       expect(LnFees().maxProtocolAndBankFee(btcAmount)).toEqual({
+        amount: 50n,
+        currency: WalletCurrency.Btc,
+      })
+    })
+
+    it("returns the minFeeFromPriceRatio", () => {
+      const btc = {
+        amount: 4995n,
+        currency: WalletCurrency.Btc,
+      }
+      const usd = {
+        amount: 100n,
+        currency: WalletCurrency.Usd,
+      }
+      const priceRatio = PriceRatio({ btc, usd })
+      if (priceRatio instanceof Error) throw priceRatio
+
+      expect(LnFees().minFeeFromPriceRatio(priceRatio)).toEqual({
         amount: 50n,
         currency: WalletCurrency.Btc,
       })

--- a/test/unit/domain/payments/ln-fees.spec.ts
+++ b/test/unit/domain/payments/ln-fees.spec.ts
@@ -141,7 +141,7 @@ describe("LnFees", () => {
           maxFeeAmount: calc.add(validUsdMaxFeeInBtcToVerify, ONE_SAT),
           btcPaymentAmount: ONE_SAT,
           priceRatio,
-          senderWalletCurrency: WalletCurrency.Btc,
+          senderWalletCurrency: WalletCurrency.Usd,
         }),
       ).toBeInstanceOf(MaxFeeTooLargeForRoutelessPaymentError)
     })

--- a/test/unit/domain/payments/ln-fees.spec.ts
+++ b/test/unit/domain/payments/ln-fees.spec.ts
@@ -54,7 +54,7 @@ describe("LnFees", () => {
     if (priceRatio instanceof Error) throw priceRatio
 
     const validBtcMaxFeeToVerify = LnFees().maxProtocolAndBankFee(btc)
-    const validUsdMaxFeeToVerify = priceRatio.convertFromUsd(
+    const validUsdMaxFeeInBtcToVerify = priceRatio.convertFromUsd(
       LnFees().maxProtocolAndBankFee(usd),
     )
 
@@ -72,7 +72,7 @@ describe("LnFees", () => {
     it("correctly verifies a valid Usd maxFee", () => {
       expect(
         LnFees().verifyMaxFee({
-          maxFeeAmount: validUsdMaxFeeToVerify,
+          maxFeeAmount: validUsdMaxFeeInBtcToVerify,
           btcPaymentAmount: btc,
           priceRatio,
           senderWalletCurrency: WalletCurrency.Usd,
@@ -94,7 +94,7 @@ describe("LnFees", () => {
     it("correctly verifies 1 sat Usd payment", () => {
       expect(
         LnFees().verifyMaxFee({
-          maxFeeAmount: validUsdMaxFeeToVerify,
+          maxFeeAmount: validUsdMaxFeeInBtcToVerify,
           btcPaymentAmount: ONE_SAT,
           priceRatio,
           senderWalletCurrency: WalletCurrency.Usd,
@@ -116,7 +116,7 @@ describe("LnFees", () => {
     it("fails for a large Usd maxFee", () => {
       expect(
         LnFees().verifyMaxFee({
-          maxFeeAmount: calc.add(validUsdMaxFeeToVerify, ONE_SAT),
+          maxFeeAmount: calc.add(validUsdMaxFeeInBtcToVerify, ONE_SAT),
           btcPaymentAmount: btc,
           priceRatio,
           senderWalletCurrency: WalletCurrency.Usd,
@@ -138,7 +138,7 @@ describe("LnFees", () => {
     it("fails for a 1 sat large Usd maxFee", () => {
       expect(
         LnFees().verifyMaxFee({
-          maxFeeAmount: calc.add(validUsdMaxFeeToVerify, ONE_SAT),
+          maxFeeAmount: calc.add(validUsdMaxFeeInBtcToVerify, ONE_SAT),
           btcPaymentAmount: ONE_SAT,
           priceRatio,
           senderWalletCurrency: WalletCurrency.Btc,

--- a/test/unit/domain/payments/ln-fees.spec.ts
+++ b/test/unit/domain/payments/ln-fees.spec.ts
@@ -61,7 +61,7 @@ describe("LnFees", () => {
     it("correctly verifies a valid Btc maxFee", () => {
       expect(
         LnFees().verifyMaxFee({
-          maxFeeToVerify: validBtcMaxFeeToVerify,
+          maxFeeAmount: validBtcMaxFeeToVerify,
           btcPaymentAmount: btc,
           priceRatio,
           senderWalletCurrency: WalletCurrency.Btc,
@@ -72,7 +72,7 @@ describe("LnFees", () => {
     it("correctly verifies a valid Usd maxFee", () => {
       expect(
         LnFees().verifyMaxFee({
-          maxFeeToVerify: validUsdMaxFeeToVerify,
+          maxFeeAmount: validUsdMaxFeeToVerify,
           btcPaymentAmount: btc,
           priceRatio,
           senderWalletCurrency: WalletCurrency.Usd,
@@ -83,7 +83,7 @@ describe("LnFees", () => {
     it("correctly verifies 1 sat Btc payment", () => {
       expect(
         LnFees().verifyMaxFee({
-          maxFeeToVerify: ONE_SAT,
+          maxFeeAmount: ONE_SAT,
           btcPaymentAmount: ONE_SAT,
           priceRatio,
           senderWalletCurrency: WalletCurrency.Btc,
@@ -94,7 +94,7 @@ describe("LnFees", () => {
     it("correctly verifies 1 sat Usd payment", () => {
       expect(
         LnFees().verifyMaxFee({
-          maxFeeToVerify: validUsdMaxFeeToVerify,
+          maxFeeAmount: validUsdMaxFeeToVerify,
           btcPaymentAmount: ONE_SAT,
           priceRatio,
           senderWalletCurrency: WalletCurrency.Usd,
@@ -105,7 +105,7 @@ describe("LnFees", () => {
     it("fails for a large Btc maxFee", () => {
       expect(
         LnFees().verifyMaxFee({
-          maxFeeToVerify: calc.add(validBtcMaxFeeToVerify, ONE_SAT),
+          maxFeeAmount: calc.add(validBtcMaxFeeToVerify, ONE_SAT),
           btcPaymentAmount: btc,
           priceRatio,
           senderWalletCurrency: WalletCurrency.Btc,
@@ -116,7 +116,7 @@ describe("LnFees", () => {
     it("fails for a large Usd maxFee", () => {
       expect(
         LnFees().verifyMaxFee({
-          maxFeeToVerify: calc.add(validUsdMaxFeeToVerify, ONE_SAT),
+          maxFeeAmount: calc.add(validUsdMaxFeeToVerify, ONE_SAT),
           btcPaymentAmount: btc,
           priceRatio,
           senderWalletCurrency: WalletCurrency.Usd,
@@ -127,7 +127,7 @@ describe("LnFees", () => {
     it("fails for a 1 sat large Btc maxFee", () => {
       expect(
         LnFees().verifyMaxFee({
-          maxFeeToVerify: calc.add(ONE_SAT, ONE_SAT),
+          maxFeeAmount: calc.add(ONE_SAT, ONE_SAT),
           btcPaymentAmount: ONE_SAT,
           priceRatio,
           senderWalletCurrency: WalletCurrency.Btc,
@@ -138,7 +138,7 @@ describe("LnFees", () => {
     it("fails for a 1 sat large Usd maxFee", () => {
       expect(
         LnFees().verifyMaxFee({
-          maxFeeToVerify: calc.add(validUsdMaxFeeToVerify, ONE_SAT),
+          maxFeeAmount: calc.add(validUsdMaxFeeToVerify, ONE_SAT),
           btcPaymentAmount: ONE_SAT,
           priceRatio,
           senderWalletCurrency: WalletCurrency.Btc,

--- a/test/unit/domain/payments/ln-fees.spec.ts
+++ b/test/unit/domain/payments/ln-fees.spec.ts
@@ -1,5 +1,8 @@
-import { WalletCurrency } from "@domain/shared"
+import { AmountCalculator, ONE_SAT, WalletCurrency } from "@domain/shared"
 import { LnFees, PriceRatio } from "@domain/payments"
+import { MaxFeeTooLargeForRoutelessPaymentError } from "@domain/bitcoin/lightning"
+
+const calc = AmountCalculator()
 
 describe("LnFees", () => {
   describe("maxProtocolAndBankFee", () => {
@@ -9,24 +12,6 @@ describe("LnFees", () => {
         currency: WalletCurrency.Btc,
       }
       expect(LnFees().maxProtocolAndBankFee(btcAmount)).toEqual({
-        amount: 50n,
-        currency: WalletCurrency.Btc,
-      })
-    })
-
-    it("returns the minFeeFromPriceRatio", () => {
-      const btc = {
-        amount: 4995n,
-        currency: WalletCurrency.Btc,
-      }
-      const usd = {
-        amount: 100n,
-        currency: WalletCurrency.Usd,
-      }
-      const priceRatio = PriceRatio({ btc, usd })
-      if (priceRatio instanceof Error) throw priceRatio
-
-      expect(LnFees().minFeeFromPriceRatio(priceRatio)).toEqual({
         amount: 50n,
         currency: WalletCurrency.Btc,
       })
@@ -52,6 +37,113 @@ describe("LnFees", () => {
         amount: 1n,
         currency: WalletCurrency.Btc,
       })
+    })
+  })
+
+  describe("verifyMaxFee", () => {
+    const btc = {
+      amount: 4995n,
+      currency: WalletCurrency.Btc,
+    }
+    const usd = {
+      amount: 100n,
+      currency: WalletCurrency.Usd,
+    }
+
+    const priceRatio = PriceRatio({ btc, usd })
+    if (priceRatio instanceof Error) throw priceRatio
+
+    const validBtcMaxFeeToVerify = LnFees().maxProtocolAndBankFee(btc)
+    const validUsdMaxFeeToVerify = priceRatio.convertFromUsd(
+      LnFees().maxProtocolAndBankFee(usd),
+    )
+
+    it("correctly verifies a valid Btc maxFee", () => {
+      expect(
+        LnFees().verifyMaxFee({
+          maxFeeToVerify: validBtcMaxFeeToVerify,
+          btcPaymentAmount: btc,
+          priceRatio,
+          senderWalletCurrency: WalletCurrency.Btc,
+        }),
+      ).toBe(true)
+    })
+
+    it("correctly verifies a valid Usd maxFee", () => {
+      expect(
+        LnFees().verifyMaxFee({
+          maxFeeToVerify: validUsdMaxFeeToVerify,
+          btcPaymentAmount: btc,
+          priceRatio,
+          senderWalletCurrency: WalletCurrency.Usd,
+        }),
+      ).toBe(true)
+    })
+
+    it("correctly verifies 1 sat Btc payment", () => {
+      expect(
+        LnFees().verifyMaxFee({
+          maxFeeToVerify: ONE_SAT,
+          btcPaymentAmount: ONE_SAT,
+          priceRatio,
+          senderWalletCurrency: WalletCurrency.Btc,
+        }),
+      ).toBe(true)
+    })
+
+    it("correctly verifies 1 sat Usd payment", () => {
+      expect(
+        LnFees().verifyMaxFee({
+          maxFeeToVerify: validUsdMaxFeeToVerify,
+          btcPaymentAmount: ONE_SAT,
+          priceRatio,
+          senderWalletCurrency: WalletCurrency.Usd,
+        }),
+      ).toBe(true)
+    })
+
+    it("fails for a large Btc maxFee", () => {
+      expect(
+        LnFees().verifyMaxFee({
+          maxFeeToVerify: calc.add(validBtcMaxFeeToVerify, ONE_SAT),
+          btcPaymentAmount: btc,
+          priceRatio,
+          senderWalletCurrency: WalletCurrency.Btc,
+        }),
+      ).toBeInstanceOf(MaxFeeTooLargeForRoutelessPaymentError)
+    })
+
+    it("fails for a large Usd maxFee", () => {
+      expect(
+        LnFees().verifyMaxFee({
+          maxFeeToVerify: calc.add(validUsdMaxFeeToVerify, ONE_SAT),
+          btcPaymentAmount: btc,
+          priceRatio,
+          senderWalletCurrency: WalletCurrency.Usd,
+        }),
+      ).toBeInstanceOf(MaxFeeTooLargeForRoutelessPaymentError)
+    })
+
+    it("fails for a 1 sat large Btc maxFee", () => {
+      expect(
+        LnFees().verifyMaxFee({
+          maxFeeToVerify: calc.add(ONE_SAT, ONE_SAT),
+          btcPaymentAmount: ONE_SAT,
+          priceRatio,
+          senderWalletCurrency: WalletCurrency.Btc,
+        }),
+      ).toBeInstanceOf(MaxFeeTooLargeForRoutelessPaymentError)
+    })
+
+    it("fails for a 1 sat large Usd maxFee", () => {
+      expect(
+        LnFees().verifyMaxFee({
+          maxFeeToVerify: calc.add(validUsdMaxFeeToVerify, ONE_SAT),
+          btcPaymentAmount: ONE_SAT,
+          priceRatio,
+          senderWalletCurrency: WalletCurrency.Btc,
+        }),
+      ).toBeInstanceOf(MaxFeeTooLargeForRoutelessPaymentError)
     })
   })
 


### PR DESCRIPTION
## Description

This is to explicitly capture some of the logic around max fees when making routeless payments.

In the case of a payment without a fee probe the max fee should always be enforced as this has implications for how we calculate fee reimbursements. If a max fee at the lnd level exceeds what our fee reimbursement expects then this could be a potential attack vector.

Within the lnd service, to correctly catch this we would need to also be aware of sender wallet currencies and price ratios since the actual amount of sats being sent may be less than the actual sender currency amount being deducted (and the corresponding max fee calculation).

**_A new error and test cases were added to ensure we have this included in the lnd service._**

_Note: This shouldn't change any existing maxFee logic. It simply adds additional checks and tests._
