### PR TITLE
fix: revert payment on verifyMaxFee error

### DIFF
--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -583,14 +583,15 @@ const executePaymentViaLn = async ({
         priceRatio,
         senderWalletCurrency: paymentFlow.senderWalletDescriptor().currency,
       }
-
       const maxFeeCheck = LnFees().verifyMaxFee(maxFeeCheckArgs)
-      if (maxFeeCheck instanceof Error) return maxFeeCheck
 
-      payResult = await lndService.payInvoiceViaPaymentDetails({
-        ...maxFeeCheckArgs,
-        decodedInvoice,
-      })
+      payResult =
+        maxFeeCheck instanceof Error
+          ? maxFeeCheck
+          : await lndService.payInvoiceViaPaymentDetails({
+              ...maxFeeCheckArgs,
+              decodedInvoice,
+            })
     }
 
     // Fire-and-forget update to 'lnPayments' collection


### PR DESCRIPTION
## Description

Handles `verifyMaxFee` error as if it were a `payResult` error in send-lightning use-case.

This is to correct an issue where this error was thrown and the user's payment is stuck as pending since the "revert" code path was never executed. The pending payment also doesn't get picked up by 'updatePendingPayments' since a corresponding lnd payment is never created.

_Note: I added a new test case and jest mock for `verifyMaxFee` that I'm sure can be done in a more elegant way (edit: fixed by @dolcalmi https://github.com/GaloyMoney/galoy/pull/2364/commits/3f710ee66b8ecde8a749756295079503e359c3d9)_