### PR TITLE
fix: update tracing service and trigger record errors properly

### DIFF
--- a/src/app/accounts/active-accounts.ts
+++ b/src/app/accounts/active-accounts.ts
@@ -34,7 +34,7 @@ export const getRecentlyActiveAccounts = async function* ():
     const wallets = await WalletsRepository().listByAccountId(account.id)
     if (wallets instanceof Error) {
       recordExceptionInCurrentSpan({
-        error: "impossible to listByAccountId",
+        error: wallets,
         level: ErrorLevel.Critical,
         attributes: { account: account.id },
       })
@@ -44,7 +44,7 @@ export const getRecentlyActiveAccounts = async function* ():
     const isActive = await activityChecker.aboveThreshold(wallets)
     if (isActive instanceof Error) {
       recordExceptionInCurrentSpan({
-        error: "impossible to get aboveThreshold value",
+        error: isActive,
         level: ErrorLevel.Critical,
         attributes: { account: account.id, wallets: JSON.stringify(wallets) },
       })

--- a/src/app/accounts/update-account-ip.ts
+++ b/src/app/accounts/update-account-ip.ts
@@ -76,7 +76,7 @@ export const updateAccountIPsInfo = async ({
 
     if (ipFetcherInfo instanceof IpFetcherServiceError) {
       recordExceptionInCurrentSpan({
-        error: ipFetcherInfo.message,
+        error: ipFetcherInfo,
         level: ErrorLevel.Warn,
         attributes: {
           ip,
@@ -103,9 +103,9 @@ export const updateAccountIPsInfo = async ({
       ipFetcherInfo.proxy === undefined ||
       !ipFetcherInfo.asn
     ) {
-      const error = `missing mandatory fields. isoCode: ${ipFetcherInfo.isoCode}, proxy: ${ipFetcherInfo.proxy}, asn: ${ipFetcherInfo.asn}`
+      const errorMsg = `missing mandatory fields. isoCode: ${ipFetcherInfo.isoCode}, proxy: ${ipFetcherInfo.proxy}, asn: ${ipFetcherInfo.asn}`
       recordExceptionInCurrentSpan({
-        error,
+        error: new IpFetcherServiceError(errorMsg),
         level: ErrorLevel.Warn,
         attributes: {
           ip,

--- a/src/app/auth/index.ts
+++ b/src/app/auth/index.ts
@@ -7,6 +7,7 @@ import { extendSession, IdentityRepository } from "@services/kratos"
 
 // TODO: interface/type should be reworked so that it doesn't have to come from private
 import { listSessionsInternal } from "@services/kratos/private"
+import { ExtendSessionKratosError } from "@services/kratos/errors"
 import {
   recordExceptionInCurrentSpan,
   addAttributesToCurrentSpan,
@@ -39,7 +40,7 @@ export const extendSessions = async (
     const sessions = await listSessionsInternal(user.id)
     if (sessions instanceof Error) {
       recordExceptionInCurrentSpan({
-        error: "impossible to get session",
+        error: sessions,
         level: ErrorLevel.Info,
         attributes: { user: user.id, phone: user.phone },
       })
@@ -52,7 +53,7 @@ export const extendSessions = async (
       if (hasExtended instanceof Error) {
         countOfExtendedSessionErrors++
         recordExceptionInCurrentSpan({
-          error: "impossible to extend session",
+          error: new ExtendSessionKratosError("impossible to extend session"),
           level: ErrorLevel.Info,
           attributes: { user: user.id, phone: user.phone },
         })

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -546,6 +546,8 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "UnknownBigIntConversionError":
     case "KratosError":
     case "AuthenticationKratosError":
+    case "ExtendSessionKratosError":
+    case "MissingCreatedAtKratosError":
     case "MissingExpiredAtKratosError":
     case "MissingTotpKratosError":
     case "IncompatibleSchemaUpgradeError":

--- a/src/servers/errors.ts
+++ b/src/servers/errors.ts
@@ -1,0 +1,3 @@
+import { DomainError } from "@domain/shared"
+
+export class SubscriptionInterruptedError extends DomainError {}

--- a/src/servers/trigger.ts
+++ b/src/servers/trigger.ts
@@ -55,6 +55,7 @@ import { activateLndHealthCheck, lndStatusEvent } from "@services/lnd/health"
 import { recordExceptionInCurrentSpan, wrapAsyncToRunInSpan } from "@services/tracing"
 
 import healthzHandler from "./middlewares/healthz"
+import { SubscriptionInterruptedError } from "./errors"
 
 const redisCache = RedisCacheService()
 const logger = baseLogger.child({ module: "trigger" })
@@ -319,7 +320,7 @@ const listenerOnchain = (lnd: AuthenticatedLnd) => {
   subTransactions.on("error", (err) => {
     baseLogger.error({ err }, "error subTransactions")
     recordExceptionInCurrentSpan({
-      error: err,
+      error: new SubscriptionInterruptedError((err && err.message) || "subTransactions"),
       level: ErrorLevel.Warn,
       attributes: { ["error.subscription"]: "subTransactions" },
     })
@@ -337,7 +338,7 @@ const listenerOnchain = (lnd: AuthenticatedLnd) => {
   subBlocks.on("error", (err) => {
     baseLogger.error({ err }, "error subBlocks")
     recordExceptionInCurrentSpan({
-      error: err,
+      error: new SubscriptionInterruptedError((err && err.message) || "subBlocks"),
       level: ErrorLevel.Warn,
       attributes: { ["error.subscription"]: "subBlocks" },
     })
@@ -370,9 +371,9 @@ const listenerHodlInvoice = ({
   subInvoice.on("error", (err) => {
     baseLogger.info({ err }, "error subChannels")
     recordExceptionInCurrentSpan({
-      error: err,
+      error: new SubscriptionInterruptedError((err && err.message) || "subInvoice"),
       level: ErrorLevel.Warn,
-      attributes: { ["error.subscription"]: "subChannels" },
+      attributes: { ["error.subscription"]: "subInvoice" },
     })
     subInvoice.removeAllListeners()
   })
@@ -440,7 +441,7 @@ export const setupInvoiceSubscribe = ({
   subInvoices.on("error", (err) => {
     baseLogger.info({ err }, "error subInvoices")
     recordExceptionInCurrentSpan({
-      error: err,
+      error: new SubscriptionInterruptedError((err && err.message) || "subInvoices"),
       level: ErrorLevel.Warn,
       attributes: { ["error.subscription"]: "subInvoices" },
     })
@@ -465,7 +466,7 @@ const listenerOffchain = ({ lnd, pubkey }: { lnd: AuthenticatedLnd; pubkey: Pubk
   subChannels.on("error", (err) => {
     baseLogger.info({ err }, "error subChannels")
     recordExceptionInCurrentSpan({
-      error: err,
+      error: new SubscriptionInterruptedError((err && err.message) || "subChannels"),
       level: ErrorLevel.Warn,
       attributes: { ["error.subscription"]: "subChannels" },
     })
@@ -484,7 +485,7 @@ const listenerOffchain = ({ lnd, pubkey }: { lnd: AuthenticatedLnd; pubkey: Pubk
   subBackups.on("error", (err) => {
     baseLogger.info({ err }, "error subBackups")
     recordExceptionInCurrentSpan({
-      error: err,
+      error: new SubscriptionInterruptedError((err && err.message) || "subBackups"),
       level: ErrorLevel.Warn,
       attributes: { ["error.subscription"]: "subBackups" },
     })

--- a/src/services/dealer-price/dealer-price.ts
+++ b/src/services/dealer-price/dealer-price.ts
@@ -17,7 +17,7 @@ import { defaultTimeToExpiryInSeconds } from "@domain/bitcoin/lightning"
 
 import { toWalletPriceRatio } from "@domain/payments"
 
-import { wrapToAddAttributes } from "@services/tracing"
+import { wrapAsyncFunctionsToRunInSpan } from "@services/tracing"
 
 import { baseLogger } from "../logger"
 
@@ -253,8 +253,9 @@ export const DealerPriceService = (
     }
   }
 
-  return wrapToAddAttributes({
-    attributes: { ["slo.dealerCalled"]: "true" },
+  return wrapAsyncFunctionsToRunInSpan({
+    namespace: "services.dealer-price",
+    spanAttributes: { ["slo.dealerCalled"]: "true" },
     fns: {
       getCentsFromSatsForImmediateBuy,
       getCentsFromSatsForImmediateSell,

--- a/src/services/kratos/errors.ts
+++ b/src/services/kratos/errors.ts
@@ -3,6 +3,11 @@ import { ErrorLevel } from "@domain/shared"
 
 export class KratosError extends AuthenticationError {}
 export class AuthenticationKratosError extends KratosError {}
+export class ExtendSessionKratosError extends KratosError {}
+
+export class MissingCreatedAtKratosError extends KratosError {
+  level = ErrorLevel.Critical
+}
 
 export class MissingExpiredAtKratosError extends KratosError {
   level = ErrorLevel.Critical

--- a/src/services/kratos/private.ts
+++ b/src/services/kratos/private.ts
@@ -4,7 +4,11 @@ import { ErrorLevel } from "@domain/shared"
 import { Configuration, FrontendApi, IdentityApi } from "@ory/client"
 import { recordExceptionInCurrentSpan } from "@services/tracing"
 
-import { MissingExpiredAtKratosError, UnknownKratosError } from "./errors"
+import {
+  MissingCreatedAtKratosError,
+  MissingExpiredAtKratosError,
+  UnknownKratosError,
+} from "./errors"
 
 const { publicApi, adminApi } = getKratosConfig()
 
@@ -28,7 +32,9 @@ export const toDomainIdentityPhone = (identity: KratosIdentity): IdentityPhone =
     createdAt = new Date(identity.created_at)
   } else {
     recordExceptionInCurrentSpan({
-      error: "createdAt should always be set? type approximation from kratos",
+      error: new MissingCreatedAtKratosError(
+        "createdAt should always be set? type approximation from kratos",
+      ),
       level: ErrorLevel.Critical,
     })
     createdAt = new Date()
@@ -49,6 +55,6 @@ export const listSessionsInternal = async (
     if (res.data === null) return []
     return res.data
   } catch (err) {
-    return new UnknownKratosError(err)
+    return new UnknownKratosError(err.message || err)
   }
 }

--- a/src/services/notifications/push-notifications.ts
+++ b/src/services/notifications/push-notifications.ts
@@ -49,7 +49,7 @@ const sendToDevice = async (
     response.results.forEach((item) => {
       if (item?.error?.message) {
         recordExceptionInCurrentSpan({
-          error: item.error.message,
+          error: new InvalidDeviceNotificationsServiceError(item.error.message),
           level: ErrorLevel.Info,
         })
       }
@@ -84,13 +84,10 @@ const sendToDevice = async (
 
     return true
   } catch (err) {
-    recordExceptionInCurrentSpan({
-      error: err.message,
-      level: ErrorLevel.Warn,
-    })
-
     logger.error({ err, tokens, message }, "impossible to send notification")
-    return handleCommonNotificationErrors(err)
+    const error = handleCommonNotificationErrors(err)
+    recordExceptionInCurrentSpan({ error, level: ErrorLevel.Warn })
+    return error
   }
 }
 


### PR DESCRIPTION
Fix crash in trigger because of invalid error reported by subscription + remove `// @ts-nocheck` from tracing service

```
/app/lib/services/tracing.js:207
        span.setAttribute("error.name", exception["name"]);
                                                 ^

TypeError: Cannot read properties of undefined (reading 'name')
    at recordException (/app/lib/services/tracing.js:207:50)
    at recordExceptionInCurrentSpan (/app/lib/services/tracing.js:193:5)
    at EventEmitter.<anonymous> (/app/lib/servers/trigger.js:354:52)
    at EventEmitter.emit (node:events:513:28)
    at finished (/app/node_modules/lightning/lnd_methods/invoices/subscribe_to_invoices.js:106:22)
    at ClientReadableStreamImpl.<anonymous> (/app/node_modules/lightning/lnd_methods/invoices/subscribe_to_invoices.js:158:34)
    at /app/node_modules/@opentelemetry/context-async-hooks/build/src/AbstractAsyncHooksContextManager.js:50:55
    at AsyncLocalStorage.run (node:async_hooks:330:14)
    at AsyncLocalStorageContextManager.with (/app/node_modules/@opentelemetry/context-async-hooks/build/src/AsyncLocalStorageContextManager.js:33:40)
    at ClientReadableStreamImpl.contextWrapper (/app/node_modules/@opentelemetry/context-async-hooks/build/src/AbstractAsyncHooksContextManager.js:50:32)
```