### PR TITLE
feat: add minorUnitToMajorUnitOffset to realtime price query/subscription

### DIFF
--- a/src/domain/fiat/display-currency.ts
+++ b/src/domain/fiat/display-currency.ts
@@ -2,6 +2,7 @@ export const CENTS_PER_USD = 100
 
 export const MajorExponent = {
   STANDARD: 2,
+  ZERO: 0,
   ONE: 1,
   THREE: 3,
 } as const
@@ -25,5 +26,34 @@ export const majorToMinorUnit = ({
   displayMajorExponent: CurrencyMajorExponent
 }) => Number(Number(amount) * 10 ** displayMajorExponent)
 
-export const usdMajorToMinorUnit = (amount: number | bigint) =>
-  majorToMinorUnit({ amount, displayMajorExponent: MajorExponent.STANDARD })
+export const currencyMajorToMinorUnit = ({
+  amount,
+  displayCurrency,
+}: {
+  amount: number | bigint
+  displayCurrency: DisplayCurrency
+}) => {
+  const displayMajorExponent = getCurrencyMajorExponent(displayCurrency)
+  return majorToMinorUnit({ amount, displayMajorExponent })
+}
+
+export const getCurrencyMajorExponent = (
+  currency: DisplayCurrency,
+): CurrencyMajorExponent => {
+  try {
+    const formatter = new Intl.NumberFormat("en-US", { style: "currency", currency })
+    const { minimumFractionDigits } = formatter.resolvedOptions()
+    switch (minimumFractionDigits) {
+      case 0:
+        return MajorExponent.ZERO
+      case 1:
+        return MajorExponent.ONE
+      case 3:
+        return MajorExponent.THREE
+      default:
+        return MajorExponent.STANDARD
+    }
+  } catch {
+    return MajorExponent.STANDARD
+  }
+}

--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -260,6 +260,11 @@ type Currency {
   symbol: String!
 }
 
+enum CurrencyUnit {
+  MAJOR
+  MINOR
+}
+
 input DeviceNotificationTokenCreateInput {
   deviceToken: String!
 }
