### PR TITLE
chore(migration): add sats amount props to intraledger txns

### DIFF
--- a/src/migrations/20230319091251-add-sats-amounts-to-intraledger.ts
+++ b/src/migrations/20230319091251-add-sats-amounts-to-intraledger.ts
@@ -1,0 +1,90 @@
+module.exports = {
+  async up(db) {
+    const txTypes = ["on_us", "onchain_on_us"]
+
+    const collection = db.collection("medici_transactions")
+
+    try {
+      const allTxns = await collection.aggregate([
+        {
+          $match: {
+            type: { $in: txTypes },
+            satsAmount: { $exists: false },
+            currency: "BTC",
+          },
+        },
+        {
+          $group: {
+            _id: "$_journal",
+            // 'debit' here would be the full BTC amount sent
+            debit: { $max: "$debit" },
+            fee: { $first: "$fee" },
+            usd: { $first: "$usd" },
+            feeUsd: { $first: "$feeUsd" },
+          },
+        },
+      ])
+      for await (const { _id: journalId, debit, fee, usd, feeUsd } of allTxns) {
+        const satsAmount = Math.round(debit - fee)
+        const centsAmount = Math.round((usd - feeUsd) * 100)
+        const centsFee = Math.round(feeUsd * 100)
+
+        const resultRest = await collection.update(
+          { _journal: journalId },
+          [
+            {
+              $set: {
+                satsAmount,
+                satsFee: fee,
+                centsAmount,
+                centsFee,
+                displayAmount: centsAmount,
+                displayFee: centsFee,
+                displayCurrency: "USD",
+                satsAmountMigration: true,
+              },
+            },
+          ],
+          {
+            multi: true,
+          },
+        )
+        const { matchedCount: n, modifiedCount: nModified } = resultRest
+        console.log(
+          `added new props to ${nModified} of ${n}  transactions for journal: ${journalId}`,
+        )
+      }
+    } catch (error) {
+      console.log(
+        { result: error },
+        "Couldn't add new props to rest of medici_transactions",
+      )
+    }
+  },
+
+  async down(db) {
+    const txTypes = ["on_us", "onchain_on_us"]
+
+    try {
+      const result = await db.collection("medici_transactions").update(
+        { type: { $in: txTypes }, satsAmountMigration: true },
+        {
+          $unset: {
+            satsAmount: "",
+            satsFee: "",
+            centsAmount: "",
+            centsFee: "",
+            displayAmount: "",
+            displayFee: "",
+            displayCurrency: "",
+            satsAmountMigration: "",
+          },
+        },
+        { multi: true },
+      )
+      console.log({ result }, "removed new props from medici_transactions")
+    } catch (error) {
+      console.log({ result: error }, "Couldn't remove new props from medici_transactions")
+    }
+  },
+}


### PR DESCRIPTION
## Description

Add missing migration for `on_us` and `onchain_on_us` transaction for `satsAmount` related properties. This migration follows from the  migration scripts for previous migrations.

### Testing

To test this locally I manually edited `on_us` and `onchain_on_us` txns in the db to remove all `satsAmount` related props and to add `usd`/`feeUsd`/`fee` properties with the appropriate pre-migration values.