### PR TITLE
fix: add timeout to getPayment

### DIFF
--- a/src/domain/bitcoin/lightning/errors.ts
+++ b/src/domain/bitcoin/lightning/errors.ts
@@ -42,6 +42,9 @@ export class ProbeForRouteTimedOutFromApplicationError extends LightningServiceE
 export class PaymentInTransitionError extends LightningServiceError {}
 export class TemporaryChannelFailureError extends LightningServiceError {}
 export class DestinationMissingDependentFeatureError extends LightningServiceError {}
+export class LookupPaymentTimedOutError extends LightningServiceError {
+  level = ErrorLevel.Critical
+}
 export class InvalidFeeProbeStateError extends LightningServiceError {
   level = ErrorLevel.Critical
 }

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -491,6 +491,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "BigIntFloatConversionError":
     case "SafeWrapperError":
     case "InvalidFeeProbeStateError":
+    case "LookupPaymentTimedOutError":
     case "InvalidPubKeyError":
     case "SkipProbeForPubkeyError":
     case "SecretDoesNotMatchAnyExistingHodlInvoiceError":


### PR DESCRIPTION
lightning library stuck when trackpayment response does not have a HTLC (lnd error). this is an issue in cron because it get stuck and is killed by timeout

ref: https://github.com/alexbosworth/lightning/issues/133