### PR TITLE
chore: add message to MaxFee... error

### DIFF
--- a/src/domain/payments/ln-fees.ts
+++ b/src/domain/payments/ln-fees.ts
@@ -52,7 +52,13 @@ export const LnFees = () => {
         maxFeeAmount.amount > calculatedMinFeeAmount.amount) &&
       maxFeeAmount.amount > calculatedMaxFeeAmount.amount
     ) {
-      return new MaxFeeTooLargeForRoutelessPaymentError()
+      return new MaxFeeTooLargeForRoutelessPaymentError(
+        JSON.stringify({
+          btcPaymentAmount: Number(btcPaymentAmount.amount),
+          maxFeeBtcAmount: Number(maxFeeAmount.amount),
+          calculatedMaxFeeBtcAmount: Number(calculatedMaxFeeAmount.amount),
+        }),
+      )
     }
 
     return true


### PR DESCRIPTION
## Description

Add details from max-fee check to help debug ([trace](https://ui.honeycomb.io/galoy/datasets/galoy-bbw?query=%7B%22time_range%22%3A86400%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22service.name%22%2C%22name%22%2C%22error.name%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22COUNT%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22error%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3Atrue%7D%2C%7B%22column%22%3A%22error.level%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22critical%22%7D%2C%7B%22column%22%3A%22error.name%22%2C%22op%22%3A%22!%3D%22%2C%22value%22%3A%22CouldNotFindExpectedTransactionMetadataError%22%7D%2C%7B%22column%22%3A%22error.name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22MaxFeeTooLargeForRoutelessPaymentError%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22op%22%3A%22COUNT%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22limit%22%3A1000%7D))