### PR TITLE
feat!: include route channel ids in skipFeeProbe checks

### DIFF
--- a/galoy.yaml
+++ b/galoy.yaml
@@ -198,11 +198,8 @@ oathkeeperConfig:
   decisionsApi: http://127.0.0.1:4456/decisions/
 captcha:
   mandatory: false
-# deprecated: use skipFeeProbeConfig instead
 skipFeeProbe:
   - 038f8f113c580048d847d6949371726653e02b928196bad310e3eda39ff61723f6
 skipFeeProbeConfig:
-  pubkey:
-    - 038f8f113c580048d847d6949371726653e02b928196bad310e3eda39ff61723f6
-  chanId:
-    - 1x0x0
+  pubkey: []
+  chanId: []

--- a/galoy.yaml
+++ b/galoy.yaml
@@ -198,8 +198,6 @@ oathkeeperConfig:
   decisionsApi: http://127.0.0.1:4456/decisions/
 captcha:
   mandatory: false
-skipFeeProbe:
-  - 038f8f113c580048d847d6949371726653e02b928196bad310e3eda39ff61723f6
 skipFeeProbeConfig:
   pubkey: []
   chanId: []

--- a/galoy.yaml
+++ b/galoy.yaml
@@ -198,7 +198,10 @@ oathkeeperConfig:
   decisionsApi: http://127.0.0.1:4456/decisions/
 captcha:
   mandatory: false
+# deprecated: use skipFeeProbeConfig instead
 skipFeeProbe:
+  - 038f8f113c580048d847d6949371726653e02b928196bad310e3eda39ff61723f6
+skipFeeProbeConfig:
   pubkey:
     - 038f8f113c580048d847d6949371726653e02b928196bad310e3eda39ff61723f6
   chanId:

--- a/galoy.yaml
+++ b/galoy.yaml
@@ -199,4 +199,7 @@ oathkeeperConfig:
 captcha:
   mandatory: false
 skipFeeProbe:
-  - 038f8f113c580048d847d6949371726653e02b928196bad310e3eda39ff61723f6
+  pubkey:
+    - 038f8f113c580048d847d6949371726653e02b928196bad310e3eda39ff61723f6
+  chanId:
+    - 1x0x0