@@ -929,8 +934,7 @@ input PriceInput {
 
 interface PriceInterface {
   base: SafeInt!
-  currencyUnit: String!
-    @deprecated(reason: "Deprecated in favor of minorUnitToMajorUnitOffset")
+  currencyUnit: CurrencyUnit!
   minorUnitToMajorUnitOffset: Int!
   offset: Int!
 }
@@ -940,8 +944,7 @@ Price of 1 sat in base/offset. To calculate, use: `base / 10^offset`
 """
 type PriceOfOneSat implements PriceInterface {
   base: SafeInt!
-  currencyUnit: String!
-    @deprecated(reason: "Deprecated in favor of minorUnitToMajorUnitOffset")
+  currencyUnit: CurrencyUnit!
   minorUnitToMajorUnitOffset: Int!
   offset: Int!
 }
@@ -951,8 +954,7 @@ Price of 1 usd cent in base/offset. To calculate, use: `base / 10^offset`
 """
 type PriceOfOneUsdCent implements PriceInterface {
   base: SafeInt!
-  currencyUnit: String!
-    @deprecated(reason: "Deprecated in favor of minorUnitToMajorUnitOffset")
+  currencyUnit: CurrencyUnit!
   minorUnitToMajorUnitOffset: Int!
   offset: Int!
 }

--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -935,6 +935,7 @@ input PriceInput {
 interface PriceInterface {
   base: SafeInt!
   currencyUnit: CurrencyUnit!
+    @deprecated(reason: "Deprecated in favor of minorUnitToMajorUnitOffset")
   minorUnitToMajorUnitOffset: Int!
   offset: Int!
 }
@@ -945,6 +946,7 @@ Price of 1 sat in base/offset. To calculate, use: `base / 10^offset`
 type PriceOfOneSat implements PriceInterface {
   base: SafeInt!
   currencyUnit: CurrencyUnit!
+    @deprecated(reason: "Deprecated in favor of minorUnitToMajorUnitOffset")
   minorUnitToMajorUnitOffset: Int!
   offset: Int!
 }
@@ -955,6 +957,7 @@ Price of 1 usd cent in base/offset. To calculate, use: `base / 10^offset`
 type PriceOfOneUsdCent implements PriceInterface {
   base: SafeInt!
   currencyUnit: CurrencyUnit!
+    @deprecated(reason: "Deprecated in favor of minorUnitToMajorUnitOffset")
   minorUnitToMajorUnitOffset: Int!
   offset: Int!
 }

--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -930,6 +930,8 @@ input PriceInput {
 interface PriceInterface {
   base: SafeInt!
   currencyUnit: String!
+    @deprecated(reason: "Deprecated in favor of minorUnitToMajorUnitOffset")
+  minorUnitToMajorUnitOffset: Int!
   offset: Int!
 }
 
@@ -939,6 +941,8 @@ Price of 1 sat in base/offset. To calculate, use: `base / 10^offset`
 type PriceOfOneSat implements PriceInterface {
   base: SafeInt!
   currencyUnit: String!
+    @deprecated(reason: "Deprecated in favor of minorUnitToMajorUnitOffset")
+  minorUnitToMajorUnitOffset: Int!
   offset: Int!
 }
 
@@ -948,6 +952,8 @@ Price of 1 usd cent in base/offset. To calculate, use: `base / 10^offset`
 type PriceOfOneUsdCent implements PriceInterface {
   base: SafeInt!
   currencyUnit: String!
+    @deprecated(reason: "Deprecated in favor of minorUnitToMajorUnitOffset")
+  minorUnitToMajorUnitOffset: Int!
   offset: Int!
 }
 

--- a/src/graphql/root/query/realtime-price.ts
+++ b/src/graphql/root/query/realtime-price.ts
@@ -53,13 +53,13 @@ const RealtimePriceQuery = GT.Field({
         base: Math.round(minorUnitPerSat * 10 ** SAT_PRICE_PRECISION_OFFSET),
         offset: SAT_PRICE_PRECISION_OFFSET,
         minorUnitToMajorUnitOffset,
-        currencyUnit: `${currency}CENT`,
+        currencyUnit: "MINOR",
       },
       usdCentPrice: {
         base: Math.round(minorUnitPerUsdCent * 10 ** USD_PRICE_PRECISION_OFFSET),
         offset: USD_PRICE_PRECISION_OFFSET,
         minorUnitToMajorUnitOffset,
-        currencyUnit: `${currency}CENT`,
+        currencyUnit: "MINOR",
       },
     }
   },

--- a/src/graphql/root/query/realtime-price.ts
+++ b/src/graphql/root/query/realtime-price.ts
@@ -2,7 +2,11 @@ import { SAT_PRICE_PRECISION_OFFSET, USD_PRICE_PRECISION_OFFSET } from "@config"
 
 import { Prices } from "@app"
 
-import { DisplayCurrency, usdMajorToMinorUnit } from "@domain/fiat"
+import {
+  currencyMajorToMinorUnit,
+  DisplayCurrency,
+  getCurrencyMajorExponent,
+} from "@domain/fiat"
 
 import { GT } from "@graphql/index"
 import { mapError } from "@graphql/error-map"
@@ -32,20 +36,29 @@ const RealtimePriceQuery = GT.Field({
     })
     if (usdPrice instanceof Error) throw mapError(usdPrice)
 
-    const centsPerSat = usdMajorToMinorUnit(btcPrice.price)
-    const centsPerUsdCent = usdMajorToMinorUnit(usdPrice.price)
+    const minorUnitToMajorUnitOffset = getCurrencyMajorExponent(currency)
+    const minorUnitPerSat = currencyMajorToMinorUnit({
+      amount: btcPrice.price,
+      displayCurrency: currency,
+    })
+    const minorUnitPerUsdCent = currencyMajorToMinorUnit({
+      amount: usdPrice.price,
+      displayCurrency: currency,
+    })
 
     return {
       timestamp: btcPrice.timestamp,
       denominatorCurrency: currency,
       btcSatPrice: {
-        base: Math.round(centsPerSat * 10 ** SAT_PRICE_PRECISION_OFFSET),
+        base: Math.round(minorUnitPerSat * 10 ** SAT_PRICE_PRECISION_OFFSET),
         offset: SAT_PRICE_PRECISION_OFFSET,
+        minorUnitToMajorUnitOffset,
         currencyUnit: `${currency}CENT`,
       },
       usdCentPrice: {
-        base: Math.round(centsPerUsdCent * 10 ** USD_PRICE_PRECISION_OFFSET),
+        base: Math.round(minorUnitPerUsdCent * 10 ** USD_PRICE_PRECISION_OFFSET),
         offset: USD_PRICE_PRECISION_OFFSET,
+        minorUnitToMajorUnitOffset,
         currencyUnit: `${currency}CENT`,
       },
     }

--- a/src/graphql/root/subscription/realtime-price.ts
+++ b/src/graphql/root/subscription/realtime-price.ts
@@ -50,8 +50,8 @@ const RealtimePriceSubscription = {
       | {
           errors: IError[]
           timestamp?: Date
-          minorUnitPerSat?: number
-          minorUnitPerUsdCent?: number
+          pricePerSat?: number
+          pricePerUsdCent?: number
           displayCurrency?: DisplayCurrency
         }
       | undefined,
@@ -66,10 +66,9 @@ const RealtimePriceSubscription = {
       })
     }
 
-    const { errors, timestamp, minorUnitPerSat, minorUnitPerUsdCent, displayCurrency } =
-      source
+    const { errors, timestamp, pricePerSat, pricePerUsdCent, displayCurrency } = source
     if (errors) return { errors: errors }
-    if (!timestamp || !minorUnitPerSat || !minorUnitPerUsdCent || !displayCurrency) {
+    if (!timestamp || !pricePerSat || !pricePerUsdCent || !displayCurrency) {
       return { errors: [{ message: "No price info" }] }
     }
 
@@ -85,6 +84,14 @@ const RealtimePriceSubscription = {
     }
 
     const minorUnitToMajorUnitOffset = getCurrencyMajorExponent(currency)
+    const minorUnitPerSat = currencyMajorToMinorUnit({
+      amount: pricePerSat,
+      displayCurrency: currency,
+    })
+    const minorUnitPerUsdCent = currencyMajorToMinorUnit({
+      amount: pricePerUsdCent,
+      displayCurrency: currency,
+    })
 
     return {
       errors: [],
@@ -95,13 +102,13 @@ const RealtimePriceSubscription = {
           base: Math.round(minorUnitPerSat * 10 ** SAT_PRICE_PRECISION_OFFSET),
           offset: SAT_PRICE_PRECISION_OFFSET,
           minorUnitToMajorUnitOffset,
-          currencyUnit: `${currency}CENT`,
+          currencyUnit: "MINOR",
         },
         usdCentPrice: {
           base: Math.round(minorUnitPerUsdCent * 10 ** USD_PRICE_PRECISION_OFFSET),
           offset: USD_PRICE_PRECISION_OFFSET,
           minorUnitToMajorUnitOffset,
-          currencyUnit: `${currency}CENT`,
+          currencyUnit: "MINOR",
         },
       },
     }
@@ -155,14 +162,8 @@ const RealtimePriceSubscription = {
         payload: {
           timestamp,
           displayCurrency,
-          minorUnitPerSat: currencyMajorToMinorUnit({
-            amount: pricePerSat.price,
-            displayCurrency,
-          }),
-          minorUnitPerUsdCent: currencyMajorToMinorUnit({
-            amount: pricePerUsdCent.price,
-            displayCurrency,
-          }),
+          pricePerSat: pricePerSat.price,
+          pricePerUsdCent: pricePerUsdCent.price,
         },
       })
     }

