### PR TITLE
feat: add settlement display amount props to gql Transation object

### DIFF
--- a/src/domain/fiat/display-currency.ts
+++ b/src/domain/fiat/display-currency.ts
@@ -10,7 +10,7 @@ export const usdMinorToMajorUnit = (amount: number | bigint) =>
   Number((Number(amount) / CENTS_PER_USD).toFixed(2))
 
 // TODO: update by display currency
-export const majorToMinorUnit = (amount: number | bigint) =>
+export const usdMajorToMinorUnit = (amount: number | bigint) =>
   Number(Number(amount) * CENTS_PER_USD)
 
 export const toDisplayCurrencyBaseAmount = (amount: number) =>

--- a/src/domain/fiat/display-currency.ts
+++ b/src/domain/fiat/display-currency.ts
@@ -6,12 +6,33 @@ export const MajorExponent = {
   THREE: 3n,
 } as const
 
-export const usdMinorToMajorUnit = (amount: number | bigint) =>
-  Number((Number(amount) / CENTS_PER_USD).toFixed(2))
+export const minorToMajorUnit = ({
+  amount,
+  displayMajorExponent,
+}: {
+  amount: number | bigint
+  displayMajorExponent: CurrencyMajorExponent
+}) => {
+  const majorExponent = Number(displayMajorExponent)
+  return Number((Number(amount) / 10 ** majorExponent).toFixed(majorExponent))
+}
 
-// TODO: update by display currency
+export const usdMinorToMajorUnit = (amount: number | bigint) =>
+  minorToMajorUnit({ amount, displayMajorExponent: MajorExponent.STANDARD })
+
+export const majorToMinorUnit = ({
+  amount,
+  displayMajorExponent,
+}: {
+  amount: number | bigint
+  displayMajorExponent: CurrencyMajorExponent
+}) => {
+  const majorExponent = Number(displayMajorExponent)
+  return Number(Number(amount) * 10 ** majorExponent)
+}
+
 export const usdMajorToMinorUnit = (amount: number | bigint) =>
