### PR TITLE
fix: oathkeeper cookie rules

### DIFF
--- a/dev/ory/oathkeeper_rules.yaml
+++ b/dev/ory/oathkeeper_rules.yaml
@@ -2,29 +2,9 @@
   upstream:
     url: "http://e2e-tests:4012"
   match:
-    url: "<(http|https)>://<[a-zA-Z0-9-.:]+>/auth/clearCookies"
+    url: "<(http|https)>://<[a-zA-Z0-9-.:]+>/auth/<(clearCookies|login|logout)>"
     methods: ["GET", "POST", "OPTIONS"]
   authenticators:
-    - handler: anonymous
-  authorizer:
-    handler: allow
-  mutators:
-    - handler: noop
-
-- id: cookie-auth-routes
-  upstream:
-    url: "http://e2e-tests:4012"
-  match:
-    url: "<(http|https)>://<[a-zA-Z0-9-.:]+>/auth/<(login|logout)>"
-    methods: ["GET", "POST", "OPTIONS"]
-  authenticators:
-    - handler: cookie_session
-      config:
-        check_session_url: http://kratos:4433/sessions/whoami
-        preserve_path: true
-        preserve_query: true
-        subject_from: identity.id
-        extra_from: identity.traits
     - handler: anonymous
   authorizer:
     handler: allow


### PR DESCRIPTION
This PR fixes the oathkeeper cookie rules. No need to check the cookie on the `/auth/login`or `logout` routes. Without this rule it falsey checks any cookie (_ga cookies) and returns 401.

See related PR comment https://github.com/GaloyMoney/galoy-deployments/pull/3292#issue-1636753015