### PR TITLE
feat: export task span on cron process kill

### DIFF
--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -2,6 +2,8 @@ import { ValidationError, DomainError, ErrorLevel } from "./shared"
 
 export class InconsistentDataError extends DomainError {}
 
+export class OperationInterruptedError extends DomainError {}
+
 export class AuthorizationError extends DomainError {}
 
 export class RepositoryError extends DomainError {}

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -369,6 +369,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "LnPaymentPendingError":
     case "LnAlreadyPaidError":
     case "PaymentNotFoundError":
+    case "OperationInterruptedError":
     case "InconsistentDataError":
     case "AuthorizationError":
     case "RepositoryError":

--- a/src/servers/cron.ts
+++ b/src/servers/cron.ts
@@ -100,10 +100,10 @@ const main = async () => {
 
           // Same function reference must be passed to process.on & process.removeListener. Listeners
           // aren't removed if an anonymous function or different functions are used
-          const signalHandler = async () => {
-            const finishDelay = 1
+          const signalHandler = async (eventName: string) => {
+            const finishDelay = 1_000
 
-            logger.info(`Received SIGINT signal. Finishing span...`)
+            logger.info(`Received ${eventName} signal. Finishing span...`)
             span?.end()
             await sleep(finishDelay)
             logger.info(`Finished span after setTimeout '${finishDelay}'`)

--- a/src/servers/cron.ts
+++ b/src/servers/cron.ts
@@ -87,7 +87,7 @@ const main = async () => {
     extendSessions,
   ]
 
-  const PROCESS_KILL_EVENTS = ["SIGINT"]
+  const PROCESS_KILL_EVENTS = ["SIGTERM", "SIGINT"]
   for (const task of tasks) {
     try {
       logger.info(`starting ${task.name}`)

--- a/src/servers/cron.ts
+++ b/src/servers/cron.ts
@@ -101,7 +101,7 @@ const main = async () => {
           // Same function reference must be passed to process.on & process.removeListener. Listeners
           // aren't removed if an anonymous function or different functions are used
           const signalHandler = async (eventName: string) => {
-            const finishDelay = 1_000
+            const finishDelay = 5_000
 
             logger.info(`Received ${eventName} signal. Finishing span...`)
             span?.end()

--- a/src/servers/cron.ts
+++ b/src/servers/cron.ts
@@ -111,10 +111,6 @@ const main = async () => {
 
           // Alway remove listener on loop continue, else signalHandler will target incorrect span
           try {
-            if (task.name === "extendSessions") {
-              console.log("Sleeping...")
-              await sleep(30_000)
-            }
             const res = await task()
 
             process.removeListener("SIGINT", signalHandler)

--- a/src/services/tracing.ts
+++ b/src/services/tracing.ts
@@ -230,6 +230,7 @@ export const addAttributesToCurrentSpan = (attributes: Attributes) => {
       }
     }
   }
+  return span
 }
 
 export const addEventToCurrentSpan = (


### PR DESCRIPTION
## Description

This PR is a continuation of efforts from #2503 to track if a cron task has timed out via an external process kill. It consists of two parts:
- adding the `jobCompleted` attribute to the span and only setting to true when the task has either completed or errored
- adding process listeners to export the current span if the process has been killed prematurely with `activeDeadlineSeconds` from k8s. The SIGTERM listener should allow for span flush and [graceful shutdown](https://cloud.google.com/blog/products/containers-kubernetes/kubernetes-best-practices-terminating-with-grace).