### PR TITLE
fix: udpate distroless images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN yarn build
 
 RUN yarn install --frozen-lockfile --production
 
-FROM gcr.io/distroless/nodejs:20
+FROM gcr.io/distroless/nodejs20-debian11
 COPY --from=BUILD_IMAGE /app/lib /app/lib
 COPY --from=BUILD_IMAGE /app/src/config/locales /app/lib/config/locales
 COPY --from=BUILD_IMAGE /app/node_modules /app/node_modules

--- a/Dockerfile-debug
+++ b/Dockerfile-debug
@@ -13,7 +13,7 @@ COPY ./test ./test
 
 RUN yarn build
 
-FROM gcr.io/distroless/nodejs:20-debug
+FROM gcr.io/distroless/nodejs20-debian11:debug
 COPY --from=BUILD_IMAGE /app/lib /app/lib
 COPY --from=BUILD_IMAGE /app/src/config/locales /app/lib/config/locales
 COPY --from=BUILD_IMAGE /app/node_modules /app/node_modules

--- a/Dockerfile-websocket
+++ b/Dockerfile-websocket
@@ -14,7 +14,7 @@ RUN yarn build
 
 RUN yarn install --frozen-lockfile --production
 
-FROM gcr.io/distroless/nodejs:20
+FROM gcr.io/distroless/nodejs20-debian11
 COPY --from=BUILD_IMAGE /app/lib /app/lib
 COPY --from=BUILD_IMAGE /app/src/config/locales /app/lib/config/locales
 COPY --from=BUILD_IMAGE /app/node_modules /app/node_modules


### PR DESCRIPTION
fix issue with distroless images

nodejs 20: https://github.com/GoogleContainerTools/distroless/tree/main/nodejs
debug images: https://github.com/GoogleContainerTools/distroless#debug-images