--- a/src/graphql/types/abstract/price.ts
+++ b/src/graphql/types/abstract/price.ts
@@ -9,7 +9,10 @@ const IPrice = GT.Interface({
     base: { type: GT.NonNull(SafeInt) },
     offset: { type: GT.NonNull(GT.Int) },
     minorUnitToMajorUnitOffset: { type: GT.NonNull(GT.Int) },
-    currencyUnit: { type: GT.NonNull(CurrencyUnit) },
+    currencyUnit: {
+      deprecationReason: "Deprecated in favor of minorUnitToMajorUnitOffset",
+      type: GT.NonNull(CurrencyUnit),
+    },
   }),
 })
 

--- a/src/graphql/types/abstract/price.ts
+++ b/src/graphql/types/abstract/price.ts
@@ -7,7 +7,11 @@ const IPrice = GT.Interface({
   fields: () => ({
     base: { type: GT.NonNull(SafeInt) },
     offset: { type: GT.NonNull(GT.Int) },
-    currencyUnit: { type: GT.NonNull(GT.String) },
+    minorUnitToMajorUnitOffset: { type: GT.NonNull(GT.Int) },
+    currencyUnit: {
+      deprecationReason: "Deprecated in favor of minorUnitToMajorUnitOffset",
+      type: GT.NonNull(GT.String),
+    },
   }),
 })
 