-  Number(Number(amount) * CENTS_PER_USD)
+  majorToMinorUnit({ amount, displayMajorExponent: MajorExponent.STANDARD })
 
 export const toDisplayCurrencyBaseAmount = (amount: number) =>
   amount as DisplayCurrencyBaseAmount

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -52,6 +52,8 @@ type BaseWalletTransaction = {
   readonly settlementAmount: Satoshis | UsdCents
   readonly settlementFee: Satoshis | UsdCents
   readonly settlementCurrency: WalletCurrency
+  readonly settlementDisplayAmount: number
+  readonly settlementDisplayCurrency: DisplayCurrency | ""
   readonly displayCurrencyPerSettlementCurrencyUnit: number
   readonly status: TxStatus
   readonly memo: string | null

--- a/src/graphql/admin/schema.graphql
+++ b/src/graphql/admin/schema.graphql
@@ -170,6 +170,11 @@ type Coordinates {
   longitude: Float!
 }
 
+"""
+Display currency of an account
+"""
+scalar DisplayCurrency
+
 interface Error {
   code: String
   message: String!
@@ -377,6 +382,11 @@ An amount (of a currency) that can be negative (e.g. in a transaction)
 """
 scalar SignedAmount
 
+"""
+A string amount (of a currency) that can be negative (e.g. in a transaction)
+"""
+scalar SignedDisplayMajorAmount
+
 type SuccessPayload {
   errors: [Error!]!
   success: Boolean
@@ -419,6 +429,8 @@ type Transaction {
   Wallet currency for transaction.
   """
   settlementCurrency: WalletCurrency!
+  settlementDisplayAmount: SignedDisplayMajorAmount!
+  settlementDisplayCurrency: DisplayCurrency!
   settlementFee: SignedAmount!
 
   """

--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -1106,6 +1106,11 @@ An amount (of a currency) that can be negative (e.g. in a transaction)
 """
 scalar SignedAmount
 
+"""
+A string amount (of a currency) that can be negative (e.g. in a transaction)
+"""
+scalar SignedDisplayMajorAmount
+
 type Subscription {
   lnInvoicePaymentStatus(
     input: LnInvoicePaymentStatusInput!
@@ -1161,6 +1166,8 @@ type Transaction {
   Wallet currency for transaction.
   """
   settlementCurrency: WalletCurrency!
+  settlementDisplayAmount: SignedDisplayMajorAmount!
+  settlementDisplayCurrency: DisplayCurrency!
   settlementFee: SignedAmount!
 
   """

--- a/src/graphql/root/query/realtime-price.ts
+++ b/src/graphql/root/query/realtime-price.ts
@@ -2,7 +2,7 @@ import { SAT_PRICE_PRECISION_OFFSET, USD_PRICE_PRECISION_OFFSET } from "@config"
 
 import { Prices } from "@app"
 
-import { DisplayCurrency, majorToMinorUnit } from "@domain/fiat"
+import { DisplayCurrency, usdMajorToMinorUnit } from "@domain/fiat"
 
 import { GT } from "@graphql/index"
 import { mapError } from "@graphql/error-map"
@@ -32,8 +32,8 @@ const RealtimePriceQuery = GT.Field({
     })
     if (usdPrice instanceof Error) throw mapError(usdPrice)
 
-    const centsPerSat = majorToMinorUnit(btcPrice.price)
-    const centsPerUsdCent = majorToMinorUnit(usdPrice.price)
+    const centsPerSat = usdMajorToMinorUnit(btcPrice.price)
+    const centsPerUsdCent = usdMajorToMinorUnit(usdPrice.price)
 
     return {
       timestamp: btcPrice.timestamp,

--- a/src/graphql/root/subscription/my-updates.ts
+++ b/src/graphql/root/subscription/my-updates.ts
@@ -2,7 +2,7 @@ import { SAT_PRICE_PRECISION_OFFSET, USD_PRICE_PRECISION_OFFSET } from "@config"
 
 import { Prices } from "@app"
 
-import { DisplayCurrency, majorToMinorUnit } from "@domain/fiat"
+import { DisplayCurrency, usdMajorToMinorUnit } from "@domain/fiat"
 import { customPubSubTrigger, PubSubDefaultTriggers } from "@domain/pubsub"
 
 import { GT } from "@graphql/index"
@@ -250,8 +250,8 @@ const MeSubscription = {
       const priceData = {
         timestamp: pricePerSat.timestamp,
         displayCurrency,
-        centsPerSat: majorToMinorUnit(pricePerSat.price),
-        centsPerUsdCent: majorToMinorUnit(pricePerUsdCent.price),
+        centsPerSat: usdMajorToMinorUnit(pricePerSat.price),
+        centsPerUsdCent: usdMajorToMinorUnit(pricePerUsdCent.price),
       }
       if (displayCurrency === DisplayCurrency.Usd) {
         pubsub.publishImmediate({

--- a/src/graphql/root/subscription/realtime-price.ts
+++ b/src/graphql/root/subscription/realtime-price.ts
@@ -5,7 +5,11 @@ import { SAT_PRICE_PRECISION_OFFSET, USD_PRICE_PRECISION_OFFSET } from "@config"
 import { Prices } from "@app"
 
 import { customPubSubTrigger, PubSubDefaultTriggers } from "@domain/pubsub"
-import { checkedToDisplayCurrency, DisplayCurrency, majorToMinorUnit } from "@domain/fiat"
+import {
+  checkedToDisplayCurrency,
+  DisplayCurrency,
+  usdMajorToMinorUnit,
+} from "@domain/fiat"
 
 import { GT } from "@graphql/index"
 import { UnknownClientError } from "@graphql/error"
@@ -145,8 +149,8 @@ const RealtimePriceSubscription = {
         payload: {
           timestamp,
           displayCurrency,
-          centsPerSat: majorToMinorUnit(pricePerSat.price),
-          centsPerUsdCent: majorToMinorUnit(pricePerUsdCent.price),
+          centsPerSat: usdMajorToMinorUnit(pricePerSat.price),
+          centsPerUsdCent: usdMajorToMinorUnit(pricePerUsdCent.price),
         },
       })
     }

--- a/src/graphql/types/object/business-account.ts
+++ b/src/graphql/types/object/business-account.ts
@@ -4,7 +4,7 @@ import { SAT_PRICE_PRECISION_OFFSET, USD_PRICE_PRECISION_OFFSET } from "@config"
 
 import { Accounts, Prices, Wallets } from "@app"
 
-import { majorToMinorUnit } from "@domain/fiat"
+import { usdMajorToMinorUnit } from "@domain/fiat"
 import { CouldNotFindTransactionsForAccountError } from "@domain/errors"
 
 import { GT } from "@graphql/index"
@@ -65,8 +65,8 @@ const BusinessAccount = GT.Object({
         const usdPrice = await Prices.getCurrentUsdCentPrice({ currency })
         if (usdPrice instanceof Error) throw mapError(usdPrice)
 
-        const centsPerSat = majorToMinorUnit(btcPrice.price)
-        const centsPerUsdCent = majorToMinorUnit(usdPrice.price)
+        const centsPerSat = usdMajorToMinorUnit(btcPrice.price)
+        const centsPerUsdCent = usdMajorToMinorUnit(usdPrice.price)
 
         return {
           timestamp: btcPrice.timestamp,

--- a/src/graphql/types/object/consumer-account.ts
+++ b/src/graphql/types/object/consumer-account.ts
@@ -4,7 +4,7 @@ import { SAT_PRICE_PRECISION_OFFSET, USD_PRICE_PRECISION_OFFSET } from "@config"
 
 import { Accounts, Prices, Wallets } from "@app"
 
-import { majorToMinorUnit } from "@domain/fiat"
+import { usdMajorToMinorUnit } from "@domain/fiat"
 import { CouldNotFindTransactionsForAccountError } from "@domain/errors"
 
 import { GT } from "@graphql/index"
@@ -65,8 +65,8 @@ const ConsumerAccount = GT.Object<Account>({
         const usdPrice = await Prices.getCurrentUsdCentPrice({ currency })
         if (usdPrice instanceof Error) throw mapError(usdPrice)
 
-        const centsPerSat = majorToMinorUnit(btcPrice.price)
-        const centsPerUsdCent = majorToMinorUnit(usdPrice.price)
+        const centsPerSat = usdMajorToMinorUnit(btcPrice.price)
+        const centsPerUsdCent = usdMajorToMinorUnit(usdPrice.price)
 
         return {
           timestamp: btcPrice.timestamp,

--- a/src/graphql/types/object/transaction.ts
+++ b/src/graphql/types/object/transaction.ts
@@ -16,6 +16,8 @@ import TxDirection, { txDirectionValues } from "../scalar/tx-direction"
 import TxStatus from "../scalar/tx-status"
 import SignedAmount from "../scalar/signed-amount"
 import WalletCurrency from "../scalar/wallet-currency"
+import SignedDisplayMajorAmount from "../scalar/signed-display-amount"
+import DisplayCurrency from "../scalar/display-currency"
 
 import Price from "./price"
 
@@ -98,6 +100,13 @@ const Transaction = GT.Object<WalletTransaction>({
     settlementCurrency: {
       type: GT.NonNull(WalletCurrency),
       description: "Wallet currency for transaction.",
+    },
+    settlementDisplayAmount: {
+      type: GT.NonNull(SignedDisplayMajorAmount),
+      resolve: (source) => `${source.settlementDisplayAmount}`,
+    },
+    settlementDisplayCurrency: {
+      type: GT.NonNull(DisplayCurrency),
     },
     direction: {
       type: GT.NonNull(TxDirection),

--- a/src/graphql/types/scalar/signed-display-amount.ts
+++ b/src/graphql/types/scalar/signed-display-amount.ts
@@ -1,0 +1,41 @@
+import { InputValidationError } from "@graphql/error"
+import { GT } from "@graphql/index"
+
+const isNumber = (value: string) => /^-?(\d+|\d*\.\d+)$/.test(value)
+
+const SignedDisplayMajorAmount = GT.Scalar({
+  name: "SignedDisplayMajorAmount",
+  description:
+    "A string amount (of a currency) that can be negative (e.g. in a transaction)",
+  parseValue(value) {
+    if (typeof value !== "string") {
+      return new InputValidationError({
+        message: "Invalid type for SignedDisplayMajorAmount",
+      })
+    }
+    return validSignedDisplayMajorAmount(value)
+  },
+  parseLiteral(ast) {
+    if (ast.kind === GT.Kind.INT || ast.kind === GT.Kind.FLOAT) {
+      return validSignedDisplayMajorAmount(ast.value)
+    }
+    return new InputValidationError({
+      message: "Invalid type for SignedDisplayMajorAmount",
+    })
+  },
+})
+
+function validSignedDisplayMajorAmount(
+  value: string | number,
+): string | CustomApolloError {
+  const numberValue = typeof value === "number" ? `${value}` : value
+
+  if (isNumber(numberValue)) {
+    return numberValue
+  }
+  return new InputValidationError({
+    message: "Invalid value for SignedDisplayMajorAmount",
+  })
+}
+
+export default SignedDisplayMajorAmount

--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -1,6 +1,6 @@
 import { toSats } from "@domain/bitcoin"
 import { WalletCurrency } from "@domain/shared"
-import { DisplayCurrency, majorToMinorUnit, toCents } from "@domain/fiat"
+import { DisplayCurrency, usdMajorToMinorUnit, toCents } from "@domain/fiat"
 import { customPubSubTrigger, PubSubDefaultTriggers } from "@domain/pubsub"
 import { NotificationsServiceError, NotificationType } from "@domain/notifications"
 
@@ -261,8 +261,8 @@ export const NotificationsService = (): INotificationsService => {
     const payload = {
       timestamp,
       displayCurrency,
-      centsPerSat: majorToMinorUnit(pricePerSat.price),
-      centsPerUsdCent: majorToMinorUnit(pricePerUsdCent.price),
+      centsPerSat: usdMajorToMinorUnit(pricePerSat.price),
+      centsPerUsdCent: usdMajorToMinorUnit(pricePerUsdCent.price),
     }
 
     const priceUpdateTrigger = customPubSubTrigger({

--- a/test/e2e/servers/graphql-main-server/queries/main.gql
+++ b/test/e2e/servers/graphql-main-server/queries/main.gql
@@ -72,6 +72,8 @@ fragment TransactionList on TransactionConnection {
       createdAt
       settlementAmount
       settlementFee
+      settlementDisplayAmount
+      settlementDisplayCurrency
       settlementCurrency
       settlementPrice {
         base

--- a/test/e2e/servers/graphql-main-server/queries/transactions-by-wallet-ids.gql
+++ b/test/e2e/servers/graphql-main-server/queries/transactions-by-wallet-ids.gql
@@ -25,6 +25,8 @@ fragment TransactionList on TransactionConnection {
       settlementAmount
       settlementFee
       settlementCurrency
+      settlementDisplayAmount
+      settlementDisplayCurrency
       settlementPrice {
         base
         offset

--- a/test/e2e/servers/graphql-main-server/with-auth-requests.spec.ts
+++ b/test/e2e/servers/graphql-main-server/with-auth-requests.spec.ts
@@ -4,7 +4,7 @@ import axios from "axios"
 import { Accounts } from "@app"
 import { WalletType } from "@domain/wallets"
 import { toSats } from "@domain/bitcoin"
-import { toCents } from "@domain/fiat"
+import { DisplayCurrency, toCents } from "@domain/fiat"
 import { WalletCurrency } from "@domain/shared"
 import { LnFees } from "@domain/payments"
 
@@ -196,6 +196,8 @@ describe("graphql", () => {
                         status: expect.any(String),
                         settlementAmount: expect.any(Number),
                         settlementFee: expect.any(Number),
+                        settlementDisplayAmount: expect.any(String),
+                        settlementDisplayCurrency: DisplayCurrency.Usd,
                         createdAt: expect.any(Number),
                       }),
                     }),
@@ -257,12 +259,16 @@ describe("graphql", () => {
             node: expect.objectContaining({
               settlementAmount: 4_000,
               settlementCurrency: WalletCurrency.Usd,
+              settlementDisplayAmount: "40",
+              settlementDisplayCurrency: DisplayCurrency.Usd,
             }),
           }),
           expect.objectContaining({
             node: expect.objectContaining({
               settlementAmount: 50_000,
               settlementCurrency: WalletCurrency.Btc,
+              settlementDisplayAmount: expect.any(String),
+              settlementDisplayCurrency: DisplayCurrency.Usd,
             }),
           }),
         ]),

--- a/test/unit/domain/wallets/tx-history.spec.ts
+++ b/test/unit/domain/wallets/tx-history.spec.ts
@@ -23,6 +23,7 @@ describe("translates ledger txs to wallet txs", () => {
     satsFee,
     centsFee,
     displayFee,
+    displayCurrency: DisplayCurrency.Usd,
     pendingConfirmation: false,
     journalId: "journalId" as LedgerJournalId,
     timestamp,
@@ -136,6 +137,8 @@ describe("translates ledger txs to wallet txs", () => {
 
       settlementAmount,
       settlementFee,
+      settlementDisplayAmount: centsAmount / 100,
+      settlementDisplayCurrency: DisplayCurrency.Usd,
       displayCurrencyPerSettlementCurrencyUnit,
     }
 
@@ -415,6 +418,8 @@ describe("ConfirmedTransactionHistory.addPendingIncoming", () => {
         },
         settlementAmount: toSats(25000),
         settlementFee: toSats(0),
+        settlementDisplayAmount: 25000 / 100,
+        settlementDisplayCurrency: DisplayCurrency.Usd,
         settlementCurrency: WalletCurrency.Btc,
         displayCurrencyPerSettlementCurrencyUnit: 1,
         status: TxStatus.Pending,
@@ -433,6 +438,8 @@ describe("ConfirmedTransactionHistory.addPendingIncoming", () => {
         },
         settlementAmount: toSats(50000),
         settlementCurrency: WalletCurrency.Btc,
+        settlementDisplayAmount: 50000 / 100,
+        settlementDisplayCurrency: DisplayCurrency.Usd,
         memo: null,
         settlementFee: toSats(0),
         displayCurrencyPerSettlementCurrencyUnit: 1,
@@ -500,6 +507,8 @@ describe("ConfirmedTransactionHistory.addPendingIncoming", () => {
         settlementAmount: toSats(25000),
         settlementFee: toSats(0),
         settlementCurrency: WalletCurrency.Btc,
+        settlementDisplayAmount: NaN,
+        settlementDisplayCurrency: DisplayCurrency.Usd,
         displayCurrencyPerSettlementCurrencyUnit: NaN,
         status: TxStatus.Pending,
         createdAt: timestamp,


### PR DESCRIPTION
## Description

This PR adds two new selections to the `Transaction` object:
- `settlementDisplayAmount`
- `settlementDisplayCurrency`