### PR TITLE
fix: realtime price when wallet currency is equal to display currency

### DIFF
--- a/src/services/price/index.ts
+++ b/src/services/price/index.ts
@@ -66,9 +66,11 @@ export const PriceService = (): IPriceService => {
   > => {
     try {
       if (walletCurrency === displayCurrency) {
+        const offset =
+          displayCurrency === DisplayCurrency.Usd ? CENTS_PER_USD : SATS_PER_BTC
         return {
           timestamp: new Date(Date.now()),
-          price: 1,
+          price: 1 / offset,
           currency: displayCurrency,
         }
       }


### PR DESCRIPTION
Fix an issue in price service when wallet currency is equal to display currency