### PR TITLE
chore: update default mobile min build versions

### DIFF
--- a/galoy.yaml
+++ b/galoy.yaml
@@ -14,11 +14,11 @@ dealer:
 ratioPrecision: 1000000
 buildVersion:
   android:
-    minBuildNumber: 182
-    lastBuildNumber: 294
+    minBuildNumber: 362
+    lastBuildNumber: 362
   ios:
-    minBuildNumber: 182
-    lastBuildNumber: 269
+    minBuildNumber: 362
+    lastBuildNumber: 362
 rewards:
   allowPhoneCountries:
     - SV

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -113,12 +113,12 @@ export const configSchema = {
       },
       default: {
         android: {
-          minBuildNumber: 182,
-          lastBuildNumber: 294,
+          minBuildNumber: 362,
+          lastBuildNumber: 362,
         },
         ios: {
-          minBuildNumber: 182,
-          lastBuildNumber: 269,
+          minBuildNumber: 362,
+          lastBuildNumber: 362,
         },
       },
       required: ["ios", "android"],


### PR DESCRIPTION
checked with sam on the app/play store that version 362 is a recent stable version of the apk and ipa.