### PR TITLE
tests: make build/test work on m1/m2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       - DB_DEBUG=false
     depends_on: [postgres-price-history]
   redis:
-    image: bitnami/redis:7.0.7
+    image: redis:7.0.8
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
       - REDIS_DISABLE_COMMANDS=FLUSHDB,FLUSHALL
@@ -85,14 +85,9 @@ services:
     environment:
       - MONGODB_ADDRESS=mongodb
   mongodb:
-    image: bitnami/mongodb:5.0.10-debian-11-r3
+    image: mongo:5.0.10
     environment:
-      - MONGODB_PASSWORD=password
-      - MONGODB_USERNAME=testGaloy
-      - MONGODB_DATABASE=galoy
-      - MONGODB_REPLICA_SET_MODE=primary
-      - MONGODB_ROOT_PASSWORD=password
-      - MONGODB_REPLICA_SET_KEY=replicasetkey
+      - MONGO_INITDB_DATABASE=galoy
   postgres-price-history:
     image: postgres:14.1
     environment:

--- a/src/config/process.ts
+++ b/src/config/process.ts
@@ -144,7 +144,7 @@ export const googleApplicationCredentialsIsSet = (): boolean => {
 }
 
 export const mongodbCredentials = () => {
-  const user = process.env.MONGODB_USER ?? "testGaloy"
+  const user = process.env.MONGODB_USER
   const password = process.env.MONGODB_PASSWORD
   const address = process.env.MONGODB_ADDRESS ?? "mongodb"
   const db = process.env.MONGODB_DATABASE ?? "galoy"

--- a/src/migrations/migrate-mongo-config.js
+++ b/src/migrations/migrate-mongo-config.js
@@ -1,9 +1,15 @@
-const user = process.env.MONGODB_USER ?? "testGaloy"
-const password = process.env.MONGODB_PASSWORD ?? "password"
+const user = process.env.MONGODB_USER
+const password = process.env.MONGODB_PASSWORD
 const address = process.env.MONGODB_ADDRESS ?? "localhost"
 const db = process.env.MONGODB_DATABASE ?? "galoy"
 
-const url = `mongodb://${user}:${password}@${address}/${db}`
+let url
+if (user && password) {
+  url = `mongodb://${user}:${password}@${address}/${db}`
+} else {
+  url = `mongodb://${address}/${db}`
+  console.log({ path: url }, "Connecting to MongoDB without a username and password")
+}
 
 const config = {
   mongodb: {

--- a/src/services/mongodb/index.ts
+++ b/src/services/mongodb/index.ts
@@ -71,7 +71,15 @@ export const ledgerAdmin = lazyLoadLedgerAdmin({
 
 const mgCred = mongodbCredentials()
 
-const path = `mongodb://${mgCred.user}:${mgCred.password}@${mgCred.address}/${mgCred.db}`
+let path: string
+if (mgCred.user && mgCred.password) {
+  path = `mongodb://${mgCred.user}:${mgCred.password}@${mgCred.address}/${mgCred.db}`
+} else {
+  path = `mongodb://${mgCred.address}/${mgCred.db}`
+  if (process.env.NODE_ENV !== "development") {
+    baseLogger.warn({ path }, "Connecting to MongoDB without a username and password")
+  }
+}
 
 export const setupMongoConnection = async (syncIndexes = false) => {
   try {


### PR DESCRIPTION
compilation and test of the backend on m1/m2 breaks some months ago.
the issue with the docker image from bitnami is that they only contains amd64 binary.
so I'm moving to use the "official" images from mongo and redis as those contains arm64 that works correctly on new Mac.

the downside of using the official images is that there is less configurability. for mongodb, it seems (based on very quick search) that adding user needs some dedicated script and I didn't want to do that/maintain it. 

so I created a branch such that we don't need to have username/password in the docker-compose environement for mongodb.