--- a/src/graphql/types/abstract/price.ts
+++ b/src/graphql/types/abstract/price.ts
@@ -1,6 +1,7 @@
 import { GT } from "@graphql/index"
 
 import SafeInt from "../scalar/safe-int"
+import CurrencyUnit from "../scalar/currency-unit"
 
 const IPrice = GT.Interface({
   name: "PriceInterface",
@@ -8,10 +9,7 @@ const IPrice = GT.Interface({
     base: { type: GT.NonNull(SafeInt) },
     offset: { type: GT.NonNull(GT.Int) },
     minorUnitToMajorUnitOffset: { type: GT.NonNull(GT.Int) },
-    currencyUnit: {
-      deprecationReason: "Deprecated in favor of minorUnitToMajorUnitOffset",
-      type: GT.NonNull(GT.String),
-    },
+    currencyUnit: { type: GT.NonNull(CurrencyUnit) },
   }),
 })
 

--- a/src/graphql/types/object/business-account.ts
+++ b/src/graphql/types/object/business-account.ts
@@ -4,7 +4,7 @@ import { SAT_PRICE_PRECISION_OFFSET, USD_PRICE_PRECISION_OFFSET } from "@config"
 
 import { Accounts, Prices, Wallets } from "@app"
 
-import { usdMajorToMinorUnit } from "@domain/fiat"
+import { currencyMajorToMinorUnit, getCurrencyMajorExponent } from "@domain/fiat"
 import { CouldNotFindTransactionsForAccountError } from "@domain/errors"
 
 import { GT } from "@graphql/index"
