### PR TITLE
chore: randomly assign default wallet currencies

### DIFF
--- a/galoy.yaml
+++ b/galoy.yaml
@@ -126,6 +126,7 @@ accounts:
   initialStatus: active
   initialWallets:
     - BTC
+  randomizeDefaultWallet: false
 accountLimits:
   withdrawal:
     level:

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -385,12 +385,14 @@ export const configSchema = {
             enum: Object.values(WalletCurrency),
           },
         },
+        randomizeDefaultWallet: { type: "boolean" },
       },
       required: ["initialStatus", "initialWallets"],
       additionalProperties: false,
       default: {
         initialStatus: "active",
         initialWallets: ["BTC"],
+        randomizeDefaultWallet: false,
       },
     },
     accountLimits: {

--- a/src/config/schema.types.d.ts
+++ b/src/config/schema.types.d.ts
@@ -79,6 +79,7 @@ type YamlSchema = {
   accounts: {
     initialStatus: string
     initialWallets: WalletCurrency[]
+    randomizeDefaultWallet: boolean
   }
   accountLimits: {
     withdrawal: AccountLimitsConfig

--- a/src/config/types.d.ts
+++ b/src/config/types.d.ts
@@ -28,4 +28,5 @@ type ApolloConfig = {
 type AccountsConfig = {
   initialStatus: AccountStatus
   initialWallets: WalletCurrency[]
+  randomizeDefaultWallet?: boolean
 }

--- a/src/config/yaml.ts
+++ b/src/config/yaml.ts
@@ -320,6 +320,7 @@ export const getRewardsConfig = () => {
 export const getDefaultAccountsConfig = (config = yamlConfig): AccountsConfig => ({
   initialStatus: config.accounts.initialStatus as AccountStatus,
   initialWallets: config.accounts.initialWallets,
+  randomizeDefaultWallet: config.accounts.randomizeDefaultWallet,
 })
 
 export const getSwapConfig = (): SwapConfig => {

--- a/test/helpers/user.ts
+++ b/test/helpers/user.ts
@@ -113,14 +113,26 @@ export const createUserAndWalletFromUserRef = async (ref: string) => {
   await createUserAndWallet(entry)
 }
 
-export const createAccount = async (initialWallets: WalletCurrency[]) => {
+export const createAccount = async ({
+  initialWallets,
+  userId,
+  randomizeDefaultWallet,
+}: {
+  initialWallets: WalletCurrency[]
+  userId?: UserId
+  randomizeDefaultWallet?: boolean
+}) => {
   const phone = randomPhone()
 
-  const kratosUserId = randomUserId()
+  const kratosUserId = userId || randomUserId()
 
   const account = await Accounts.createAccountWithPhoneIdentifier({
     newAccountInfo: { phone, kratosUserId },
-    config: { initialStatus: AccountStatus.Active, initialWallets },
+    config: {
+      initialStatus: AccountStatus.Active,
+      initialWallets,
+      randomizeDefaultWallet,
+    },
   })
   if (account instanceof Error) throw account
 

--- a/test/integration/app/users/user-wallets.spec.ts
+++ b/test/integration/app/users/user-wallets.spec.ts
@@ -10,7 +10,9 @@ describe("Users - wallets", () => {
     it("adds a USD wallet for new user if config is set to true", async () => {
       const initialWallets = [WalletCurrency.Btc, WalletCurrency.Usd]
 
-      let account: Account | RepositoryError = await createAccount(initialWallets)
+      let account: Account | RepositoryError = await createAccount({
+        initialWallets,
+      })
 
       // Check all wallets were created
       const wallets = await WalletsRepository().listByAccountId(account.id)
@@ -36,7 +38,9 @@ describe("Users - wallets", () => {
     it("does not add a USD wallet for new user if config is set to false", async () => {
       const initialWallets = [WalletCurrency.Btc]
 
-      let account: Account | RepositoryError = await createAccount(initialWallets)
+      let account: Account | RepositoryError = await createAccount({
+        initialWallets,
+      })
 
       // Check all wallets were created
       const wallets = await WalletsRepository().listByAccountId(account.id)
@@ -62,7 +66,9 @@ describe("Users - wallets", () => {
     it("sets USD wallet as default if BTC wallet does not exist", async () => {
       const initialWallets = [WalletCurrency.Usd]
 
-      let account: Account | RepositoryError = await createAccount(initialWallets)
+      let account: Account | RepositoryError = await createAccount({
+        initialWallets,
+      })
 
       // Check all wallets were created
       const wallets = await WalletsRepository().listByAccountId(account.id)
@@ -83,6 +89,48 @@ describe("Users - wallets", () => {
         throw new Error(`${WalletCurrency.Usd} wallet not found`)
       }
       expect(account.defaultWalletId).toEqual(usdWallet.id)
+    })
+
+    it("sets default wallet to USD if randomizeDefaultWallet is true and userId is odd", async () => {
+      const initialWallets = [WalletCurrency.Btc, WalletCurrency.Usd]
+
+      const account: Account | RepositoryError = await createAccount({
+        initialWallets,
+        userId: "660be61b-1e34-4f33-ba9f-764c17949381" as UserId,
+        randomizeDefaultWallet: true,
+      })
+
+      const wallets = await WalletsRepository().listByAccountId(account.id)
+      if (wallets instanceof Error) throw wallets
+
+      const usdWallet = wallets.filter(
+        (wallet) => wallet.currency === WalletCurrency.Usd,
+      )[0]
+      if (usdWallet === undefined) {
+        throw new Error(`${WalletCurrency.Usd} wallet not found`)
+      }
+      expect(account.defaultWalletId).toEqual(usdWallet.id)
+    })
+
+    it("sets default wallet to BTC if randomizeDefaultWallet is true and userId is even", async () => {
+      const initialWallets = [WalletCurrency.Btc, WalletCurrency.Usd]
+
+      const account: Account | RepositoryError = await createAccount({
+        initialWallets,
+        userId: "660be61b-1e34-4f33-ba9f-764c17949380" as UserId,
+        randomizeDefaultWallet: true,
+      })
+
+      const wallets = await WalletsRepository().listByAccountId(account.id)
+      if (wallets instanceof Error) throw wallets
+
+      const btcWallet = wallets.filter(
+        (wallet) => wallet.currency === WalletCurrency.Btc,
+      )[0]
+      if (btcWallet === undefined) {
+        throw new Error(`${WalletCurrency.Btc} wallet not found`)
+      }
+      expect(account.defaultWalletId).toEqual(btcWallet.id)
     })
   })
 


### PR DESCRIPTION
- if userId is an even number assign BTC default wallet, otherwise assign USD
- this will be used as part of an A/B test to analyze retention and spending for different default currencies