### PR TITLE
fix: pass in usd amount to verifyFee explicitly

### DIFF
--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -666,6 +666,7 @@ const executePaymentViaLn = async ({
       const maxFeeCheckArgs = {
         maxFeeAmount: paymentFlow.btcProtocolAndBankFee,
         btcPaymentAmount: paymentFlow.btcPaymentAmount,
+        usdPaymentAmount: paymentFlow.usdPaymentAmount,
         priceRatio: walletPriceRatio,
         senderWalletCurrency: paymentFlow.senderWalletDescriptor().currency,
       }

--- a/src/domain/payments/ln-fees.ts
+++ b/src/domain/payments/ln-fees.ts
@@ -37,18 +37,19 @@ export const LnFees = () => {
   const verifyMaxFee = ({
     maxFeeAmount,
     btcPaymentAmount,
+    usdPaymentAmount,
     priceRatio,
     senderWalletCurrency,
   }: {
     maxFeeAmount: BtcPaymentAmount
     btcPaymentAmount: BtcPaymentAmount
+    usdPaymentAmount: UsdPaymentAmount
     priceRatio: WalletPriceRatio
     senderWalletCurrency: WalletCurrency
   }) => {
     let calculatedMaxFeeAmount = maxProtocolAndBankFee(btcPaymentAmount)
     if (senderWalletCurrency === WalletCurrency.Usd) {
-      const usdAmount = priceRatio.convertFromBtc(btcPaymentAmount)
-      const maxFeeInUsd = maxProtocolAndBankFee(usdAmount)
+      const maxFeeInUsd = maxProtocolAndBankFee(usdPaymentAmount)
       calculatedMaxFeeAmount = priceRatio.convertFromUsd(maxFeeInUsd)
     }
 
@@ -62,7 +63,9 @@ export const LnFees = () => {
       return new MaxFeeTooLargeForRoutelessPaymentError(
         JSON.stringify({
           btcPaymentAmount: Number(btcPaymentAmount.amount),
+          usdPaymentAmount: Number(usdPaymentAmount.amount),
           maxFeeBtcAmount: Number(maxFeeAmount.amount),
+          senderWalletCurrency: senderWalletCurrency,
           calculatedMaxFeeBtcAmount: Number(calculatedMaxFeeAmount.amount),
         }),
       )

--- a/test/unit/domain/payments/ln-fees.spec.ts
+++ b/test/unit/domain/payments/ln-fees.spec.ts
@@ -90,6 +90,7 @@ describe("LnFees", () => {
           LnFees().verifyMaxFee({
             maxFeeAmount: validBtcMaxFeeToVerify,
             btcPaymentAmount: btc,
+            usdPaymentAmount: usd,
             priceRatio,
             senderWalletCurrency: WalletCurrency.Btc,
           }),
@@ -101,6 +102,7 @@ describe("LnFees", () => {
           LnFees().verifyMaxFee({
             maxFeeAmount: validUsdMaxFeeInBtcToVerify,
             btcPaymentAmount: btc,
+            usdPaymentAmount: usd,
             priceRatio,
             senderWalletCurrency: WalletCurrency.Usd,
           }),
@@ -112,6 +114,7 @@ describe("LnFees", () => {
           LnFees().verifyMaxFee({
             maxFeeAmount: ONE_SAT,
             btcPaymentAmount: ONE_SAT,
+            usdPaymentAmount: ONE_CENT,
             priceRatio,
             senderWalletCurrency: WalletCurrency.Btc,
           }),
@@ -123,6 +126,7 @@ describe("LnFees", () => {
           LnFees().verifyMaxFee({
             maxFeeAmount: priceRatio.convertFromUsd(ONE_CENT),
             btcPaymentAmount: ONE_SAT,
+            usdPaymentAmount: ONE_CENT,
             priceRatio,
             senderWalletCurrency: WalletCurrency.Usd,
           }),
@@ -134,6 +138,7 @@ describe("LnFees", () => {
           LnFees().verifyMaxFee({
             maxFeeAmount: calc.add(validBtcMaxFeeToVerify, ONE_SAT),
             btcPaymentAmount: btc,
+            usdPaymentAmount: usd,
             priceRatio,
             senderWalletCurrency: WalletCurrency.Btc,
           }),
@@ -145,6 +150,7 @@ describe("LnFees", () => {
           LnFees().verifyMaxFee({
             maxFeeAmount: calc.add(validUsdMaxFeeInBtcToVerify, ONE_SAT),
             btcPaymentAmount: btc,
+            usdPaymentAmount: usd,
             priceRatio,
             senderWalletCurrency: WalletCurrency.Usd,
           }),
@@ -156,6 +162,7 @@ describe("LnFees", () => {
           LnFees().verifyMaxFee({
             maxFeeAmount: calc.add(ONE_SAT, ONE_SAT),
             btcPaymentAmount: ONE_SAT,
+            usdPaymentAmount: ONE_CENT,
             priceRatio,
             senderWalletCurrency: WalletCurrency.Btc,
           }),
@@ -167,6 +174,7 @@ describe("LnFees", () => {
           LnFees().verifyMaxFee({
             maxFeeAmount: calc.add(validUsdMaxFeeInBtcToVerify, ONE_SAT),
             btcPaymentAmount: ONE_SAT,
+            usdPaymentAmount: ONE_CENT,
             priceRatio,
             senderWalletCurrency: WalletCurrency.Usd,
           }),


### PR DESCRIPTION
## Description

This is to remove any potential inconsistencies from trying to calculate this from the price ratio. For context, the max fees in the verifyMaxFee function should follow how these values are calculated in payment-flow-builder. See [traces](https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/sqBQjaLEDJV).