### PR TITLE
fix: correct receive-side settlementAmount calculation for API

### DIFF
--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -97,10 +97,10 @@ const translateLedgerTxnToWalletTxn = <S extends WalletCurrency>(
   const isSend = debit > credit
 
   let settlementAmount: Satoshis | UsdCents = isSend
-    ? toSats(debit)
+    ? toSats(-debit)
     : toSats(credit - satsFee)
   if (currency === WalletCurrency.Usd) {
-    settlementAmount = isSend ? toCents(debit) : toCents(credit - centsFee)
+    settlementAmount = isSend ? toCents(-debit) : toCents(credit - centsFee)
   }
   const settlementFee =
     currency === WalletCurrency.Btc ? toSats(satsFee) : toCents(centsFee)

--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -94,15 +94,20 @@ const translateLedgerTxnToWalletTxn = <S extends WalletCurrency>(
     centsFee = centsFeeRaw || 0
   }
 
-  const settlementAmount =
-    currency === WalletCurrency.Btc ? toSats(credit - debit) : toCents(credit - debit)
+  const isSend = debit > credit
+
+  let settlementAmount: Satoshis | UsdCents = isSend
+    ? toSats(debit)
+    : toSats(credit - satsFee)
+  if (currency === WalletCurrency.Usd) {
+    settlementAmount = isSend ? toCents(debit) : toCents(credit - centsFee)
+  }
   const settlementFee =
     currency === WalletCurrency.Btc ? toSats(satsFee) : toCents(centsFee)
 
   // 'displayAmount' is before fees. For total amount:
   // - send: displayAmount + displayFee
   // - recv: displayAmount
-  const isSend = settlementAmount < 0
   const displayAmountAsNumber =
     isSend && !isAdmin ? displayAmount + displayFee : displayAmount
 

--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -305,8 +305,12 @@ const displayCurrencyPerBaseUnitFromAmounts = ({
   displayAmountAsNumber: number
   settlementAmountInBaseAsNumber: number
 }): number => {
-  const displayAmountMajorUnit = Number((displayAmountMinorUnit / 100).toFixed(2))
-  return settlementAmountInBaseAsNumber === 0
-    ? 0
-    : Math.abs(displayAmountMajorUnit / settlementAmountInBaseAsNumber)
+  const majorExponent = 2
+
+  const priceInMinor =
+    settlementAmountInBaseAsNumber === 0
+      ? 0
+      : Math.abs(displayAmountMinorUnit / settlementAmountInBaseAsNumber)
+
+  return priceInMinor / 10 ** majorExponent
 }

--- a/test/integration/02-user-wallet/02-receive-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-onchain.spec.ts
@@ -531,7 +531,7 @@ async function sendToWalletTestWrapper({
     const txn = transactions.slice[0] as WalletOnChainTransaction
     expect(txn.settlementVia.type).toBe("onchain")
     expect(txn.settlementFee).toBe(Math.round(txn.settlementFee))
-    expect(txn.settlementAmount).toBe(
+    expect(txn.settlementAmount + txn.settlementFee).toBe(
       amountAfterFeeDeduction({
         amount: amountSats,
         depositFeeRatio: depositFeeRatio,
@@ -666,7 +666,7 @@ async function testTxnsByAddressWrapper({
     const txn = transactions.slice[0] as WalletOnChainTransaction
     expect(txn.settlementVia.type).toBe("onchain")
     expect(txn.settlementFee).toBe(Math.round(txn.settlementFee))
-    expect(txn.settlementAmount).toBe(
+    expect(txn.settlementAmount + txn.settlementFee).toBe(
       amountAfterFeeDeduction({
         amount: amountSats,
         depositFeeRatio: depositFeeRatio,

--- a/test/integration/app/trigger/trigger.fn.spec.ts
+++ b/test/integration/app/trigger/trigger.fn.spec.ts
@@ -177,7 +177,9 @@ describe("onchainBlockEventHandler", () => {
       expect(lastTransaction.settlementFee).toBe(
         Math.round(lastTransaction.settlementFee),
       )
-      expect(lastTransaction.settlementAmount).toBe(finalAmount)
+      expect(lastTransaction.settlementAmount + lastTransaction.settlementFee).toBe(
+        finalAmount,
+      )
       expect((lastTransaction as WalletOnChainTransaction).initiationVia.address).toBe(
         address,
       )


### PR DESCRIPTION
## Description

This fixes the issue where in mongo `satsAmount` and `centsAmount` reflect receive amounts less fees which no longer matches with the `credit` value which includes fees when doing display price calculations.