### PR TITLE
fix: verifyMaxFee when usd send is calculated from btc amount

### DIFF
--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -669,6 +669,8 @@ const executePaymentViaLn = async ({
         usdPaymentAmount: paymentFlow.usdPaymentAmount,
         priceRatio: walletPriceRatio,
         senderWalletCurrency: paymentFlow.senderWalletDescriptor().currency,
+        isFromNoAmountInvoice:
+          decodedInvoice.amount === 0 || decodedInvoice.amount === null,
       }
       const maxFeeCheck = LnFees().verifyMaxFee(maxFeeCheckArgs)
 

--- a/src/domain/payments/ln-fees.ts
+++ b/src/domain/payments/ln-fees.ts
@@ -40,17 +40,28 @@ export const LnFees = () => {
     usdPaymentAmount,
     priceRatio,
     senderWalletCurrency,
+    isFromNoAmountInvoice,
   }: {
     maxFeeAmount: BtcPaymentAmount
     btcPaymentAmount: BtcPaymentAmount
     usdPaymentAmount: UsdPaymentAmount
     priceRatio: WalletPriceRatio
     senderWalletCurrency: WalletCurrency
+    isFromNoAmountInvoice: boolean
   }) => {
-    let calculatedMaxFeeAmount = maxProtocolAndBankFee(btcPaymentAmount)
+    const btcCalculatedMaxFeeAmount = maxProtocolAndBankFee(btcPaymentAmount)
+    let calculatedMaxFeeAmount = btcCalculatedMaxFeeAmount
     if (senderWalletCurrency === WalletCurrency.Usd) {
       const maxFeeInUsd = maxProtocolAndBankFee(usdPaymentAmount)
-      calculatedMaxFeeAmount = priceRatio.convertFromUsd(maxFeeInUsd)
+      const usdCalculatedMaxFeeAmount = priceRatio.convertFromUsd(maxFeeInUsd)
+
+      calculatedMaxFeeAmount = usdCalculatedMaxFeeAmount
+      if (isFromNoAmountInvoice === false) {
+        calculatedMaxFeeAmount =
+          btcCalculatedMaxFeeAmount.amount > usdCalculatedMaxFeeAmount.amount
+            ? btcCalculatedMaxFeeAmount
+            : usdCalculatedMaxFeeAmount
+      }
     }
 
     const calculatedMinFeeAmount = priceRatio.convertFromUsd(ONE_CENT)

--- a/test/unit/domain/payments/ln-fees.spec.ts
+++ b/test/unit/domain/payments/ln-fees.spec.ts
@@ -93,6 +93,7 @@ describe("LnFees", () => {
             usdPaymentAmount: usd,
             priceRatio,
             senderWalletCurrency: WalletCurrency.Btc,
+            isFromNoAmountInvoice: true,
           }),
         ).toBe(true)
       })
@@ -105,6 +106,7 @@ describe("LnFees", () => {
             usdPaymentAmount: usd,
             priceRatio,
             senderWalletCurrency: WalletCurrency.Usd,
+            isFromNoAmountInvoice: false,
           }),
         ).toBe(true)
       })
@@ -117,6 +119,7 @@ describe("LnFees", () => {
             usdPaymentAmount: usd,
             priceRatio,
             senderWalletCurrency: WalletCurrency.Usd,
+            isFromNoAmountInvoice: true,
           }),
         ).toBe(true)
       })
@@ -129,6 +132,7 @@ describe("LnFees", () => {
             usdPaymentAmount: ONE_CENT,
             priceRatio,
             senderWalletCurrency: WalletCurrency.Btc,
+            isFromNoAmountInvoice: true,
           }),
         ).toBe(true)
       })
@@ -141,6 +145,7 @@ describe("LnFees", () => {
             usdPaymentAmount: ONE_CENT,
             priceRatio,
             senderWalletCurrency: WalletCurrency.Usd,
+            isFromNoAmountInvoice: true,
           }),
         ).toBe(true)
       })
@@ -153,6 +158,7 @@ describe("LnFees", () => {
             usdPaymentAmount: usd,
             priceRatio,
             senderWalletCurrency: WalletCurrency.Btc,
+            isFromNoAmountInvoice: true,
           }),
         ).toBeInstanceOf(MaxFeeTooLargeForRoutelessPaymentError)
       })
@@ -165,6 +171,7 @@ describe("LnFees", () => {
             usdPaymentAmount: usd,
             priceRatio,
             senderWalletCurrency: WalletCurrency.Usd,
+            isFromNoAmountInvoice: true,
           }),
         ).toBeInstanceOf(MaxFeeTooLargeForRoutelessPaymentError)
       })
@@ -177,6 +184,7 @@ describe("LnFees", () => {
             usdPaymentAmount: ONE_CENT,
             priceRatio,
             senderWalletCurrency: WalletCurrency.Btc,
+            isFromNoAmountInvoice: true,
           }),
         ).toBeInstanceOf(MaxFeeTooLargeForRoutelessPaymentError)
       })
@@ -189,6 +197,7 @@ describe("LnFees", () => {
             usdPaymentAmount: ONE_CENT,
             priceRatio,
             senderWalletCurrency: WalletCurrency.Usd,
+            isFromNoAmountInvoice: true,
           }),
         ).toBeInstanceOf(MaxFeeTooLargeForRoutelessPaymentError)
       })

--- a/test/unit/domain/payments/ln-fees.spec.ts
+++ b/test/unit/domain/payments/ln-fees.spec.ts
@@ -63,14 +63,14 @@ describe("LnFees", () => {
         currency: WalletCurrency.Usd,
       },
     },
-    // Live prod error case #2 (fails in the same way as case #1, likely redundant)
+    // Live prod error case #2 (a Usd payment, with max fee from btc passed in)
     {
       btc: {
-        amount: 11140n,
+        amount: 1342241n,
         currency: WalletCurrency.Btc,
       },
       usd: {
-        amount: 320n,
+        amount: 38254n,
         currency: WalletCurrency.Usd,
       },
     },
@@ -93,6 +93,18 @@ describe("LnFees", () => {
             usdPaymentAmount: usd,
             priceRatio,
             senderWalletCurrency: WalletCurrency.Btc,
+          }),
+        ).toBe(true)
+      })
+
+      it("correctly verifies a valid Btc maxFee from Usd wallet", () => {
+        expect(
+          LnFees().verifyMaxFee({
+            maxFeeAmount: validBtcMaxFeeToVerify,
+            btcPaymentAmount: btc,
+            usdPaymentAmount: usd,
+            priceRatio,
+            senderWalletCurrency: WalletCurrency.Usd,
           }),
         ).toBe(true)
       })


### PR DESCRIPTION
## Description

This PR adds a previously unhandled edge case when a usd send's fees are calculated from a btc amount [here](https://github.com/GaloyMoney/galoy/blob/35c7516c80ec1a0e3800ce2de521ccbe2ae5e711/src/domain/payments/payment-flow-builder.ts#L171)