@@ -65,20 +65,29 @@ const BusinessAccount = GT.Object({
         const usdPrice = await Prices.getCurrentUsdCentPrice({ currency })
         if (usdPrice instanceof Error) throw mapError(usdPrice)
 
-        const centsPerSat = usdMajorToMinorUnit(btcPrice.price)
-        const centsPerUsdCent = usdMajorToMinorUnit(usdPrice.price)
+        const minorUnitToMajorUnitOffset = getCurrencyMajorExponent(currency)
+        const minorUnitPerSat = currencyMajorToMinorUnit({
+          amount: btcPrice.price,
+          displayCurrency: currency,
+        })
+        const minorUnitPerUsdCent = currencyMajorToMinorUnit({
+          amount: usdPrice.price,
+          displayCurrency: currency,
+        })
 
         return {
           timestamp: btcPrice.timestamp,
           denominatorCurrency: currency,
           btcSatPrice: {
-            base: Math.round(centsPerSat * 10 ** SAT_PRICE_PRECISION_OFFSET),
+            base: Math.round(minorUnitPerSat * 10 ** SAT_PRICE_PRECISION_OFFSET),
             offset: SAT_PRICE_PRECISION_OFFSET,
+            minorUnitToMajorUnitOffset,
             currencyUnit: `${currency}CENT`,
           },
           usdCentPrice: {
-            base: Math.round(centsPerUsdCent * 10 ** USD_PRICE_PRECISION_OFFSET),
+            base: Math.round(minorUnitPerUsdCent * 10 ** USD_PRICE_PRECISION_OFFSET),
             offset: USD_PRICE_PRECISION_OFFSET,
+            minorUnitToMajorUnitOffset,
             currencyUnit: `${currency}CENT`,
           },
         }

--- a/src/graphql/types/object/business-account.ts
+++ b/src/graphql/types/object/business-account.ts
@@ -82,13 +82,13 @@ const BusinessAccount = GT.Object({
             base: Math.round(minorUnitPerSat * 10 ** SAT_PRICE_PRECISION_OFFSET),
             offset: SAT_PRICE_PRECISION_OFFSET,
             minorUnitToMajorUnitOffset,
-            currencyUnit: `${currency}CENT`,
+            currencyUnit: "MINOR",
           },
           usdCentPrice: {
             base: Math.round(minorUnitPerUsdCent * 10 ** USD_PRICE_PRECISION_OFFSET),
             offset: USD_PRICE_PRECISION_OFFSET,
             minorUnitToMajorUnitOffset,
-            currencyUnit: `${currency}CENT`,
+            currencyUnit: "MINOR",
           },
         }
       },

--- a/src/graphql/types/object/consumer-account.ts
+++ b/src/graphql/types/object/consumer-account.ts
@@ -82,13 +82,13 @@ const ConsumerAccount = GT.Object<Account>({
             base: Math.round(minorUnitPerSat * 10 ** SAT_PRICE_PRECISION_OFFSET),
             offset: SAT_PRICE_PRECISION_OFFSET,
             minorUnitToMajorUnitOffset,
-            currencyUnit: `${currency}CENT`,
+            currencyUnit: "MINOR",
           },
           usdCentPrice: {
             base: Math.round(minorUnitPerUsdCent * 10 ** USD_PRICE_PRECISION_OFFSET),
             offset: USD_PRICE_PRECISION_OFFSET,
             minorUnitToMajorUnitOffset,
-            currencyUnit: `${currency}CENT`,
+            currencyUnit: "MINOR",
           },
         }
       },

--- a/src/graphql/types/object/price-of-one-sat.ts
+++ b/src/graphql/types/object/price-of-one-sat.ts
@@ -10,7 +10,11 @@ const PriceOfOneSat = GT.Object({
   fields: () => ({
     base: { type: GT.NonNull(SafeInt) },
     offset: { type: GT.NonNull(GT.Int) },
-    currencyUnit: { type: GT.NonNull(GT.String) },
+    minorUnitToMajorUnitOffset: { type: GT.NonNull(GT.Int) },
+    currencyUnit: {
+      deprecationReason: "Deprecated in favor of minorUnitToMajorUnitOffset",
+      type: GT.NonNull(GT.String),
+    },
   }),
 })
 

--- a/src/graphql/types/object/price-of-one-sat.ts
+++ b/src/graphql/types/object/price-of-one-sat.ts
@@ -12,7 +12,10 @@ const PriceOfOneSat = GT.Object({
     base: { type: GT.NonNull(SafeInt) },
     offset: { type: GT.NonNull(GT.Int) },
     minorUnitToMajorUnitOffset: { type: GT.NonNull(GT.Int) },
-    currencyUnit: { type: GT.NonNull(CurrencyUnit) },
+    currencyUnit: {
+      deprecationReason: "Deprecated in favor of minorUnitToMajorUnitOffset",
+      type: GT.NonNull(CurrencyUnit),
+    },
   }),
 })
 

--- a/src/graphql/types/object/price-of-one-sat.ts
+++ b/src/graphql/types/object/price-of-one-sat.ts
@@ -2,6 +2,7 @@ import { GT } from "@graphql/index"
 
 import IPrice from "../abstract/price"
 import SafeInt from "../scalar/safe-int"
+import CurrencyUnit from "../scalar/currency-unit"
 
 const PriceOfOneSat = GT.Object({
   name: "PriceOfOneSat",
@@ -11,10 +12,7 @@ const PriceOfOneSat = GT.Object({
     base: { type: GT.NonNull(SafeInt) },
     offset: { type: GT.NonNull(GT.Int) },
     minorUnitToMajorUnitOffset: { type: GT.NonNull(GT.Int) },
-    currencyUnit: {
-      deprecationReason: "Deprecated in favor of minorUnitToMajorUnitOffset",
-      type: GT.NonNull(GT.String),
-    },
+    currencyUnit: { type: GT.NonNull(CurrencyUnit) },
   }),
 })
 

