### PR TITLE
fix: `displayCurrency` not present in ledger transaction

### DIFF
--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -54,7 +54,7 @@ type BaseWalletTransaction = {
   readonly settlementCurrency: WalletCurrency
   readonly settlementDisplayAmount: DisplayCurrencyMajorAmount
   readonly settlementDisplayFee: DisplayCurrencyMajorAmount
-  readonly settlementDisplayCurrency: DisplayCurrency | ""
+  readonly settlementDisplayCurrency: DisplayCurrency
   readonly displayCurrencyPerSettlementCurrencyUnit: number
   readonly status: TxStatus
   readonly memo: string | null

--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -4,7 +4,7 @@ import {
   OnboardingEarn,
 } from "@config"
 
-import { MajorExponent, minorToMajorUnit, toCents } from "@domain/fiat"
+import { DisplayCurrency, MajorExponent, minorToMajorUnit, toCents } from "@domain/fiat"
 import { toSats } from "@domain/bitcoin"
 import { WalletCurrency } from "@domain/shared"
 import { AdminLedgerTransactionType, LedgerTransactionType } from "@domain/ledger"
@@ -187,7 +187,7 @@ const translateLedgerTxnToWalletTxn = <S extends WalletCurrency>({
     settlementCurrency: txn.currency,
     settlementDisplayAmount,
     settlementDisplayFee,
-    settlementDisplayCurrency: displayCurrency || "",
+    settlementDisplayCurrency: displayCurrency || DisplayCurrency.Usd,
     displayCurrencyPerSettlementCurrencyUnit: displayCurrencyPerBaseUnitFromAmounts({
       displayAmount,
       baseAmount: txn.currency === WalletCurrency.Btc ? satsAmount : centsAmount,


### PR DESCRIPTION
## Description

This PR fixes the issue where we're adding an invalid `""` value when the value isn't present