### PR TITLE
refactor: separate send/receive display intraledger metadata

### DIFF
--- a/src/app/payments/send-intraledger.ts
+++ b/src/app/payments/send-intraledger.ts
@@ -284,23 +284,23 @@ const executePaymentViaIntraledger = async <
       [key: string]: Username | DisplayCurrencyBaseAmount | DisplayCurrency | undefined
     } = {}
     let additionalCreditMetadata: {
-      [key: string]: Username | DisplayCurrencyBaseAmount | DisplayCurrency | undefined
+      [key: string]: DisplayCurrencyBaseAmount | DisplayCurrency | undefined
+    }
+    let additionalInternalMetadata: {
+      [key: string]: DisplayCurrencyBaseAmount | DisplayCurrency | undefined
     } = {}
     if (senderWallet.accountId === recipientWallet.accountId) {
       ;({
         metadata,
         debitAccountAdditionalMetadata: additionalDebitMetadata,
         creditAccountAdditionalMetadata: additionalCreditMetadata,
+        internalAccountsAdditionalMetadata: additionalInternalMetadata,
       } = LedgerFacade.WalletIdTradeIntraAccountLedgerMetadata({
         paymentAmounts: paymentFlow,
 
         senderAmountDisplayCurrency: senderAmountDisplayCurrencyAsNumber,
         senderFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
         senderDisplayCurrency: senderDisplayCurrency,
-
-        recipientAmountDisplayCurrency: recipientAmountDisplayCurrencyAsNumber,
-        recipientFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-        recipientDisplayCurrency: recipientAccount.displayCurrency,
 
         memoOfPayer: memo || undefined,
       }))
@@ -309,6 +309,7 @@ const executePaymentViaIntraledger = async <
         metadata,
         debitAccountAdditionalMetadata: additionalDebitMetadata,
         creditAccountAdditionalMetadata: additionalCreditMetadata,
+        internalAccountsAdditionalMetadata: additionalInternalMetadata,
       } = LedgerFacade.WalletIdIntraledgerLedgerMetadata({
         paymentAmounts: paymentFlow,
 
@@ -341,6 +342,7 @@ const executePaymentViaIntraledger = async <
       metadata,
       additionalDebitMetadata,
       additionalCreditMetadata,
+      additionalInternalMetadata,
     })
     if (journal instanceof Error) return journal
 

--- a/src/app/payments/send-intraledger.ts
+++ b/src/app/payments/send-intraledger.ts
@@ -280,30 +280,50 @@ const executePaymentViaIntraledger = async <
     let metadata:
       | AddWalletIdIntraledgerSendLedgerMetadata
       | AddWalletIdTradeIntraAccountLedgerMetadata
-    let additionalDebitMetadata: { [key: string]: Username | undefined } = {}
+    let additionalDebitMetadata: {
+      [key: string]: Username | DisplayCurrencyBaseAmount | DisplayCurrency | undefined
+    } = {}
+    let additionalCreditMetadata: {
+      [key: string]: Username | DisplayCurrencyBaseAmount | DisplayCurrency | undefined
+    } = {}
     if (senderWallet.accountId === recipientWallet.accountId) {
-      metadata = LedgerFacade.WalletIdTradeIntraAccountLedgerMetadata({
+      ;({
+        metadata,
+        debitAccountAdditionalMetadata: additionalDebitMetadata,
+        creditAccountAdditionalMetadata: additionalCreditMetadata,
+      } = LedgerFacade.WalletIdTradeIntraAccountLedgerMetadata({
         paymentAmounts: paymentFlow,
 
-        amountDisplayCurrency: senderAmountDisplayCurrencyAsNumber,
-        feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-        displayCurrency: senderDisplayCurrency,
+        senderAmountDisplayCurrency: senderAmountDisplayCurrencyAsNumber,
+        senderFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+        senderDisplayCurrency: senderDisplayCurrency,
+
+        recipientAmountDisplayCurrency: recipientAmountDisplayCurrencyAsNumber,
+        recipientFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+        recipientDisplayCurrency: recipientAccount.displayCurrency,
 
         memoOfPayer: memo || undefined,
-      })
+      }))
     } else {
-      ;({ metadata, debitAccountAdditionalMetadata: additionalDebitMetadata } =
-        LedgerFacade.WalletIdIntraledgerLedgerMetadata({
-          paymentAmounts: paymentFlow,
+      ;({
+        metadata,
+        debitAccountAdditionalMetadata: additionalDebitMetadata,
+        creditAccountAdditionalMetadata: additionalCreditMetadata,
+      } = LedgerFacade.WalletIdIntraledgerLedgerMetadata({
+        paymentAmounts: paymentFlow,
 
-          amountDisplayCurrency: senderAmountDisplayCurrencyAsNumber,
-          feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-          displayCurrency: senderDisplayCurrency,
+        senderAmountDisplayCurrency: senderAmountDisplayCurrencyAsNumber,
+        senderFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+        senderDisplayCurrency: senderDisplayCurrency,
 
-          memoOfPayer: memo || undefined,
-          senderUsername: senderAccount.username,
-          recipientUsername,
-        }))
+        recipientAmountDisplayCurrency: recipientAmountDisplayCurrencyAsNumber,
+        recipientFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+        recipientDisplayCurrency: recipientAccount.displayCurrency,
+
+        memoOfPayer: memo || undefined,
+        senderUsername: senderAccount.username,
+        recipientUsername,
+      }))
     }
 
     const recipientWalletDescriptor = paymentFlow.recipientWalletDescriptor()
@@ -320,7 +340,7 @@ const executePaymentViaIntraledger = async <
       recipientWalletDescriptor,
       metadata,
       additionalDebitMetadata,
-      additionalCreditMetadata: {},
+      additionalCreditMetadata,
     })
     if (journal instanceof Error) return journal
 

--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -422,35 +422,59 @@ const executePaymentViaIntraledger = async <
     let metadata:
       | AddLnIntraledgerSendLedgerMetadata
       | AddLnTradeIntraAccountLedgerMetadata
-    let additionalDebitMetadata: { [key: string]: string | undefined } = {}
+    let additionalDebitMetadata: {
+      [key: string]:
+        | Username
+        | DisplayCurrencyBaseAmount
+        | DisplayCurrency
+        | string
+        | undefined
+    } = {}
+    let additionalCreditMetadata: {
+      [key: string]: Username | DisplayCurrencyBaseAmount | DisplayCurrency | undefined
+    } = {}
     if (senderWallet.accountId === recipientWallet.accountId) {
-      ;({ metadata, debitAccountAdditionalMetadata: additionalDebitMetadata } =
-        LedgerFacade.LnTradeIntraAccountLedgerMetadata({
-          paymentHash,
-          pubkey: recipientPubkey,
-          paymentAmounts: paymentFlow,
+      ;({
+        metadata,
+        debitAccountAdditionalMetadata: additionalDebitMetadata,
+        creditAccountAdditionalMetadata: additionalCreditMetadata,
+      } = LedgerFacade.LnTradeIntraAccountLedgerMetadata({
+        paymentHash,
+        pubkey: recipientPubkey,
+        paymentAmounts: paymentFlow,
 
-          amountDisplayCurrency: senderAmountDisplayCurrencyAsNumber,
-          feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-          displayCurrency: senderDisplayCurrency,
+        senderAmountDisplayCurrency: senderAmountDisplayCurrencyAsNumber,
+        senderFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+        senderDisplayCurrency: senderDisplayCurrency,
 
-          memoOfPayer: memo || undefined,
-        }))
+        recipientAmountDisplayCurrency: recipientAmountDisplayCurrencyAsNumber,
+        recipientFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+        recipientDisplayCurrency: recipientAccount.displayCurrency,
+
+        memoOfPayer: memo || undefined,
+      }))
     } else {
-      ;({ metadata, debitAccountAdditionalMetadata: additionalDebitMetadata } =
-        LedgerFacade.LnIntraledgerLedgerMetadata({
-          paymentHash,
-          pubkey: recipientPubkey,
-          paymentAmounts: paymentFlow,
+      ;({
+        metadata,
+        debitAccountAdditionalMetadata: additionalDebitMetadata,
+        creditAccountAdditionalMetadata: additionalCreditMetadata,
+      } = LedgerFacade.LnIntraledgerLedgerMetadata({
+        paymentHash,
+        pubkey: recipientPubkey,
+        paymentAmounts: paymentFlow,
 
-          amountDisplayCurrency: senderAmountDisplayCurrencyAsNumber,
-          feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-          displayCurrency: senderDisplayCurrency,
+        senderAmountDisplayCurrency: senderAmountDisplayCurrencyAsNumber,
+        senderFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+        senderDisplayCurrency: senderDisplayCurrency,
 
-          memoOfPayer: memo || undefined,
-          senderUsername,
-          recipientUsername,
-        }))
+        recipientAmountDisplayCurrency: recipientAmountDisplayCurrencyAsNumber,
+        recipientFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+        recipientDisplayCurrency: recipientAccount.displayCurrency,
+
+        memoOfPayer: memo || undefined,
+        senderUsername,
+        recipientUsername,
+      }))
     }
 
     const journal = await LedgerFacade.recordIntraledger({
@@ -463,7 +487,7 @@ const executePaymentViaIntraledger = async <
       recipientWalletDescriptor,
       metadata,
       additionalDebitMetadata,
-      additionalCreditMetadata: {},
+      additionalCreditMetadata,
     })
     if (journal instanceof Error) return journal
 

