### PR TITLE
feat: add fraction digits to currency list

### DIFF
--- a/src/domain/price/index.types.d.ts
+++ b/src/domain/price/index.types.d.ts
@@ -21,6 +21,7 @@ type PriceCurrency = {
   readonly symbol: string // currency symbol. E.g. $
   readonly name: string // currency name. E.g. US Dollar
   readonly flag: string // currency country flag (emoji). E.g. 🇺🇸
+  readonly fractionDigits: number // fraction digits . E.g. 2
 }
 
 type GetRealTimePriceArgs = {

--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -254,6 +254,7 @@ type Coordinates {
 
 type Currency {
   flag: String!
+  fractionDigits: Int!
   id: ID!
   name: String!
   symbol: String!

--- a/src/graphql/types/object/currency.ts
+++ b/src/graphql/types/object/currency.ts
@@ -10,6 +10,7 @@ const Currency = GT.Object({
     symbol: { type: GT.NonNull(GT.String) },
     name: { type: GT.NonNull(GT.String) },
     flag: { type: GT.NonNull(GT.String) },
+    fractionDigits: { type: GT.NonNull(GT.Int) },
   }),
 })
 

--- a/src/services/price/index.ts
+++ b/src/services/price/index.ts
@@ -119,12 +119,19 @@ export const PriceService = (): IPriceService => {
         return new PriceCurrenciesNotAvailableError()
 
       return currencies.map(
-        (c: { code: string; symbol: string; name: string; flag: string }) =>
+        (c: {
+          code: string
+          symbol: string
+          name: string
+          flag: string
+          fractionDigits: number
+        }) =>
           ({
             code: c.code,
             symbol: c.symbol,
             name: c.name,
             flag: c.flag,
+            fractionDigits: c.fractionDigits,
           } as PriceCurrency),
       )
     } catch (err) {

--- a/src/services/price/protos/price.proto
+++ b/src/services/price/protos/price.proto
@@ -24,4 +24,5 @@ message Currency {
   string symbol = 2;
   string name = 3;
   string flag = 4;
+  int32 fractionDigits = 5;
 }

--- a/test/unit/app/prices/list-currencies.spec.ts
+++ b/test/unit/app/prices/list-currencies.spec.ts
@@ -27,7 +27,13 @@ describe("Prices", () => {
           getUsdCentRealTimePrice: jest.fn(),
           listCurrencies: () =>
             Promise.resolve([
-              { code: "USD", symbol: "$", name: "US Dollar", flag: "🇺🇸" },
+              {
+                code: "USD",
+                symbol: "$",
+                name: "US Dollar",
+                flag: "🇺🇸",
+                fractionDigits: 2,
+              },
             ]),
         }))
         .mockImplementationOnce(() => ({
@@ -49,6 +55,7 @@ describe("Prices", () => {
             symbol: expect.any(String),
             name: expect.any(String),
             flag: expect.any(String),
+            fractionDigits: expect.any(Number),
           }),
         ]),
       )


### PR DESCRIPTION
Add fraction digits to currency list query

Merge after https://github.com/GaloyMoney/price/pull/41