### PR TITLE
refactor: remove usd from non-admin txn types

### DIFF
--- a/src/app/payments/send-intraledger.ts
+++ b/src/app/payments/send-intraledger.ts
@@ -2,7 +2,11 @@ import { getPubkeysToSkipProbe } from "@config"
 
 import { AccountValidator } from "@domain/accounts"
 import { PaymentSendStatus } from "@domain/bitcoin/lightning"
-import { DisplayCurrency, NewDisplayCurrencyConverter } from "@domain/fiat"
+import {
+  DisplayCurrency,
+  NewDisplayCurrencyConverter,
+  usdMinorToMajorUnit,
+} from "@domain/fiat"
 import {
   InvalidLightningPaymentFlowBuilderStateError,
   InvalidZeroAmountPriceRatioInputError,
@@ -328,7 +332,7 @@ const executePaymentViaIntraledger = async <
       recipientLanguage: recipientUser.language,
       paymentAmount: { amount, currency: recipientWallet.currency },
       displayPaymentAmount: {
-        amount: metadata.usd,
+        amount: usdMinorToMajorUnit(totalSendAmounts.usd.amount),
         currency: DisplayCurrency.Usd,
       },
     })

--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -7,7 +7,11 @@ import {
   PaymentSendStatus,
 } from "@domain/bitcoin/lightning"
 import { AlreadyPaidError, CouldNotFindLightningPaymentFlowError } from "@domain/errors"