--- a/src/graphql/types/object/price-of-one-usd-cent.ts
+++ b/src/graphql/types/object/price-of-one-usd-cent.ts
@@ -11,7 +11,11 @@ const PriceOfOneUsdCent = GT.Object({
   fields: () => ({
     base: { type: GT.NonNull(SafeInt) },
     offset: { type: GT.NonNull(GT.Int) },
-    currencyUnit: { type: GT.NonNull(GT.String) },
+    minorUnitToMajorUnitOffset: { type: GT.NonNull(GT.Int) },
+    currencyUnit: {
+      deprecationReason: "Deprecated in favor of minorUnitToMajorUnitOffset",
+      type: GT.NonNull(GT.String),
+    },
   }),
 })
 

--- a/src/graphql/types/object/price-of-one-usd-cent.ts
+++ b/src/graphql/types/object/price-of-one-usd-cent.ts
@@ -2,6 +2,7 @@ import { GT } from "@graphql/index"
 
 import IPrice from "../abstract/price"
 import SafeInt from "../scalar/safe-int"
+import CurrencyUnit from "../scalar/currency-unit"
 
 const PriceOfOneUsdCent = GT.Object({
   name: "PriceOfOneUsdCent",
@@ -12,10 +13,7 @@ const PriceOfOneUsdCent = GT.Object({
     base: { type: GT.NonNull(SafeInt) },
     offset: { type: GT.NonNull(GT.Int) },
     minorUnitToMajorUnitOffset: { type: GT.NonNull(GT.Int) },
-    currencyUnit: {
-      deprecationReason: "Deprecated in favor of minorUnitToMajorUnitOffset",
-      type: GT.NonNull(GT.String),
-    },
+    currencyUnit: { type: GT.NonNull(CurrencyUnit) },
   }),
 })
 

--- a/src/graphql/types/object/price-of-one-usd-cent.ts
+++ b/src/graphql/types/object/price-of-one-usd-cent.ts
@@ -13,7 +13,10 @@ const PriceOfOneUsdCent = GT.Object({
     base: { type: GT.NonNull(SafeInt) },
     offset: { type: GT.NonNull(GT.Int) },
     minorUnitToMajorUnitOffset: { type: GT.NonNull(GT.Int) },
-    currencyUnit: { type: GT.NonNull(CurrencyUnit) },
+    currencyUnit: {
+      deprecationReason: "Deprecated in favor of minorUnitToMajorUnitOffset",
+      type: GT.NonNull(CurrencyUnit),
+    },
   }),
 })
 

--- a/src/graphql/types/scalar/currency-unit.ts
+++ b/src/graphql/types/scalar/currency-unit.ts
@@ -1,0 +1,11 @@
+import { GT } from "@graphql/index"
+
+const CurrencyUnit = GT.Enum({
+  name: "CurrencyUnit",
+  values: {
+    MINOR: { value: "MINOR" },
+    MAJOR: { value: "MAJOR" },
+  },
+})
+
+export default CurrencyUnit

--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -1,6 +1,6 @@
 import { toSats } from "@domain/bitcoin"
 import { WalletCurrency } from "@domain/shared"
-import { DisplayCurrency, usdMajorToMinorUnit, toCents } from "@domain/fiat"
+import { DisplayCurrency, currencyMajorToMinorUnit, toCents } from "@domain/fiat"
 import { customPubSubTrigger, PubSubDefaultTriggers } from "@domain/pubsub"
 import { NotificationsServiceError, NotificationType } from "@domain/notifications"
 
