### PR TITLE
refactor: change MajorExponent type from bigint to Number

### DIFF
--- a/src/domain/fiat/display-currency.ts
+++ b/src/domain/fiat/display-currency.ts
@@ -1,9 +1,9 @@
 export const CENTS_PER_USD = 100
 
 export const MajorExponent = {
-  STANDARD: 2n,
-  ONE: 1n,
-  THREE: 3n,
+  STANDARD: 2,
+  ONE: 1,
+  THREE: 3,
 } as const
 
 export const minorToMajorUnit = ({
@@ -12,10 +12,7 @@ export const minorToMajorUnit = ({
 }: {
   amount: number | bigint
   displayMajorExponent: CurrencyMajorExponent
-}) => {
-  const majorExponent = Number(displayMajorExponent)
-  return (Number(amount) / 10 ** majorExponent).toFixed(majorExponent)
-}
+}) => (Number(amount) / 10 ** displayMajorExponent).toFixed(displayMajorExponent)
 
 export const usdMinorToMajorUnit = (amount: number | bigint) =>
   Number(minorToMajorUnit({ amount, displayMajorExponent: MajorExponent.STANDARD }))
@@ -26,10 +23,7 @@ export const majorToMinorUnit = ({
 }: {
   amount: number | bigint
   displayMajorExponent: CurrencyMajorExponent
-}) => {
-  const majorExponent = Number(displayMajorExponent)
-  return Number(Number(amount) * 10 ** majorExponent)
-}
+}) => Number(Number(amount) * 10 ** displayMajorExponent)
 
 export const usdMajorToMinorUnit = (amount: number | bigint) =>
   majorToMinorUnit({ amount, displayMajorExponent: MajorExponent.STANDARD })

--- a/src/domain/payments/price-ratio.ts
+++ b/src/domain/payments/price-ratio.ts
@@ -126,10 +126,9 @@ export const DisplayPriceRatio = <S extends WalletCurrency, T extends DisplayCur
     amountInMinor: bigint
     currency: T
   }): NewDisplayAmount<T> => {
-    const displayInMajor = (
-      Number(amountInMinor) /
-      10 ** Number(displayMajorExponent)
-    ).toFixed(Number(displayMajorExponent))
+    const displayInMajor = (Number(amountInMinor) / 10 ** displayMajorExponent).toFixed(
+      displayMajorExponent,
+    )
 
     return {
       amountInMinor,

--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -35,7 +35,7 @@ const filterPendingIncoming = ({
             const settlementAmount = toSats(sats - fee)
 
             const priceForMinorUnit =
-              displayCurrencyPerSat.price * 10 ** Number(MajorExponent.STANDARD)
+              displayCurrencyPerSat.price * 10 ** MajorExponent.STANDARD
 
             const settlementDisplayAmount = minorToMajorUnit({
               amount: Math.round(priceForMinorUnit * settlementAmount),


### PR DESCRIPTION
## Description

Removes unnecessary `Number()` calls, and since it's a constant that's never used in division we probably don't need this to be a bigint.