--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -91,8 +91,7 @@ export const payInvoiceByWalletId = async ({
     ? executePaymentViaIntraledger({
         paymentFlow,
         senderWallet,
-        senderUsername: senderAccount.username,
-        senderDisplayCurrency: senderAccount.displayCurrency,
+        senderAccount,
         memo,
       })
     : executePaymentViaLn({
@@ -137,8 +136,7 @@ const payNoAmountInvoiceByWalletId = async ({
     ? executePaymentViaIntraledger({
         paymentFlow,
         senderWallet,
-        senderUsername: senderAccount.username,
-        senderDisplayCurrency: senderAccount.displayCurrency,
+        senderAccount,
         memo,
       })
     : executePaymentViaLn({
@@ -333,14 +331,12 @@ const executePaymentViaIntraledger = async <
 >({
   paymentFlow,
   senderWallet,
-  senderUsername,
-  senderDisplayCurrency,
+  senderAccount,
   memo,
 }: {
   paymentFlow: PaymentFlow<S, R>
   senderWallet: WalletDescriptor<S>
-  senderUsername: Username | undefined
-  senderDisplayCurrency: DisplayCurrency
+  senderAccount: Account
   memo: string | null
 }): Promise<PaymentSendStatus | ApplicationError> => {
   addAttributesToCurrentSpan({
@@ -398,7 +394,7 @@ const executePaymentViaIntraledger = async <
     if (balanceCheck instanceof Error) return balanceCheck
 
     const senderDisplayPriceRatio = await getCurrentPriceAsDisplayPriceRatio({
-      currency: senderDisplayCurrency,
+      currency: senderAccount.displayCurrency,
     })
     if (senderDisplayPriceRatio instanceof Error) return senderDisplayPriceRatio
     const senderAmountDisplayCurrencyAsNumber = Number(
@@ -445,7 +441,7 @@ const executePaymentViaIntraledger = async <
 
         senderAmountDisplayCurrency: senderAmountDisplayCurrencyAsNumber,
         senderFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-        senderDisplayCurrency: senderDisplayCurrency,
+        senderDisplayCurrency: senderAccount.displayCurrency,
 
         recipientAmountDisplayCurrency: recipientAmountDisplayCurrencyAsNumber,
         recipientFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
@@ -465,14 +461,14 @@ const executePaymentViaIntraledger = async <
 
         senderAmountDisplayCurrency: senderAmountDisplayCurrencyAsNumber,
         senderFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-        senderDisplayCurrency: senderDisplayCurrency,
+        senderDisplayCurrency: senderAccount.displayCurrency,
 
         recipientAmountDisplayCurrency: recipientAmountDisplayCurrencyAsNumber,
         recipientFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
         recipientDisplayCurrency: recipientAccount.displayCurrency,
 
         memoOfPayer: memo || undefined,
-        senderUsername,
+        senderUsername: senderAccount.username,
         recipientUsername,
       }))
     }

--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -583,7 +583,7 @@ const executePaymentViaLn = async ({
       displayPriceRatio.convertFromWallet(paymentFlow.btcPaymentAmount).amountInMinor,
     ) as DisplayCurrencyBaseAmount
     const feeDisplayCurrencyAsNumber = Number(
-      displayPriceRatio.convertFromWallet(paymentFlow.btcProtocolAndBankFee)
+      displayPriceRatio.convertFromWalletToCeil(paymentFlow.btcProtocolAndBankFee)
         .amountInMinor,
     ) as DisplayCurrencyBaseAmount
 

--- a/src/app/payments/update-pending-payments.ts
+++ b/src/app/payments/update-pending-payments.ts
@@ -5,8 +5,8 @@ import {
   CouldNotFindTransactionError,
   inputAmountFromLedgerTransaction,
   LedgerTransactionType,
+  MissingExpectedDisplayAmountsForTransactionError,
   MultiplePendingPaymentsForHashError,
-  UnknownLedgerError,
 } from "@domain/ledger"
 import { MissingPropsInTransactionForPaymentFlowError } from "@domain/payments"
 import { setErrorCritical, WalletCurrency } from "@domain/shared"
@@ -206,7 +206,8 @@ const updatePendingPayment = wrapAsyncToRunInSpan({
         }
 
         const reimbursed = await Wallets.reimburseFailedUsdPayment({
-          journalId: pendingPayment.journalId,
+          walletId,
+          pendingPayment,
           paymentFlow,
         })
         if (reimbursed instanceof Error) {
@@ -236,7 +237,7 @@ const updatePendingPayment = wrapAsyncToRunInSpan({
         displayFee === undefined ||
         displayCurrency === undefined
       ) {
-        return new UnknownLedgerError("missing display-related values in transaction")
+        return new MissingExpectedDisplayAmountsForTransactionError()
       }
 
       return Wallets.reimburseFee({

--- a/src/app/wallets/send-on-chain.ts
+++ b/src/app/wallets/send-on-chain.ts
@@ -317,12 +317,16 @@ const executePaymentViaIntraledger = async <
     let additionalCreditMetadata: {
       [key: string]: Username | DisplayCurrencyBaseAmount | DisplayCurrency | undefined
     } = {}
+    let additionalInternalMetadata: {
+      [key: string]: DisplayCurrencyBaseAmount | DisplayCurrency | undefined
+    } = {}
 
     if (senderWallet.accountId === recipientWallet.accountId) {
       ;({
         metadata,
         debitAccountAdditionalMetadata: additionalDebitMetadata,
         creditAccountAdditionalMetadata: additionalCreditMetadata,
+        internalAccountsAdditionalMetadata: additionalInternalMetadata,
       } = LedgerFacade.OnChainTradeIntraAccountLedgerMetadata({
         payeeAddresses,
         sendAll,
@@ -332,10 +336,6 @@ const executePaymentViaIntraledger = async <
         senderFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
         senderDisplayCurrency: senderDisplayCurrency,
 
-        recipientAmountDisplayCurrency: recipientAmountDisplayCurrencyAsNumber,
-        recipientFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-        recipientDisplayCurrency: recipientAccount.displayCurrency,
-
         memoOfPayer: memo || undefined,
       }))
     } else {
@@ -343,6 +343,7 @@ const executePaymentViaIntraledger = async <
         metadata,
         debitAccountAdditionalMetadata: additionalDebitMetadata,
         creditAccountAdditionalMetadata: additionalCreditMetadata,
+        internalAccountsAdditionalMetadata: additionalInternalMetadata,
       } = LedgerFacade.OnChainIntraledgerLedgerMetadata({
         payeeAddresses,
         sendAll,
@@ -374,6 +375,7 @@ const executePaymentViaIntraledger = async <
       metadata,
       additionalDebitMetadata,
       additionalCreditMetadata,
+      additionalInternalMetadata,
     })
     if (journal instanceof Error) return journal
 
@@ -510,7 +512,11 @@ const executePaymentViaOnChain = async <
         .amountInMinor,
     ) as DisplayCurrencyBaseAmount
 
-    const metadata = LedgerFacade.OnChainSendLedgerMetadata({
+    const {
+      metadata,
+      debitAccountAdditionalMetadata,
+      internalAccountsAdditionalMetadata,
+    } = LedgerFacade.OnChainSendLedgerMetadata({
       // we need a temporary hash to be able to search in admin panel
       onChainTxHash: crypto.randomBytes(32).toString("hex") as OnChainTxHash,
       paymentAmounts: paymentFlow,
@@ -544,6 +550,8 @@ const executePaymentViaOnChain = async <
       bankFee,
       senderWalletDescriptor: paymentFlow.senderWalletDescriptor(),
       metadata,
+      additionalDebitMetadata: debitAccountAdditionalMetadata,
+      additionalInternalMetadata: internalAccountsAdditionalMetadata,
     })
     if (journal instanceof Error) return journal
 

--- a/src/app/wallets/send-on-chain.ts
+++ b/src/app/wallets/send-on-chain.ts
@@ -306,35 +306,60 @@ const executePaymentViaIntraledger = async <
     let metadata:
       | AddOnChainIntraledgerSendLedgerMetadata
       | AddOnChainTradeIntraAccountLedgerMetadata
-    let additionalDebitMetadata: { [key: string]: string | undefined } = {}
+    let additionalDebitMetadata: {
+      [key: string]:
+        | Username
+        | DisplayCurrencyBaseAmount
+        | DisplayCurrency
+        | string
+        | undefined
+    } = {}
+    let additionalCreditMetadata: {
+      [key: string]: Username | DisplayCurrencyBaseAmount | DisplayCurrency | undefined
+    } = {}
+
     if (senderWallet.accountId === recipientWallet.accountId) {
-      ;({ metadata, debitAccountAdditionalMetadata: additionalDebitMetadata } =
-        LedgerFacade.OnChainTradeIntraAccountLedgerMetadata({
-          payeeAddresses,
-          sendAll,
-          paymentAmounts: paymentFlow,
+      ;({
+        metadata,
+        debitAccountAdditionalMetadata: additionalDebitMetadata,
+        creditAccountAdditionalMetadata: additionalCreditMetadata,
+      } = LedgerFacade.OnChainTradeIntraAccountLedgerMetadata({
+        payeeAddresses,
+        sendAll,
+        paymentAmounts: paymentFlow,
 
-          amountDisplayCurrency: senderAmountDisplayCurrencyAsNumber,
-          feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-          displayCurrency: DisplayCurrency.Usd,
+        senderAmountDisplayCurrency: senderAmountDisplayCurrencyAsNumber,
+        senderFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+        senderDisplayCurrency: senderDisplayCurrency,
 
-          memoOfPayer: memo || undefined,
-        }))
+        recipientAmountDisplayCurrency: recipientAmountDisplayCurrencyAsNumber,
+        recipientFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+        recipientDisplayCurrency: recipientAccount.displayCurrency,
+
+        memoOfPayer: memo || undefined,
+      }))
     } else {
-      ;({ metadata, debitAccountAdditionalMetadata: additionalDebitMetadata } =
-        LedgerFacade.OnChainIntraledgerLedgerMetadata({
-          payeeAddresses,
-          sendAll,
-          paymentAmounts: paymentFlow,
+      ;({
+        metadata,
+        debitAccountAdditionalMetadata: additionalDebitMetadata,
+        creditAccountAdditionalMetadata: additionalCreditMetadata,
+      } = LedgerFacade.OnChainIntraledgerLedgerMetadata({
+        payeeAddresses,
+        sendAll,
+        paymentAmounts: paymentFlow,
 
-          amountDisplayCurrency: senderAmountDisplayCurrencyAsNumber,
-          feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-          displayCurrency: DisplayCurrency.Usd,
+        senderAmountDisplayCurrency: senderAmountDisplayCurrencyAsNumber,
+        senderFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+        senderDisplayCurrency: senderDisplayCurrency,
 
-          memoOfPayer: memo || undefined,
-          senderUsername,
-          recipientUsername,
-        }))
+        recipientAmountDisplayCurrency: recipientAmountDisplayCurrencyAsNumber,
+        recipientFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+        recipientDisplayCurrency: recipientAccount.displayCurrency,
+
+        memoOfPayer: memo || undefined,
+        senderUsername,
+        recipientUsername,
+      }))
     }
 
     // Record transaction
@@ -348,7 +373,7 @@ const executePaymentViaIntraledger = async <
       recipientWalletDescriptor,
       metadata,
       additionalDebitMetadata,
-      additionalCreditMetadata: {},
+      additionalCreditMetadata,
     })
     if (journal instanceof Error) return journal
 

--- a/src/app/wallets/send-on-chain.ts
+++ b/src/app/wallets/send-on-chain.ts
@@ -508,7 +508,7 @@ const executePaymentViaOnChain = async <
       displayPriceRatio.convertFromWallet(paymentFlow.btcPaymentAmount).amountInMinor,
     ) as DisplayCurrencyBaseAmount
     const feeDisplayCurrencyAsNumber = Number(
-      displayPriceRatio.convertFromWallet(paymentFlow.btcProtocolAndBankFee)
+      displayPriceRatio.convertFromWalletToCeil(paymentFlow.btcProtocolAndBankFee)
         .amountInMinor,
     ) as DisplayCurrencyBaseAmount
 

--- a/src/app/wallets/update-on-chain-receipt.ts
+++ b/src/app/wallets/update-on-chain-receipt.ts
@@ -179,7 +179,11 @@ const processTxForWallet = async (
 
           const displayCurrency = DisplayCurrency.Usd
 
-          const metadata = LedgerFacade.OnChainReceiveLedgerMetadata({
+          const {
+            metadata,
+            creditAccountAdditionalMetadata,
+            internalAccountsAdditionalMetadata,
+          } = LedgerFacade.OnChainReceiveLedgerMetadata({
             onChainTxHash: tx.rawTx.txHash,
             paymentAmounts: {
               btcPaymentAmount: walletAddressReceiver.btcToCreditReceiver,
@@ -206,6 +210,8 @@ const processTxForWallet = async (
               btc: walletAddressReceiver.btcBankFee,
             },
             metadata,
+            additionalCreditMetadata: creditAccountAdditionalMetadata,
+            additionalInternalMetadata: internalAccountsAdditionalMetadata,
           })
 
           if (result instanceof Error) {

--- a/src/app/wallets/update-pending-invoices.ts
+++ b/src/app/wallets/update-pending-invoices.ts
@@ -191,7 +191,11 @@ const updatePendingInvoiceBeforeFinally = async ({
     // for walletInvoicesRepo, but also in the ledger to make sure in case the process crash in this
     // loop that an eventual consistency doesn't lead to a double credit
 
-    const metadata = LedgerFacade.LnReceiveLedgerMetadata({
+    const {
+      metadata,
+      creditAccountAdditionalMetadata,
+      internalAccountsAdditionalMetadata,
+    } = LedgerFacade.LnReceiveLedgerMetadata({
       paymentHash,
       pubkey: walletInvoice.pubkey,
       paymentAmounts: {
@@ -239,6 +243,8 @@ const updatePendingInvoiceBeforeFinally = async ({
       txMetadata: {
         hash: metadata.hash,
       },
+      additionalCreditMetadata: creditAccountAdditionalMetadata,
+      additionalInternalMetadata: internalAccountsAdditionalMetadata,
     })
 
     if (result instanceof Error) return result

--- a/src/domain/fiat/index.types.d.ts
+++ b/src/domain/fiat/index.types.d.ts
@@ -7,6 +7,12 @@ type DisplayCurrency =
 type CurrencyMajorExponent =
   typeof import("./index").MajorExponent[keyof typeof import("./index").MajorExponent]
 
+type DisplayTxnAmounts = {
+  displayAmount: DisplayCurrencyBaseAmount
+  displayFee: DisplayCurrencyBaseAmount
+  displayCurrency: DisplayCurrency
+}
+
 // TODO: a better way to type it can be:
 // <T extends Satoshis | UsdCents> someFunction({amount}: {amount: T})
 type CurrencyBaseAmount = Satoshis | UsdCents

--- a/src/domain/ledger/errors.ts
+++ b/src/domain/ledger/errors.ts
@@ -10,6 +10,9 @@ export class MismatchedResultForTransactionMetadataQuery extends LedgerServiceEr
 export class MultiplePendingPaymentsForHashError extends LedgerServiceError {
   level = ErrorLevel.Critical
 }
+export class MissingExpectedDisplayAmountsForTransactionError extends LedgerServiceError {
+  level = ErrorLevel.Critical
+}
 export class UnknownLedgerError extends LedgerServiceError {
   level = ErrorLevel.Critical
 }

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -425,6 +425,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "MismatchedResultForTransactionMetadataQuery":
     case "InvalidLedgerTransactionId":
     case "MultiplePendingPaymentsForHashError":
+    case "MissingExpectedDisplayAmountsForTransactionError":
     case "CacheError":
     case "CacheNotAvailableError":
     case "CacheServiceError":

--- a/src/services/ledger/domain/index.types.d.ts
+++ b/src/services/ledger/domain/index.types.d.ts
@@ -31,11 +31,13 @@ type EntryBuilderConfig<M extends MediciEntry> = {
   entry: M
   staticAccountIds: StaticAccountIds
   metadata: TxMetadata
+  additionalInternalMetadata: TxMetadata
 }
 
 type EntryBuilderFeeState<M extends MediciEntry> = {
   entry: M
   metadata: TxMetadata
+  additionalInternalMetadata: TxMetadata
   staticAccountIds: StaticAccountIds
   amountWithFees: {
     usdWithFees: UsdPaymentAmount
@@ -56,6 +58,7 @@ type EntryBuilderFee<M extends MediciEntry> = {
 type EntryBuilderDebitState<M extends MediciEntry> = {
   entry: M
   metadata: TxMetadata
+  additionalInternalMetadata: TxMetadata
   staticAccountIds: StaticAccountIds
   amountWithFees: {
     usdWithFees: UsdPaymentAmount
@@ -73,7 +76,7 @@ type EntryBuilderDebit<M extends MediciEntry> = {
     additionalMetadata,
   }: {
     accountDescriptor: LedgerAccountDescriptor<D>
-    additionalMetadata?: TxMetadata
+    additionalMetadata: TxMetadata
   }) => EntryBuilderCredit<M>
   debitLnd: () => EntryBuilderCredit<M>
   debitColdStorage: () => EntryBuilderCredit<M>
@@ -82,6 +85,7 @@ type EntryBuilderDebit<M extends MediciEntry> = {
 type EntryBuilderCreditState<M extends MediciEntry> = {
   entry: M
   metadata: TxMetadata
+  additionalInternalMetadata: TxMetadata
   debitCurrency: WalletCurrency
   amountWithFees: {
     usdWithFees: UsdPaymentAmount
@@ -105,7 +109,7 @@ type EntryBuilderCredit<M extends MediciEntry> = {
     additionalMetadata,
   }: {
     accountDescriptor: LedgerAccountDescriptor<C>
-    additionalMetadata?: TxMetadata
+    additionalMetadata: TxMetadata
   }) => M
 }
 

--- a/src/services/ledger/domain/index.types.d.ts
+++ b/src/services/ledger/domain/index.types.d.ts
@@ -1,8 +1,18 @@
 declare const ledgerAccountId: unique symbol
 type LedgerAccountId = string & { [ledgerAccountId]: never }
 
-// eslint-disable-next-line
-type TxMetadata = any
+type TxMetadata = Record<
+  string,
+  | string // TODO: add branded type for memo/memoPayer/memoFromPayer and remove this
+  | DisplayCurrency
+  | Username
+  | Satoshis
+  | UsdCents
+  | DisplayCurrencyBaseAmount
+  | boolean
+  | OnChainAddress[]
+  | undefined
+>
 
 type LedgerAccountDescriptor<T extends WalletCurrency> = {
   id: LedgerAccountId

--- a/src/services/ledger/facade.ts
+++ b/src/services/ledger/facade.ts
@@ -36,6 +36,8 @@ export const recordSend = async ({
   amountToDebitSender,
   bankFee,
   metadata,
+  additionalDebitMetadata,
+  additionalInternalMetadata,
 }: RecordSendArgs) => {
   const actualFee = bankFee || { usd: ZERO_CENTS, btc: ZERO_SATS }
 
@@ -44,6 +46,7 @@ export const recordSend = async ({
     staticAccountIds: await staticAccountIds(),
     entry,
     metadata,
+    additionalInternalMetadata,
   })
 
   entry = builder
@@ -54,6 +57,7 @@ export const recordSend = async ({
     .withBankFee({ usdBankFee: actualFee.usd, btcBankFee: actualFee.btc })
     .debitAccount({
       accountDescriptor: toLedgerAccountDescriptor(senderWalletDescriptor),
+      additionalMetadata: additionalDebitMetadata,
     })
     .creditLnd()
 
@@ -67,6 +71,8 @@ export const recordReceive = async ({
   bankFee,
   metadata,
   txMetadata,
+  additionalCreditMetadata,
+  additionalInternalMetadata,
 }: RecordReceiveArgs) => {
   const actualFee = bankFee || { usd: ZERO_CENTS, btc: ZERO_SATS }
 
@@ -75,6 +81,7 @@ export const recordReceive = async ({
     staticAccountIds: await staticAccountIds(),
     entry,
     metadata,
+    additionalInternalMetadata,
   })
 
   const amountWithFees = {
@@ -88,6 +95,7 @@ export const recordReceive = async ({
     .debitLnd()
     .creditAccount({
       accountDescriptor: toLedgerAccountDescriptor(recipientWalletDescriptor),
+      additionalMetadata: additionalCreditMetadata,
     })
 
   return persistAndReturnEntry({ entry, ...txMetadata })
@@ -115,12 +123,14 @@ export const recordIntraledger = async ({
   metadata,
   additionalDebitMetadata,
   additionalCreditMetadata,
+  additionalInternalMetadata,
 }: RecordIntraledgerArgs) => {
   let entry = MainBook.entry(description)
   const builder = EntryBuilder({
     staticAccountIds: await staticAccountIds(),
     entry,
     metadata,
+    additionalInternalMetadata,
   })
 
   entry = builder

--- a/src/services/ledger/index.types.d.ts
+++ b/src/services/ledger/index.types.d.ts
@@ -9,6 +9,8 @@ type RecordSendArgs = {
     btc: BtcPaymentAmount
   }
   metadata: SendLedgerMetadata
+  additionalDebitMetadata: TxMetadata
+  additionalInternalMetadata: TxMetadata
   bankFee?: {
     usd: UsdPaymentAmount
     btc: BtcPaymentAmount
@@ -23,6 +25,8 @@ type RecordReceiveArgs = {
     btc: BtcPaymentAmount
   }
   metadata: ReceiveLedgerMetadata
+  additionalCreditMetadata: TxMetadata
+  additionalInternalMetadata: TxMetadata
   txMetadata?: LnLedgerTransactionMetadataUpdate
   bankFee?: {
     usd: UsdPaymentAmount
@@ -41,6 +45,7 @@ type RecordIntraledgerArgs = {
   metadata: IntraledgerLedgerMetadata
   additionalDebitMetadata: TxMetadata
   additionalCreditMetadata: TxMetadata
+  additionalInternalMetadata: TxMetadata
 }
 
 type LedgerMetadata = {

--- a/src/services/ledger/index.types.d.ts
+++ b/src/services/ledger/index.types.d.ts
@@ -192,6 +192,12 @@ type IntraledgerLedgerMetadata =
 
 type SendLedgerMetadata = AddOnchainSendLedgerMetadata | AddLnSendLedgerMetadata
 
+type DisplayTxnAmountsArg = {
+  feeDisplayCurrency: DisplayCurrencyBaseAmount
+  amountDisplayCurrency: DisplayCurrencyBaseAmount
+  displayCurrency: DisplayCurrency
+}
+
 type PaginatedArray<T> = { slice: T[]; total: number }
 
 // The following is needed for src/services/ledger/paginated-ledger.ts

--- a/src/services/ledger/index.types.d.ts
+++ b/src/services/ledger/index.types.d.ts
@@ -75,6 +75,13 @@ type SendAmountsMetadata = {
   displayCurrency: DisplayCurrency
 }
 
+type IntraLedgerSendAmountsMetadata = {
+  satsAmount: Satoshis
+  centsAmount: UsdCents
+  satsFee: Satoshis
+  centsFee: UsdCents
+}
+
 type AddLnSendLedgerMetadata = LedgerMetadata &
   LedgerSendMetadata &
   SendAmountsMetadata & {
@@ -113,7 +120,7 @@ type IntraledgerSendBaseMetadata = LedgerMetadata &
   }
 
 type AddLnIntraledgerSendLedgerMetadata = IntraledgerSendBaseMetadata &
-  SendAmountsMetadata & {
+  IntraLedgerSendAmountsMetadata & {
     hash: PaymentHash
     pubkey: Pubkey
   }
@@ -124,7 +131,7 @@ type AddLnTradeIntraAccountLedgerMetadata = Omit<
 >
 
 type AddOnChainIntraledgerSendLedgerMetadata = IntraledgerSendBaseMetadata &
-  SendAmountsMetadata & {
+  IntraLedgerSendAmountsMetadata & {
     payee_addresses: OnChainAddress[]
     sendAll: boolean
   }
@@ -135,7 +142,7 @@ type AddOnChainTradeIntraAccountLedgerMetadata = Omit<
 >
 
 type AddWalletIdIntraledgerSendLedgerMetadata = IntraledgerSendBaseMetadata &
-  SendAmountsMetadata
+  IntraLedgerSendAmountsMetadata
 
 type AddWalletIdTradeIntraAccountLedgerMetadata = Omit<
   AddWalletIdIntraledgerSendLedgerMetadata,

--- a/src/services/ledger/index.types.d.ts
+++ b/src/services/ledger/index.types.d.ts
@@ -69,10 +69,6 @@ type SendAmountsMetadata = {
   centsAmount: UsdCents
   satsFee: Satoshis
   centsFee: UsdCents
-
-  displayAmount: DisplayCurrencyBaseAmount
-  displayFee: DisplayCurrencyBaseAmount
-  displayCurrency: DisplayCurrency
 }
 
 type IntraLedgerSendAmountsMetadata = {

--- a/src/services/ledger/tx-metadata.ts
+++ b/src/services/ledger/tx-metadata.ts
@@ -404,6 +404,59 @@ export const LnFeeReimbursementReceiveLedgerMetadata = ({
   }
 }
 
+export const LnFailedPaymentReceiveLedgerMetadata = ({
+  paymentAmounts,
+  paymentHash,
+  journalId,
+  feeDisplayCurrency: displayAmount,
+  amountDisplayCurrency: displayFee,
+  displayCurrency,
+}: {
+  paymentAmounts: AmountsAndFees
+  paymentHash: PaymentHash
+  journalId: LedgerJournalId
+  feeDisplayCurrency: DisplayCurrencyBaseAmount
+  amountDisplayCurrency: DisplayCurrencyBaseAmount
+  displayCurrency: DisplayCurrency
+}) => {
+  const {
+    btcPaymentAmount: { amount: satsAmount },
+    usdPaymentAmount: { amount: centsAmount },
+    btcProtocolAndBankFee: { amount: satsFee },
+    usdProtocolAndBankFee: { amount: centsFee },
+  } = paymentAmounts
+
+  const metadata: FailedPaymentLedgerMetadata = {
+    type: LedgerTransactionType.Payment,
+    hash: paymentHash,
+    related_journal: journalId,
+    pending: false,
+
+    satsAmount: toSats(satsAmount),
+    satsFee: toSats(satsFee),
+    centsAmount: toCents(centsAmount),
+    centsFee: toCents(centsFee),
+  }
+
+  const {
+    debitOrCreditAdditionalMetadata: creditAccountAdditionalMetadata,
+    internalAccountsAdditionalMetadata,
+  } = debitOrCreditMetadataAmounts({
+    centsAmount,
+    centsFee,
+
+    displayAmount,
+    displayFee,
+    displayCurrency,
+  })
+
+  return {
+    metadata,
+    creditAccountAdditionalMetadata,
+    internalAccountsAdditionalMetadata,
+  }
+}
+
 export const OnChainIntraledgerLedgerMetadata = ({
   payeeAddresses,
   sendAll,

--- a/src/services/ledger/tx-metadata.ts
+++ b/src/services/ledger/tx-metadata.ts
@@ -300,8 +300,8 @@ export const LnReceiveLedgerMetadata = ({
   pubkey,
   paymentAmounts,
 
-  feeDisplayCurrency: displayAmount,
-  amountDisplayCurrency: displayFee,
+  feeDisplayCurrency: displayFee,
+  amountDisplayCurrency: displayAmount,
   displayCurrency,
 }: {
   paymentHash: PaymentHash

--- a/src/services/ledger/tx-metadata.ts
+++ b/src/services/ledger/tx-metadata.ts
@@ -355,8 +355,8 @@ export const LnFeeReimbursementReceiveLedgerMetadata = ({
   paymentAmounts,
   paymentHash,
   journalId,
-  feeDisplayCurrency: displayAmount,
-  amountDisplayCurrency: displayFee,
+  feeDisplayCurrency: displayFee,
+  amountDisplayCurrency: displayAmount,
   displayCurrency,
 }: {
   paymentAmounts: AmountsAndFees
@@ -408,8 +408,8 @@ export const LnFailedPaymentReceiveLedgerMetadata = ({
   paymentAmounts,
   paymentHash,
   journalId,
-  feeDisplayCurrency: displayAmount,
-  amountDisplayCurrency: displayFee,
+  feeDisplayCurrency: displayFee,
+  amountDisplayCurrency: displayAmount,
   displayCurrency,
 }: {
   paymentAmounts: AmountsAndFees

--- a/src/services/ledger/tx-metadata.ts
+++ b/src/services/ledger/tx-metadata.ts
@@ -232,9 +232,12 @@ export const OnChainIntraledgerLedgerMetadata = ({
   payeeAddresses,
   sendAll,
   paymentAmounts,
-  feeDisplayCurrency,
-  amountDisplayCurrency,
-  displayCurrency,
+  senderFeeDisplayCurrency,
+  senderAmountDisplayCurrency,
+  senderDisplayCurrency,
+  recipientFeeDisplayCurrency,
+  recipientAmountDisplayCurrency,
+  recipientDisplayCurrency,
   memoOfPayer,
   senderUsername,
   recipientUsername,
@@ -243,9 +246,13 @@ export const OnChainIntraledgerLedgerMetadata = ({
   sendAll: boolean
   paymentAmounts: AmountsAndFees
 
-  feeDisplayCurrency: DisplayCurrencyBaseAmount
-  amountDisplayCurrency: DisplayCurrencyBaseAmount
-  displayCurrency: DisplayCurrency
+  senderFeeDisplayCurrency: DisplayCurrencyBaseAmount
+  senderAmountDisplayCurrency: DisplayCurrencyBaseAmount
+  senderDisplayCurrency: DisplayCurrency
+
+  recipientFeeDisplayCurrency: DisplayCurrencyBaseAmount
+  recipientAmountDisplayCurrency: DisplayCurrencyBaseAmount
+  recipientDisplayCurrency: DisplayCurrency
 
   memoOfPayer?: string
   senderUsername?: Username
@@ -267,10 +274,7 @@ export const OnChainIntraledgerLedgerMetadata = ({
     sendAll,
 
     satsFee: toSats(satsFee),
-    displayFee: feeDisplayCurrency,
-    displayAmount: amountDisplayCurrency,
 
-    displayCurrency,
     centsAmount: toCents(centsAmount),
     satsAmount: toSats(satsAmount),
     centsFee: toCents(centsFee),
@@ -278,23 +282,42 @@ export const OnChainIntraledgerLedgerMetadata = ({
   const debitAccountAdditionalMetadata = {
     memoPayer: memoOfPayer,
     username: recipientUsername,
+    displayAmount: senderAmountDisplayCurrency,
+    displayFee: senderFeeDisplayCurrency,
+    displayCurrency: senderDisplayCurrency,
   }
-  return { metadata, debitAccountAdditionalMetadata }
+
+  const creditAccountAdditionalMetadata = {
+    displayAmount: recipientAmountDisplayCurrency,
+    displayFee: recipientFeeDisplayCurrency,
+    displayCurrency: recipientDisplayCurrency,
+  }
+
+  return { metadata, debitAccountAdditionalMetadata, creditAccountAdditionalMetadata }
 }
 
 export const WalletIdIntraledgerLedgerMetadata = ({
   paymentAmounts,
-  feeDisplayCurrency,
-  amountDisplayCurrency,
-  displayCurrency,
+  senderFeeDisplayCurrency,
+  senderAmountDisplayCurrency,
+  senderDisplayCurrency,
+  recipientFeeDisplayCurrency,
+  recipientAmountDisplayCurrency,
+  recipientDisplayCurrency,
   memoOfPayer,
   senderUsername,
   recipientUsername,
 }: {
   paymentAmounts: AmountsAndFees
-  feeDisplayCurrency: DisplayCurrencyBaseAmount
-  amountDisplayCurrency: DisplayCurrencyBaseAmount
-  displayCurrency: DisplayCurrency
+
+  senderFeeDisplayCurrency: DisplayCurrencyBaseAmount
+  senderAmountDisplayCurrency: DisplayCurrencyBaseAmount
+  senderDisplayCurrency: DisplayCurrency
+
+  recipientFeeDisplayCurrency: DisplayCurrencyBaseAmount
+  recipientAmountDisplayCurrency: DisplayCurrencyBaseAmount
+  recipientDisplayCurrency: DisplayCurrency
+
   memoOfPayer?: string
   senderUsername?: Username
   recipientUsername?: Username
@@ -313,28 +336,38 @@ export const WalletIdIntraledgerLedgerMetadata = ({
     username: senderUsername,
 
     satsFee: toSats(satsFee),
-    displayFee: feeDisplayCurrency,
-    displayAmount: amountDisplayCurrency,
 
-    displayCurrency,
     centsAmount: toCents(centsAmount),
     satsAmount: toSats(satsAmount),
     centsFee: toCents(centsFee),
   }
+
   const debitAccountAdditionalMetadata = {
     username: recipientUsername,
+    displayAmount: senderAmountDisplayCurrency,
+    displayFee: senderFeeDisplayCurrency,
+    displayCurrency: senderDisplayCurrency,
   }
 
-  return { metadata, debitAccountAdditionalMetadata }
+  const creditAccountAdditionalMetadata = {
+    displayAmount: recipientAmountDisplayCurrency,
+    displayFee: recipientFeeDisplayCurrency,
+    displayCurrency: recipientDisplayCurrency,
+  }
+
+  return { metadata, debitAccountAdditionalMetadata, creditAccountAdditionalMetadata }
 }
 
 export const LnIntraledgerLedgerMetadata = ({
   paymentHash,
   pubkey,
   paymentAmounts,
-  feeDisplayCurrency,
-  amountDisplayCurrency,
-  displayCurrency,
+  senderFeeDisplayCurrency,
+  senderAmountDisplayCurrency,
+  senderDisplayCurrency,
+  recipientFeeDisplayCurrency,
+  recipientAmountDisplayCurrency,
+  recipientDisplayCurrency,
   memoOfPayer,
   senderUsername,
   recipientUsername,
@@ -342,9 +375,15 @@ export const LnIntraledgerLedgerMetadata = ({
   paymentHash: PaymentHash
   pubkey: Pubkey
   paymentAmounts: AmountsAndFees
-  feeDisplayCurrency: DisplayCurrencyBaseAmount
-  amountDisplayCurrency: DisplayCurrencyBaseAmount
-  displayCurrency: DisplayCurrency
+
+  senderFeeDisplayCurrency: DisplayCurrencyBaseAmount
+  senderAmountDisplayCurrency: DisplayCurrencyBaseAmount
+  senderDisplayCurrency: DisplayCurrency
+
+  recipientFeeDisplayCurrency: DisplayCurrencyBaseAmount
+  recipientAmountDisplayCurrency: DisplayCurrencyBaseAmount
+  recipientDisplayCurrency: DisplayCurrency
+
   memoOfPayer?: string
   senderUsername?: Username
   recipientUsername?: Username
@@ -365,37 +404,53 @@ export const LnIntraledgerLedgerMetadata = ({
     pubkey,
 
     satsFee: toSats(satsFee),
-    displayFee: feeDisplayCurrency,
-    displayAmount: amountDisplayCurrency,
 
-    displayCurrency,
     centsAmount: toCents(centsAmount),
     satsAmount: toSats(satsAmount),
     centsFee: toCents(centsFee),
   }
+
   const debitAccountAdditionalMetadata = {
     memoPayer: memoOfPayer,
     username: recipientUsername,
+    displayAmount: senderAmountDisplayCurrency,
+    displayFee: senderFeeDisplayCurrency,
+    displayCurrency: senderDisplayCurrency,
   }
-  return { metadata, debitAccountAdditionalMetadata }
+
+  const creditAccountAdditionalMetadata = {
+    displayAmount: recipientAmountDisplayCurrency,
+    displayFee: recipientFeeDisplayCurrency,
+    displayCurrency: recipientDisplayCurrency,
+  }
+
+  return { metadata, debitAccountAdditionalMetadata, creditAccountAdditionalMetadata }
 }
 
 export const OnChainTradeIntraAccountLedgerMetadata = ({
   payeeAddresses,
   sendAll,
   paymentAmounts,
-  feeDisplayCurrency,
-  amountDisplayCurrency,
-  displayCurrency,
+  senderFeeDisplayCurrency,
+  senderAmountDisplayCurrency,
+  senderDisplayCurrency,
+  recipientFeeDisplayCurrency,
+  recipientAmountDisplayCurrency,
+  recipientDisplayCurrency,
   memoOfPayer,
 }: {
   payeeAddresses: OnChainAddress[]
   sendAll: boolean
   paymentAmounts: AmountsAndFees
 
-  feeDisplayCurrency: DisplayCurrencyBaseAmount
-  amountDisplayCurrency: DisplayCurrencyBaseAmount
-  displayCurrency: DisplayCurrency
+  senderFeeDisplayCurrency: DisplayCurrencyBaseAmount
+  senderAmountDisplayCurrency: DisplayCurrencyBaseAmount
+  senderDisplayCurrency: DisplayCurrency
+
+  recipientFeeDisplayCurrency: DisplayCurrencyBaseAmount
+  recipientAmountDisplayCurrency: DisplayCurrencyBaseAmount
+  recipientDisplayCurrency: DisplayCurrency
+
   memoOfPayer?: string
 }) => {
   const {
@@ -413,31 +468,47 @@ export const OnChainTradeIntraAccountLedgerMetadata = ({
     sendAll,
 
     satsFee: toSats(satsFee),
-    displayFee: feeDisplayCurrency,
-    displayAmount: amountDisplayCurrency,
 
-    displayCurrency,
     centsAmount: toCents(centsAmount),
     satsAmount: toSats(satsAmount),
     centsFee: toCents(centsFee),
   }
+
   const debitAccountAdditionalMetadata = {
     memoPayer: memoOfPayer,
+    displayAmount: senderAmountDisplayCurrency,
+    displayFee: senderFeeDisplayCurrency,
+    displayCurrency: senderDisplayCurrency,
   }
-  return { metadata, debitAccountAdditionalMetadata }
+
+  const creditAccountAdditionalMetadata = {
+    displayAmount: recipientAmountDisplayCurrency,
+    displayFee: recipientFeeDisplayCurrency,
+    displayCurrency: recipientDisplayCurrency,
+  }
+  return { metadata, debitAccountAdditionalMetadata, creditAccountAdditionalMetadata }
 }
 
 export const WalletIdTradeIntraAccountLedgerMetadata = ({
   paymentAmounts,
-  feeDisplayCurrency,
-  amountDisplayCurrency,
-  displayCurrency,
+  senderFeeDisplayCurrency,
+  senderAmountDisplayCurrency,
+  senderDisplayCurrency,
+  recipientFeeDisplayCurrency,
+  recipientAmountDisplayCurrency,
+  recipientDisplayCurrency,
   memoOfPayer,
 }: {
   paymentAmounts: AmountsAndFees
-  feeDisplayCurrency: DisplayCurrencyBaseAmount
-  amountDisplayCurrency: DisplayCurrencyBaseAmount
-  displayCurrency: DisplayCurrency
+
+  senderFeeDisplayCurrency: DisplayCurrencyBaseAmount
+  senderAmountDisplayCurrency: DisplayCurrencyBaseAmount
+  senderDisplayCurrency: DisplayCurrency
+
+  recipientFeeDisplayCurrency: DisplayCurrencyBaseAmount
+  recipientAmountDisplayCurrency: DisplayCurrencyBaseAmount
+  recipientDisplayCurrency: DisplayCurrency
+
   memoOfPayer?: string
 }) => {
   const {
@@ -453,33 +524,51 @@ export const WalletIdTradeIntraAccountLedgerMetadata = ({
     memoPayer: memoOfPayer,
 
     satsFee: toSats(satsFee),
-    displayFee: feeDisplayCurrency,
-    displayAmount: amountDisplayCurrency,
 
-    displayCurrency,
     centsAmount: toCents(centsAmount),
     satsAmount: toSats(satsAmount),
     centsFee: toCents(centsFee),
   }
 
-  return metadata
+  const debitAccountAdditionalMetadata = {
+    displayAmount: senderAmountDisplayCurrency,
+    displayFee: senderFeeDisplayCurrency,
+    displayCurrency: senderDisplayCurrency,
+  }
+
+  const creditAccountAdditionalMetadata = {
+    displayAmount: recipientAmountDisplayCurrency,
+    displayFee: recipientFeeDisplayCurrency,
+    displayCurrency: recipientDisplayCurrency,
+  }
+
+  return { metadata, debitAccountAdditionalMetadata, creditAccountAdditionalMetadata }
 }
 
 export const LnTradeIntraAccountLedgerMetadata = ({
   paymentHash,
   pubkey,
   paymentAmounts,
-  feeDisplayCurrency,
-  amountDisplayCurrency,
-  displayCurrency,
+  senderFeeDisplayCurrency,
+  senderAmountDisplayCurrency,
+  senderDisplayCurrency,
+  recipientFeeDisplayCurrency,
+  recipientAmountDisplayCurrency,
+  recipientDisplayCurrency,
   memoOfPayer,
 }: {
   paymentHash: PaymentHash
   pubkey: Pubkey
   paymentAmounts: AmountsAndFees
-  feeDisplayCurrency: DisplayCurrencyBaseAmount
-  amountDisplayCurrency: DisplayCurrencyBaseAmount
-  displayCurrency: DisplayCurrency
+
+  senderFeeDisplayCurrency: DisplayCurrencyBaseAmount
+  senderAmountDisplayCurrency: DisplayCurrencyBaseAmount
+  senderDisplayCurrency: DisplayCurrency
+
+  recipientFeeDisplayCurrency: DisplayCurrencyBaseAmount
+  recipientAmountDisplayCurrency: DisplayCurrencyBaseAmount
+  recipientDisplayCurrency: DisplayCurrency
+
   memoOfPayer?: string
 }) => {
   const {
@@ -497,18 +586,25 @@ export const LnTradeIntraAccountLedgerMetadata = ({
     pubkey,
 
     satsFee: toSats(satsFee),
-    displayFee: feeDisplayCurrency,
-    displayAmount: amountDisplayCurrency,
-
-    displayCurrency,
     centsAmount: toCents(centsAmount),
     satsAmount: toSats(satsAmount),
     centsFee: toCents(centsFee),
   }
+
   const debitAccountAdditionalMetadata = {
     memoPayer: memoOfPayer,
+    displayAmount: senderAmountDisplayCurrency,
+    displayFee: senderFeeDisplayCurrency,
+    displayCurrency: senderDisplayCurrency,
   }
-  return { metadata, debitAccountAdditionalMetadata }
+
+  const creditAccountAdditionalMetadata = {
+    displayAmount: recipientAmountDisplayCurrency,
+    displayFee: recipientFeeDisplayCurrency,
+    displayCurrency: recipientDisplayCurrency,
+  }
+
+  return { metadata, debitAccountAdditionalMetadata, creditAccountAdditionalMetadata }
 }
 
 // Non-LedgerFacade constructors from legacy admin service

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -1716,6 +1716,12 @@ describe("USD Wallets - Lightning Pay", () => {
         currency: senderAccount.displayCurrency,
       })
       if (displayPriceRatio instanceof Error) throw displayPriceRatio
+      const displayAmount = Number(
+        displayPriceRatio.convertFromWallet(btcPaymentAmount).amountInMinor,
+      )
+      const displayFee = Number(
+        displayPriceRatio.convertFromWallet(feeAmountSats).amountInMinor,
+      )
 
       const expectedFields = {
         type: LedgerTransactionType.Payment,
@@ -1727,12 +1733,10 @@ describe("USD Wallets - Lightning Pay", () => {
         satsFee,
         centsAmount: cents,
         centsFee,
-        displayAmount: Number(
-          displayPriceRatio.convertFromWallet(btcPaymentAmount).amountInMinor,
-        ),
-        displayFee: Number(
-          displayPriceRatio.convertFromWallet(feeAmountSats).amountInMinor,
-        ),
+        displayAmount:
+          senderAccount.displayCurrency === DisplayCurrency.Usd ? cents : displayAmount,
+        displayFee:
+          senderAccount.displayCurrency === DisplayCurrency.Usd ? centsFee : displayFee,
 
         displayCurrency: DisplayCurrency.Usd,
       }
@@ -2307,7 +2311,10 @@ describe("USD Wallets - Lightning Pay", () => {
         satsFee: 0,
         centsAmount,
         centsFee: 0,
-        displayAmount,
+        displayAmount:
+          senderAccount.displayCurrency === DisplayCurrency.Usd
+            ? centsAmount
+            : displayAmount,
         displayFee: 0,
 
         displayCurrency: DisplayCurrency.Usd,

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -409,10 +409,14 @@ const testExternalSend = async ({
         satsFee,
         centsAmount,
         centsFee,
-        displayAmount,
-        displayFee,
+        displayAmount:
+          senderAccount.displayCurrency === DisplayCurrency.Usd
+            ? centsAmount
+            : displayAmount,
+        displayFee:
+          senderAccount.displayCurrency === DisplayCurrency.Usd ? centsFee : displayFee,
 
-        displayCurrency: DisplayCurrency.Usd,
+        displayCurrency: senderAccount.displayCurrency,
       }),
     )
 
@@ -720,8 +724,10 @@ const testInternalSend = async ({
     satsFee,
     centsAmount,
     centsFee,
-    displayAmount,
-    displayFee,
+    displayAmount:
+      senderAccount.displayCurrency === DisplayCurrency.Usd ? centsAmount : displayAmount,
+    displayFee:
+      senderAccount.displayCurrency === DisplayCurrency.Usd ? centsFee : displayFee,
 
     displayCurrency: DisplayCurrency.Usd,
   }

--- a/test/integration/services/ledger/facade.spec.ts
+++ b/test/integration/services/ledger/facade.spec.ts
@@ -9,6 +9,8 @@ import { LedgerService } from "@services/ledger"
 import * as LedgerFacade from "@services/ledger/facade"
 
 import {
+  recordLnFailedPayment,
+  recordLnFeeReimbursement,
   recordLnIntraLedgerPayment,
   recordLnTradeIntraAccountTxn,
   recordOnChainIntraLedgerPayment,
@@ -167,6 +169,16 @@ describe("Facade", () => {
         name: "recordReceiveOnChainPayment",
         recordFn: recordReceiveOnChainPayment,
         metadata: LedgerTransactionType.OnchainReceipt,
+      },
+      {
+        name: "recordLnFailedPayment",
+        recordFn: recordLnFailedPayment,
+        metadata: LedgerTransactionType.Payment,
+      },
+      {
+        name: "recordLnFeeReimbursement",
+        recordFn: recordLnFeeReimbursement,
+        metadata: LedgerTransactionType.LnFeeReimbursement,
       },
     ]
 

--- a/test/integration/services/ledger/helpers.ts
+++ b/test/integration/services/ledger/helpers.ts
@@ -177,22 +177,33 @@ export const recordLnIntraLedgerPayment = async ({
   recipientWalletDescriptor,
   paymentAmount,
 }) => {
-  const { metadata, debitAccountAdditionalMetadata } =
-    LedgerFacade.LnIntraledgerLedgerMetadata({
-      paymentHash: crypto.randomUUID() as PaymentHash,
-      amountDisplayCurrency: Number(
-        paymentAmount.usd.amount,
-      ) as DisplayCurrencyBaseAmount,
-      feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-      displayCurrency: DisplayCurrency.Usd,
-      pubkey: crypto.randomUUID() as Pubkey,
-      paymentAmounts: {
-        btcPaymentAmount: paymentAmount.btc,
-        usdPaymentAmount: paymentAmount.usd,
-        btcProtocolAndBankFee: ZERO_SATS,
-        usdProtocolAndBankFee: ZERO_CENTS,
-      },
-    })
+  const {
+    metadata,
+    debitAccountAdditionalMetadata: additionalDebitMetadata,
+    creditAccountAdditionalMetadata: additionalCreditMetadata,
+  } = LedgerFacade.LnIntraledgerLedgerMetadata({
+    paymentHash: crypto.randomUUID() as PaymentHash,
+
+    senderAmountDisplayCurrency: Number(
+      paymentAmount.usd.amount,
+    ) as DisplayCurrencyBaseAmount,
+    senderFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+    senderDisplayCurrency: DisplayCurrency.Usd,
+
+    recipientAmountDisplayCurrency: Number(
+      paymentAmount.usd.amount,
+    ) as DisplayCurrencyBaseAmount,
+    recipientFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+    recipientDisplayCurrency: DisplayCurrency.Usd,
+
+    pubkey: crypto.randomUUID() as Pubkey,
+    paymentAmounts: {
+      btcPaymentAmount: paymentAmount.btc,
+      usdPaymentAmount: paymentAmount.usd,
+      btcProtocolAndBankFee: ZERO_SATS,
+      usdProtocolAndBankFee: ZERO_CENTS,
+    },
+  })
 
   return LedgerFacade.recordIntraledger({
     description: "sends/receives ln intraledger",
@@ -200,8 +211,8 @@ export const recordLnIntraLedgerPayment = async ({
     senderWalletDescriptor,
     recipientWalletDescriptor,
     metadata,
-    additionalDebitMetadata: debitAccountAdditionalMetadata,
-    additionalCreditMetadata: {},
+    additionalDebitMetadata,
+    additionalCreditMetadata,
   })
 }
 
@@ -210,20 +221,30 @@ export const recordWalletIdIntraLedgerPayment = async ({
   recipientWalletDescriptor,
   paymentAmount,
 }) => {
-  const { metadata, debitAccountAdditionalMetadata } =
-    LedgerFacade.WalletIdIntraledgerLedgerMetadata({
-      amountDisplayCurrency: Number(
-        paymentAmount.usd.amount,
-      ) as DisplayCurrencyBaseAmount,
-      feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-      displayCurrency: DisplayCurrency.Usd,
-      paymentAmounts: {
-        btcPaymentAmount: paymentAmount.btc,
-        usdPaymentAmount: paymentAmount.usd,
-        btcProtocolAndBankFee: ZERO_SATS,
-        usdProtocolAndBankFee: ZERO_CENTS,
-      },
-    })
+  const {
+    metadata,
+    debitAccountAdditionalMetadata: additionalDebitMetadata,
+    creditAccountAdditionalMetadata: additionalCreditMetadata,
+  } = LedgerFacade.WalletIdIntraledgerLedgerMetadata({
+    senderAmountDisplayCurrency: Number(
+      paymentAmount.usd.amount,
+    ) as DisplayCurrencyBaseAmount,
+    senderFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+    senderDisplayCurrency: DisplayCurrency.Usd,
+
+    recipientAmountDisplayCurrency: Number(
+      paymentAmount.usd.amount,
+    ) as DisplayCurrencyBaseAmount,
+    recipientFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+    recipientDisplayCurrency: DisplayCurrency.Usd,
+
+    paymentAmounts: {
+      btcPaymentAmount: paymentAmount.btc,
+      usdPaymentAmount: paymentAmount.usd,
+      btcProtocolAndBankFee: ZERO_SATS,
+      usdProtocolAndBankFee: ZERO_CENTS,
+    },
+  })
 
   return LedgerFacade.recordIntraledger({
     description: "sends/receives walletId intraledger",
@@ -231,8 +252,8 @@ export const recordWalletIdIntraLedgerPayment = async ({
     senderWalletDescriptor,
     recipientWalletDescriptor,
     metadata,
-    additionalDebitMetadata: debitAccountAdditionalMetadata,
-    additionalCreditMetadata: {},
+    additionalDebitMetadata,
+    additionalCreditMetadata,
   })
 }
 
@@ -241,22 +262,32 @@ export const recordOnChainIntraLedgerPayment = async ({
   recipientWalletDescriptor,
   paymentAmount,
 }) => {
-  const { metadata, debitAccountAdditionalMetadata } =
-    LedgerFacade.OnChainIntraledgerLedgerMetadata({
-      amountDisplayCurrency: Number(
-        paymentAmount.usd.amount,
-      ) as DisplayCurrencyBaseAmount,
-      feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-      displayCurrency: DisplayCurrency.Usd,
-      sendAll: false,
-      payeeAddresses: ["address1" as OnChainAddress],
-      paymentAmounts: {
-        btcPaymentAmount: paymentAmount.btc,
-        usdPaymentAmount: paymentAmount.usd,
-        btcProtocolAndBankFee: ZERO_SATS,
-        usdProtocolAndBankFee: ZERO_CENTS,
-      },
-    })
+  const {
+    metadata,
+    debitAccountAdditionalMetadata: additionalDebitMetadata,
+    creditAccountAdditionalMetadata: additionalCreditMetadata,
+  } = LedgerFacade.OnChainIntraledgerLedgerMetadata({
+    senderAmountDisplayCurrency: Number(
+      paymentAmount.usd.amount,
+    ) as DisplayCurrencyBaseAmount,
+    senderFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+    senderDisplayCurrency: DisplayCurrency.Usd,
+
+    recipientAmountDisplayCurrency: Number(
+      paymentAmount.usd.amount,
+    ) as DisplayCurrencyBaseAmount,
+    recipientFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+    recipientDisplayCurrency: DisplayCurrency.Usd,
+
+    sendAll: false,
+    payeeAddresses: ["address1" as OnChainAddress],
+    paymentAmounts: {
+      btcPaymentAmount: paymentAmount.btc,
+      usdPaymentAmount: paymentAmount.usd,
+      btcProtocolAndBankFee: ZERO_SATS,
+      usdProtocolAndBankFee: ZERO_CENTS,
+    },
+  })
 
   return LedgerFacade.recordIntraledger({
     description: "sends/receives onchain intraledger",
@@ -264,8 +295,8 @@ export const recordOnChainIntraLedgerPayment = async ({
     senderWalletDescriptor,
     recipientWalletDescriptor,
     metadata,
-    additionalDebitMetadata: debitAccountAdditionalMetadata,
-    additionalCreditMetadata: {},
+    additionalDebitMetadata,
+    additionalCreditMetadata,
   })
 }
 
@@ -274,22 +305,32 @@ export const recordLnTradeIntraAccountTxn = async ({
   recipientWalletDescriptor,
   paymentAmount,
 }) => {
-  const { metadata, debitAccountAdditionalMetadata } =
-    LedgerFacade.LnTradeIntraAccountLedgerMetadata({
-      paymentHash: crypto.randomUUID() as PaymentHash,
-      amountDisplayCurrency: Number(
-        paymentAmount.usd.amount,
-      ) as DisplayCurrencyBaseAmount,
-      feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-      displayCurrency: DisplayCurrency.Usd,
-      pubkey: crypto.randomUUID() as Pubkey,
-      paymentAmounts: {
-        btcPaymentAmount: paymentAmount.btc,
-        usdPaymentAmount: paymentAmount.usd,
-        btcProtocolAndBankFee: ZERO_SATS,
-        usdProtocolAndBankFee: ZERO_CENTS,
-      },
-    })
+  const {
+    metadata,
+    debitAccountAdditionalMetadata: additionalDebitMetadata,
+    creditAccountAdditionalMetadata: additionalCreditMetadata,
+  } = LedgerFacade.LnTradeIntraAccountLedgerMetadata({
+    paymentHash: crypto.randomUUID() as PaymentHash,
+    senderAmountDisplayCurrency: Number(
+      paymentAmount.usd.amount,
+    ) as DisplayCurrencyBaseAmount,
+    senderFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+    senderDisplayCurrency: DisplayCurrency.Usd,
+
+    recipientAmountDisplayCurrency: Number(
+      paymentAmount.usd.amount,
+    ) as DisplayCurrencyBaseAmount,
+    recipientFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+    recipientDisplayCurrency: DisplayCurrency.Usd,
+
+    pubkey: crypto.randomUUID() as Pubkey,
+    paymentAmounts: {
+      btcPaymentAmount: paymentAmount.btc,
+      usdPaymentAmount: paymentAmount.usd,
+      btcProtocolAndBankFee: ZERO_SATS,
+      usdProtocolAndBankFee: ZERO_CENTS,
+    },
+  })
 
   return LedgerFacade.recordIntraledger({
     description: "sends/receives ln trade",
@@ -297,8 +338,8 @@ export const recordLnTradeIntraAccountTxn = async ({
     senderWalletDescriptor,
     recipientWalletDescriptor,
     metadata,
-    additionalDebitMetadata: debitAccountAdditionalMetadata,
-    additionalCreditMetadata: {},
+    additionalDebitMetadata,
+    additionalCreditMetadata,
   })
 }
 
@@ -307,10 +348,23 @@ export const recordWalletIdTradeIntraAccountTxn = async ({
   recipientWalletDescriptor,
   paymentAmount,
 }) => {
-  const metadata = LedgerFacade.WalletIdTradeIntraAccountLedgerMetadata({
-    amountDisplayCurrency: Number(paymentAmount.usd.amount) as DisplayCurrencyBaseAmount,
-    feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-    displayCurrency: DisplayCurrency.Usd,
+  const {
+    metadata,
+    debitAccountAdditionalMetadata: additionalDebitMetadata,
+    creditAccountAdditionalMetadata: additionalCreditMetadata,
+  } = LedgerFacade.WalletIdTradeIntraAccountLedgerMetadata({
+    senderAmountDisplayCurrency: Number(
+      paymentAmount.usd.amount,
+    ) as DisplayCurrencyBaseAmount,
+    senderFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+    senderDisplayCurrency: DisplayCurrency.Usd,
+
+    recipientAmountDisplayCurrency: Number(
+      paymentAmount.usd.amount,
+    ) as DisplayCurrencyBaseAmount,
+    recipientFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+    recipientDisplayCurrency: DisplayCurrency.Usd,
+
     paymentAmounts: {
       btcPaymentAmount: paymentAmount.btc,
       usdPaymentAmount: paymentAmount.usd,
@@ -325,8 +379,8 @@ export const recordWalletIdTradeIntraAccountTxn = async ({
     senderWalletDescriptor,
     recipientWalletDescriptor,
     metadata,
-    additionalDebitMetadata: {},
-    additionalCreditMetadata: {},
+    additionalDebitMetadata,
+    additionalCreditMetadata,
   })
 }
 
@@ -335,22 +389,32 @@ export const recordOnChainTradeIntraAccountTxn = async ({
   recipientWalletDescriptor,
   paymentAmount,
 }) => {
-  const { metadata, debitAccountAdditionalMetadata } =
-    LedgerFacade.OnChainTradeIntraAccountLedgerMetadata({
-      amountDisplayCurrency: Number(
-        paymentAmount.usd.amount,
-      ) as DisplayCurrencyBaseAmount,
-      feeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-      displayCurrency: DisplayCurrency.Usd,
-      sendAll: false,
-      payeeAddresses: ["address1" as OnChainAddress],
-      paymentAmounts: {
-        btcPaymentAmount: paymentAmount.btc,
-        usdPaymentAmount: paymentAmount.usd,
-        btcProtocolAndBankFee: ZERO_SATS,
-        usdProtocolAndBankFee: ZERO_CENTS,
-      },
-    })
+  const {
+    metadata,
+    debitAccountAdditionalMetadata: additionalDebitMetadata,
+    creditAccountAdditionalMetadata: additionalCreditMetadata,
+  } = LedgerFacade.OnChainTradeIntraAccountLedgerMetadata({
+    senderAmountDisplayCurrency: Number(
+      paymentAmount.usd.amount,
+    ) as DisplayCurrencyBaseAmount,
+    senderFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+    senderDisplayCurrency: DisplayCurrency.Usd,
+
+    recipientAmountDisplayCurrency: Number(
+      paymentAmount.usd.amount,
+    ) as DisplayCurrencyBaseAmount,
+    recipientFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
+    recipientDisplayCurrency: DisplayCurrency.Usd,
+
+    sendAll: false,
+    payeeAddresses: ["address1" as OnChainAddress],
+    paymentAmounts: {
+      btcPaymentAmount: paymentAmount.btc,
+      usdPaymentAmount: paymentAmount.usd,
+      btcProtocolAndBankFee: ZERO_SATS,
+      usdProtocolAndBankFee: ZERO_CENTS,
+    },
+  })
 
   return LedgerFacade.recordIntraledger({
     description: "sends/receives onchain trade",
@@ -358,8 +422,8 @@ export const recordOnChainTradeIntraAccountTxn = async ({
     senderWalletDescriptor,
     recipientWalletDescriptor,
     metadata,
-    additionalDebitMetadata: debitAccountAdditionalMetadata,
-    additionalCreditMetadata: {},
+    additionalDebitMetadata,
+    additionalCreditMetadata,
   })
 }
 

--- a/test/integration/services/ledger/helpers.ts
+++ b/test/integration/services/ledger/helpers.ts
@@ -1,9 +1,6 @@
 import crypto from "crypto"
 
-import { getDisplayCurrencyConfig } from "@config"
-
 import { WalletCurrency, ZERO_CENTS, ZERO_SATS } from "@domain/shared"
-import { DisplayCurrency } from "@domain/fiat"
 import { LedgerTransactionType, toLiabilitiesWalletId } from "@domain/ledger"
 
 import * as LedgerFacade from "@services/ledger/facade"
@@ -17,11 +14,12 @@ import {
 import { translateToLedgerJournal } from "@services/ledger"
 import { toSats } from "@domain/bitcoin"
 
-export const recordReceiveLnPayment = async ({
+export const recordReceiveLnPayment = async <S extends WalletCurrency>({
   walletDescriptor,
   paymentAmount,
   bankFee,
-}) => {
+  displayAmounts,
+}: RecordExternalTxTestArgs<S>) => {
   const paymentHash = crypto.randomUUID() as PaymentHash
 
   const {
@@ -38,9 +36,7 @@ export const recordReceiveLnPayment = async ({
       usdProtocolAndBankFee: bankFee.usd,
     },
 
-    feeDisplayCurrency: Number(bankFee.usd.amount) as DisplayCurrencyBaseAmount,
-    amountDisplayCurrency: Number(paymentAmount.usd.amount) as DisplayCurrencyBaseAmount,
-    displayCurrency: DisplayCurrency.Usd,
+    ...displayAmounts,
   })
 
   return LedgerFacade.recordReceive({
@@ -55,11 +51,12 @@ export const recordReceiveLnPayment = async ({
   })
 }
 
-export const recordReceiveOnChainPayment = async ({
+export const recordReceiveOnChainPayment = async <S extends WalletCurrency>({
   walletDescriptor,
   paymentAmount,
   bankFee,
-}) => {
+  displayAmounts,
+}: RecordExternalTxTestArgs<S>) => {
   const onChainTxHash = crypto.randomUUID() as OnChainTxHash
 
   const {
@@ -75,9 +72,7 @@ export const recordReceiveOnChainPayment = async ({
       usdProtocolAndBankFee: bankFee.usd,
     },
 
-    feeDisplayCurrency: Number(bankFee.usd.amount) as DisplayCurrencyBaseAmount,
-    amountDisplayCurrency: Number(paymentAmount.usd.amount) as DisplayCurrencyBaseAmount,
-    displayCurrency: DisplayCurrency.Usd,
+    ...displayAmounts,
 
     payeeAddresses: ["address1" as OnChainAddress],
   })
@@ -93,19 +88,15 @@ export const recordReceiveOnChainPayment = async ({
   })
 }
 
-export const recordSendLnPayment = async ({
+export const recordSendLnPayment = async <S extends WalletCurrency>({
   walletDescriptor,
   paymentAmount,
   bankFee,
-}) => {
+  displayAmounts,
+}: RecordExternalTxTestArgs<S>) => {
   const { metadata, debitAccountAdditionalMetadata, internalAccountsAdditionalMetadata } =
     LedgerFacade.LnSendLedgerMetadata({
       paymentHash: crypto.randomUUID() as PaymentHash,
-      feeDisplayCurrency: Number(bankFee.usd.amount) as DisplayCurrencyBaseAmount,
-      amountDisplayCurrency: Number(
-        paymentAmount.usd.amount,
-      ) as DisplayCurrencyBaseAmount,
-      displayCurrency: getDisplayCurrencyConfig().code,
       pubkey: crypto.randomUUID() as Pubkey,
       feeKnownInAdvance: true,
       paymentAmounts: {
@@ -114,6 +105,8 @@ export const recordSendLnPayment = async ({
         btcProtocolAndBankFee: bankFee.btc,
         usdProtocolAndBankFee: bankFee.usd,
       },
+
+      ...displayAmounts,
     })
 
   return LedgerFacade.recordSend({
@@ -127,11 +120,12 @@ export const recordSendLnPayment = async ({
   })
 }
 
-export const recordSendOnChainPayment = async ({
+export const recordSendOnChainPayment = async <S extends WalletCurrency>({
   walletDescriptor,
   paymentAmount,
   bankFee,
-}) => {
+  displayAmounts,
+}: RecordExternalTxTestArgs<S>) => {
   const { metadata, debitAccountAdditionalMetadata, internalAccountsAdditionalMetadata } =
     LedgerFacade.OnChainSendLedgerMetadata({
       onChainTxHash: crypto.randomUUID() as OnChainTxHash,
@@ -142,11 +136,7 @@ export const recordSendOnChainPayment = async ({
         usdProtocolAndBankFee: bankFee.usd,
       },
 
-      feeDisplayCurrency: Number(bankFee.usd.amount) as DisplayCurrencyBaseAmount,
-      amountDisplayCurrency: Number(
-        paymentAmount.usd.amount,
-      ) as DisplayCurrencyBaseAmount,
-      displayCurrency: getDisplayCurrencyConfig().code,
+      ...displayAmounts,
 
       payeeAddresses: ["address1" as OnChainAddress],
       sendAll: false,
@@ -163,11 +153,12 @@ export const recordSendOnChainPayment = async ({
   })
 }
 
-export const recordLnFeeReimbursement = async ({
+export const recordLnFeeReimbursement = async <S extends WalletCurrency>({
   walletDescriptor,
   paymentAmount,
   bankFee,
-}) => {
+  displayAmounts,
+}: RecordExternalTxTestArgs<S>) => {
   const paymentHash = crypto.randomUUID() as PaymentHash
 
   const {
@@ -176,9 +167,6 @@ export const recordLnFeeReimbursement = async ({
     internalAccountsAdditionalMetadata,
   } = LedgerFacade.LnFeeReimbursementReceiveLedgerMetadata({
     paymentHash,
-    feeDisplayCurrency: Number(bankFee.usd.amount) as DisplayCurrencyBaseAmount,
-    amountDisplayCurrency: Number(paymentAmount.usd.amount) as DisplayCurrencyBaseAmount,
-    displayCurrency: getDisplayCurrencyConfig().code,
     paymentAmounts: {
       btcPaymentAmount: paymentAmount.btc,
       usdPaymentAmount: paymentAmount.usd,
@@ -186,6 +174,8 @@ export const recordLnFeeReimbursement = async ({
       usdProtocolAndBankFee: bankFee.usd,
     },
     journalId: "031a419636dbf6d25981d6d2" as LedgerJournalId,
+
+    ...displayAmounts,
   })
 
   return LedgerFacade.recordReceive({
@@ -200,11 +190,12 @@ export const recordLnFeeReimbursement = async ({
   })
 }
 
-export const recordLnFailedPayment = async ({
+export const recordLnFailedPayment = async <S extends WalletCurrency>({
   walletDescriptor,
   paymentAmount,
   bankFee,
-}) => {
+  displayAmounts,
+}: RecordExternalTxTestArgs<S>) => {
   const paymentHash = crypto.randomUUID() as PaymentHash
 
   const {
@@ -213,9 +204,6 @@ export const recordLnFailedPayment = async ({
     internalAccountsAdditionalMetadata,
   } = LedgerFacade.LnFailedPaymentReceiveLedgerMetadata({
     paymentHash,
-    feeDisplayCurrency: Number(bankFee.usd.amount) as DisplayCurrencyBaseAmount,
-    amountDisplayCurrency: Number(paymentAmount.usd.amount) as DisplayCurrencyBaseAmount,
-    displayCurrency: getDisplayCurrencyConfig().code,
     paymentAmounts: {
       btcPaymentAmount: paymentAmount.btc,
       usdPaymentAmount: paymentAmount.usd,
@@ -223,6 +211,8 @@ export const recordLnFailedPayment = async ({
       usdProtocolAndBankFee: bankFee.usd,
     },
     journalId: "031a419636dbf6d25981d6d2" as LedgerJournalId,
+
+    ...displayAmounts,
   })
 
   return LedgerFacade.recordReceive({
@@ -237,11 +227,16 @@ export const recordLnFailedPayment = async ({
   })
 }
 
-export const recordLnIntraLedgerPayment = async ({
+export const recordLnIntraLedgerPayment: RecordInternalTxTestFn = async <
+  S extends WalletCurrency,
+  R extends WalletCurrency,
+>({
   senderWalletDescriptor,
   recipientWalletDescriptor,
   paymentAmount,
-}) => {
+  senderDisplayAmounts,
+  recipientDisplayAmounts,
+}: RecordInternalTxTestArgs<S, R>) => {
   const {
     metadata,
     debitAccountAdditionalMetadata: additionalDebitMetadata,
@@ -250,17 +245,8 @@ export const recordLnIntraLedgerPayment = async ({
   } = LedgerFacade.LnIntraledgerLedgerMetadata({
     paymentHash: crypto.randomUUID() as PaymentHash,
 
-    senderAmountDisplayCurrency: Number(
-      paymentAmount.usd.amount,
-    ) as DisplayCurrencyBaseAmount,
-    senderFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-    senderDisplayCurrency: DisplayCurrency.Usd,
-
-    recipientAmountDisplayCurrency: Number(
-      paymentAmount.usd.amount,
-    ) as DisplayCurrencyBaseAmount,
-    recipientFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-    recipientDisplayCurrency: DisplayCurrency.Usd,
+    ...senderDisplayAmounts,
+    ...recipientDisplayAmounts,
 
     pubkey: crypto.randomUUID() as Pubkey,
     paymentAmounts: {
@@ -283,28 +269,24 @@ export const recordLnIntraLedgerPayment = async ({
   })
 }
 
-export const recordWalletIdIntraLedgerPayment = async ({
+export const recordWalletIdIntraLedgerPayment: RecordInternalTxTestFn = async <
+  S extends WalletCurrency,
+  R extends WalletCurrency,
+>({
   senderWalletDescriptor,
   recipientWalletDescriptor,
   paymentAmount,
-}) => {
+  senderDisplayAmounts,
+  recipientDisplayAmounts,
+}: RecordInternalTxTestArgs<S, R>) => {
   const {
     metadata,
     debitAccountAdditionalMetadata: additionalDebitMetadata,
     creditAccountAdditionalMetadata: additionalCreditMetadata,
     internalAccountsAdditionalMetadata: additionalInternalMetadata,
   } = LedgerFacade.WalletIdIntraledgerLedgerMetadata({
-    senderAmountDisplayCurrency: Number(
-      paymentAmount.usd.amount,
-    ) as DisplayCurrencyBaseAmount,
-    senderFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-    senderDisplayCurrency: DisplayCurrency.Usd,
-
-    recipientAmountDisplayCurrency: Number(
-      paymentAmount.usd.amount,
-    ) as DisplayCurrencyBaseAmount,
-    recipientFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-    recipientDisplayCurrency: DisplayCurrency.Usd,
+    ...senderDisplayAmounts,
+    ...recipientDisplayAmounts,
 
     paymentAmounts: {
       btcPaymentAmount: paymentAmount.btc,
@@ -326,28 +308,24 @@ export const recordWalletIdIntraLedgerPayment = async ({
   })
 }
 
-export const recordOnChainIntraLedgerPayment = async ({
+export const recordOnChainIntraLedgerPayment: RecordInternalTxTestFn = async <
+  S extends WalletCurrency,
+  R extends WalletCurrency,
+>({
   senderWalletDescriptor,
   recipientWalletDescriptor,
   paymentAmount,
-}) => {
+  senderDisplayAmounts,
+  recipientDisplayAmounts,
+}: RecordInternalTxTestArgs<S, R>) => {
   const {
     metadata,
     debitAccountAdditionalMetadata: additionalDebitMetadata,
     creditAccountAdditionalMetadata: additionalCreditMetadata,
     internalAccountsAdditionalMetadata: additionalInternalMetadata,
   } = LedgerFacade.OnChainIntraledgerLedgerMetadata({
-    senderAmountDisplayCurrency: Number(
-      paymentAmount.usd.amount,
-    ) as DisplayCurrencyBaseAmount,
-    senderFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-    senderDisplayCurrency: DisplayCurrency.Usd,
-
-    recipientAmountDisplayCurrency: Number(
-      paymentAmount.usd.amount,
-    ) as DisplayCurrencyBaseAmount,
-    recipientFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-    recipientDisplayCurrency: DisplayCurrency.Usd,
+    ...senderDisplayAmounts,
+    ...recipientDisplayAmounts,
 
     sendAll: false,
     payeeAddresses: ["address1" as OnChainAddress],
@@ -371,11 +349,15 @@ export const recordOnChainIntraLedgerPayment = async ({
   })
 }
 
-export const recordLnTradeIntraAccountTxn = async ({
+export const recordLnTradeIntraAccountTxn: RecordInternalTxTestFn = async <
+  S extends WalletCurrency,
+  R extends WalletCurrency,
+>({
   senderWalletDescriptor,
   recipientWalletDescriptor,
   paymentAmount,
-}) => {
+  senderDisplayAmounts,
+}: RecordInternalTxTestArgs<S, R>) => {
   const {
     metadata,
     debitAccountAdditionalMetadata: additionalDebitMetadata,
@@ -383,11 +365,8 @@ export const recordLnTradeIntraAccountTxn = async ({
     internalAccountsAdditionalMetadata: additionalInternalMetadata,
   } = LedgerFacade.LnTradeIntraAccountLedgerMetadata({
     paymentHash: crypto.randomUUID() as PaymentHash,
-    senderAmountDisplayCurrency: Number(
-      paymentAmount.usd.amount,
-    ) as DisplayCurrencyBaseAmount,
-    senderFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-    senderDisplayCurrency: DisplayCurrency.Usd,
+
+    ...senderDisplayAmounts,
 
     pubkey: crypto.randomUUID() as Pubkey,
     paymentAmounts: {
@@ -410,22 +389,22 @@ export const recordLnTradeIntraAccountTxn = async ({
   })
 }
 
-export const recordWalletIdTradeIntraAccountTxn = async ({
+export const recordWalletIdTradeIntraAccountTxn: RecordInternalTxTestFn = async <
+  S extends WalletCurrency,
+  R extends WalletCurrency,
+>({
   senderWalletDescriptor,
   recipientWalletDescriptor,
   paymentAmount,
-}) => {
+  senderDisplayAmounts,
+}: RecordInternalTxTestArgs<S, R>) => {
   const {
     metadata,
     debitAccountAdditionalMetadata: additionalDebitMetadata,
     creditAccountAdditionalMetadata: additionalCreditMetadata,
     internalAccountsAdditionalMetadata: additionalInternalMetadata,
   } = LedgerFacade.WalletIdTradeIntraAccountLedgerMetadata({
-    senderAmountDisplayCurrency: Number(
-      paymentAmount.usd.amount,
-    ) as DisplayCurrencyBaseAmount,
-    senderFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-    senderDisplayCurrency: DisplayCurrency.Usd,
+    ...senderDisplayAmounts,
 
     paymentAmounts: {
       btcPaymentAmount: paymentAmount.btc,
@@ -447,22 +426,22 @@ export const recordWalletIdTradeIntraAccountTxn = async ({
   })
 }
 
-export const recordOnChainTradeIntraAccountTxn = async ({
+export const recordOnChainTradeIntraAccountTxn: RecordInternalTxTestFn = async <
+  S extends WalletCurrency,
+  R extends WalletCurrency,
+>({
   senderWalletDescriptor,
   recipientWalletDescriptor,
   paymentAmount,
-}) => {
+  senderDisplayAmounts,
+}: RecordInternalTxTestArgs<S, R>) => {
   const {
     metadata,
     debitAccountAdditionalMetadata: additionalDebitMetadata,
     creditAccountAdditionalMetadata: additionalCreditMetadata,
     internalAccountsAdditionalMetadata: additionalInternalMetadata,
   } = LedgerFacade.OnChainTradeIntraAccountLedgerMetadata({
-    senderAmountDisplayCurrency: Number(
-      paymentAmount.usd.amount,
-    ) as DisplayCurrencyBaseAmount,
-    senderFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-    senderDisplayCurrency: DisplayCurrency.Usd,
+    ...senderDisplayAmounts,
 
     sendAll: false,
     payeeAddresses: ["address1" as OnChainAddress],

--- a/test/integration/services/ledger/helpers.ts
+++ b/test/integration/services/ledger/helpers.ts
@@ -24,7 +24,11 @@ export const recordReceiveLnPayment = async ({
 }) => {
   const paymentHash = crypto.randomUUID() as PaymentHash
 
-  const metadata = LedgerFacade.LnReceiveLedgerMetadata({
+  const {
+    metadata,
+    creditAccountAdditionalMetadata,
+    internalAccountsAdditionalMetadata,
+  } = LedgerFacade.LnReceiveLedgerMetadata({
     paymentHash,
     pubkey: crypto.randomUUID() as Pubkey,
     paymentAmounts: {
@@ -46,6 +50,8 @@ export const recordReceiveLnPayment = async ({
     bankFee,
     metadata,
     txMetadata: { hash: paymentHash },
+    additionalCreditMetadata: creditAccountAdditionalMetadata,
+    additionalInternalMetadata: internalAccountsAdditionalMetadata,
   })
 }
 
@@ -56,7 +62,11 @@ export const recordReceiveOnChainPayment = async ({
 }) => {
   const onChainTxHash = crypto.randomUUID() as OnChainTxHash
 
-  const metadata = LedgerFacade.OnChainReceiveLedgerMetadata({
+  const {
+    metadata,
+    creditAccountAdditionalMetadata,
+    internalAccountsAdditionalMetadata,
+  } = LedgerFacade.OnChainReceiveLedgerMetadata({
     onChainTxHash,
     paymentAmounts: {
       btcPaymentAmount: paymentAmount.btc,
@@ -78,6 +88,8 @@ export const recordReceiveOnChainPayment = async ({
     recipientWalletDescriptor: walletDescriptor,
     bankFee,
     metadata,
+    additionalCreditMetadata: creditAccountAdditionalMetadata,
+    additionalInternalMetadata: internalAccountsAdditionalMetadata,
   })
 }
 
@@ -86,20 +98,23 @@ export const recordSendLnPayment = async ({
   paymentAmount,
   bankFee,
 }) => {
-  const metadata = LedgerFacade.LnSendLedgerMetadata({
-    paymentHash: crypto.randomUUID() as PaymentHash,
-    feeDisplayCurrency: Number(bankFee.usd.amount) as DisplayCurrencyBaseAmount,
-    amountDisplayCurrency: Number(paymentAmount.usd.amount) as DisplayCurrencyBaseAmount,
-    displayCurrency: getDisplayCurrencyConfig().code,
-    pubkey: crypto.randomUUID() as Pubkey,
-    feeKnownInAdvance: true,
-    paymentAmounts: {
-      btcPaymentAmount: paymentAmount.btc,
-      usdPaymentAmount: paymentAmount.usd,
-      btcProtocolAndBankFee: bankFee.btc,
-      usdProtocolAndBankFee: bankFee.usd,
-    },
-  })
+  const { metadata, debitAccountAdditionalMetadata, internalAccountsAdditionalMetadata } =
+    LedgerFacade.LnSendLedgerMetadata({
+      paymentHash: crypto.randomUUID() as PaymentHash,
+      feeDisplayCurrency: Number(bankFee.usd.amount) as DisplayCurrencyBaseAmount,
+      amountDisplayCurrency: Number(
+        paymentAmount.usd.amount,
+      ) as DisplayCurrencyBaseAmount,
+      displayCurrency: getDisplayCurrencyConfig().code,
+      pubkey: crypto.randomUUID() as Pubkey,
+      feeKnownInAdvance: true,
+      paymentAmounts: {
+        btcPaymentAmount: paymentAmount.btc,
+        usdPaymentAmount: paymentAmount.usd,
+        btcProtocolAndBankFee: bankFee.btc,
+        usdProtocolAndBankFee: bankFee.usd,
+      },
+    })
 
   return LedgerFacade.recordSend({
     description: "sends bitcoin via ln",
@@ -107,6 +122,8 @@ export const recordSendLnPayment = async ({
     senderWalletDescriptor: walletDescriptor,
     bankFee,
     metadata,
+    additionalDebitMetadata: debitAccountAdditionalMetadata,
+    additionalInternalMetadata: internalAccountsAdditionalMetadata,
   })
 }
 
@@ -115,22 +132,25 @@ export const recordSendOnChainPayment = async ({
   paymentAmount,
   bankFee,
 }) => {
-  const metadata = LedgerFacade.OnChainSendLedgerMetadata({
-    onChainTxHash: crypto.randomUUID() as OnChainTxHash,
-    paymentAmounts: {
-      btcPaymentAmount: paymentAmount.btc,
-      usdPaymentAmount: paymentAmount.usd,
-      btcProtocolAndBankFee: bankFee.btc,
-      usdProtocolAndBankFee: bankFee.usd,
-    },
+  const { metadata, debitAccountAdditionalMetadata, internalAccountsAdditionalMetadata } =
+    LedgerFacade.OnChainSendLedgerMetadata({
+      onChainTxHash: crypto.randomUUID() as OnChainTxHash,
+      paymentAmounts: {
+        btcPaymentAmount: paymentAmount.btc,
+        usdPaymentAmount: paymentAmount.usd,
+        btcProtocolAndBankFee: bankFee.btc,
+        usdProtocolAndBankFee: bankFee.usd,
+      },
 
-    feeDisplayCurrency: Number(bankFee.usd.amount) as DisplayCurrencyBaseAmount,
-    amountDisplayCurrency: Number(paymentAmount.usd.amount) as DisplayCurrencyBaseAmount,
-    displayCurrency: getDisplayCurrencyConfig().code,
+      feeDisplayCurrency: Number(bankFee.usd.amount) as DisplayCurrencyBaseAmount,
+      amountDisplayCurrency: Number(
+        paymentAmount.usd.amount,
+      ) as DisplayCurrencyBaseAmount,
+      displayCurrency: getDisplayCurrencyConfig().code,
 
-    payeeAddresses: ["address1" as OnChainAddress],
-    sendAll: false,
-  })
+      payeeAddresses: ["address1" as OnChainAddress],
+      sendAll: false,
+    })
 
   return LedgerFacade.recordSend({
     description: "sends bitcoin via onchain",
@@ -138,6 +158,8 @@ export const recordSendOnChainPayment = async ({
     senderWalletDescriptor: walletDescriptor,
     bankFee,
     metadata,
+    additionalDebitMetadata: debitAccountAdditionalMetadata,
+    additionalInternalMetadata: internalAccountsAdditionalMetadata,
   })
 }
 
@@ -148,7 +170,11 @@ export const recordLnFeeReimbursement = async ({
 }) => {
   const paymentHash = crypto.randomUUID() as PaymentHash
 
-  const metadata = LedgerFacade.LnFeeReimbursementReceiveLedgerMetadata({
+  const {
+    metadata,
+    creditAccountAdditionalMetadata,
+    internalAccountsAdditionalMetadata,
+  } = LedgerFacade.LnFeeReimbursementReceiveLedgerMetadata({
     paymentHash,
     feeDisplayCurrency: Number(bankFee.usd.amount) as DisplayCurrencyBaseAmount,
     amountDisplayCurrency: Number(paymentAmount.usd.amount) as DisplayCurrencyBaseAmount,
@@ -169,6 +195,45 @@ export const recordLnFeeReimbursement = async ({
     bankFee,
     metadata,
     txMetadata: { hash: paymentHash },
+    additionalCreditMetadata: creditAccountAdditionalMetadata,
+    additionalInternalMetadata: internalAccountsAdditionalMetadata,
+  })
+}
+
+export const recordLnFailedPayment = async ({
+  walletDescriptor,
+  paymentAmount,
+  bankFee,
+}) => {
+  const paymentHash = crypto.randomUUID() as PaymentHash
+
+  const {
+    metadata,
+    creditAccountAdditionalMetadata,
+    internalAccountsAdditionalMetadata,
+  } = LedgerFacade.LnFailedPaymentReceiveLedgerMetadata({
+    paymentHash,
+    feeDisplayCurrency: Number(bankFee.usd.amount) as DisplayCurrencyBaseAmount,
+    amountDisplayCurrency: Number(paymentAmount.usd.amount) as DisplayCurrencyBaseAmount,
+    displayCurrency: getDisplayCurrencyConfig().code,
+    paymentAmounts: {
+      btcPaymentAmount: paymentAmount.btc,
+      usdPaymentAmount: paymentAmount.usd,
+      btcProtocolAndBankFee: bankFee.btc,
+      usdProtocolAndBankFee: bankFee.usd,
+    },
+    journalId: "031a419636dbf6d25981d6d2" as LedgerJournalId,
+  })
+
+  return LedgerFacade.recordReceive({
+    description: "receives ln fee reimburse",
+    amountToCreditReceiver: paymentAmount,
+    recipientWalletDescriptor: walletDescriptor,
+    bankFee,
+    metadata,
+    txMetadata: { hash: paymentHash },
+    additionalCreditMetadata: creditAccountAdditionalMetadata,
+    additionalInternalMetadata: internalAccountsAdditionalMetadata,
   })
 }
 
@@ -181,6 +246,7 @@ export const recordLnIntraLedgerPayment = async ({
     metadata,
     debitAccountAdditionalMetadata: additionalDebitMetadata,
     creditAccountAdditionalMetadata: additionalCreditMetadata,
+    internalAccountsAdditionalMetadata: additionalInternalMetadata,
   } = LedgerFacade.LnIntraledgerLedgerMetadata({
     paymentHash: crypto.randomUUID() as PaymentHash,
 
@@ -213,6 +279,7 @@ export const recordLnIntraLedgerPayment = async ({
     metadata,
     additionalDebitMetadata,
     additionalCreditMetadata,
+    additionalInternalMetadata,
   })
 }
 
@@ -225,6 +292,7 @@ export const recordWalletIdIntraLedgerPayment = async ({
     metadata,
     debitAccountAdditionalMetadata: additionalDebitMetadata,
     creditAccountAdditionalMetadata: additionalCreditMetadata,
+    internalAccountsAdditionalMetadata: additionalInternalMetadata,
   } = LedgerFacade.WalletIdIntraledgerLedgerMetadata({
     senderAmountDisplayCurrency: Number(
       paymentAmount.usd.amount,
@@ -254,6 +322,7 @@ export const recordWalletIdIntraLedgerPayment = async ({
     metadata,
     additionalDebitMetadata,
     additionalCreditMetadata,
+    additionalInternalMetadata,
   })
 }
 
@@ -266,6 +335,7 @@ export const recordOnChainIntraLedgerPayment = async ({
     metadata,
     debitAccountAdditionalMetadata: additionalDebitMetadata,
     creditAccountAdditionalMetadata: additionalCreditMetadata,
+    internalAccountsAdditionalMetadata: additionalInternalMetadata,
   } = LedgerFacade.OnChainIntraledgerLedgerMetadata({
     senderAmountDisplayCurrency: Number(
       paymentAmount.usd.amount,
@@ -297,6 +367,7 @@ export const recordOnChainIntraLedgerPayment = async ({
     metadata,
     additionalDebitMetadata,
     additionalCreditMetadata,
+    additionalInternalMetadata,
   })
 }
 
@@ -309,6 +380,7 @@ export const recordLnTradeIntraAccountTxn = async ({
     metadata,
     debitAccountAdditionalMetadata: additionalDebitMetadata,
     creditAccountAdditionalMetadata: additionalCreditMetadata,
+    internalAccountsAdditionalMetadata: additionalInternalMetadata,
   } = LedgerFacade.LnTradeIntraAccountLedgerMetadata({
     paymentHash: crypto.randomUUID() as PaymentHash,
     senderAmountDisplayCurrency: Number(
@@ -316,12 +388,6 @@ export const recordLnTradeIntraAccountTxn = async ({
     ) as DisplayCurrencyBaseAmount,
     senderFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
     senderDisplayCurrency: DisplayCurrency.Usd,
-
-    recipientAmountDisplayCurrency: Number(
-      paymentAmount.usd.amount,
-    ) as DisplayCurrencyBaseAmount,
-    recipientFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-    recipientDisplayCurrency: DisplayCurrency.Usd,
 
     pubkey: crypto.randomUUID() as Pubkey,
     paymentAmounts: {
@@ -340,6 +406,7 @@ export const recordLnTradeIntraAccountTxn = async ({
     metadata,
     additionalDebitMetadata,
     additionalCreditMetadata,
+    additionalInternalMetadata,
   })
 }
 
@@ -352,18 +419,13 @@ export const recordWalletIdTradeIntraAccountTxn = async ({
     metadata,
     debitAccountAdditionalMetadata: additionalDebitMetadata,
     creditAccountAdditionalMetadata: additionalCreditMetadata,
+    internalAccountsAdditionalMetadata: additionalInternalMetadata,
   } = LedgerFacade.WalletIdTradeIntraAccountLedgerMetadata({
     senderAmountDisplayCurrency: Number(
       paymentAmount.usd.amount,
     ) as DisplayCurrencyBaseAmount,
     senderFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
     senderDisplayCurrency: DisplayCurrency.Usd,
-
-    recipientAmountDisplayCurrency: Number(
-      paymentAmount.usd.amount,
-    ) as DisplayCurrencyBaseAmount,
-    recipientFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-    recipientDisplayCurrency: DisplayCurrency.Usd,
 
     paymentAmounts: {
       btcPaymentAmount: paymentAmount.btc,
@@ -381,6 +443,7 @@ export const recordWalletIdTradeIntraAccountTxn = async ({
     metadata,
     additionalDebitMetadata,
     additionalCreditMetadata,
+    additionalInternalMetadata,
   })
 }
 
@@ -393,18 +456,13 @@ export const recordOnChainTradeIntraAccountTxn = async ({
     metadata,
     debitAccountAdditionalMetadata: additionalDebitMetadata,
     creditAccountAdditionalMetadata: additionalCreditMetadata,
+    internalAccountsAdditionalMetadata: additionalInternalMetadata,
   } = LedgerFacade.OnChainTradeIntraAccountLedgerMetadata({
     senderAmountDisplayCurrency: Number(
       paymentAmount.usd.amount,
     ) as DisplayCurrencyBaseAmount,
     senderFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
     senderDisplayCurrency: DisplayCurrency.Usd,
-
-    recipientAmountDisplayCurrency: Number(
-      paymentAmount.usd.amount,
-    ) as DisplayCurrencyBaseAmount,
-    recipientFeeDisplayCurrency: 0 as DisplayCurrencyBaseAmount,
-    recipientDisplayCurrency: DisplayCurrency.Usd,
 
     sendAll: false,
     payeeAddresses: ["address1" as OnChainAddress],
@@ -424,6 +482,7 @@ export const recordOnChainTradeIntraAccountTxn = async ({
     metadata,
     additionalDebitMetadata,
     additionalCreditMetadata,
+    additionalInternalMetadata,
   })
 }
 

--- a/test/integration/services/ledger/helpers.type.d.ts
+++ b/test/integration/services/ledger/helpers.type.d.ts
@@ -9,13 +9,12 @@ type RecordExternalTxTestArgs<S extends WalletCurrency> = {
   }
 }
 
-type RecordInternalTxTestFn = <S extends WalletCurrency, R extends WalletCurrency>({
-  senderWalletDescriptor,
-  recipientWalletDescriptor,
+type RecordExternalTxTestFn = <S extends WalletCurrency>({
+  walletDescriptor,
   paymentAmount,
-  senderDisplayAmounts,
-  recipientDisplayAmounts,
-}: RecordInternalTxTestArgs<S, R>) => Promise<LedgerJournal | LedgerError>
+  bankFee,
+  displayAmounts,
+}: RecordExternalTxTestArgs<S>) => Promise<LedgerJournal | LedgerError>
 
 type RecordInternalTxTestArgs<S extends WalletCurrency, R extends WalletCurrency> = {
   senderWalletDescriptor: WalletDescriptor<S>
@@ -32,3 +31,11 @@ type RecordInternalTxTestArgs<S extends WalletCurrency, R extends WalletCurrency
     recipientDisplayCurrency: DisplayCurrency
   }
 }
+
+type RecordInternalTxTestFn = <S extends WalletCurrency, R extends WalletCurrency>({
+  senderWalletDescriptor,
+  recipientWalletDescriptor,
+  paymentAmount,
+  senderDisplayAmounts,
+  recipientDisplayAmounts,
+}: RecordInternalTxTestArgs<S, R>) => Promise<LedgerJournal | LedgerError>

--- a/test/integration/services/ledger/helpers.type.d.ts
+++ b/test/integration/services/ledger/helpers.type.d.ts
@@ -1,0 +1,34 @@
+type RecordExternalTxTestArgs<S extends WalletCurrency> = {
+  walletDescriptor: WalletDescriptor<S>
+  paymentAmount: { btc: BtcPaymentAmount; usd: UsdPaymentAmount }
+  bankFee: { btc: BtcPaymentAmount; usd: UsdPaymentAmount }
+  displayAmounts: {
+    amountDisplayCurrency: DisplayCurrencyBaseAmount
+    feeDisplayCurrency: DisplayCurrencyBaseAmount
+    displayCurrency: DisplayCurrency
+  }
+}
+
+type RecordInternalTxTestFn = <S extends WalletCurrency, R extends WalletCurrency>({
+  senderWalletDescriptor,
+  recipientWalletDescriptor,
+  paymentAmount,
+  senderDisplayAmounts,
+  recipientDisplayAmounts,
+}: RecordInternalTxTestArgs<S, R>) => Promise<LedgerJournal | LedgerError>
+
+type RecordInternalTxTestArgs<S extends WalletCurrency, R extends WalletCurrency> = {
+  senderWalletDescriptor: WalletDescriptor<S>
+  recipientWalletDescriptor: WalletDescriptor<R>
+  paymentAmount: { btc: BtcPaymentAmount; usd: UsdPaymentAmount }
+  senderDisplayAmounts: {
+    senderAmountDisplayCurrency: DisplayCurrencyBaseAmount
+    senderFeeDisplayCurrency: DisplayCurrencyBaseAmount
+    senderDisplayCurrency: DisplayCurrency
+  }
+  recipientDisplayAmounts: {
+    recipientAmountDisplayCurrency: DisplayCurrencyBaseAmount
+    recipientFeeDisplayCurrency: DisplayCurrencyBaseAmount
+    recipientDisplayCurrency: DisplayCurrency
+  }
+}

--- a/test/integration/services/ledger/service.spec.ts
+++ b/test/integration/services/ledger/service.spec.ts
@@ -18,6 +18,7 @@ import { ModifiedSet, timestampDaysAgo } from "@utils"
 import {
   recordLnIntraLedgerPayment,
   recordLnFeeReimbursement,
+  recordLnFailedPayment,
   recordReceiveLnPayment,
   recordSendLnPayment,
   recordSendOnChainPayment,
@@ -318,6 +319,10 @@ describe("Volumes", () => {
         testExternalTxReceiveWLE({
           recordTx: recordLnFeeReimbursement,
         }),
+      LnFailedPayment: () =>
+        testExternalTxReceiveWLE({
+          recordTx: recordLnFailedPayment,
+        }),
       IntraLedgerSend: () =>
         testInternalTxSendWLE({
           recordTx: recordWalletIdIntraLedgerPayment,
@@ -384,6 +389,7 @@ describe("Volumes", () => {
       Payment: () => testExternalTxNLE({ recordTx: recordSendLnPayment }),
       OnchainPayment: () => testExternalTxNLE({ recordTx: recordSendOnChainPayment }),
       LnFeeReimbursement: () => testExternalTxNLE({ recordTx: recordLnFeeReimbursement }),
+      LnFailedPayment: () => testExternalTxNLE({ recordTx: recordLnFailedPayment }),
       Fee: () => testExternalTxNLE({ recordTx: recordLnChannelOpenOrClosingFee }),
       EscrowCredit: () => testExternalTxNLE({ recordTx: recordLndEscrowCredit }),
       EscrowDebit: () => testExternalTxNLE({ recordTx: recordLndEscrowDebit }),

--- a/test/unit/services/ledger/domain/tx-metadata.spec.ts
+++ b/test/unit/services/ledger/domain/tx-metadata.spec.ts
@@ -41,21 +41,38 @@ describe("Tx metadata", () => {
   }
 
   describe("intraledger", () => {
+    const senderAmountDisplayCurrency = amountDisplayCurrency
+    const senderFeeDisplayCurrency = feeDisplayCurrency
+    const senderDisplayCurrency = displayCurrency
+
+    const recipientAmountDisplayCurrency = (amountDisplayCurrency +
+      1) as DisplayCurrencyBaseAmount
+    const recipientFeeDisplayCurrency = (feeDisplayCurrency +
+      1) as DisplayCurrencyBaseAmount
+    const recipientDisplayCurrency = displayCurrency
+
     it("onchain", () => {
-      const { metadata, debitAccountAdditionalMetadata } =
-        OnChainIntraledgerLedgerMetadata({
-          payeeAddresses,
-          sendAll: true,
-          paymentAmounts: onChainPaymentAmounts,
+      const {
+        metadata,
+        debitAccountAdditionalMetadata,
+        creditAccountAdditionalMetadata,
+      } = OnChainIntraledgerLedgerMetadata({
+        payeeAddresses,
+        sendAll: true,
+        paymentAmounts: onChainPaymentAmounts,
 
-          amountDisplayCurrency,
-          feeDisplayCurrency,
-          displayCurrency,
+        senderAmountDisplayCurrency,
+        senderFeeDisplayCurrency,
+        senderDisplayCurrency,
 
-          memoOfPayer,
-          senderUsername,
-          recipientUsername,
-        })
+        recipientAmountDisplayCurrency,
+        recipientFeeDisplayCurrency,
+        recipientDisplayCurrency,
+
+        memoOfPayer,
+        senderUsername,
+        recipientUsername,
+      })
 
       expect(metadata).toEqual(
         expect.objectContaining({
@@ -64,26 +81,46 @@ describe("Tx metadata", () => {
           type: LedgerTransactionType.OnchainIntraLedger,
         }),
       )
+
       expect(debitAccountAdditionalMetadata).toEqual(
         expect.objectContaining({
           username: recipientUsername,
           memoPayer: memoOfPayer,
+
+          displayAmount: senderAmountDisplayCurrency,
+          displayFee: senderFeeDisplayCurrency,
+          displayCurrency: senderDisplayCurrency,
+        }),
+      )
+
+      expect(creditAccountAdditionalMetadata).toEqual(
+        expect.objectContaining({
+          displayAmount: recipientAmountDisplayCurrency,
+          displayFee: recipientFeeDisplayCurrency,
+          displayCurrency: recipientDisplayCurrency,
         }),
       )
     })
     it("onchain trade", () => {
-      const { metadata, debitAccountAdditionalMetadata } =
-        OnChainTradeIntraAccountLedgerMetadata({
-          payeeAddresses,
-          sendAll: true,
-          paymentAmounts: onChainPaymentAmounts,
+      const {
+        metadata,
+        debitAccountAdditionalMetadata,
+        creditAccountAdditionalMetadata,
+      } = OnChainTradeIntraAccountLedgerMetadata({
+        payeeAddresses,
+        sendAll: true,
+        paymentAmounts: onChainPaymentAmounts,
 
-          amountDisplayCurrency,
-          feeDisplayCurrency,
-          displayCurrency,
+        senderAmountDisplayCurrency,
+        senderFeeDisplayCurrency,
+        senderDisplayCurrency,
 
-          memoOfPayer,
-        })
+        recipientAmountDisplayCurrency,
+        recipientFeeDisplayCurrency,
+        recipientDisplayCurrency,
+
+        memoOfPayer,
+      })
 
       expect(metadata).toEqual(
         expect.objectContaining({
@@ -91,22 +128,43 @@ describe("Tx metadata", () => {
           type: LedgerTransactionType.OnChainTradeIntraAccount,
         }),
       )
+
       expect(debitAccountAdditionalMetadata).toEqual(
         expect.objectContaining({
           memoPayer: memoOfPayer,
+
+          displayAmount: senderAmountDisplayCurrency,
+          displayFee: senderFeeDisplayCurrency,
+          displayCurrency: senderDisplayCurrency,
+        }),
+      )
+
+      expect(creditAccountAdditionalMetadata).toEqual(
+        expect.objectContaining({
+          displayAmount: recipientAmountDisplayCurrency,
+          displayFee: recipientFeeDisplayCurrency,
+          displayCurrency: recipientDisplayCurrency,
         }),
       )
     })
 
     it("ln", () => {
-      const { metadata, debitAccountAdditionalMetadata } = LnIntraledgerLedgerMetadata({
+      const {
+        metadata,
+        debitAccountAdditionalMetadata,
+        creditAccountAdditionalMetadata,
+      } = LnIntraledgerLedgerMetadata({
         paymentHash,
         pubkey,
         paymentAmounts,
 
-        amountDisplayCurrency,
-        feeDisplayCurrency,
-        displayCurrency,
+        senderAmountDisplayCurrency,
+        senderFeeDisplayCurrency,
+        senderDisplayCurrency,
+
+        recipientAmountDisplayCurrency,
+        recipientFeeDisplayCurrency,
+        recipientDisplayCurrency,
 
         memoOfPayer,
         senderUsername,
@@ -120,36 +178,53 @@ describe("Tx metadata", () => {
           type: LedgerTransactionType.LnIntraLedger,
 
           satsFee: toSats(0),
-          displayFee: feeDisplayCurrency,
-          displayAmount: amountDisplayCurrency,
 
-          displayCurrency,
           centsAmount: toCents(10),
           satsAmount: toSats(2000),
           centsFee: toCents(0),
         }),
       )
+
       expect(debitAccountAdditionalMetadata).toEqual(
         expect.objectContaining({
           username: recipientUsername,
           memoPayer: memoOfPayer,
+
+          displayAmount: senderAmountDisplayCurrency,
+          displayFee: senderFeeDisplayCurrency,
+          displayCurrency: senderDisplayCurrency,
+        }),
+      )
+
+      expect(creditAccountAdditionalMetadata).toEqual(
+        expect.objectContaining({
+          displayAmount: recipientAmountDisplayCurrency,
+          displayFee: recipientFeeDisplayCurrency,
+          displayCurrency: recipientDisplayCurrency,
         }),
       )
     })
 
     it("ln trade", () => {
-      const { metadata, debitAccountAdditionalMetadata } =
-        LnTradeIntraAccountLedgerMetadata({
-          paymentHash,
-          pubkey,
-          paymentAmounts,
+      const {
+        metadata,
+        debitAccountAdditionalMetadata,
+        creditAccountAdditionalMetadata,
+      } = LnTradeIntraAccountLedgerMetadata({
+        paymentHash,
+        pubkey,
+        paymentAmounts,
 
-          amountDisplayCurrency,
-          feeDisplayCurrency,
-          displayCurrency,
+        senderAmountDisplayCurrency,
+        senderFeeDisplayCurrency,
+        senderDisplayCurrency,
 
-          memoOfPayer,
-        })
+        recipientAmountDisplayCurrency,
+        recipientFeeDisplayCurrency,
+        recipientDisplayCurrency,
+
+        memoOfPayer,
+      })
 
       expect(metadata).toEqual(
         expect.objectContaining({
@@ -157,35 +232,52 @@ describe("Tx metadata", () => {
           type: LedgerTransactionType.LnTradeIntraAccount,
 
           satsFee: toSats(0),
-          displayFee: feeDisplayCurrency,
-          displayAmount: amountDisplayCurrency,
 
-          displayCurrency,
           centsAmount: toCents(10),
           satsAmount: toSats(2000),
           centsFee: toCents(0),
         }),
       )
+
       expect(debitAccountAdditionalMetadata).toEqual(
         expect.objectContaining({
           memoPayer: memoOfPayer,
+
+          displayAmount: senderAmountDisplayCurrency,
+          displayFee: senderFeeDisplayCurrency,
+          displayCurrency: senderDisplayCurrency,
+        }),
+      )
+
+      expect(creditAccountAdditionalMetadata).toEqual(
+        expect.objectContaining({
+          displayAmount: recipientAmountDisplayCurrency,
+          displayFee: recipientFeeDisplayCurrency,
+          displayCurrency: recipientDisplayCurrency,
         }),
       )
     })
 
     it("wallet id", () => {
-      const { metadata, debitAccountAdditionalMetadata } =
-        WalletIdIntraledgerLedgerMetadata({
-          paymentAmounts,
+      const {
+        metadata,
+        debitAccountAdditionalMetadata,
+        creditAccountAdditionalMetadata,
+      } = WalletIdIntraledgerLedgerMetadata({
+        paymentAmounts,
 
-          feeDisplayCurrency,
-          amountDisplayCurrency,
-          displayCurrency,
+        senderAmountDisplayCurrency,
+        senderFeeDisplayCurrency,
+        senderDisplayCurrency,
 
-          memoOfPayer,
-          senderUsername,
-          recipientUsername,
-        })
+        recipientAmountDisplayCurrency,
+        recipientFeeDisplayCurrency,
+        recipientDisplayCurrency,
+
+        memoOfPayer,
+        senderUsername,
+        recipientUsername,
+      })
 
       expect(metadata).toEqual(
         expect.objectContaining({
@@ -194,29 +286,47 @@ describe("Tx metadata", () => {
           type: LedgerTransactionType.IntraLedger,
 
           satsFee: toSats(0),
-          displayFee: feeDisplayCurrency,
-          displayAmount: amountDisplayCurrency,
 
-          displayCurrency,
           centsAmount: toCents(10),
           satsAmount: toSats(2000),
           centsFee: toCents(0),
         }),
       )
+
       expect(debitAccountAdditionalMetadata).toEqual(
         expect.objectContaining({
           username: recipientUsername,
+
+          displayAmount: senderAmountDisplayCurrency,
+          displayFee: senderFeeDisplayCurrency,
+          displayCurrency: senderDisplayCurrency,
+        }),
+      )
+
+      expect(creditAccountAdditionalMetadata).toEqual(
+        expect.objectContaining({
+          displayAmount: recipientAmountDisplayCurrency,
+          displayFee: recipientFeeDisplayCurrency,
+          displayCurrency: recipientDisplayCurrency,
         }),
       )
     })
 
     it("wallet id trade", () => {
-      const metadata = WalletIdTradeIntraAccountLedgerMetadata({
+      const {
+        metadata,
+        debitAccountAdditionalMetadata,
+        creditAccountAdditionalMetadata,
+      } = WalletIdTradeIntraAccountLedgerMetadata({
         paymentAmounts,
 
-        feeDisplayCurrency,
-        amountDisplayCurrency,
-        displayCurrency,
+        senderAmountDisplayCurrency,
+        senderFeeDisplayCurrency,
+        senderDisplayCurrency,
+
+        recipientAmountDisplayCurrency,
+        recipientFeeDisplayCurrency,
+        recipientDisplayCurrency,
 
         memoOfPayer,
       })
@@ -227,13 +337,26 @@ describe("Tx metadata", () => {
           type: LedgerTransactionType.WalletIdTradeIntraAccount,
 
           satsFee: toSats(0),
-          displayFee: feeDisplayCurrency,
-          displayAmount: amountDisplayCurrency,
 
-          displayCurrency,
           centsAmount: toCents(10),
           satsAmount: toSats(2000),
           centsFee: toCents(0),
+        }),
+      )
+
+      expect(debitAccountAdditionalMetadata).toEqual(
+        expect.objectContaining({
+          displayAmount: senderAmountDisplayCurrency,
+          displayFee: senderFeeDisplayCurrency,
+          displayCurrency: senderDisplayCurrency,
+        }),
+      )
+
+      expect(creditAccountAdditionalMetadata).toEqual(
+        expect.objectContaining({
+          displayAmount: recipientAmountDisplayCurrency,
+          displayFee: recipientFeeDisplayCurrency,
+          displayCurrency: recipientDisplayCurrency,
         }),
       )
     })

--- a/test/unit/services/ledger/domain/tx-metadata.spec.ts
+++ b/test/unit/services/ledger/domain/tx-metadata.spec.ts
@@ -9,6 +9,12 @@ import {
   OnChainTradeIntraAccountLedgerMetadata,
   WalletIdIntraledgerLedgerMetadata,
   WalletIdTradeIntraAccountLedgerMetadata,
+  LnSendLedgerMetadata,
+  OnChainSendLedgerMetadata,
+  OnChainReceiveLedgerMetadata,
+  LnReceiveLedgerMetadata,
+  LnFeeReimbursementReceiveLedgerMetadata,
+  LnFailedPaymentReceiveLedgerMetadata,
 } from "@services/ledger/tx-metadata"
 
 describe("Tx metadata", () => {
@@ -18,6 +24,8 @@ describe("Tx metadata", () => {
   const pubkey = "pubkey" as Pubkey
   const payeeAddresses: OnChainAddress[] = ["Address" as OnChainAddress]
   const paymentHash = "paymenthash" as PaymentHash
+  const onChainTxHash = "onChainTxHash" as OnChainTxHash
+  const journalId = "journalId" as LedgerJournalId
 
   const senderAmountDisplayCurrency = 100 as DisplayCurrencyBaseAmount
   const senderFeeDisplayCurrency = 10 as DisplayCurrencyBaseAmount
@@ -44,7 +52,7 @@ describe("Tx metadata", () => {
     memoOfPayer,
   }
 
-  const expectedMetadata = {
+  const expectedCommonMetadata = {
     satsAmount: toSats(2000),
     centsAmount: toCents(10),
 
@@ -54,8 +62,12 @@ describe("Tx metadata", () => {
 
   const expectedAmounts = {
     internal: {
-      displayAmount: Number(paymentAmounts.usdPaymentAmount.amount),
-      displayFee: Number(paymentAmounts.usdProtocolAndBankFee.amount),
+      displayAmount: Number(
+        paymentAmounts.usdPaymentAmount.amount,
+      ) as DisplayCurrencyBaseAmount,
+      displayFee: Number(
+        paymentAmounts.usdProtocolAndBankFee.amount,
+      ) as DisplayCurrencyBaseAmount,
       displayCurrency: DisplayCurrency.Usd,
     },
 
@@ -85,14 +97,16 @@ describe("Tx metadata", () => {
             pubkey: Pubkey
           }
         | undefined
-      expectedMetadata
+      expectedCommonMetadata
       expectedAdditionalDebitMetadata
       crossAccount: {
         MetadataFn
+        title: string
         type: LedgerTransactionType
       }
       selfTrade: {
         MetadataFn
+        title: string
         type: LedgerTransactionType
       }
     }) => {
@@ -102,7 +116,7 @@ describe("Tx metadata", () => {
           ...testCase.commonMetadataArgs,
         }
 
-        describe("cross-account", () => {
+        describe(`cross-account (${testCase.crossAccount.title})`, () => {
           const { MetadataFn, type } = testCase.crossAccount
 
           const metadataArgs = {
@@ -126,8 +140,8 @@ describe("Tx metadata", () => {
 
             expect(metadata).toEqual(
               expect.objectContaining({
-                ...expectedMetadata,
-                ...testCase.expectedMetadata,
+                ...expectedCommonMetadata,
+                ...testCase.expectedCommonMetadata,
                 username: senderUsername,
                 type,
               }),
@@ -216,7 +230,7 @@ describe("Tx metadata", () => {
           })
         })
 
-        describe("trade (self-account)", () => {
+        describe(`self-trade (${testCase.selfTrade.title})`, () => {
           const { MetadataFn, type } = testCase.selfTrade
 
           const metadataArgs = commonMetadataArgs
@@ -231,8 +245,8 @@ describe("Tx metadata", () => {
 
             expect(metadata).toEqual(
               expect.objectContaining({
-                ...expectedMetadata,
-                ...testCase.expectedMetadata,
+                ...expectedCommonMetadata,
+                ...testCase.expectedCommonMetadata,
                 type,
               }),
             )
@@ -268,8 +282,8 @@ describe("Tx metadata", () => {
 
             expect(metadata).toEqual(
               expect.objectContaining({
-                ...expectedMetadata,
-                ...testCase.expectedMetadata,
+                ...expectedCommonMetadata,
+                ...testCase.expectedCommonMetadata,
                 type,
               }),
             )
@@ -303,13 +317,15 @@ describe("Tx metadata", () => {
           payeeAddresses,
           sendAll: true,
         },
-        expectedMetadata: { memoPayer: undefined },
+        expectedCommonMetadata: { memoPayer: undefined },
         expectedAdditionalDebitMetadata: { memoPayer: memoOfPayer },
         crossAccount: {
+          title: "OnChainIntraledgerLedgerMetadata",
           MetadataFn: OnChainIntraledgerLedgerMetadata,
           type: LedgerTransactionType.OnchainIntraLedger,
         },
         selfTrade: {
+          title: "OnChainTradeIntraAccountLedgerMetadata",
           MetadataFn: OnChainTradeIntraAccountLedgerMetadata,
           type: LedgerTransactionType.OnChainTradeIntraAccount,
         },
@@ -321,13 +337,15 @@ describe("Tx metadata", () => {
           paymentHash,
           pubkey,
         },
-        expectedMetadata: { memoPayer: undefined },
+        expectedCommonMetadata: { memoPayer: undefined },
         expectedAdditionalDebitMetadata: { memoPayer: memoOfPayer },
         crossAccount: {
+          title: "LnIntraledgerLedgerMetadata",
           MetadataFn: LnIntraledgerLedgerMetadata,
           type: LedgerTransactionType.LnIntraLedger,
         },
         selfTrade: {
+          title: "LnTradeIntraAccountLedgerMetadata",
           MetadataFn: LnTradeIntraAccountLedgerMetadata,
           type: LedgerTransactionType.LnTradeIntraAccount,
         },
@@ -336,13 +354,15 @@ describe("Tx metadata", () => {
       {
         title: "walletId",
         commonMetadataArgs: undefined,
-        expectedMetadata: { memoPayer: memoOfPayer },
+        expectedCommonMetadata: { memoPayer: memoOfPayer },
         expectedAdditionalDebitMetadata: {},
         crossAccount: {
+          title: "WalletIdIntraledgerLedgerMetadata",
           MetadataFn: WalletIdIntraledgerLedgerMetadata,
           type: LedgerTransactionType.IntraLedger,
         },
         selfTrade: {
+          title: "WalletIdTradeIntraAccountLedgerMetadata",
           MetadataFn: WalletIdTradeIntraAccountLedgerMetadata,
           type: LedgerTransactionType.WalletIdTradeIntraAccount,
         },
@@ -350,5 +370,283 @@ describe("Tx metadata", () => {
     ]
 
     testCases.forEach(runTest)
+  })
+
+  describe("external", () => {
+    const commonCrcMetadataArgs = {
+      paymentAmounts,
+      feeDisplayCurrency: expectedAmounts.sender.displayFee,
+      amountDisplayCurrency: expectedAmounts.sender.displayAmount,
+      displayCurrency: expectedAmounts.sender.displayCurrency,
+    }
+
+    const commonUsdMetadataArgs = {
+      paymentAmounts,
+      feeDisplayCurrency: expectedAmounts.internal.displayFee,
+      amountDisplayCurrency: expectedAmounts.internal.displayAmount,
+      displayCurrency: expectedAmounts.internal.displayCurrency as DisplayCurrency,
+    }
+
+    const sendMetadataArgs = {
+      memoOfPayer,
+    }
+    const expectedSendMetadataArgs = {
+      memoPayer: sendMetadataArgs.memoOfPayer,
+      pending: true,
+    }
+
+    const receiveMetadataArgs = {}
+    const expectedReceiveMetadataArgs = { pending: false }
+
+    const onchainMetadataArgs = {
+      onChainTxHash,
+      payeeAddresses,
+    }
+    const expectedOnChainMetadataArgs = {
+      hash: onchainMetadataArgs.onChainTxHash,
+      payee_addresses: onchainMetadataArgs.payeeAddresses,
+    }
+
+    const lnMetadataArgs = {
+      paymentHash,
+      pubkey,
+    }
+
+    const expectedLnMetadataArgs = {
+      hash: lnMetadataArgs.paymentHash,
+    }
+
+    describe("send", () => {
+      const expectedMetadata = {
+        ...expectedCommonMetadata,
+        ...expectedSendMetadataArgs,
+      }
+
+      const displayCurrencyCases = [
+        {
+          commonMetadataArgs: commonUsdMetadataArgs,
+          expectedDebitAmounts: expectedAmounts.internal,
+        },
+        {
+          commonMetadataArgs: commonCrcMetadataArgs,
+          expectedDebitAmounts: expectedAmounts.sender,
+        },
+      ]
+
+      describe("onchain", () => {
+        describe("OnChainSendLedgerMetadata", () => {
+          for (const {
+            commonMetadataArgs,
+            expectedDebitAmounts,
+          } of displayCurrencyCases) {
+            it(`${commonMetadataArgs.displayCurrency} sender`, () => {
+              const metadataArgs = {
+                ...commonMetadataArgs,
+                ...sendMetadataArgs,
+                ...onchainMetadataArgs,
+                sendAll: true,
+              }
+
+              const {
+                metadata,
+                debitAccountAdditionalMetadata,
+                internalAccountsAdditionalMetadata,
+              } = OnChainSendLedgerMetadata(metadataArgs)
+
+              expect(metadata).toEqual(
+                expect.objectContaining({
+                  type: LedgerTransactionType.OnchainPayment,
+                  ...expectedMetadata,
+                  ...expectedOnChainMetadataArgs,
+                  sendAll: true,
+                }),
+              )
+
+              expect(debitAccountAdditionalMetadata).toEqual(
+                expect.objectContaining(expectedDebitAmounts),
+              )
+
+              expect(internalAccountsAdditionalMetadata).toEqual(
+                expect.objectContaining(expectedAmounts.internal),
+              )
+              expect(internalAccountsAdditionalMetadata).not.toHaveProperty(["memoPayer"])
+            })
+          }
+        })
+      })
+
+      describe("ln", () => {
+        describe("LnSendLedgerMetadata", () => {
+          for (const {
+            commonMetadataArgs,
+            expectedDebitAmounts,
+          } of displayCurrencyCases) {
+            it(`${commonMetadataArgs.displayCurrency} sender`, () => {
+              const metadataArgs = {
+                ...commonMetadataArgs,
+                ...sendMetadataArgs,
+                ...lnMetadataArgs,
+                feeKnownInAdvance: true,
+              }
+
+              const {
+                metadata,
+                debitAccountAdditionalMetadata,
+                internalAccountsAdditionalMetadata,
+              } = LnSendLedgerMetadata(metadataArgs)
+
+              expect(metadata).toEqual(
+                expect.objectContaining({
+                  type: LedgerTransactionType.Payment,
+                  ...expectedMetadata,
+                  ...expectedLnMetadataArgs,
+                  feeKnownInAdvance: true,
+                  pubkey,
+                }),
+              )
+
+              expect(debitAccountAdditionalMetadata).toEqual(
+                expect.objectContaining(expectedDebitAmounts),
+              )
+
+              expect(internalAccountsAdditionalMetadata).toEqual(
+                expect.objectContaining(expectedAmounts.internal),
+              )
+              expect(internalAccountsAdditionalMetadata).not.toHaveProperty(["memoPayer"])
+            })
+          }
+        })
+      })
+    })
+
+    describe("receive", () => {
+      const expectedMetadata = {
+        ...expectedCommonMetadata,
+        ...expectedReceiveMetadataArgs,
+      }
+
+      const displayCurrencyCases = [
+        {
+          commonMetadataArgs: commonUsdMetadataArgs,
+          expectedCreditAmounts: expectedAmounts.internal,
+        },
+        {
+          commonMetadataArgs: commonCrcMetadataArgs,
+          expectedCreditAmounts: expectedAmounts.sender,
+        },
+      ]
+
+      describe("onchain", () => {
+        describe("OnChainReceiveLedgerMetadata", () => {
+          for (const {
+            commonMetadataArgs,
+            expectedCreditAmounts,
+          } of displayCurrencyCases) {
+            it(`${commonMetadataArgs.displayCurrency} sender`, () => {
+              const metadataArgs = {
+                ...commonMetadataArgs,
+                ...receiveMetadataArgs,
+                ...onchainMetadataArgs,
+              }
+
+              const {
+                metadata,
+                creditAccountAdditionalMetadata,
+                internalAccountsAdditionalMetadata,
+              } = OnChainReceiveLedgerMetadata(metadataArgs)
+
+              expect(metadata).toEqual(
+                expect.objectContaining({
+                  type: LedgerTransactionType.OnchainReceipt,
+                  ...expectedMetadata,
+                  ...expectedOnChainMetadataArgs,
+                }),
+              )
+
+              expect(creditAccountAdditionalMetadata).toEqual(
+                expect.objectContaining(expectedCreditAmounts),
+              )
+
+              expect(internalAccountsAdditionalMetadata).toEqual(
+                expect.objectContaining(expectedAmounts.internal),
+              )
+              expect(internalAccountsAdditionalMetadata).not.toHaveProperty(["memoPayer"])
+            })
+          }
+        })
+      })
+
+      describe("ln", () => {
+        const lnReceiveCases = [
+          {
+            title: "LnReceiveLedgerMetadata",
+            MetadataFn: LnReceiveLedgerMetadata,
+            type: LedgerTransactionType.Invoice,
+            expectedAdditionalMetadata: {},
+          },
+          {
+            title: "LnFeeReimbursementReceiveLedgerMetadata",
+            MetadataFn: LnFeeReimbursementReceiveLedgerMetadata,
+            type: LedgerTransactionType.LnFeeReimbursement,
+            expectedAdditionalMetadata: { related_journal: journalId },
+          },
+          {
+            title: "LnFailedPaymentReceiveLedgerMetadata",
+            MetadataFn: LnFailedPaymentReceiveLedgerMetadata,
+            type: LedgerTransactionType.Payment,
+            expectedAdditionalMetadata: { related_journal: journalId },
+          },
+        ]
+
+        for (const {
+          title,
+          MetadataFn,
+          type,
+          expectedAdditionalMetadata,
+        } of lnReceiveCases) {
+          describe(`${title}`, () => {
+            for (const {
+              commonMetadataArgs,
+              expectedCreditAmounts,
+            } of displayCurrencyCases) {
+              it(`${commonMetadataArgs.displayCurrency} sender`, () => {
+                const metadataArgs = {
+                  ...commonMetadataArgs,
+                  ...receiveMetadataArgs,
+                  ...lnMetadataArgs,
+                  journalId,
+                }
+
+                const {
+                  metadata,
+                  creditAccountAdditionalMetadata,
+                  internalAccountsAdditionalMetadata,
+                } = MetadataFn(metadataArgs)
+
+                expect(metadata).toEqual(
+                  expect.objectContaining({
+                    type,
+                    ...expectedMetadata,
+                    ...expectedLnMetadataArgs,
+                    ...expectedAdditionalMetadata,
+                  }),
+                )
+
+                expect(creditAccountAdditionalMetadata).toEqual(
+                  expect.objectContaining(expectedCreditAmounts),
+                )
+
+                expect(internalAccountsAdditionalMetadata).toEqual(
+                  expect.objectContaining(expectedAmounts.internal),
+                )
+                expect(internalAccountsAdditionalMetadata).not.toHaveProperty([
+                  "memoPayer",
+                ])
+              })
+            }
+          })
+        }
+      })
+    })
   })
 })


### PR DESCRIPTION
## Description

This PR separates display amounts across transaction entries based on different user account default display currency settings.

For context each given transaction (journal) is made up of multiple entries in our `medici_transactions` collection:
- (user) sender/recipient entry for external transactions
- (user) optional recipient/sender counter-entry for intraledger transactions
- (internal) bank owner entry for fees
- (internal) lnd entries for external transactions
- (internal) dealer entries for stablesats transactions

The approach taken in this PR is to:
- assign display properties for user-entries based on user-account default currency settings
- assign display properties for internal-entries based on second non-btc system wallet currency (currently USD)

This has meant touching code in the following places to introduce this new distinction across different entries in a single transaction (journal):
- `tx-metadata`, to return `internal`/`user-debit`/`user-credit` metadata
- `entry-builder`, to apply the distinct display properties to different entries
- `facade`, to accommodate passing in the actual value for different display properties from the outer use-cases

### Open `TODO`s
- [x] re-add (usd) display props to non-end-user entries for intraledger txns
- [x] double-check builder & facade tests
- [x] add missing non-intraledger tx-metadata tests
- [x] consider adding any integration tests (will leave for next PR where we remove `DisplayCurrency` hardcoding)