@@ -261,8 +261,14 @@ export const NotificationsService = (): INotificationsService => {
     const payload = {
       timestamp,
       displayCurrency,
-      centsPerSat: usdMajorToMinorUnit(pricePerSat.price),
-      centsPerUsdCent: usdMajorToMinorUnit(pricePerUsdCent.price),
+      minorUnitPerSat: currencyMajorToMinorUnit({
+        amount: pricePerSat.price,
+        displayCurrency,
+      }),
+      minorUnitPerUsdCent: currencyMajorToMinorUnit({
+        amount: pricePerUsdCent.price,
+        displayCurrency,
+      }),
     }
 
     const priceUpdateTrigger = customPubSubTrigger({

--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -1,6 +1,6 @@
 import { toSats } from "@domain/bitcoin"
 import { WalletCurrency } from "@domain/shared"
-import { DisplayCurrency, currencyMajorToMinorUnit, toCents } from "@domain/fiat"
+import { DisplayCurrency, toCents } from "@domain/fiat"
 import { customPubSubTrigger, PubSubDefaultTriggers } from "@domain/pubsub"
 import { NotificationsServiceError, NotificationType } from "@domain/notifications"
 
@@ -261,14 +261,8 @@ export const NotificationsService = (): INotificationsService => {
     const payload = {
       timestamp,
       displayCurrency,
-      minorUnitPerSat: currencyMajorToMinorUnit({
-        amount: pricePerSat.price,
-        displayCurrency,
-      }),
-      minorUnitPerUsdCent: currencyMajorToMinorUnit({
-        amount: pricePerUsdCent.price,
-        displayCurrency,
-      }),
+      pricePerSat: pricePerSat.price,
+      pricePerUsdCent: pricePerUsdCent.price,
     }
 
     const priceUpdateTrigger = customPubSubTrigger({

--- a/test/e2e/servers/graphql-main-server/no-auth-requests.spec.ts
+++ b/test/e2e/servers/graphql-main-server/no-auth-requests.spec.ts
@@ -121,16 +121,18 @@ describe("graphql", () => {
       expect(realtimePrice).toHaveProperty("btcSatPrice.base", expect.any(Number))
       expect(realtimePrice).toHaveProperty("btcSatPrice.offset", expect.any(Number))
       expect(realtimePrice).toHaveProperty(
-        "btcSatPrice.currencyUnit",
-        input.currency + "CENT",
+        "btcSatPrice.minorUnitToMajorUnitOffset",
+        expect.any(Number),
       )
+      expect(realtimePrice).toHaveProperty("btcSatPrice.currencyUnit", "MINOR")
 
       expect(realtimePrice).toHaveProperty("usdCentPrice.base", expect.any(Number))
       expect(realtimePrice).toHaveProperty("usdCentPrice.offset", expect.any(Number))
       expect(realtimePrice).toHaveProperty(
-        "usdCentPrice.currencyUnit",
-        input.currency + "CENT",
+        "usdCentPrice.minorUnitToMajorUnitOffset",
+        expect.any(Number),
       )
+      expect(realtimePrice).toHaveProperty("usdCentPrice.currencyUnit", "MINOR")
     })
   })
 

--- a/test/e2e/servers/graphql-main-server/subscriptions/my-updates-ln.gql
+++ b/test/e2e/servers/graphql-main-server/subscriptions/my-updates-ln.gql
@@ -29,11 +29,13 @@ subscription myUpdates {
         btcSatPrice {
           base
           offset
+          minorUnitToMajorUnitOffset
           currencyUnit
         }
         usdCentPrice {
           base
           offset
+          minorUnitToMajorUnitOffset
           currencyUnit
         }
       }

--- a/test/e2e/servers/graphql-main-server/subscriptions/realtime-price.gql
+++ b/test/e2e/servers/graphql-main-server/subscriptions/realtime-price.gql
@@ -16,11 +16,13 @@ subscription realtimePrice(
       btcSatPrice {
         base
         offset
+        minorUnitToMajorUnitOffset
         currencyUnit
       }
       usdCentPrice {
         base
         offset
+        minorUnitToMajorUnitOffset
         currencyUnit
       }
     }


### PR DESCRIPTION
- ~currencyUnit now is an Enum (default is `MINOR` but adds the option to include/return `MAJOR` based on a param)~
- Add minorUnitToMajorUnitOffset to realtimePrice query and subscriptions