### PR TITLE
chore: add new "no price from dealer" error

### DIFF
--- a/src/domain/dealer-price/errors.ts
+++ b/src/domain/dealer-price/errors.ts
@@ -10,6 +10,9 @@ export class NoConnectionToDealerError extends DealerPriceServiceError {
 export class DealerStalePriceError extends DealerPriceServiceError {
   level = ErrorLevel.Critical
 }
+export class NoDealerPriceDataAvailableError extends DealerPriceServiceError {
+  level = ErrorLevel.Critical
+}
 export class UnknownDealerPriceServiceError extends DealerPriceServiceError {
   level = ErrorLevel.Critical
 }

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -21,6 +21,7 @@ import {
   OnChainPaymentError,
   PhoneProviderError,
   UnexpectedClientError,
+  DealerError,
 } from "@graphql/error"
 import { baseLogger } from "@services/logger"
 
@@ -224,6 +225,10 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "InvalidIPMetadataForRewardError":
       message = "Unsupported IP for rewards."
       return new ValidationInternalError({ message, logger: baseLogger })
+
+    case "NoDealerPriceDataAvailableError":
+      message = "No price data from dealer to perform USD operation."
+      return new DealerError({ message, logger: baseLogger })
 
     case "NoConnectionToDealerError":
       message = "No connection to dealer to perform USD operation."

--- a/src/graphql/error.ts
+++ b/src/graphql/error.ts
@@ -166,6 +166,17 @@ export class LndOfflineError extends CustomApolloError {
   }
 }
 
+export class DealerError extends CustomApolloError {
+  constructor(errData: PartialBy<CustomApolloErrorData, "logger" | "forwardToClient">) {
+    super({
+      code: "DEALER_ERROR",
+      forwardToClient: true,
+      ...errData,
+      logger: baseLogger,
+    })
+  }
+}
+
 export class DealerOfflineError extends CustomApolloError {
   constructor(errData: PartialBy<CustomApolloErrorData, "logger" | "forwardToClient">) {
     super({

--- a/src/services/dealer-price/dealer-price.ts
+++ b/src/services/dealer-price/dealer-price.ts
@@ -9,6 +9,7 @@ import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
 import {
   DealerStalePriceError,
   NoConnectionToDealerError,
+  NoDealerPriceDataAvailableError,
   UnknownDealerPriceServiceError,
 } from "@domain/dealer-price"
 
@@ -280,6 +281,10 @@ const parseDealerErrors = (error): DealerPriceServiceError => {
   }
   if (error.message.includes("StalePrice")) {
     return new DealerStalePriceError()
+  }
+
+  if (error.message.includes("No price data available")) {
+    return new NoDealerPriceDataAvailableError()
   }
 
   return new UnknownDealerPriceServiceError(error.message)

--- a/src/services/dealer-price/dealer-price.ts
+++ b/src/services/dealer-price/dealer-price.ts
@@ -110,7 +110,7 @@ export const DealerPriceService = (
       return paymentAmountFromNumber({ amount, currency: WalletCurrency.Usd })
     } catch (error) {
       baseLogger.error({ error }, "GetCentsFromSatsForImmediateBuy unable to fetch price")
-      return parseDealerErrors(error)
+      return handleDealerErrors(error)
     }
   }
 
@@ -130,7 +130,7 @@ export const DealerPriceService = (
         { error },
         "GetCentsFromSatsForImmediateSell unable to fetch price",
       )
-      return parseDealerErrors(error)
+      return handleDealerErrors(error)
     }
   }
 
@@ -147,7 +147,7 @@ export const DealerPriceService = (
       return paymentAmountFromNumber({ amount, currency: WalletCurrency.Usd })
     } catch (error) {
       baseLogger.error({ error }, "GetCentsFromSatsForFutureBuy unable to fetch price")
-      return parseDealerErrors(error)
+      return handleDealerErrors(error)
     }
   }
 
