### PR TITLE
chore: add new 'DestinationMissingDependentFeatureError'

### DIFF
--- a/src/domain/bitcoin/lightning/errors.ts
+++ b/src/domain/bitcoin/lightning/errors.ts
@@ -38,6 +38,7 @@ export class ProbeForRouteTimedOutError extends LightningServiceError {}
 export class ProbeForRouteTimedOutFromApplicationError extends LightningServiceError {}
 export class PaymentInTransitionError extends LightningServiceError {}
 export class TemporaryChannelFailureError extends LightningServiceError {}
+export class DestinationMissingDependentFeatureError extends LightningServiceError {}
 export class InvalidFeeProbeStateError extends LightningServiceError {
   level = ErrorLevel.Critical
 }

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -237,6 +237,10 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       message = "Unable to find a route for payment."
       return new RouteFindingError({ message, logger: baseLogger })
 
+    case "DestinationMissingDependentFeatureError":
+      message = "Unable to pay incompatible recipient."
+      return new RouteFindingError({ message, logger: baseLogger })
+
     case "UnknownNextPeerError":
       message = "Unable to find a route for payment."
       return new RouteFindingError({ message, logger: baseLogger })

--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -53,6 +53,7 @@ import {
   TemporaryChannelFailureError,
   UnknownLightningServiceError,
   UnknownRouteNotFoundError,
+  DestinationMissingDependentFeatureError,
 } from "@domain/bitcoin/lightning"
 import { CacheKeys } from "@domain/cache"
 import { LnFees } from "@domain/payments"
@@ -800,6 +801,7 @@ export const KnownLndErrorDetails = {
   TemporaryChannelFailure: /TemporaryChannelFailure/,
   InvoiceAlreadySettled: /invoice already settled/,
   NoConnectionEstablished: /No connection established/,
+  MissingDependentFeature: /missing dependent feature/,
 } as const
 
 /* eslint @typescript-eslint/ban-ts-comment: "off" */
@@ -948,6 +950,10 @@ const handleCommonRouteNotFoundErrors = (err: Error) => {
     case match(KnownLndErrorDetails.ConnectionDropped):
     case match(KnownLndErrorDetails.NoConnectionEstablished):
       return new OffChainServiceUnavailableError()
+
+    case match(KnownLndErrorDetails.MissingDependentFeature):
+      return new DestinationMissingDependentFeatureError()
+
     default:
       return new UnknownRouteNotFoundError(msgForUnknown(err))
   }


### PR DESCRIPTION
This happens when the destination misses a feature that a feature our node requires depends on.

More: https://github.com/lightningnetwork/lnd/blob/f245591e4bfc18d50326938d1f50bf8dc5fe4771/routing/payment_session.go#L63