-import { DisplayCurrency, NewDisplayCurrencyConverter } from "@domain/fiat"
+import {
+  DisplayCurrency,
+  NewDisplayCurrencyConverter,
+  usdMinorToMajorUnit,
+} from "@domain/fiat"
 import {
   checkedToBtcPaymentAmount,
   checkedToUsdPaymentAmount,
@@ -463,7 +467,7 @@ const executePaymentViaIntraledger = async <
       recipientWalletId,
       paymentAmount: { amount, currency: recipientWalletCurrency },
       displayPaymentAmount: {
-        amount: metadata.usd,
+        amount: usdMinorToMajorUnit(paymentFlow.usdPaymentAmount.amount),
         currency: DisplayCurrency.Usd,
       },
       paymentHash,

--- a/src/app/wallets/reimburse-failed-usd.ts
+++ b/src/app/wallets/reimburse-failed-usd.ts
@@ -2,12 +2,10 @@ import { toSats } from "@domain/bitcoin"
 import { CouldNotFindBtcWalletForAccountError } from "@domain/errors"
 import { DisplayCurrency, toCents } from "@domain/fiat"
 import { LedgerTransactionType } from "@domain/ledger"
-import { AmountCalculator, WalletCurrency } from "@domain/shared"
+import { WalletCurrency } from "@domain/shared"
 
 import { WalletsRepository } from "@services/mongoose"
 import * as LedgerFacade from "@services/ledger/facade"
-
-const calc = AmountCalculator()
 
 export const reimburseFailedUsdPayment = async <
   S extends WalletCurrency,
@@ -27,10 +25,6 @@ export const reimburseFailedUsdPayment = async <
     type: LedgerTransactionType.Payment,
     pending: false,
     related_journal: journalId,
-
-    usd: Number(
-      calc.divFloor(paymentFlow.usdPaymentAmount, 100n).amount,
-    ) as DisplayCurrencyBaseAmount,
 
     satsAmount: toSats(paymentFlow.btcPaymentAmount.amount),
     centsAmount: toCents(paymentFlow.usdPaymentAmount.amount),

--- a/src/app/wallets/reimburse-fee.ts
+++ b/src/app/wallets/reimburse-fee.ts
@@ -64,8 +64,6 @@ export const reimburseFee = async <S extends WalletCurrency, R extends WalletCur
     pending: false,
     related_journal: journalId,
 
-    usd: (reimburseAmountDisplayCurrency / 100) as DisplayCurrencyBaseAmount,
-
     satsAmount: toSats(feeDifference.btc.amount),
     centsAmount: toCents(feeDifference.usd.amount),
     satsFee: toSats(0),

--- a/src/app/wallets/send-on-chain.ts
+++ b/src/app/wallets/send-on-chain.ts
@@ -24,7 +24,10 @@ import {
 } from "@domain/bitcoin/onchain"
 import { CouldNotFindError, InsufficientBalanceError } from "@domain/errors"
 import { DisplayCurrency } from "@domain/fiat"
-import { NewDisplayCurrencyConverter } from "@domain/fiat/display-currency"
+import {
+  NewDisplayCurrencyConverter,
+  usdMinorToMajorUnit,
+} from "@domain/fiat/display-currency"
 import { ResourceExpiredLockServiceError } from "@domain/lock"
 import { WalletCurrency } from "@domain/shared"
 import { PaymentInputValidator, SettlementMethod } from "@domain/wallets"
@@ -341,7 +344,7 @@ const executePaymentViaIntraledger = async <
       recipientWalletId: recipientWallet.id,
       paymentAmount: { amount, currency: recipientWalletCurrency },
       displayPaymentAmount: {
-        amount: metadata.usd,
+        amount: usdMinorToMajorUnit(paymentFlow.usdPaymentAmount.amount),
         currency: DisplayCurrency.Usd,
       },
       recipientDeviceTokens: recipientUser.deviceTokens,

--- a/src/services/ledger/index.types.d.ts
+++ b/src/services/ledger/index.types.d.ts
@@ -109,7 +109,6 @@ type AddColdStorageSendLedgerMetadata = AddColdStorageLedgerMetadata
 
 type IntraledgerSendBaseMetadata = LedgerMetadata &
   LedgerSendMetadata & {
-    usd: DisplayCurrencyBaseAmount // to be renamed amountDisplayCurrency
     username?: Username
   }
 
@@ -146,7 +145,6 @@ type AddWalletIdTradeIntraAccountLedgerMetadata = Omit<
 type ReimbursementLedgerMetadata = SendAmountsMetadata & {
   hash: PaymentHash
   pending: boolean
-  usd: DisplayCurrencyBaseAmount
   related_journal: LedgerJournalId
 }
 

--- a/src/services/ledger/tx-metadata.ts
+++ b/src/services/ledger/tx-metadata.ts
@@ -216,9 +216,6 @@ export const LnFeeReimbursementReceiveLedgerMetadata = ({
     related_journal: journalId,
     pending: false,
 
-    usd: ((amountDisplayCurrency + feeDisplayCurrency) /
-      100) as DisplayCurrencyBaseAmount,
-
     satsFee: toSats(satsFee),
     displayFee: feeDisplayCurrency,
     displayAmount: amountDisplayCurrency,
@@ -269,8 +266,6 @@ export const OnChainIntraledgerLedgerMetadata = ({
     payee_addresses: payeeAddresses,
     sendAll,
 
-    usd: (amountDisplayCurrency / 100) as DisplayCurrencyBaseAmount,
-
     satsFee: toSats(satsFee),
     displayFee: feeDisplayCurrency,
     displayAmount: amountDisplayCurrency,
@@ -316,8 +311,6 @@ export const WalletIdIntraledgerLedgerMetadata = ({
     pending: false,
     memoPayer: memoOfPayer,
     username: senderUsername,
-
-    usd: (amountDisplayCurrency / 100) as DisplayCurrencyBaseAmount,
 
     satsFee: toSats(satsFee),
     displayFee: feeDisplayCurrency,
@@ -371,8 +364,6 @@ export const LnIntraledgerLedgerMetadata = ({
     hash: paymentHash,
     pubkey,
 
-    usd: (amountDisplayCurrency / 100) as DisplayCurrencyBaseAmount,
-
     satsFee: toSats(satsFee),
     displayFee: feeDisplayCurrency,
     displayAmount: amountDisplayCurrency,
@@ -421,8 +412,6 @@ export const OnChainTradeIntraAccountLedgerMetadata = ({
     payee_addresses: payeeAddresses,
     sendAll,
 
-    usd: (amountDisplayCurrency / 100) as DisplayCurrencyBaseAmount,
-
     satsFee: toSats(satsFee),
     displayFee: feeDisplayCurrency,
     displayAmount: amountDisplayCurrency,
@@ -462,8 +451,6 @@ export const WalletIdTradeIntraAccountLedgerMetadata = ({
     type: LedgerTransactionType.WalletIdTradeIntraAccount,
     pending: false,
     memoPayer: memoOfPayer,
-
-    usd: (amountDisplayCurrency / 100) as DisplayCurrencyBaseAmount,
 
     satsFee: toSats(satsFee),
     displayFee: feeDisplayCurrency,
@@ -508,8 +495,6 @@ export const LnTradeIntraAccountLedgerMetadata = ({
     memoPayer: undefined,
     hash: paymentHash,
     pubkey,
-
-    usd: (amountDisplayCurrency / 100) as DisplayCurrencyBaseAmount,
 
     satsFee: toSats(satsFee),
     displayFee: feeDisplayCurrency,

--- a/test/unit/services/ledger/domain/tx-metadata.spec.ts
+++ b/test/unit/services/ledger/domain/tx-metadata.spec.ts
@@ -119,8 +119,6 @@ describe("Tx metadata", () => {
           memoPayer: undefined,
           type: LedgerTransactionType.LnIntraLedger,
 
-          usd: (amountDisplayCurrency / 100) as DisplayCurrencyBaseAmount,
-
           satsFee: toSats(0),
           displayFee: feeDisplayCurrency,
           displayAmount: amountDisplayCurrency,
@@ -157,8 +155,6 @@ describe("Tx metadata", () => {
         expect.objectContaining({
           memoPayer: undefined,
           type: LedgerTransactionType.LnTradeIntraAccount,
-
-          usd: (amountDisplayCurrency / 100) as DisplayCurrencyBaseAmount,
 
           satsFee: toSats(0),
           displayFee: feeDisplayCurrency,
@@ -197,8 +193,6 @@ describe("Tx metadata", () => {
           memoPayer: memoOfPayer,
           type: LedgerTransactionType.IntraLedger,
 
-          usd: (amountDisplayCurrency / 100) as DisplayCurrencyBaseAmount,
-
           satsFee: toSats(0),
           displayFee: feeDisplayCurrency,
           displayAmount: amountDisplayCurrency,
@@ -231,8 +225,6 @@ describe("Tx metadata", () => {
         expect.objectContaining({
           memoPayer: memoOfPayer,
           type: LedgerTransactionType.WalletIdTradeIntraAccount,
-
-          usd: (amountDisplayCurrency / 100) as DisplayCurrencyBaseAmount,
 
           satsFee: toSats(0),
           displayFee: feeDisplayCurrency,


### PR DESCRIPTION
## Description

This is to remove the remaining `usd` property from intraledger transactions where we no longer use that property anymore (see #2191)