@@ -164,7 +164,7 @@ export const DealerPriceService = (
       return paymentAmountFromNumber({ amount, currency: WalletCurrency.Usd })
     } catch (error) {
       baseLogger.error({ error }, "GetCentsFromSatsForFutureSell unable to fetch price")
-      return parseDealerErrors(error)
+      return handleDealerErrors(error)
     }
   }
 
@@ -181,7 +181,7 @@ export const DealerPriceService = (
       return paymentAmountFromNumber({ amount, currency: WalletCurrency.Btc })
     } catch (error) {
       baseLogger.error({ error }, "GetSatsFromCentsForImmediateBuy unable to fetch price")
-      return parseDealerErrors(error)
+      return handleDealerErrors(error)
     }
   }
 
@@ -201,7 +201,7 @@ export const DealerPriceService = (
         { error },
         "GetSatsFromCentsForImmediateSell unable to fetch price",
       )
-      return parseDealerErrors(error)
+      return handleDealerErrors(error)
     }
   }
 
@@ -218,7 +218,7 @@ export const DealerPriceService = (
       return paymentAmountFromNumber({ amount, currency: WalletCurrency.Btc })
     } catch (error) {
       baseLogger.error({ error }, "GetSatsFromCentsForFutureBuy unable to fetch price")
-      return parseDealerErrors(error)
+      return handleDealerErrors(error)
     }
   }
 
@@ -235,7 +235,7 @@ export const DealerPriceService = (
       return paymentAmountFromNumber({ amount, currency: WalletCurrency.Btc })
     } catch (error) {
       baseLogger.error({ error }, "GetSatsFromCentsForFutureSell unable to fetch price")
-      return parseDealerErrors(error)
+      return handleDealerErrors(error)
     }
   }
 
@@ -249,7 +249,7 @@ export const DealerPriceService = (
       return toWalletPriceRatio(response.getRatioInCentsPerSatoshis())
     } catch (error) {
       baseLogger.error({ error }, "GetCentsPerSatsExchangeMidRate unable to fetch price")
-      return parseDealerErrors(error)
+      return handleDealerErrors(error)
     }
   }
 
@@ -273,19 +273,28 @@ export const DealerPriceService = (
   })
 }
 
-/* eslint @typescript-eslint/ban-ts-comment: "off" */
-// @ts-ignore-next-line no-implicit-any error
-const parseDealerErrors = (error): DealerPriceServiceError => {
-  if (error.details === "No connection established") {
-    return new NoConnectionToDealerError()
-  }
-  if (error.message.includes("StalePrice")) {
-    return new DealerStalePriceError()
-  }
+const handleDealerErrors = (err: Error | string) => {
+  const errMsg = typeof err === "string" ? err : err.message
 
-  if (error.message.includes("No price data available")) {
-    return new NoDealerPriceDataAvailableError()
-  }
+  const match = (knownErrDetail: RegExp): boolean => knownErrDetail.test(errMsg)
 
-  return new UnknownDealerPriceServiceError(error.message)
+  switch (true) {
+    case match(KnownDealerErrorDetails.NoConnection):
+      return new NoConnectionToDealerError(errMsg)
+
+    case match(KnownDealerErrorDetails.StalePrice):
+      return new DealerStalePriceError(errMsg)
+
+    case match(KnownDealerErrorDetails.NoPriceData):
+      return new NoDealerPriceDataAvailableError(errMsg)
+
+    default:
+      return new UnknownDealerPriceServiceError(errMsg)
+  }
 }
+
+export const KnownDealerErrorDetails = {
+  NoConnection: /No connection established/,
+  StalePrice: /StalePrice/,
+  NoPriceData: /No price data available/,
+} as const


### PR DESCRIPTION
## Description

This PR is to add a new dealer error type and to refactor error handling to use regexes.

---
### Context

This was prompted from an issue (discovered in #2398) where we received an error when we passed `0` in for `amountToSend` below which has since been fixed in stablesats to simply return `0` instead of the price error.
```
dealerFns.getSatsFromCentsForImmediateSell({
      amount: BigInt(amountToSend),
      currency: WalletCurrency.Usd,
    })
```