--- a/src/app/payments/helpers.ts
+++ b/src/app/payments/helpers.ts
@@ -2,7 +2,6 @@ import { btcFromUsdMidPriceFn, usdFromBtcMidPriceFn } from "@app/prices"
 import { addNewContact } from "@app/accounts/add-new-contact"
 import {
   getAccountLimits,
-  getPubkeysToSkipProbe,
   getValuesToSkipProbe,
   MIN_SATS_FOR_PRICE_RATIO_PRECISION,
   ONE_DAY,
@@ -46,14 +45,9 @@ export const constructPaymentFlowBuilder = async <
 }): Promise<LPFBWithConversion<S, R> | ApplicationError> => {
   const lndService = LndService()
   if (lndService instanceof Error) return lndService
-  const skipProbePubkeysLegacy = getPubkeysToSkipProbe()
-  const skipProbeValues = getValuesToSkipProbe()
   const paymentBuilder = LightningPaymentFlowBuilder({
     localNodeIds: lndService.listAllPubkeys(),
-    skipProbe: {
-      pubkey: Array.from(new Set([...skipProbeValues.pubkey, ...skipProbePubkeysLegacy])),
-      chanId: skipProbeValues.chanId,
-    },
+    skipProbe: getValuesToSkipProbe(),
   })
   const builderWithInvoice = uncheckedAmount
     ? (paymentBuilder.withNoAmountInvoice({

--- a/src/app/payments/helpers.ts
+++ b/src/app/payments/helpers.ts
@@ -50,7 +50,7 @@ export const constructPaymentFlowBuilder = async <
   const skipProbeValues = getValuesToSkipProbe()
   const paymentBuilder = LightningPaymentFlowBuilder({
     localNodeIds: lndService.listAllPubkeys(),
-    flagged: {
+    skipProbe: {
       pubkey: Array.from(new Set([...skipProbeValues.pubkey, ...skipProbePubkeysLegacy])),
       chanId: skipProbeValues.chanId,
     },

--- a/src/app/payments/helpers.ts
+++ b/src/app/payments/helpers.ts
@@ -2,7 +2,7 @@ import { btcFromUsdMidPriceFn, usdFromBtcMidPriceFn } from "@app/prices"
 import { addNewContact } from "@app/accounts/add-new-contact"
 import {
   getAccountLimits,
-  getPubkeysToSkipProbe,
+  getValuesToSkipProbe,
   MIN_SATS_FOR_PRICE_RATIO_PRECISION,
   ONE_DAY,
 } from "@config"
@@ -47,7 +47,7 @@ export const constructPaymentFlowBuilder = async <
   if (lndService instanceof Error) return lndService
   const paymentBuilder = LightningPaymentFlowBuilder({
     localNodeIds: lndService.listAllPubkeys(),
-    flaggedPubkeys: getPubkeysToSkipProbe(),
+    flagged: getValuesToSkipProbe(),
   })
   const builderWithInvoice = uncheckedAmount
     ? (paymentBuilder.withNoAmountInvoice({

--- a/src/app/payments/send-intraledger.ts
+++ b/src/app/payments/send-intraledger.ts
@@ -1,4 +1,4 @@
-import { getPubkeysToSkipProbe } from "@config"
+import { getValuesToSkipProbe } from "@config"
 
 import { AccountValidator } from "@domain/accounts"
 import { PaymentSendStatus } from "@domain/bitcoin/lightning"
@@ -70,7 +70,7 @@ const intraledgerPaymentSendWalletId = async ({
 
   const paymentBuilder = LightningPaymentFlowBuilder({
     localNodeIds: [],
-    flaggedPubkeys: getPubkeysToSkipProbe(),
+    flagged: getValuesToSkipProbe(),
   })
   const builderWithInvoice = paymentBuilder.withoutInvoice({
     uncheckedAmount,

--- a/src/app/payments/send-intraledger.ts
+++ b/src/app/payments/send-intraledger.ts
@@ -70,7 +70,7 @@ const intraledgerPaymentSendWalletId = async ({
 
   const paymentBuilder = LightningPaymentFlowBuilder({
     localNodeIds: [],
-    flagged: getValuesToSkipProbe(),
+    skipProbe: getValuesToSkipProbe(),
   })
   const builderWithInvoice = paymentBuilder.withoutInvoice({
     uncheckedAmount,

--- a/src/config/index.types.d.ts
+++ b/src/config/index.types.d.ts
@@ -23,3 +23,5 @@ type QuizQuestionId =
   | "HighlyDivisible"
   | "securePartOne"
   | "securePartTwo"
+
+type SkipFeeProbeConfig = { pubkey: Pubkey[]; chanId: ChanId[] }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -652,12 +652,28 @@ export const configSchema = {
       default: { mandatory: false },
     },
     skipFeeProbe: {
-      type: "array",
-      items: { type: "string", maxLength: 66, minLength: 66 },
-      uniqueItems: true,
-      default: [
-        "038f8f113c580048d847d6949371726653e02b928196bad310e3eda39ff61723f6", // Muun
-      ],
+      type: "object",
+      properties: {
+        pubkey: {
+          type: "array",
+          items: { type: "string", maxLength: 66, minLength: 66 },
+          uniqueItems: true,
+        },
+        chanId: {
+          type: "array",
+          items: { type: "string" },
+          uniqueItems: true,
+        },
+      },
+      additionalProperties: false,
+      default: {
+        pubkey: [
+          "038f8f113c580048d847d6949371726653e02b928196bad310e3eda39ff61723f6", // Muun
+        ],
+        chanId: [
+          "1x0x0", // Breez on-the-fly channel
+        ],
+      },
     },
   },
   required: [

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -676,12 +676,8 @@ export const configSchema = {
       },
       additionalProperties: false,
       default: {
-        pubkey: [
-          "038f8f113c580048d847d6949371726653e02b928196bad310e3eda39ff61723f6", // Muun
-        ],
-        chanId: [
-          "1x0x0", // Breez on-the-fly channel
-        ],
+        pubkey: [],
+        chanId: [],
       },
     },
   },

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -651,7 +651,16 @@ export const configSchema = {
       additionalProperties: false,
       default: { mandatory: false },
     },
+    // deprecated: use skipFeeProbeConfig instead
     skipFeeProbe: {
+      type: "array",
+      items: { type: "string", maxLength: 66, minLength: 66 },
+      uniqueItems: true,
+      default: [
+        "038f8f113c580048d847d6949371726653e02b928196bad310e3eda39ff61723f6", // Muun
+      ],
+    },
+    skipFeeProbeConfig: {
       type: "object",
       properties: {
         pubkey: {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -651,15 +651,6 @@ export const configSchema = {
       additionalProperties: false,
       default: { mandatory: false },
     },
-    // deprecated: use skipFeeProbeConfig instead
-    skipFeeProbe: {
-      type: "array",
-      items: { type: "string", maxLength: 66, minLength: 66 },
-      uniqueItems: true,
-      default: [
-        "038f8f113c580048d847d6949371726653e02b928196bad310e3eda39ff61723f6", // Muun
-      ],
-    },
     skipFeeProbeConfig: {
       type: "object",
       properties: {

--- a/src/config/schema.types.d.ts
+++ b/src/config/schema.types.d.ts
@@ -149,7 +149,5 @@ type YamlSchema = {
   captcha: {
     mandatory: boolean
   }
-  // deprecated: use skipFeeProbeConfig instead
-  skipFeeProbe: string[]
   skipFeeProbeConfig: { pubkey: string[]; chanId: string[] }
 }

--- a/src/config/schema.types.d.ts
+++ b/src/config/schema.types.d.ts
@@ -149,5 +149,7 @@ type YamlSchema = {
   captcha: {
     mandatory: boolean
   }
-  skipFeeProbe: { pubkey: string[]; chanId: string[] }
+  // deprecated: use skipFeeProbeConfig instead
+  skipFeeProbe: string[]
+  skipFeeProbeConfig: { pubkey: string[]; chanId: string[] }
 }

--- a/src/config/schema.types.d.ts
+++ b/src/config/schema.types.d.ts
@@ -149,5 +149,5 @@ type YamlSchema = {
   captcha: {
     mandatory: boolean
   }
-  skipFeeProbe: Pubkey[]
+  skipFeeProbe: { pubkey: string[]; chanId: string[] }
 }

--- a/src/config/yaml.ts
+++ b/src/config/yaml.ts
@@ -88,10 +88,13 @@ export const getLightningAddressDomainAliases = (): string[] =>
   yamlConfig.lightningAddressDomainAliases
 export const getLocale = (): UserLanguage => yamlConfig.locale as UserLanguage
 
+export const getPubkeysToSkipProbe = (): Pubkey[] =>
+  (yamlConfig.skipFeeProbe || []) as Pubkey[]
+
 export const getValuesToSkipProbe = (): SkipFeeProbeConfig => {
   return {
-    pubkey: (yamlConfig.skipFeeProbe.pubkey || []) as Pubkey[],
-    chanId: (yamlConfig.skipFeeProbe.chanId || []) as ChanId[],
+    pubkey: (yamlConfig.skipFeeProbeConfig.pubkey || []) as Pubkey[],
+    chanId: (yamlConfig.skipFeeProbeConfig.chanId || []) as ChanId[],
   }
 }
 

--- a/src/config/yaml.ts
+++ b/src/config/yaml.ts
@@ -88,7 +88,12 @@ export const getLightningAddressDomainAliases = (): string[] =>
   yamlConfig.lightningAddressDomainAliases
 export const getLocale = (): UserLanguage => yamlConfig.locale as UserLanguage
 
-export const getPubkeysToSkipProbe = (): Pubkey[] => yamlConfig.skipFeeProbe
+export const getValuesToSkipProbe = (): SkipFeeProbeConfig => {
+  return {
+    pubkey: (yamlConfig.skipFeeProbe.pubkey || []) as Pubkey[],
+    chanId: (yamlConfig.skipFeeProbe.chanId || []) as ChanId[],
+  }
+}
 
 const i18n = new I18n()
 i18n.configure({

--- a/src/config/yaml.ts
+++ b/src/config/yaml.ts
@@ -88,9 +88,6 @@ export const getLightningAddressDomainAliases = (): string[] =>
   yamlConfig.lightningAddressDomainAliases
 export const getLocale = (): UserLanguage => yamlConfig.locale as UserLanguage
 
-export const getPubkeysToSkipProbe = (): Pubkey[] =>
-  (yamlConfig.skipFeeProbe || []) as Pubkey[]
-
 export const getValuesToSkipProbe = (): SkipFeeProbeConfig => {
   return {
     pubkey: (yamlConfig.skipFeeProbeConfig.pubkey || []) as Pubkey[],

--- a/src/domain/bitcoin/lightning/index.ts
+++ b/src/domain/bitcoin/lightning/index.ts
@@ -42,6 +42,19 @@ export const parseFinalHopsFromInvoice = (invoice: LnInvoice): Pubkey[] => {
   return Array.from(new Set(pubkeys))
 }
 
+export const parseFinalChanIdFromInvoice = (invoice: LnInvoice): ChanId[] => {
+  const chanIds = [] as ChanId[]
+  const routes = invoice.routeHints
+  for (const route of routes) {
+    const lastIdx = route.length - 1
+    const destinationChanId = route[lastIdx].channel
+    if (destinationChanId !== undefined) {
+      chanIds.push(destinationChanId)
+    }
+  }
+  return Array.from(new Set(chanIds))
+}
+
 export const sha256 = (buffer: Buffer) =>
   createHash("sha256").update(buffer).digest("hex")
 const randomSecret = () => randomBytes(32)

--- a/src/domain/bitcoin/lightning/index.types.d.ts
+++ b/src/domain/bitcoin/lightning/index.types.d.ts
@@ -12,6 +12,7 @@ type RevealedPreImage = string & { readonly brand: unique symbol }
 type PaymentIdentifyingSecret = string & { readonly brand: unique symbol }
 type FeatureBit = number & { readonly brand: unique symbol }
 type FeatureType = string & { readonly brand: unique symbol }
+type ChanId = string & { readonly brand: unique symbol }
 
 type PagingStartToken = undefined
 type PagingContinueToken = string & { readonly brand: unique symbol }
@@ -31,7 +32,7 @@ type PaymentSendStatus =
 
 type Hop = {
   baseFeeMTokens?: string
-  channel?: string
+  channel?: ChanId
   cltvDelta?: number
   feeRate?: number
   nodePubkey: Pubkey

--- a/src/domain/bitcoin/lightning/ln-invoice.ts
+++ b/src/domain/bitcoin/lightning/ln-invoice.ts
@@ -41,7 +41,7 @@ export const decodeInvoice = (
     routeHints = invoicesRoutes.map((rawRoute) =>
       rawRoute.map((route) => ({
         baseFeeMTokens: route.base_fee_mtokens,
-        channel: route.channel,
+        channel: route.channel as ChanId,
         cltvDelta: route.cltv_delta,
         feeRate: route.fee_rate,
         nodePubkey: route.public_key as Pubkey,

--- a/src/domain/payments/index.types.d.ts
+++ b/src/domain/payments/index.types.d.ts
@@ -318,7 +318,7 @@ type BtcFromUsdMidPriceFn = (
 
 type LightningPaymentFlowBuilderConfig = {
   localNodeIds: Pubkey[]
-  flagged: SkipFeeProbeConfig
+  skipProbe: SkipFeeProbeConfig
 }
 
 type OnChainPaymentFlowBuilderConfig = {

--- a/src/domain/payments/index.types.d.ts
+++ b/src/domain/payments/index.types.d.ts
@@ -318,7 +318,7 @@ type BtcFromUsdMidPriceFn = (
 
 type LightningPaymentFlowBuilderConfig = {
   localNodeIds: Pubkey[]
-  flaggedPubkeys: Pubkey[]
+  flagged: SkipFeeProbeConfig
 }
 
 type OnChainPaymentFlowBuilderConfig = {

--- a/src/domain/payments/payment-flow-builder.ts
+++ b/src/domain/payments/payment-flow-builder.ts
@@ -8,6 +8,8 @@ import {
   parseFinalHopsFromInvoice,
 } from "@domain/bitcoin/lightning"
 
+import { addAttributesToCurrentSpan } from "@services/tracing"
+
 import { ModifiedSet } from "@utils"
 
 import {
@@ -55,6 +57,14 @@ export const LightningPaymentFlowBuilder = <S extends WalletCurrency>(
     const invoiceChanIdSet = new ModifiedSet(parseFinalChanIdFromInvoice(invoice))
     const flaggedChanIdSet = new ModifiedSet(config.flagged.chanId)
     const chanIdIsFlagged = invoiceChanIdSet.intersect(flaggedChanIdSet).size > 0
+
+    addAttributesToCurrentSpan({
+      pubkeyIsFlagged: `${pubkeyIsFlagged}`,
+      pubkeysFromInvoice: `${Array.from(invoicePubkeySet)}`,
+
+      chanIdIsFlagged: `${chanIdIsFlagged}`,
+      chanIdsFromInvoice: `${Array.from(invoiceChanIdSet)}`,
+    })
 
     return pubkeyIsFlagged || chanIdIsFlagged
   }

--- a/src/domain/payments/payment-flow-builder.ts
+++ b/src/domain/payments/payment-flow-builder.ts
@@ -51,11 +51,11 @@ export const LightningPaymentFlowBuilder = <S extends WalletCurrency>(
 
   const skipProbeFromInvoice = (invoice: LnInvoice): boolean => {
     const invoicePubkeySet = new ModifiedSet(parseFinalHopsFromInvoice(invoice))
-    const flaggedPubkeySet = new ModifiedSet(config.flagged.pubkey)
+    const flaggedPubkeySet = new ModifiedSet(config.skipProbe.pubkey)
     const pubkeyIsFlagged = invoicePubkeySet.intersect(flaggedPubkeySet).size > 0
 
     const invoiceChanIdSet = new ModifiedSet(parseFinalChanIdFromInvoice(invoice))
-    const flaggedChanIdSet = new ModifiedSet(config.flagged.chanId)
+    const flaggedChanIdSet = new ModifiedSet(config.skipProbe.chanId)
     const chanIdIsFlagged = invoiceChanIdSet.intersect(flaggedChanIdSet).size > 0
 
     addAttributesToCurrentSpan({

--- a/src/domain/payments/payment-flow-builder.ts
+++ b/src/domain/payments/payment-flow-builder.ts
@@ -3,7 +3,10 @@ import { SelfPaymentError } from "@domain/errors"
 import { PaymentInitiationMethod, SettlementMethod } from "@domain/wallets"
 import { checkedToBtcPaymentAmount, checkedToUsdPaymentAmount } from "@domain/payments"
 import { generateIntraLedgerHash } from "@domain/payments/get-intraledger-hash"
-import { parseFinalHopsFromInvoice } from "@domain/bitcoin/lightning"
+import {
+  parseFinalChanIdFromInvoice,
+  parseFinalHopsFromInvoice,
+} from "@domain/bitcoin/lightning"
 
 import { ModifiedSet } from "@utils"
 
@@ -46,9 +49,14 @@ export const LightningPaymentFlowBuilder = <S extends WalletCurrency>(
 
   const skipProbeFromInvoice = (invoice: LnInvoice): boolean => {
     const invoicePubkeySet = new ModifiedSet(parseFinalHopsFromInvoice(invoice))
-    const flaggedPubkeySet = new ModifiedSet(config.flaggedPubkeys)
+    const flaggedPubkeySet = new ModifiedSet(config.flagged.pubkey)
+    const pubkeyIsFlagged = invoicePubkeySet.intersect(flaggedPubkeySet).size > 0
 
-    return invoicePubkeySet.intersect(flaggedPubkeySet).size > 0
+    const invoiceChanIdSet = new ModifiedSet(parseFinalChanIdFromInvoice(invoice))
+    const flaggedChanIdSet = new ModifiedSet(config.flagged.chanId)
+    const chanIdIsFlagged = invoiceChanIdSet.intersect(flaggedChanIdSet).size > 0
+
+    return pubkeyIsFlagged || chanIdIsFlagged
   }
 
   const withInvoice = (invoice: LnInvoice): LPFBWithInvoice<S> | LPFBWithError => {

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -982,23 +982,23 @@ describe("UserWallet - Lightning Pay", () => {
     expect(fee).toStrictEqual({ amount: 0n, currency: WalletCurrency.Btc })
 
     // Test that flagged destination skips feeProbe lightning service method
-    const muunRequest =
+    const skippedPubkeyRequest =
       "lnbc10u1p3w0mf7pp5v9xg3eksnsyrsa3vk5uv00rvye4wf9n0744xgtx0kcrafeanvx7sdqqcqzzgxqyz5vqrzjqwnvuc0u4txn35cafc7w94gxvq5p3cu9dd95f7hlrh0fvs46wpvhddrwgrqy63w5eyqqqqryqqqqthqqpyrzjqw8c7yfutqqy3kz8662fxutjvef7q2ujsxtt45csu0k688lkzu3lddrwgrqy63w5eyqqqqryqqqqthqqpysp53n0sc9hvqgdkrv4ppwrm2pa0gcysa8r2swjkrkjnxkcyrsjmxu4s9qypqsq5zvh7glzpas4l9ptxkdhgefyffkn8humq6amkrhrh2gq02gv8emxrynkwke3uwgf4cfevek89g4020lgldxgusmse79h4caqg30qq2cqmyrc7d" as EncodedPaymentRequest
-    const muunInvoice = decodeInvoice(muunRequest)
-    if (muunInvoice instanceof Error) throw muunInvoice
-    if (!muunInvoice.paymentAmount) throw new Error("No-amount Invoice")
-    expect(muunInvoice.paymentAmount.amount).toEqual(BigInt(sats))
+    const skippedPubkeyInvoice = decodeInvoice(skippedPubkeyRequest)
+    if (skippedPubkeyInvoice instanceof Error) throw skippedPubkeyInvoice
+    if (!skippedPubkeyInvoice.paymentAmount) throw new Error("No-amount Invoice")
+    expect(skippedPubkeyInvoice.paymentAmount.amount).toEqual(BigInt(sats))
 
     feeProbeCallsBefore = feeProbeCallCount()
-    const { result: feeMuun, error: errorMuun } =
+    const { result: feeSkippedPubkey, error: errorSkippedPubkey } =
       await Payments.getLightningFeeEstimationForBtcWallet({
         walletId: walletIdH,
-        uncheckedPaymentRequest: muunRequest,
+        uncheckedPaymentRequest: skippedPubkeyRequest,
       })
     expect(feeProbeCallCount()).toEqual(feeProbeCallsBefore)
-    expect(errorMuun).toBeUndefined()
-    expect(feeMuun).toStrictEqual(
-      LnFees().maxProtocolAndBankFee(muunInvoice.paymentAmount),
+    expect(errorSkippedPubkey).toBeUndefined()
+    expect(feeSkippedPubkey).toStrictEqual(
+      LnFees().maxProtocolAndBankFee(skippedPubkeyInvoice.paymentAmount),
     )
   })
 

--- a/test/unit/payments/payment-flow-builder.spec.ts
+++ b/test/unit/payments/payment-flow-builder.spec.ts
@@ -13,7 +13,7 @@ import { ValidationError, WalletCurrency } from "@domain/shared"
 const skippedPubkey =
   "038f8f113c580048d847d6949371726653e02b928196bad310e3eda39ff61723f6" as Pubkey
 const skippedChanId = "1x0x0" as ChanId
-const flagged = { pubkey: [skippedPubkey], chanId: [skippedChanId] }
+const skipProbe = { pubkey: [skippedPubkey], chanId: [skippedChanId] }
 
 describe("LightningPaymentFlowBuilder", () => {
   const paymentRequestWithAmount =
@@ -150,7 +150,7 @@ describe("LightningPaymentFlowBuilder", () => {
   describe("ln initiated, ln settled", () => {
     const lightningBuilder = LightningPaymentFlowBuilder({
       localNodeIds: [],
-      flagged,
+      skipProbe,
     })
     const checkSettlementMethod = (payment) => {
       expect(payment).toEqual(
@@ -200,7 +200,7 @@ describe("LightningPaymentFlowBuilder", () => {
           )
         }
 
-        it("sets 'skipProbe' property to true for flagged destination invoice", async () => {
+        it("sets 'skipProbe' property to true for skipProbe destination invoice", async () => {
           const skippedPubkeyBuilder =
             await withSkippedPubkeyBtcWalletBuilder.withConversion({
               mid,
@@ -519,7 +519,7 @@ describe("LightningPaymentFlowBuilder", () => {
   describe("ln initiated, intraledger settled", () => {
     const intraledgerBuilder = LightningPaymentFlowBuilder({
       localNodeIds: [invoiceWithAmount.destination, invoiceWithNoAmount.destination],
-      flagged,
+      skipProbe,
     })
     const checkSettlementMethod = (payment) => {
       expect(payment).toEqual(
@@ -996,7 +996,7 @@ describe("LightningPaymentFlowBuilder", () => {
   describe("intraledger initiated, intraledger settled", () => {
     const intraledgerBuilder = LightningPaymentFlowBuilder({
       localNodeIds: [],
-      flagged,
+      skipProbe,
     })
     const checkSettlementMethod = (payment) => {
       expect(payment).toEqual(
@@ -1256,7 +1256,7 @@ describe("LightningPaymentFlowBuilder", () => {
       it("returns a ValidationError", async () => {
         const payment = await LightningPaymentFlowBuilder({
           localNodeIds: [],
-          flagged,
+          skipProbe,
         })
           .withInvoice(invoiceWithNoAmount)
           .withSenderWallet(senderBtcWallet)
@@ -1275,7 +1275,7 @@ describe("LightningPaymentFlowBuilder", () => {
       it("returns a ValidationError", async () => {
         const payment = await LightningPaymentFlowBuilder({
           localNodeIds: [],
-          flagged,
+          skipProbe,
         })
           .withNoAmountInvoice({ invoice: invoiceWithNoAmount, uncheckedAmount: 0.4 })
           .withSenderWallet(senderBtcWallet)
@@ -1294,7 +1294,7 @@ describe("LightningPaymentFlowBuilder", () => {
       it("returns a ValidationError", async () => {
         const payment = await LightningPaymentFlowBuilder({
           localNodeIds: [],
-          flagged,
+          skipProbe,
         })
           .withNoAmountInvoice({ invoice: invoiceWithNoAmount, uncheckedAmount: 0 })
           .withSenderWallet(senderBtcWallet)
@@ -1313,7 +1313,7 @@ describe("LightningPaymentFlowBuilder", () => {
       it("returns InvalidLightningPaymentFlowBuilderStateError", async () => {
         const payment = await LightningPaymentFlowBuilder({
           localNodeIds: [invoiceWithAmount.destination],
-          flagged,
+          skipProbe,
         })
           .withInvoice(invoiceWithAmount)
           .withSenderWallet(senderBtcWallet)
@@ -1333,7 +1333,7 @@ describe("LightningPaymentFlowBuilder", () => {
       it("returns ImpossibleLightningPaymentFlowBuilderStateError", async () => {
         const payment = await LightningPaymentFlowBuilder({
           localNodeIds: [invoiceWithAmount.destination],
-          flagged,
+          skipProbe,
         })
           .withInvoice(invoiceWithAmount)
           .withSenderWallet(senderBtcWallet)
@@ -1353,7 +1353,7 @@ describe("LightningPaymentFlowBuilder", () => {
       it("returns ImpossibleLightningPaymentFlowBuilderStateError", async () => {
         const payment = await LightningPaymentFlowBuilder({
           localNodeIds: [invoiceWithNoAmount.destination],
-          flagged,
+          skipProbe,
         })
           .withNoAmountInvoice({ invoice: invoiceWithNoAmount, uncheckedAmount: 1000 })
           .withSenderWallet(senderBtcWallet)
@@ -1376,7 +1376,7 @@ describe("LightningPaymentFlowBuilder", () => {
       it("returns ImpossibleLightningPaymentFlowBuilderStateError", async () => {
         const payment = await LightningPaymentFlowBuilder({
           localNodeIds: [invoiceWithAmount.destination],
-          flagged,
+          skipProbe,
         })
           .withInvoice(invoiceWithAmount)
           .withSenderWallet(senderBtcWallet)


### PR DESCRIPTION
## Description

This is to address the issue where fee probes fail to Breez when an on-the-fly channel needs to be created for the end-user. Something we noticed is that these invoices have route hints where the non-existent channel's id is `1x0x0`. This PR is to add this heuristic to our code when deciding which fee probes to skip.

### Note

Breez's LSP has a solution for handling probes [here](https://github.com/breez/lspd#probing-support) where they ask that the payment hash included in the probe is formatted in a certain way. This would also help in the case where for e.g. the mobile app is offline, but this could potentially add significant complexity to our fee-probing logic and we still wouldn't be able to make the actual payment if the app is offline.