### PR TITLE
perf: update method to get last block

### DIFF
--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -10,7 +10,7 @@ import {
   GetPaymentResult,
   getPayments,
   getPendingPayments,
-  getWalletInfo,
+  getHeight,
   payViaPaymentDetails,
   PayViaPaymentDetailsArgs,
   PayViaPaymentDetailsResult,
@@ -881,7 +881,7 @@ const resolvePaymentStatus = async ({
     key: CacheKeys.BlockHeight,
     ttlSecs: SECS_PER_5_MINS,
     getForCaching: async () => {
-      const { current_block_height } = await getWalletInfo({ lnd })
+      const { current_block_height } = await getHeight({ lnd })
       return current_block_height
     },
   })

--- a/src/services/lnd/onchain-service.ts
+++ b/src/services/lnd/onchain-service.ts
@@ -17,7 +17,7 @@ import {
   getChainTransactions,
   GetChainTransactionsResult,
   getPendingChainBalance,
-  getWalletInfo,
+  getHeight,
   sendToChainAddress,
 } from "lightning"
 
@@ -90,7 +90,7 @@ export const OnChainService = (
     try {
       let blockHeight = await getCachedHeight()
       if (!blockHeight) {
-        ;({ current_block_height: blockHeight } = await getWalletInfo({ lnd }))
+        ;({ current_block_height: blockHeight } = await getHeight({ lnd }))
         await LocalCacheService().set<number>({
           key: CacheKeys.BlockHeight,
           value: blockHeight,

--- a/src/services/lnd/utils.ts
+++ b/src/services/lnd/utils.ts
@@ -29,6 +29,7 @@ import {
   getChannels,
   getClosedChannels,
   getForwards,
+  getHeight,
   getPendingChainBalance,
   getWalletInfo,
   SubscribeToChannelsChannelClosedEvent,
@@ -308,7 +309,7 @@ export const onChannelUpdated = async ({
   const { transaction_id: txid } = channel as SubscribeToChannelsChannelOpenedEvent
 
   // TODO: dedupe from onchain
-  const { current_block_height } = await getWalletInfo({ lnd })
+  const { current_block_height } = await getHeight({ lnd })
   const after = Math.max(0, current_block_height - ONCHAIN_SCAN_DEPTH_CHANNEL_UPDATE) // this is necessary for tests, otherwise after may be negative
   const { transactions } = await getChainTransactions({ lnd, after })
   // end dedupe


### PR DESCRIPTION
change getWalletInfo to getHeight to improve performance 

check duration of `grpc.lnrpc.Lightning/GetInfo` https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/mQTD25epwPm/trace/FbCmBzGDmT5?fields[]=c_name&fields[]=c_service.name&span=87a89e3a0707dca4