### PR TITLE
feat: add expired to invoice status

### DIFF
--- a/src/app/lightning/payment-status-checker.ts
+++ b/src/app/lightning/payment-status-checker.ts
@@ -6,10 +6,12 @@ export const PaymentStatusChecker = async (uncheckedPaymentRequest: string) => {
   const decodedInvoice = decodeInvoice(uncheckedPaymentRequest)
   if (decodedInvoice instanceof Error) return decodedInvoice
 
-  const { paymentHash } = decodedInvoice
+  const { paymentHash, expiresAt, isExpired } = decodedInvoice
 
   return {
     paymentHash,
+    expiresAt,
+    isExpired,
     invoiceIsPaid: async (): Promise<boolean | RepositoryError> => {
       const ledger = LedgerService()
       const recorded = await ledger.isLnTxRecorded(paymentHash)

--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -382,6 +382,7 @@ input IntraLedgerUsdPaymentSendInput {
 }
 
 enum InvoicePaymentStatus {
+  EXPIRED
   PAID
   PENDING
 }

--- a/src/graphql/root/query/ln-invoice-payment-status.ts
+++ b/src/graphql/root/query/ln-invoice-payment-status.ts
@@ -22,7 +22,8 @@ const LnInvoicePaymentStatusQuery = GT.Field({
 
     if (paid) return { errors: [], status: "PAID" }
 
-    return { errors: [], status: "PENDING" }
+    const status = paymentStatusChecker.isExpired ? "EXPIRED" : "PENDING"
+    return { errors: [], status }
   },
 })
 

--- a/src/graphql/types/scalar/invoice-payment-status.ts
+++ b/src/graphql/types/scalar/invoice-payment-status.ts
@@ -5,6 +5,7 @@ const InvoicePaymentStatus = GT.Enum({
   values: {
     PENDING: {},
     PAID: {},
+    EXPIRED: {},
   },
 })
 

--- a/test/e2e/servers/graphql-main-server/galoy-pay-testing.spec.ts
+++ b/test/e2e/servers/graphql-main-server/galoy-pay-testing.spec.ts
@@ -3,6 +3,8 @@ import crypto from "crypto"
 import { ApolloClient, NormalizedCacheObject } from "@apollo/client/core"
 import { toSats } from "@domain/bitcoin"
 
+import { sleep } from "@utils"
+
 import LN_INVOICE_CREATE_ON_BEHALF_OF from "./mutations/ln-invoice-create-on-behalf-of-recipient.gql"
 import LN_INVOICE_PAYMENT_SEND from "./mutations/ln-invoice-payment-send.gql"
 import LN_NO_AMOUNT_INVOICE_CREATE_ON_BEHALF_OF from "./mutations/ln-no-amount-invoice-create-on-behalf-of-recipient.gql"
@@ -230,6 +232,8 @@ describe("galoy-pay", () => {
         variables: { input: makePaymentInput },
       })
       expect(makePayment.data.lnInvoicePaymentSend.status).toEqual("SUCCESS")
+
+      sleep(3000)
 
       const result = (await promisifiedSubscription(subscription)) as { data }
 


### PR DESCRIPTION
Add EXPIRED to InvoicePaymentStatus, this is required in galoy pay to give feedback to the user specially for USD invoices (when default wallet is stablesats)