### PR TITLE
chore: cleanup wallet & display price ratios

### DIFF
--- a/src/app/accounts/send-default-wallet-balance-to-users.ts
+++ b/src/app/accounts/send-default-wallet-balance-to-users.ts
@@ -43,8 +43,7 @@ export const sendDefaultWalletBalanceToAccounts = async () => {
           // TODO: unify PaymentAmount, BalanceAmount, DisplayBalanceAmount types
           displayBalanceAmount = {
             amount: minorToMajorUnit({
-              amount: displayAmount.amountInMinor,
-              displayCurrency: displayAmount.currency,
+              displayAmount,
             }),
             currency: displayCurrency,
           }
@@ -63,8 +62,7 @@ export const sendDefaultWalletBalanceToAccounts = async () => {
             // TODO: unify PaymentAmount, BalanceAmount, DisplayBalanceAmount types
             displayBalanceAmount = {
               amount: minorToMajorUnit({
-                amount: displayAmount.amountInMinor,
-                displayCurrency: displayAmount.currency,
+                displayAmount,
               }),
               currency: displayCurrency,
             }

--- a/src/app/accounts/send-default-wallet-balance-to-users.ts
+++ b/src/app/accounts/send-default-wallet-balance-to-users.ts
@@ -51,12 +51,12 @@ export const sendDefaultWalletBalanceToAccounts = async () => {
         }
 
         if (balanceAmount.currency === WalletCurrency.Usd) {
-          const usdDisplayPriceRatio = await getCurrentPriceAsWalletPriceRatio({
+          const usdWalletPriceRatio = await getCurrentPriceAsWalletPriceRatio({
             currency: DisplayCurrency.Usd,
           })
 
-          if (!(usdDisplayPriceRatio instanceof Error)) {
-            const btcBalanceAmount = usdDisplayPriceRatio.convertFromUsd(
+          if (!(usdWalletPriceRatio instanceof Error)) {
+            const btcBalanceAmount = usdWalletPriceRatio.convertFromUsd(
               balanceAmount as UsdPaymentAmount,
             )
             const displayAmount = displayPriceRatio.convertFromWallet(btcBalanceAmount)

--- a/src/app/cold-storage/rebalance-to-cold-wallet.ts
+++ b/src/app/cold-storage/rebalance-to-cold-wallet.ts
@@ -1,6 +1,6 @@
 import { BTC_NETWORK, getColdStorageConfig, ONCHAIN_SCAN_DEPTH_OUTGOING } from "@config"
 
-import { getCurrentPriceAsWalletPriceRatio } from "@app/prices"
+import { getCurrentPriceAsDisplayPriceRatio } from "@app/prices"
 
 import { toSats } from "@domain/bitcoin"
 import { DisplayCurrency, minorToMajorUnit } from "@domain/fiat"
@@ -29,7 +29,7 @@ export const rebalanceToColdWallet = async (): Promise<boolean | ApplicationErro
   const offChainService = LndService()
   if (offChainService instanceof Error) return offChainService
 
-  const displayPriceRatio = await getCurrentPriceAsWalletPriceRatio({
+  const displayPriceRatio = await getCurrentPriceAsDisplayPriceRatio({
     currency: DisplayCurrency.Usd,
   })
   if (displayPriceRatio instanceof Error) return displayPriceRatio
@@ -80,9 +80,10 @@ export const rebalanceToColdWallet = async (): Promise<boolean | ApplicationErro
     currency: WalletCurrency.Btc,
   })
   if (rebalanceBtcAmount instanceof Error) return rebalanceBtcAmount
-  const amountDisplayCurrencyAmount = displayPriceRatio.convertFromBtc(rebalanceBtcAmount)
+  const amountDisplayCurrencyAmount =
+    displayPriceRatio.convertFromWallet(rebalanceBtcAmount)
   const amountDisplayCurrency = minorToMajorUnit({
-    amount: amountDisplayCurrencyAmount.amount,
+    amount: amountDisplayCurrencyAmount.amountInMinor,
     displayCurrency: amountDisplayCurrencyAmount.currency,
   }) as DisplayCurrencyBaseAmount
 
@@ -91,9 +92,9 @@ export const rebalanceToColdWallet = async (): Promise<boolean | ApplicationErro
     currency: WalletCurrency.Btc,
   })
   if (feeBtcAmount instanceof Error) return feeBtcAmount
-  const feeDisplayCurrencyAmount = displayPriceRatio.convertFromBtc(feeBtcAmount)
+  const feeDisplayCurrencyAmount = displayPriceRatio.convertFromWallet(feeBtcAmount)
   const feeDisplayCurrency = minorToMajorUnit({
-    amount: feeDisplayCurrencyAmount.amount,
+    amount: feeDisplayCurrencyAmount.amountInMinor,
     displayCurrency: feeDisplayCurrencyAmount.currency,
   }) as DisplayCurrencyBaseAmount
 

--- a/src/app/cold-storage/rebalance-to-cold-wallet.ts
+++ b/src/app/cold-storage/rebalance-to-cold-wallet.ts
@@ -83,8 +83,7 @@ export const rebalanceToColdWallet = async (): Promise<boolean | ApplicationErro
   const amountDisplayCurrencyAmount =
     displayPriceRatio.convertFromWallet(rebalanceBtcAmount)
   const amountDisplayCurrency = minorToMajorUnit({
-    amount: amountDisplayCurrencyAmount.amountInMinor,
-    displayCurrency: amountDisplayCurrencyAmount.currency,
+    displayAmount: amountDisplayCurrencyAmount,
   }) as DisplayCurrencyBaseAmount
 
   const feeBtcAmount = paymentAmountFromNumber({
@@ -94,8 +93,7 @@ export const rebalanceToColdWallet = async (): Promise<boolean | ApplicationErro
   if (feeBtcAmount instanceof Error) return feeBtcAmount
   const feeDisplayCurrencyAmount = displayPriceRatio.convertFromWallet(feeBtcAmount)
   const feeDisplayCurrency = minorToMajorUnit({
-    amount: feeDisplayCurrencyAmount.amountInMinor,
-    displayCurrency: feeDisplayCurrencyAmount.currency,
+    displayAmount: feeDisplayCurrencyAmount,
   }) as DisplayCurrencyBaseAmount
 
   const journal = await ledgerService.addColdStorageTxReceive({

--- a/src/app/payments/send-intraledger.ts
+++ b/src/app/payments/send-intraledger.ts
@@ -9,7 +9,7 @@ import {
   LightningPaymentFlowBuilder,
   ZeroAmountForUsdRecipientError,
 } from "@domain/payments"
-import { ErrorLevel, WalletCurrency } from "@domain/shared"
+import { ErrorLevel, newDisplayAmountFromNumber, WalletCurrency } from "@domain/shared"
 import { checkedToWalletId, SettlementMethod } from "@domain/wallets"
 
 import { DealerPriceService } from "@services/dealer-price"
@@ -356,6 +356,12 @@ const executePaymentViaIntraledger = async <
       amount = totalSendAmounts.usd.amount
     }
 
+    const recipientDisplayAmount = newDisplayAmountFromNumber({
+      amount: recipientAmountDisplayCurrencyAsNumber,
+      currency: recipientAccount.displayCurrency,
+    })
+    if (recipientDisplayAmount instanceof Error) return recipientDisplayAmount
+
     const notificationsService = NotificationsService()
     notificationsService.intraLedgerTxReceived({
       recipientAccountId: recipientWallet.accountId,
@@ -365,8 +371,7 @@ const executePaymentViaIntraledger = async <
       paymentAmount: { amount, currency: recipientWallet.currency },
       displayPaymentAmount: {
         amount: minorToMajorUnit({
-          amount: recipientAmountDisplayCurrencyAsNumber,
-          displayCurrency: recipientAccount.displayCurrency,
+          displayAmount: recipientDisplayAmount,
         }),
         currency: recipientAccount.displayCurrency,
       },

--- a/src/app/payments/send-intraledger.ts
+++ b/src/app/payments/send-intraledger.ts
@@ -2,14 +2,14 @@ import { getPubkeysToSkipProbe } from "@config"
 
 import { AccountValidator } from "@domain/accounts"
 import { PaymentSendStatus } from "@domain/bitcoin/lightning"
-import { minorToMajorUnit } from "@domain/fiat"
+import { minorToMajorUnit, newDisplayAmountFromNumber } from "@domain/fiat"
 import {
   InvalidLightningPaymentFlowBuilderStateError,
   InvalidZeroAmountPriceRatioInputError,
   LightningPaymentFlowBuilder,
   ZeroAmountForUsdRecipientError,
 } from "@domain/payments"
-import { ErrorLevel, newDisplayAmountFromNumber, WalletCurrency } from "@domain/shared"
+import { ErrorLevel, WalletCurrency } from "@domain/shared"
 import { checkedToWalletId, SettlementMethod } from "@domain/wallets"
 
 import { DealerPriceService } from "@services/dealer-price"

--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -7,7 +7,7 @@ import {
   PaymentSendStatus,
 } from "@domain/bitcoin/lightning"
 import { AlreadyPaidError, CouldNotFindLightningPaymentFlowError } from "@domain/errors"
-import { minorToMajorUnit } from "@domain/fiat"
+import { minorToMajorUnit, newDisplayAmountFromNumber } from "@domain/fiat"
 import {
   checkedToBtcPaymentAmount,
   checkedToUsdPaymentAmount,
@@ -18,7 +18,7 @@ import {
   LnPaymentRequestZeroAmountRequiredError,
   WalletPriceRatio,
 } from "@domain/payments"
-import { newDisplayAmountFromNumber, WalletCurrency } from "@domain/shared"
+import { WalletCurrency } from "@domain/shared"
 import {
   checkedToWalletId,
   PaymentInitiationMethod,

--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -18,7 +18,7 @@ import {
   LnPaymentRequestZeroAmountRequiredError,
   WalletPriceRatio,
 } from "@domain/payments"
-import { WalletCurrency } from "@domain/shared"
+import { newDisplayAmountFromNumber, WalletCurrency } from "@domain/shared"
 import {
   checkedToWalletId,
   PaymentInitiationMethod,
@@ -509,6 +509,12 @@ const executePaymentViaIntraledger = async <
       amount = paymentFlow.usdPaymentAmount.amount
     }
 
+    const recipientDisplayAmount = newDisplayAmountFromNumber({
+      amount: recipientAmountDisplayCurrencyAsNumber,
+      currency: recipientAccount.displayCurrency,
+    })
+    if (recipientDisplayAmount instanceof Error) return recipientDisplayAmount
+
     const notificationsService = NotificationsService()
     notificationsService.lightningTxReceived({
       recipientAccountId: recipientWallet.accountId,
@@ -516,8 +522,7 @@ const executePaymentViaIntraledger = async <
       paymentAmount: { amount, currency: recipientWalletCurrency },
       displayPaymentAmount: {
         amount: minorToMajorUnit({
-          amount: recipientAmountDisplayCurrencyAsNumber,
-          displayCurrency: recipientAccount.displayCurrency,
+          displayAmount: recipientDisplayAmount,
         }),
         currency: recipientAccount.displayCurrency,
       },

--- a/src/app/wallets/send-on-chain.ts
+++ b/src/app/wallets/send-on-chain.ts
@@ -27,9 +27,9 @@ import {
   TxDecoder,
 } from "@domain/bitcoin/onchain"
 import { CouldNotFindError, InsufficientBalanceError } from "@domain/errors"
-import { minorToMajorUnit } from "@domain/fiat"
+import { minorToMajorUnit, newDisplayAmountFromNumber } from "@domain/fiat"
 import { ResourceExpiredLockServiceError } from "@domain/lock"
-import { newDisplayAmountFromNumber, WalletCurrency } from "@domain/shared"
+import { WalletCurrency } from "@domain/shared"
 import { PaymentInputValidator, SettlementMethod } from "@domain/wallets"
 import { OnChainPaymentFlowBuilder } from "@domain/payments/onchain-payment-flow-builder"
 

--- a/src/app/wallets/update-on-chain-receipt.ts
+++ b/src/app/wallets/update-on-chain-receipt.ts
@@ -10,13 +10,13 @@ import { getCurrentPriceAsDisplayPriceRatio, usdFromBtcMidPriceFn } from "@app/p
 import { toSats } from "@domain/bitcoin"
 import { OnChainError, TxDecoder } from "@domain/bitcoin/onchain"
 import { CacheKeys } from "@domain/cache"
-import {
-  newDisplayAmountFromNumber,
-  paymentAmountFromNumber,
-  WalletCurrency,
-} from "@domain/shared"
+import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
 import { CouldNotFindWalletFromOnChainAddressesError } from "@domain/errors"
-import { DisplayCurrency, minorToMajorUnit } from "@domain/fiat"
+import {
+  DisplayCurrency,
+  minorToMajorUnit,
+  newDisplayAmountFromNumber,
+} from "@domain/fiat"
 import { DepositFeeCalculator } from "@domain/wallets"
 import { WalletAddressReceiver } from "@domain/wallet-on-chain-addresses/wallet-address-receiver"
 

--- a/src/app/wallets/update-on-chain-receipt.ts
+++ b/src/app/wallets/update-on-chain-receipt.ts
@@ -5,11 +5,7 @@ import {
   SECS_PER_10_MINS,
 } from "@config"
 
-import {
-  getCurrentPriceAsDisplayPriceRatio,
-  getCurrentPriceAsWalletPriceRatio,
-  usdFromBtcMidPriceFn,
-} from "@app/prices"
+import { getCurrentPriceAsDisplayPriceRatio, usdFromBtcMidPriceFn } from "@app/prices"
 
 import { toSats } from "@domain/bitcoin"
 import { OnChainError, TxDecoder } from "@domain/bitcoin/onchain"
@@ -296,7 +292,7 @@ const processTxForHotWallet = async ({
 
   const ledger = LedgerService()
 
-  const displayPriceRatio = await getCurrentPriceAsWalletPriceRatio({
+  const displayPriceRatio = await getCurrentPriceAsDisplayPriceRatio({
     currency: DisplayCurrency.Usd,
   })
   if (displayPriceRatio instanceof Error) return displayPriceRatio
@@ -333,8 +329,9 @@ const processTxForHotWallet = async ({
         })
         if (feeAmount instanceof Error) return feeAmount
 
-        const amountDisplayCurrencyAmount = displayPriceRatio.convertFromBtc(satsAmount)
-        const feeDisplayCurrencyAmount = displayPriceRatio.convertFromBtc(feeAmount)
+        const amountDisplayCurrencyAmount =
+          displayPriceRatio.convertFromWallet(satsAmount)
+        const feeDisplayCurrencyAmount = displayPriceRatio.convertFromWallet(feeAmount)
 
         const description = `deposit to hot wallet of ${sats} sats from the cold storage wallet`
 
@@ -344,11 +341,11 @@ const processTxForHotWallet = async ({
           sats,
           fee,
           amountDisplayCurrency: minorToMajorUnit({
-            amount: amountDisplayCurrencyAmount.amount,
+            amount: amountDisplayCurrencyAmount.amountInMinor,
             displayCurrency: DisplayCurrency.Usd,
           }) as DisplayCurrencyBaseAmount,
           feeDisplayCurrency: minorToMajorUnit({
-            amount: feeDisplayCurrencyAmount.amount,
+            amount: feeDisplayCurrencyAmount.amountInMinor,
             displayCurrency: DisplayCurrency.Usd,
           }) as DisplayCurrencyBaseAmount,
           payeeAddress: address,

--- a/src/domain/fiat/display-currency.ts
+++ b/src/domain/fiat/display-currency.ts
@@ -1,3 +1,5 @@
+import { safeBigInt } from "@domain/shared"
+
 export const CENTS_PER_USD = 100
 
 export const MajorExponent = {
@@ -66,5 +68,26 @@ export const getCurrencyMajorExponent = (
   } catch {
     // this is necessary for non-standard currencies
     return MajorExponent.STANDARD
+  }
+}
+
+export const newDisplayAmountFromNumber = <T extends DisplayCurrency>({
+  amount,
+  currency,
+}: {
+  amount: number
+  currency: T
+}): NewDisplayAmount<T> | ValidationError => {
+  const amountInMinor = safeBigInt(amount)
+  if (amountInMinor instanceof Error) return amountInMinor
+
+  const displayMajorExponent = getCurrencyMajorExponent(currency)
+
+  return {
+    amountInMinor,
+    currency,
+    displayInMajor: (Number(amountInMinor) / 10 ** displayMajorExponent).toFixed(
+      displayMajorExponent,
+    ),
   }
 }

--- a/src/domain/fiat/display-currency.ts
+++ b/src/domain/fiat/display-currency.ts
@@ -20,17 +20,17 @@ export const minorToMajorUnitFormatted = ({
   return majorAmount.toFixed(displayMajorExponent)
 }
 
-export const minorToMajorUnit = ({
-  amount,
-  displayCurrency,
+export const minorToMajorUnit = <T extends DisplayCurrency>({
+  displayAmount,
   fixed = true,
 }: {
-  amount: number | bigint
-  displayCurrency: DisplayCurrency
+  displayAmount: NewDisplayAmount<T>
   fixed?: boolean
 }): number => {
-  const displayMajorExponent = getCurrencyMajorExponent(displayCurrency)
-  const majorAmount = Number(amount) / 10 ** displayMajorExponent
+  const { amountInMinor, currency } = displayAmount
+
+  const displayMajorExponent = getCurrencyMajorExponent(currency)
+  const majorAmount = Number(amountInMinor) / 10 ** displayMajorExponent
   return fixed ? Number(majorAmount.toFixed(displayMajorExponent)) : majorAmount
 }
 

--- a/src/domain/fiat/display-currency.ts
+++ b/src/domain/fiat/display-currency.ts
@@ -24,16 +24,14 @@ export const minorToMajorUnitFormatted = ({
 
 export const minorToMajorUnit = <T extends DisplayCurrency>({
   displayAmount,
-  fixed = true,
 }: {
   displayAmount: NewDisplayAmount<T>
-  fixed?: boolean
 }): number => {
   const { amountInMinor, currency } = displayAmount
 
   const displayMajorExponent = getCurrencyMajorExponent(currency)
   const majorAmount = Number(amountInMinor) / 10 ** displayMajorExponent
-  return fixed ? Number(majorAmount.toFixed(displayMajorExponent)) : majorAmount
+  return Number(majorAmount.toFixed(displayMajorExponent))
 }
 
 export const majorToMinorUnit = ({
@@ -89,5 +87,21 @@ export const newDisplayAmountFromNumber = <T extends DisplayCurrency>({
     displayInMajor: (Number(amountInMinor) / 10 ** displayMajorExponent).toFixed(
       displayMajorExponent,
     ),
+  }
+}
+
+export const priceAmountFromNumber = <T extends DisplayCurrency>({
+  priceOfOneSatInMinorUnit,
+  currency,
+}: {
+  priceOfOneSatInMinorUnit: number
+  currency: T
+}): PriceAmount<T> => {
+  const displayMajorExponent = getCurrencyMajorExponent(currency)
+
+  return {
+    priceOfOneSatInMinorUnit,
+    priceOfOneSatInMajorUnit: priceOfOneSatInMinorUnit / 10 ** displayMajorExponent,
+    currency,
   }
 }

--- a/src/domain/shared/index.types.d.ts
+++ b/src/domain/shared/index.types.d.ts
@@ -29,6 +29,12 @@ type NewDisplayAmount<T extends DisplayCurrency> = {
   displayInMajor: DisplayCurrencyMajorAmount
 }
 
+type PriceAmount<T extends DisplayCurrency> = {
+  priceOfOneSatInMinorUnit: number
+  priceOfOneSatInMajorUnit: number
+  currency: T
+}
+
 type PaymentAmount<T extends WalletCurrency> = Amount<T> & {
   readonly brand?: unique symbol
 }

--- a/src/domain/shared/primitives.ts
+++ b/src/domain/shared/primitives.ts
@@ -1,5 +1,3 @@
-import { getCurrencyMajorExponent } from "@domain/fiat"
-
 import { safeBigInt } from "./safe"
 
 // TODO: think how to differentiate physical from synthetic USD
@@ -104,27 +102,6 @@ export const displayAmountFromNumber = <T extends DisplayCurrency>({
   return {
     amount,
     currency,
-  }
-}
-
-export const newDisplayAmountFromNumber = <T extends DisplayCurrency>({
-  amount,
-  currency,
-}: {
-  amount: number
-  currency: T
-}): NewDisplayAmount<T> | ValidationError => {
-  const amountInMinor = safeBigInt(amount)
-  if (amountInMinor instanceof Error) return amountInMinor
-
-  const displayMajorExponent = getCurrencyMajorExponent(currency)
-
-  return {
-    amountInMinor,
-    currency,
-    displayInMajor: (Number(amountInMinor) / 10 ** displayMajorExponent).toFixed(
-      displayMajorExponent,
-    ),
   }
 }
 

--- a/src/domain/shared/primitives.ts
+++ b/src/domain/shared/primitives.ts
@@ -1,3 +1,5 @@
+import { getCurrencyMajorExponent } from "@domain/fiat"
+
 import { safeBigInt } from "./safe"
 
 // TODO: think how to differentiate physical from synthetic USD
@@ -102,6 +104,27 @@ export const displayAmountFromNumber = <T extends DisplayCurrency>({
   return {
     amount,
     currency,
+  }
+}
+
+export const newDisplayAmountFromNumber = <T extends DisplayCurrency>({
+  amount,
+  currency,
+}: {
+  amount: number
+  currency: T
+}): NewDisplayAmount<T> | ValidationError => {
+  const amountInMinor = safeBigInt(amount)
+  if (amountInMinor instanceof Error) return amountInMinor
+
+  const displayMajorExponent = getCurrencyMajorExponent(currency)
+
+  return {
+    amountInMinor,
+    currency,
+    displayInMajor: (Number(amountInMinor) / 10 ** displayMajorExponent).toFixed(
+      displayMajorExponent,
+    ),
   }
 }
 

--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -11,7 +11,7 @@ import {
   toCents,
 } from "@domain/fiat"
 import { toSats } from "@domain/bitcoin"
-import { WalletCurrency } from "@domain/shared"
+import { newDisplayAmountFromNumber, WalletCurrency } from "@domain/shared"
 import { AdminLedgerTransactionType, LedgerTransactionType } from "@domain/ledger"
 
 import { TxStatus } from "./tx-status"
@@ -86,9 +86,16 @@ const filterPendingIncoming = <S extends WalletCurrency, T extends DisplayCurren
                 displayCurrency,
               })
 
-              displayCurrencyPerSettlementCurrencyMajorUnit = minorToMajorUnit({
+              const displayAmountForOneSettlementMajorUnit = newDisplayAmountFromNumber({
                 amount: displayPriceRatio.displayMinorUnitPerWalletUnit(),
-                displayCurrency,
+                currency: displayCurrency,
+              })
+              if (displayAmountForOneSettlementMajorUnit instanceof Error) {
+                return displayAmountForOneSettlementMajorUnit
+              }
+
+              displayCurrencyPerSettlementCurrencyMajorUnit = minorToMajorUnit({
+                displayAmount: displayAmountForOneSettlementMajorUnit,
                 fixed: false,
               })
             }

--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -8,10 +8,11 @@ import {
   DisplayCurrency,
   minorToMajorUnit,
   minorToMajorUnitFormatted,
+  newDisplayAmountFromNumber,
   toCents,
 } from "@domain/fiat"
 import { toSats } from "@domain/bitcoin"
-import { newDisplayAmountFromNumber, WalletCurrency } from "@domain/shared"
+import { WalletCurrency } from "@domain/shared"
 import { AdminLedgerTransactionType, LedgerTransactionType } from "@domain/ledger"
 
 import { TxStatus } from "./tx-status"

--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -6,9 +6,8 @@ import {
 
 import {
   DisplayCurrency,
-  minorToMajorUnit,
   minorToMajorUnitFormatted,
-  newDisplayAmountFromNumber,
+  priceAmountFromNumber,
   toCents,
 } from "@domain/fiat"
 import { toSats } from "@domain/bitcoin"
@@ -71,7 +70,7 @@ const filterPendingIncoming = <S extends WalletCurrency, T extends DisplayCurren
 
             let settlementDisplayAmount = `${NaN}`
             let settlementDisplayFee = `${NaN}`
-            let displayCurrencyPerSettlementCurrencyMajorUnit = NaN as number
+            let displayCurrencyPerSettlementCurrencyUnit = NaN as number
             if (displayPriceRatio) {
               const displayAmount =
                 displayPriceRatio.convertFromWallet(btcSettlementAmount)
@@ -86,19 +85,12 @@ const filterPendingIncoming = <S extends WalletCurrency, T extends DisplayCurren
                 amount: displayFee.amountInMinor,
                 displayCurrency,
               })
-
-              const displayAmountForOneSettlementMajorUnit = newDisplayAmountFromNumber({
-                amount: displayPriceRatio.displayMinorUnitPerWalletUnit(),
-                currency: displayCurrency,
-              })
-              if (displayAmountForOneSettlementMajorUnit instanceof Error) {
-                return displayAmountForOneSettlementMajorUnit
-              }
-
-              displayCurrencyPerSettlementCurrencyMajorUnit = minorToMajorUnit({
-                displayAmount: displayAmountForOneSettlementMajorUnit,
-                fixed: false,
-              })
+              ;({ priceOfOneSatInMajorUnit: displayCurrencyPerSettlementCurrencyUnit } =
+                priceAmountFromNumber({
+                  priceOfOneSatInMinorUnit:
+                    displayPriceRatio.displayMinorUnitPerWalletUnit(),
+                  currency: displayCurrency,
+                }))
             }
 
             walletTransactions.push({
@@ -110,8 +102,7 @@ const filterPendingIncoming = <S extends WalletCurrency, T extends DisplayCurren
               settlementDisplayAmount,
               settlementDisplayFee,
               settlementDisplayCurrency: displayCurrency,
-              displayCurrencyPerSettlementCurrencyUnit:
-                displayCurrencyPerSettlementCurrencyMajorUnit,
+              displayCurrencyPerSettlementCurrencyUnit,
               status: TxStatus.Pending,
               memo: null,
               createdAt: createdAt,

--- a/src/servers/trigger.ts
+++ b/src/servers/trigger.ts
@@ -125,12 +125,11 @@ export const onchainTransactionEventHandler = async <T extends DisplayCurrency>(
         currency: WalletCurrency.Btc,
       })
       if (!(satsAmount instanceof Error)) {
-        const paymentAmount = displayPriceRatio.convertFromWallet(satsAmount)
+        const displayAmount = displayPriceRatio.convertFromWallet(satsAmount)
         displayPaymentAmount = {
-          ...paymentAmount,
+          ...displayAmount,
           amount: minorToMajorUnit({
-            amount: paymentAmount.amountInMinor,
-            displayCurrency: paymentAmount.currency,
+            displayAmount,
           }),
         }
       }
@@ -232,12 +231,11 @@ export const onchainTransactionEventHandler = async <T extends DisplayCurrency>(
             currency: WalletCurrency.Btc,
           })
           if (!(satsAmount instanceof Error)) {
-            const paymentAmount = displayPriceRatio.convertFromWallet(satsAmount)
+            const displayAmount = displayPriceRatio.convertFromWallet(satsAmount)
             displayPaymentAmount = {
-              ...paymentAmount,
+              ...displayAmount,
               amount: minorToMajorUnit({
-                amount: paymentAmount.amountInMinor,
-                displayCurrency: paymentAmount.currency,
+                displayAmount,
               }),
             }
           }

--- a/test/integration/02-user-wallet/02-receive-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-onchain.spec.ts
@@ -22,7 +22,11 @@ import { LedgerTransactionType } from "@domain/ledger"
 import { NotificationType } from "@domain/notifications"
 import { WalletPriceRatio } from "@domain/payments"
 import { OnChainAddressCreateRateLimiterExceededError } from "@domain/rate-limit/errors"
-import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
+import {
+  newDisplayAmountFromNumber,
+  paymentAmountFromNumber,
+  WalletCurrency,
+} from "@domain/shared"
 import { DepositFeeCalculator, TxStatus } from "@domain/wallets"
 
 import { onchainTransactionEventHandler } from "@servers/trigger"
@@ -183,9 +187,13 @@ describe("UserWallet - On chain", () => {
 
     expect(Number(expectedSatsFee.amount)).toEqual(satsFee)
 
-    const displayAmountMajorUnit = minorToMajorUnit({
+    const displayAmountForMajor = newDisplayAmountFromNumber({
       amount: displayAmountRaw || 0,
-      displayCurrency: displayCurrency || DisplayCurrency.Usd,
+      currency: displayCurrency || DisplayCurrency.Usd,
+    })
+    if (displayAmountForMajor instanceof Error) throw displayAmountForMajor
+    const displayAmountMajorUnit = minorToMajorUnit({
+      displayAmount: displayAmountForMajor,
     })
 
     const displayAmount =

--- a/test/integration/02-user-wallet/02-receive-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-onchain.spec.ts
@@ -267,11 +267,11 @@ describe("UserWallet - On chain", () => {
     await createUserAndWalletFromUserRef("G")
     const walletIdG = await getDefaultWalletIdByTestUserRef("G")
 
-    const displayPriceRatio = await Prices.getCurrentPriceAsWalletPriceRatio({
-      currency: DisplayCurrency.Usd,
+    const walletPriceRatio = await Prices.getCurrentPriceAsWalletPriceRatio({
+      currency: WalletCurrency.Usd,
     })
-    if (displayPriceRatio instanceof Error) throw displayPriceRatio
-    const satsAmount = displayPriceRatio.convertFromUsd({
+    if (walletPriceRatio instanceof Error) throw walletPriceRatio
+    const satsAmount = walletPriceRatio.convertFromUsd({
       amount: BigInt(withdrawalLimitAccountLevel1),
       currency: WalletCurrency.Usd,
     })
@@ -292,11 +292,11 @@ describe("UserWallet - On chain", () => {
     await createUserAndWalletFromUserRef("F")
     const walletId = await getDefaultWalletIdByTestUserRef("F")
 
-    const displayPriceRatio = await Prices.getCurrentPriceAsWalletPriceRatio({
-      currency: DisplayCurrency.Usd,
+    const walletPriceRatio = await Prices.getCurrentPriceAsWalletPriceRatio({
+      currency: WalletCurrency.Usd,
     })
-    if (displayPriceRatio instanceof Error) throw displayPriceRatio
-    const satsAmount = displayPriceRatio.convertFromUsd({
+    if (walletPriceRatio instanceof Error) throw walletPriceRatio
+    const satsAmount = walletPriceRatio.convertFromUsd({
       amount: BigInt(intraLedgerLimitAccountLevel1),
       currency: WalletCurrency.Usd,
     })

--- a/test/integration/02-user-wallet/02-receive-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-onchain.spec.ts
@@ -16,17 +16,14 @@ import {
   DisplayCurrency,
   getCurrencyMajorExponent,
   minorToMajorUnit,
+  newDisplayAmountFromNumber,
   toCents,
 } from "@domain/fiat"
 import { LedgerTransactionType } from "@domain/ledger"
 import { NotificationType } from "@domain/notifications"
 import { WalletPriceRatio } from "@domain/payments"
 import { OnChainAddressCreateRateLimiterExceededError } from "@domain/rate-limit/errors"
-import {
-  newDisplayAmountFromNumber,
-  paymentAmountFromNumber,
-  WalletCurrency,
-} from "@domain/shared"
+import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
 import { DepositFeeCalculator, TxStatus } from "@domain/wallets"
 
 import { onchainTransactionEventHandler } from "@servers/trigger"

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -1121,11 +1121,11 @@ describe("BtcWallet - onChainPay", () => {
 
     const withdrawalLimit = getAccountLimits({ level: accountA.level }).withdrawalLimit
 
-    const displayPriceRatio = await Prices.getCurrentPriceAsWalletPriceRatio({
-      currency: DisplayCurrency.Usd,
+    const walletPriceRatio = await Prices.getCurrentPriceAsWalletPriceRatio({
+      currency: WalletCurrency.Usd,
     })
-    if (displayPriceRatio instanceof Error) throw displayPriceRatio
-    const satsAmount = displayPriceRatio.convertFromUsd({
+    if (walletPriceRatio instanceof Error) throw walletPriceRatio
+    const satsAmount = walletPriceRatio.convertFromUsd({
       amount: BigInt(withdrawalLimit),
       currency: WalletCurrency.Usd,
     })

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -435,10 +435,9 @@ const testExternalSend = async ({
             //       & currencies. Applying 'minorToMajorUnit' to WalletCurrency.Usd case
             //       makes no difference.
             minorToMajorUnit({
-              amount: displayPriceRatio.convertFromWallet(
+              displayAmount: displayPriceRatio.convertFromWallet(
                 paymentAmount as BtcPaymentAmount,
-              ).amountInMinor,
-              displayCurrency: senderAccount.displayCurrency,
+              ),
             })
           : amountForNotification,
       currency: DisplayCurrency.Usd,

--- a/test/integration/notifications/notification.spec.ts
+++ b/test/integration/notifications/notification.spec.ts
@@ -134,10 +134,9 @@ describe("notification", () => {
         if (balanceAmount.currency === WalletCurrency.Btc) {
           const majorBalanceAmount = Number(
             minorToMajorUnit({
-              amount: displayPriceRatio.convertFromWallet(
+              displayAmount: displayPriceRatio.convertFromWallet(
                 balanceAmount as BtcPaymentAmount,
-              ).amountInMinor,
-              displayCurrency,
+              ),
             }),
           )
 
@@ -156,8 +155,7 @@ describe("notification", () => {
 
           const majorBalanceAmount = Number(
             minorToMajorUnit({
-              amount: displayPriceRatio.convertFromWallet(btcBalanceAmount).amountInMinor,
-              displayCurrency,
+              displayAmount: displayPriceRatio.convertFromWallet(btcBalanceAmount),
             }),
           )
 


### PR DESCRIPTION
## Description

This is mostly a housekeeping PR to:
- ensure we use wallet vs. display price ratio in appropriate places
- clean up the interface for `minorToMajorUnit` interface to not expose `NewDisplayAmount` internals