### PR TITLE
fix: change usd internal calc verifyMaxFee

### DIFF
--- a/src/domain/payments/ln-fees.ts
+++ b/src/domain/payments/ln-fees.ts
@@ -45,12 +45,13 @@ export const LnFees = () => {
     priceRatio: WalletPriceRatio
     senderWalletCurrency: WalletCurrency
   }) => {
-    const calculatedMaxFeeAmount =
-      senderWalletCurrency === WalletCurrency.Btc
-        ? maxProtocolAndBankFee(btcPaymentAmount)
-        : priceRatio.convertFromUsd(
-            maxProtocolAndBankFee(priceRatio.convertFromBtc(btcPaymentAmount)),
-          )
+    let calculatedMaxFeeAmount = maxProtocolAndBankFee(btcPaymentAmount)
+    if (senderWalletCurrency === WalletCurrency.Usd) {
+      const usdAmount = priceRatio.convertFromBtc(btcPaymentAmount)
+      const maxFeeInUsd = maxProtocolAndBankFee(usdAmount)
+      calculatedMaxFeeAmount = priceRatio.convertFromUsd(maxFeeInUsd)
+    }
+
     const calculatedMinFeeAmount = priceRatio.convertFromUsd(ONE_CENT)
 
     if (

--- a/src/domain/payments/ln-fees.ts
+++ b/src/domain/payments/ln-fees.ts
@@ -45,8 +45,14 @@ export const LnFees = () => {
     priceRatio: WalletPriceRatio
     senderWalletCurrency: WalletCurrency
   }) => {
-    const calculatedMaxFeeAmount = maxProtocolAndBankFee(btcPaymentAmount)
+    const calculatedMaxFeeAmount =
+      senderWalletCurrency === WalletCurrency.Btc
+        ? maxProtocolAndBankFee(btcPaymentAmount)
+        : priceRatio.convertFromUsd(
+            maxProtocolAndBankFee(priceRatio.convertFromBtc(btcPaymentAmount)),
+          )
     const calculatedMinFeeAmount = priceRatio.convertFromUsd(ONE_CENT)
+
     if (
       (senderWalletCurrency === WalletCurrency.Btc ||
         maxFeeAmount.amount > calculatedMinFeeAmount.amount) &&

--- a/test/unit/domain/payments/ln-fees.spec.ts
+++ b/test/unit/domain/payments/ln-fees.spec.ts
@@ -40,112 +40,140 @@ describe("LnFees", () => {
     })
   })
 
-  describe("verifyMaxFee", () => {
-    const btc = {
-      amount: 871_652n,
-      currency: WalletCurrency.Btc,
-    }
-    const usd = {
-      amount: 24_346n,
-      currency: WalletCurrency.Usd,
-    }
+  const amountsToTest = [
+    // Original test case
+    {
+      btc: {
+        amount: 4995n,
+        currency: WalletCurrency.Btc,
+      },
+      usd: {
+        amount: 100n,
+        currency: WalletCurrency.Usd,
+      },
+    },
+    // Live prod error case #1
+    {
+      btc: {
+        amount: 871_652n,
+        currency: WalletCurrency.Btc,
+      },
+      usd: {
+        amount: 24_346n,
+        currency: WalletCurrency.Usd,
+      },
+    },
+    // Live prod error case #2 (fails in the same way as case #1, likely redundant)
+    {
+      btc: {
+        amount: 11140n,
+        currency: WalletCurrency.Btc,
+      },
+      usd: {
+        amount: 320n,
+        currency: WalletCurrency.Usd,
+      },
+    },
+  ]
+  for (const [i, { btc, usd }] of amountsToTest.entries()) {
+    describe(`verifyMaxFee - case #${i + 1}`, () => {
+      const priceRatio = WalletPriceRatio({ btc, usd })
+      if (priceRatio instanceof Error) throw priceRatio
 
-    const priceRatio = WalletPriceRatio({ btc, usd })
-    if (priceRatio instanceof Error) throw priceRatio
+      const validBtcMaxFeeToVerify = LnFees().maxProtocolAndBankFee(btc)
+      const validUsdMaxFeeInBtcToVerify = priceRatio.convertFromUsd(
+        LnFees().maxProtocolAndBankFee(usd),
+      )
 
-    const validBtcMaxFeeToVerify = LnFees().maxProtocolAndBankFee(btc)
-    const validUsdMaxFeeInBtcToVerify = priceRatio.convertFromUsd(
-      LnFees().maxProtocolAndBankFee(usd),
-    )
+      it("correctly verifies a valid Btc maxFee", () => {
+        expect(
+          LnFees().verifyMaxFee({
+            maxFeeAmount: validBtcMaxFeeToVerify,
+            btcPaymentAmount: btc,
+            priceRatio,
+            senderWalletCurrency: WalletCurrency.Btc,
+          }),
+        ).toBe(true)
+      })
 
-    it("correctly verifies a valid Btc maxFee", () => {
-      expect(
-        LnFees().verifyMaxFee({
-          maxFeeAmount: validBtcMaxFeeToVerify,
-          btcPaymentAmount: btc,
-          priceRatio,
-          senderWalletCurrency: WalletCurrency.Btc,
-        }),
-      ).toBe(true)
+      it("correctly verifies a valid Usd maxFee", () => {
+        expect(
+          LnFees().verifyMaxFee({
+            maxFeeAmount: validUsdMaxFeeInBtcToVerify,
+            btcPaymentAmount: btc,
+            priceRatio,
+            senderWalletCurrency: WalletCurrency.Usd,
+          }),
+        ).toBe(true)
+      })
+
+      it("correctly verifies 1 sat Btc payment", () => {
+        expect(
+          LnFees().verifyMaxFee({
+            maxFeeAmount: ONE_SAT,
+            btcPaymentAmount: ONE_SAT,
+            priceRatio,
+            senderWalletCurrency: WalletCurrency.Btc,
+          }),
+        ).toBe(true)
+      })
+
+      it("correctly verifies 1 sat Usd payment", () => {
+        expect(
+          LnFees().verifyMaxFee({
+            maxFeeAmount: priceRatio.convertFromUsd(ONE_CENT),
+            btcPaymentAmount: ONE_SAT,
+            priceRatio,
+            senderWalletCurrency: WalletCurrency.Usd,
+          }),
+        ).toBe(true)
+      })
+
+      it("fails for a large Btc maxFee", () => {
+        expect(
+          LnFees().verifyMaxFee({
+            maxFeeAmount: calc.add(validBtcMaxFeeToVerify, ONE_SAT),
+            btcPaymentAmount: btc,
+            priceRatio,
+            senderWalletCurrency: WalletCurrency.Btc,
+          }),
+        ).toBeInstanceOf(MaxFeeTooLargeForRoutelessPaymentError)
+      })
+
+      it("fails for a large Usd maxFee", () => {
+        expect(
+          LnFees().verifyMaxFee({
+            maxFeeAmount: calc.add(validUsdMaxFeeInBtcToVerify, ONE_SAT),
+            btcPaymentAmount: btc,
+            priceRatio,
+            senderWalletCurrency: WalletCurrency.Usd,
+          }),
+        ).toBeInstanceOf(MaxFeeTooLargeForRoutelessPaymentError)
+      })
+
+      it("fails for a 1 sat large Btc maxFee", () => {
+        expect(
+          LnFees().verifyMaxFee({
+            maxFeeAmount: calc.add(ONE_SAT, ONE_SAT),
+            btcPaymentAmount: ONE_SAT,
+            priceRatio,
+            senderWalletCurrency: WalletCurrency.Btc,
+          }),
+        ).toBeInstanceOf(MaxFeeTooLargeForRoutelessPaymentError)
+      })
+
+      it("fails for a 1 sat large Usd maxFee", () => {
+        expect(
+          LnFees().verifyMaxFee({
+            maxFeeAmount: calc.add(validUsdMaxFeeInBtcToVerify, ONE_SAT),
+            btcPaymentAmount: ONE_SAT,
+            priceRatio,
+            senderWalletCurrency: WalletCurrency.Usd,
+          }),
+        ).toBeInstanceOf(MaxFeeTooLargeForRoutelessPaymentError)
+      })
     })
-
-    it("correctly verifies a valid Usd maxFee", () => {
-      expect(
-        LnFees().verifyMaxFee({
-          maxFeeAmount: validUsdMaxFeeInBtcToVerify,
-          btcPaymentAmount: btc,
-          priceRatio,
-          senderWalletCurrency: WalletCurrency.Usd,
-        }),
-      ).toBe(true)
-    })
-
-    it("correctly verifies 1 sat Btc payment", () => {
-      expect(
-        LnFees().verifyMaxFee({
-          maxFeeAmount: ONE_SAT,
-          btcPaymentAmount: ONE_SAT,
-          priceRatio,
-          senderWalletCurrency: WalletCurrency.Btc,
-        }),
-      ).toBe(true)
-    })
-
-    it("correctly verifies 1 sat Usd payment", () => {
-      expect(
-        LnFees().verifyMaxFee({
-          maxFeeAmount: priceRatio.convertFromUsd(ONE_CENT),
-          btcPaymentAmount: ONE_SAT,
-          priceRatio,
-          senderWalletCurrency: WalletCurrency.Usd,
-        }),
-      ).toBe(true)
-    })
-
-    it("fails for a large Btc maxFee", () => {
-      expect(
-        LnFees().verifyMaxFee({
-          maxFeeAmount: calc.add(validBtcMaxFeeToVerify, ONE_SAT),
-          btcPaymentAmount: btc,
-          priceRatio,
-          senderWalletCurrency: WalletCurrency.Btc,
-        }),
-      ).toBeInstanceOf(MaxFeeTooLargeForRoutelessPaymentError)
-    })
-
-    it("fails for a large Usd maxFee", () => {
-      expect(
-        LnFees().verifyMaxFee({
-          maxFeeAmount: calc.add(validUsdMaxFeeInBtcToVerify, ONE_SAT),
-          btcPaymentAmount: btc,
-          priceRatio,
-          senderWalletCurrency: WalletCurrency.Usd,
-        }),
-      ).toBeInstanceOf(MaxFeeTooLargeForRoutelessPaymentError)
-    })
-
-    it("fails for a 1 sat large Btc maxFee", () => {
-      expect(
-        LnFees().verifyMaxFee({
-          maxFeeAmount: calc.add(ONE_SAT, ONE_SAT),
-          btcPaymentAmount: ONE_SAT,
-          priceRatio,
-          senderWalletCurrency: WalletCurrency.Btc,
-        }),
-      ).toBeInstanceOf(MaxFeeTooLargeForRoutelessPaymentError)
-    })
-
-    it("fails for a 1 sat large Usd maxFee", () => {
-      expect(
-        LnFees().verifyMaxFee({
-          maxFeeAmount: calc.add(validUsdMaxFeeInBtcToVerify, ONE_SAT),
-          btcPaymentAmount: ONE_SAT,
-          priceRatio,
-          senderWalletCurrency: WalletCurrency.Usd,
-        }),
-      ).toBeInstanceOf(MaxFeeTooLargeForRoutelessPaymentError)
-    })
-  })
+  }
 
   describe("feeFromRawRoute", () => {
     it("returns the feeFromRawRoute", () => {

--- a/test/unit/domain/payments/ln-fees.spec.ts
+++ b/test/unit/domain/payments/ln-fees.spec.ts
@@ -42,11 +42,11 @@ describe("LnFees", () => {
 
   describe("verifyMaxFee", () => {
     const btc = {
-      amount: 4995n,
+      amount: 871_652n,
       currency: WalletCurrency.Btc,
     }
     const usd = {
-      amount: 100n,
+      amount: 24_346n,
       currency: WalletCurrency.Usd,
     }
 

--- a/test/unit/domain/payments/ln-fees.spec.ts
+++ b/test/unit/domain/payments/ln-fees.spec.ts
@@ -1,4 +1,4 @@
-import { AmountCalculator, ONE_SAT, WalletCurrency } from "@domain/shared"
+import { AmountCalculator, ONE_CENT, ONE_SAT, WalletCurrency } from "@domain/shared"
 import { LnFees, WalletPriceRatio } from "@domain/payments"
 import { MaxFeeTooLargeForRoutelessPaymentError } from "@domain/bitcoin/lightning"
 
@@ -94,7 +94,7 @@ describe("LnFees", () => {
     it("correctly verifies 1 sat Usd payment", () => {
       expect(
         LnFees().verifyMaxFee({
-          maxFeeAmount: validUsdMaxFeeInBtcToVerify,
+          maxFeeAmount: priceRatio.convertFromUsd(ONE_CENT),
           btcPaymentAmount: ONE_SAT,
           priceRatio,
           senderWalletCurrency: WalletCurrency.Usd,


### PR DESCRIPTION
## Description

This fix changes the verifyMaxFee calc to mirror how payment flow gets to a max fee from a USD sender amount.