### PR TITLE
feat: add 'onChainUsdTxFeeAsBtcDenominated' query

### DIFF
--- a/src/graphql/main/queries.ts
+++ b/src/graphql/main/queries.ts
@@ -10,6 +10,7 @@ import RealtimePriceQuery from "@graphql/root/query/realtime-price"
 import MobileVersionsQuery from "@graphql/root/query/mobile-versions"
 import OnChainTxFeeQuery from "@graphql/root/query/on-chain-tx-fee-query"
 import OnChainUsdTxFeeQuery from "@graphql/root/query/on-chain-usd-tx-fee-query"
+import OnChainUsdTxFeeAsBtcDenominatedQuery from "@graphql/root/query/on-chain-usd-tx-fee-query-as-sats"
 import UsernameAvailableQuery from "@graphql/root/query/username-available"
 import BusinessMapMarkersQuery from "@graphql/root/query/business-map-markers"
 import AccountDefaultWalletQuery from "@graphql/root/query/account-default-wallet"
@@ -38,6 +39,7 @@ export const queryFields = {
     atWalletLevel: {
       onChainTxFee: OnChainTxFeeQuery,
       onChainUsdTxFee: OnChainUsdTxFeeQuery,
+      onChainUsdTxFeeAsBtcDenominated: OnChainUsdTxFeeAsBtcDenominatedQuery,
     },
   },
 } as const

--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -1019,6 +1019,12 @@ type Query {
     targetConfirmations: TargetConfirmations = 1
     walletId: WalletId!
   ): OnChainUsdTxFee!
+  onChainUsdTxFeeAsBtcDenominated(
+    address: OnChainAddress!
+    amount: SatAmount!
+    targetConfirmations: TargetConfirmations = 1
+    walletId: WalletId!
+  ): OnChainUsdTxFee!
   quizQuestions: [QuizQuestion]
     @deprecated(
       reason: "TODO: remove. we don't need a non authenticated version of this query. the users can only do the query while authenticated"

--- a/src/graphql/root/query/on-chain-usd-tx-fee-query-as-sats.ts
+++ b/src/graphql/root/query/on-chain-usd-tx-fee-query-as-sats.ts
@@ -1,0 +1,46 @@
+import { Wallets } from "@app"
+
+import { GT } from "@graphql/index"
+import { mapError } from "@graphql/error-map"
+
+import WalletId from "@graphql/types/scalar/wallet-id"
+import SatAmount from "@graphql/types/scalar/sat-amount"
+import OnChainAddress from "@graphql/types/scalar/on-chain-address"
+import TargetConfirmations from "@graphql/types/scalar/target-confirmations"
+
+import OnChainUsdTxFee from "@graphql/types/object/onchain-usd-tx-fee"
+
+import { normalizePaymentAmount } from "../mutation"
+
+const OnChainUsdTxFeeAsBtcDenominatedQuery = GT.Field({
+  type: GT.NonNull(OnChainUsdTxFee),
+  args: {
+    walletId: { type: GT.NonNull(WalletId) },
+    address: { type: GT.NonNull(OnChainAddress) },
+    amount: { type: GT.NonNull(SatAmount) },
+    targetConfirmations: { type: TargetConfirmations, defaultValue: 1 },
+  },
+  resolve: async (_, args, { domainAccount }) => {
+    const { walletId, address, amount, targetConfirmations } = args
+
+    for (const input of [walletId, address, amount, targetConfirmations]) {
+      if (input instanceof Error) throw input
+    }
+
+    const fee = await Wallets.getOnChainFeeForUsdWalletAndBtcAmount({
+      walletId,
+      account: domainAccount as Account,
+      amount,
+      address,
+      targetConfirmations,
+    })
+    if (fee instanceof Error) throw mapError(fee)
+
+    return {
+      amount: normalizePaymentAmount(fee).amount,
+      targetConfirmations,
+    }
+  },
+})
+
+export default OnChainUsdTxFeeAsBtcDenominatedQuery


### PR DESCRIPTION
## Description

Adds the complementary fee probe query for new `onChainUsdPaymentSendAsBtcDenominated` mutation in #2491 