### PR TITLE
fix: add '_id' sorting to txns pagination

### DIFF
--- a/src/services/ledger/paginated-ledger.ts
+++ b/src/services/ledger/paginated-ledger.ts
@@ -61,7 +61,7 @@ export const paginatedLedger = async ({
 
   const slice = await Transaction.collection
     .find<ILedgerTransaction>(filterQuery)
-    .sort({ datetime: -1, timestamp: -1 })
+    .sort({ datetime: -1, timestamp: -1, _id: 1 })
     .limit(limit)
     .skip(skip)
     .toArray()


### PR DESCRIPTION
## Description

Attempt to avoid overlapping transactions (with same timestamp) appearing in multiple pages