### PR TITLE
feat: add invoice expiration

### DIFF
--- a/src/app/wallets/index.types.d.ts
+++ b/src/app/wallets/index.types.d.ts
@@ -1,24 +1,47 @@
 type AddInvoiceForSelfArgs = {
+  walletId: WalletId
+  amount: number
+  memo?: string
+  expiresIn: Minutes
+}
+
+type AddInvoiceForSelfForBtcWalletArgs = {
   walletId: string
   amount: number
   memo?: string
+  expiresIn?: number
 }
+
+type AddInvoiceForSelfForUsdWalletArgs = AddInvoiceForSelfForBtcWalletArgs
 
 type AddInvoiceNoAmountForSelfArgs = {
   walletId: string
   memo?: string
+  expiresIn?: number
 }
 
 type AddInvoiceForRecipientArgs = {
+  recipientWalletId: WalletId
+  amount: number
+  memo?: string
+  descriptionHash?: string
+  expiresIn: Minutes
+}
+
+type AddInvoiceForRecipientForBtcWalletArgs = {
   recipientWalletId: string
   amount: number
   memo?: string
   descriptionHash?: string
+  expiresIn?: number
 }
+
+type AddInvoiceForRecipientForUsdWalletArgs = AddInvoiceForRecipientForBtcWalletArgs
 
 type AddInvoiceNoAmountForRecipientArgs = {
   recipientWalletId: string
   memo?: string
+  expiresIn?: number
 }
 
 type BuildWIBWithAmountFnArgs = {
@@ -27,7 +50,7 @@ type BuildWIBWithAmountFnArgs = {
 }
 
 type AddInvoiceArgs = {
-  walletId: string
+  walletId: WalletId
   limitCheckFn: (accountId: AccountId) => Promise<true | RateLimitServiceError>
   buildWIBWithAmountFn: (
     buildWIBWithAmountFnArgs: BuildWIBWithAmountFnArgs,

--- a/src/domain/bitcoin/lightning/invoice-expiration.ts
+++ b/src/domain/bitcoin/lightning/invoice-expiration.ts
@@ -1,18 +1,30 @@
-const SECS_PER_5_MINS = (60 * 5) as Seconds
-const SECS_PER_DAY = (60 * 60 * 24) as Seconds
+import { toSeconds } from "@domain/primitives"
+
+const SECS_PER_MIN = toSeconds(60)
+const SECS_PER_5_MINS = toSeconds(60 * 5)
+const SECS_PER_DAY = toSeconds(60 * 60 * 24)
 
 export const defaultTimeToExpiryInSeconds = SECS_PER_5_MINS
 
-const DEFAULT_EXPIRATIONS = {
-  BTC: { delay: SECS_PER_DAY },
-  USD: { delay: defaultTimeToExpiryInSeconds },
+export const DEFAULT_EXPIRATIONS = {
+  BTC: { delay: SECS_PER_DAY, delayMinutes: (SECS_PER_DAY / SECS_PER_MIN) as Minutes },
+  USD: {
+    delay: defaultTimeToExpiryInSeconds,
+    delayMinutes: (defaultTimeToExpiryInSeconds / SECS_PER_MIN) as Minutes,
+  },
 }
 
 export const invoiceExpirationForCurrency = (
   currency: WalletCurrency,
   now: Date,
+  delay?: Seconds,
 ): InvoiceExpiration => {
-  const { delay } = DEFAULT_EXPIRATIONS[currency]
-  const expirationTimestamp = now.getTime() + delay * 1000
+  let expirationDelay = delay || toSeconds(0)
+  const { delay: defaultDelay } = DEFAULT_EXPIRATIONS[currency]
+  if (expirationDelay < SECS_PER_MIN || expirationDelay > defaultDelay) {
+    expirationDelay = defaultDelay
+  }
+
+  const expirationTimestamp = now.getTime() + expirationDelay * 1000
   return new Date(expirationTimestamp) as InvoiceExpiration
 }

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -134,6 +134,9 @@ export class MismatchedCurrencyForWalletError extends ValidationError {}
 
 export class InvalidAccountStatusError extends ValidationError {}
 export class InactiveAccountError extends InvalidAccountStatusError {}
+
+export class InvalidMinutesError extends ValidationError {}
+
 export class InvalidNonHodlInvoiceError extends ValidationError {
   level = ErrorLevel.Critical
 }

--- a/src/domain/primitives/index.ts
+++ b/src/domain/primitives/index.ts
@@ -1,7 +1,15 @@
+import { InvalidMinutesError } from "@domain/errors"
+
 export const toSeconds = (seconds: number): Seconds => {
   return seconds as Seconds
 }
 
 export const toDays = (days: number): Days => {
   return days as Days
+}
+
+export const checkedToMinutes = (minutes: number): Minutes | ValidationError => {
+  const isMinutes = Number.isInteger(minutes) && minutes >= 0
+  if (!isMinutes) return new InvalidMinutesError(`Invalid value for minutes: ${minutes}`)
+  return minutes as Minutes
 }

--- a/src/domain/primitives/index.types.d.ts
+++ b/src/domain/primitives/index.types.d.ts
@@ -5,6 +5,7 @@ type Pubkey = string & { readonly brand: unique symbol }
 type WalletId = string & { readonly brand: unique symbol }
 type AccountId = string & { readonly brand: unique symbol }
 type Seconds = number & { readonly brand: unique symbol }
+type Minutes = number & { readonly brand: unique symbol }
 type MilliSeconds = number & { readonly brand: unique symbol }
 type Days = number & { readonly brand: unique symbol }
 type JwtToken = string & { readonly brand: unique symbol } // short lived asymmetric token from oathkeeper

--- a/src/domain/wallet-invoices/index.types.d.ts
+++ b/src/domain/wallet-invoices/index.types.d.ts
@@ -44,15 +44,22 @@ type WIBWithRecipientState = WIBWithOriginState & {
 }
 
 type WIBWithRecipient = {
+  withExpiration: (minutes: Minutes) => WIBWithExpiration
+}
+
+type WIBWithExpirationState = WIBWithRecipientState & {
+  invoiceExpiration: InvoiceExpiration
+}
+
+type WIBWithExpiration = {
   withAmount: (
     uncheckedAmount: number,
   ) => Promise<WIBWithAmount | ValidationError | DealerPriceServiceError>
   withoutAmount: () => Promise<WIBWithAmount>
 }
 
-type WIBWithAmountState = WIBWithRecipientState & {
+type WIBWithAmountState = WIBWithExpirationState & {
   hasAmount: boolean
-  invoiceExpiration: InvoiceExpiration
   btcAmount: BtcPaymentAmount
   usdAmount?: UsdPaymentAmount
 }

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -528,6 +528,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "InvalidNonHodlInvoiceError":
     case "InvalidAccountError":
     case "InvalidAccountIdError":
+    case "InvalidMinutesError":
     case "InvalidWalletForAccountError":
     case "AuthenticationError":
     case "LikelyNoUserWithThisPhoneExistError":

--- a/src/graphql/main/schema.graphql
+++ b/src/graphql/main/schema.graphql
@@ -443,6 +443,11 @@ input LnInvoiceCreateInput {
   amount: SatAmount!
 
   """
+  Optional invoice expiration time in minutes.
+  """
+  expiresIn: Minutes
+
+  """
   Optional memo for the lightning invoice.
   """
   memo: Memo
@@ -459,6 +464,11 @@ input LnInvoiceCreateOnBehalfOfRecipientInput {
   """
   amount: SatAmount!
   descriptionHash: Hex32Bytes
+
+  """
+  Optional invoice expiration time in minutes.
+  """
+  expiresIn: Minutes
 
   """
   Optional memo for the lightning invoice.
@@ -515,6 +525,11 @@ type LnNoAmountInvoice {
 
 input LnNoAmountInvoiceCreateInput {
   """
+  Optional invoice expiration time in minutes.
+  """
+  expiresIn: Minutes
+
+  """
   Optional memo for the lightning invoice.
   """
   memo: Memo
@@ -526,6 +541,11 @@ input LnNoAmountInvoiceCreateInput {
 }
 
 input LnNoAmountInvoiceCreateOnBehalfOfRecipientInput {
+  """
+  Optional invoice expiration time in minutes.
+  """
+  expiresIn: Minutes
+
   """
   Optional memo for the lightning invoice.
   """
@@ -620,6 +640,11 @@ input LnUsdInvoiceCreateInput {
   amount: CentAmount!
 
   """
+  Optional invoice expiration time in minutes.
+  """
+  expiresIn: Minutes
+
+  """
   Optional memo for the lightning invoice.
   """
   memo: Memo
@@ -636,6 +661,11 @@ input LnUsdInvoiceCreateOnBehalfOfRecipientInput {
   """
   amount: CentAmount!
   descriptionHash: Hex32Bytes
+
+  """
+  Optional invoice expiration time in minutes.
+  """
+  expiresIn: Minutes
 
   """
   Optional memo for the lightning invoice. Acts as a note to the recipient.
@@ -667,6 +697,11 @@ type MapMarker {
 Text field in a lightning payment transaction
 """
 scalar Memo
+
+"""
+(Positive) amount of minutes
+"""
+scalar Minutes
 
 type MobileVersions {
   currentSupported: Int!
@@ -705,14 +740,14 @@ type Mutation {
   """
   Returns a lightning invoice for an associated wallet.
   When invoice is paid the value will be credited to a BTC wallet.
-  Expires after 24 hours.
+  Expires after 'expiresIn' or 24 hours.
   """
   lnInvoiceCreate(input: LnInvoiceCreateInput!): LnInvoicePayload!
 
   """
   Returns a lightning invoice for an associated wallet.
   When invoice is paid the value will be credited to a BTC wallet.
-  Expires after 24 hours.
+  Expires after 'expiresIn' or 24 hours.
   """
   lnInvoiceCreateOnBehalfOfRecipient(
     input: LnInvoiceCreateOnBehalfOfRecipientInput!
@@ -729,14 +764,14 @@ type Mutation {
   """
   Returns a lightning invoice for an associated wallet.
   Can be used to receive any supported currency value (currently USD or BTC).
-  Expires after 24 hours.
+  Expires after 'expiresIn' or 24 hours for BTC invoices or 5 minutes for USD invoices.
   """
   lnNoAmountInvoiceCreate(input: LnNoAmountInvoiceCreateInput!): LnNoAmountInvoicePayload!
 
   """
   Returns a lightning invoice for an associated wallet.
   Can be used to receive any supported currency value (currently USD or BTC).
-  Expires after 24 hours.
+  Expires after 'expiresIn' or 24 hours for BTC invoices or 5 minutes for USD invoices.
   """
   lnNoAmountInvoiceCreateOnBehalfOfRecipient(
     input: LnNoAmountInvoiceCreateOnBehalfOfRecipientInput!
@@ -765,7 +800,7 @@ type Mutation {
   """
   Returns a lightning invoice denominated in satoshis for an associated wallet.
   When invoice is paid the equivalent value at invoice creation will be credited to a USD wallet.
-  Expires after 5 minutes (short expiry time because there is a USD/BTC exchange rate
+  Expires after 'expiresIn' or 5 minutes (short expiry time because there is a USD/BTC exchange rate
   associated with the amount).
   """
   lnUsdInvoiceCreate(input: LnUsdInvoiceCreateInput!): LnInvoicePayload!
@@ -773,7 +808,7 @@ type Mutation {
   """
   Returns a lightning invoice denominated in satoshis for an associated wallet.
   When invoice is paid the equivalent value at invoice creation will be credited to a USD wallet.
-  Expires after 5 minutes (short expiry time because there is a USD/BTC exchange rate
+  Expires after 'expiresIn' or 5 minutes (short expiry time because there is a USD/BTC exchange rate
     associated with the amount).
   """
   lnUsdInvoiceCreateOnBehalfOfRecipient(

--- a/src/graphql/root/mutation/ln-noamount-invoice-create.ts
+++ b/src/graphql/root/mutation/ln-noamount-invoice-create.ts
@@ -1,10 +1,13 @@
-import { Wallets } from "@app"
-import { mapAndParseErrorForGqlResponse } from "@graphql/error-map"
-import { GT } from "@graphql/index"
-import LnNoAmountInvoicePayload from "@graphql/types/payload/ln-noamount-invoice"
-import Memo from "@graphql/types/scalar/memo"
-import WalletId from "@graphql/types/scalar/wallet-id"
 import dedent from "dedent"
+
+import { Wallets } from "@app"
+
+import { GT } from "@graphql/index"
+import Memo from "@graphql/types/scalar/memo"
+import Minutes from "@graphql/types/scalar/minutes"
+import WalletId from "@graphql/types/scalar/wallet-id"
+import { mapAndParseErrorForGqlResponse } from "@graphql/error-map"
+import LnNoAmountInvoicePayload from "@graphql/types/payload/ln-noamount-invoice"
 
 const LnNoAmountInvoiceCreateInput = GT.Input({
   name: "LnNoAmountInvoiceCreateInput",
@@ -15,6 +18,10 @@ const LnNoAmountInvoiceCreateInput = GT.Input({
         "ID for either a USD or BTC wallet belonging to the account of the current user.",
     },
     memo: { type: Memo, description: "Optional memo for the lightning invoice." },
+    expiresIn: {
+      type: Minutes,
+      description: "Optional invoice expiration time in minutes.",
+    },
   }),
 })
 
@@ -25,14 +32,14 @@ const LnNoAmountInvoiceCreateMutation = GT.Field({
   type: GT.NonNull(LnNoAmountInvoicePayload),
   description: dedent`Returns a lightning invoice for an associated wallet.
   Can be used to receive any supported currency value (currently USD or BTC).
-  Expires after 24 hours.`,
+  Expires after 'expiresIn' or 24 hours for BTC invoices or 5 minutes for USD invoices.`,
   args: {
     input: { type: GT.NonNull(LnNoAmountInvoiceCreateInput) },
   },
   resolve: async (_, args) => {
-    const { walletId, memo } = args.input
+    const { walletId, memo, expiresIn } = args.input
 
-    for (const input of [walletId, memo]) {
+    for (const input of [walletId, memo, expiresIn]) {
       if (input instanceof Error) {
         return { errors: [{ message: input.message }] }
       }
@@ -41,6 +48,7 @@ const LnNoAmountInvoiceCreateMutation = GT.Field({
     const lnInvoice = await Wallets.addInvoiceNoAmountForSelf({
       walletId,
       memo,
+      expiresIn,
     })
 
     if (lnInvoice instanceof Error) {

--- a/src/graphql/root/mutation/ln-usd-invoice-create.ts
+++ b/src/graphql/root/mutation/ln-usd-invoice-create.ts
@@ -1,11 +1,14 @@
+import dedent from "dedent"
+
+import { Wallets } from "@app"
+
 import { GT } from "@graphql/index"
-import { mapAndParseErrorForGqlResponse } from "@graphql/error-map"
 import Memo from "@graphql/types/scalar/memo"
+import Minutes from "@graphql/types/scalar/minutes"
 import WalletId from "@graphql/types/scalar/wallet-id"
 import CentAmount from "@graphql/types/scalar/cent-amount"
 import LnInvoicePayload from "@graphql/types/payload/ln-invoice"
-import { Wallets } from "@app"
-import dedent from "dedent"
+import { mapAndParseErrorForGqlResponse } from "@graphql/error-map"
 
 const LnUsdInvoiceCreateInput = GT.Input({
   name: "LnUsdInvoiceCreateInput",
@@ -16,6 +19,10 @@ const LnUsdInvoiceCreateInput = GT.Input({
     },
     amount: { type: GT.NonNull(CentAmount), description: "Amount in USD cents." },
     memo: { type: Memo, description: "Optional memo for the lightning invoice." },
+    expiresIn: {
+      type: Minutes,
+      description: "Optional invoice expiration time in minutes.",
+    },
   }),
 })
 
@@ -26,15 +33,15 @@ const LnUsdInvoiceCreateMutation = GT.Field({
   type: GT.NonNull(LnInvoicePayload),
   description: dedent`Returns a lightning invoice denominated in satoshis for an associated wallet.
   When invoice is paid the equivalent value at invoice creation will be credited to a USD wallet.
-  Expires after 5 minutes (short expiry time because there is a USD/BTC exchange rate
+  Expires after 'expiresIn' or 5 minutes (short expiry time because there is a USD/BTC exchange rate
   associated with the amount).`,
   args: {
     input: { type: GT.NonNull(LnUsdInvoiceCreateInput) },
   },
   resolve: async (_, args) => {
-    const { walletId, memo, amount } = args.input
+    const { walletId, amount, memo, expiresIn } = args.input
 
-    for (const input of [walletId, memo, amount]) {
+    for (const input of [walletId, amount, memo, expiresIn]) {
       if (input instanceof Error) {
         return { errors: [{ message: input.message }] }
       }
@@ -44,6 +51,7 @@ const LnUsdInvoiceCreateMutation = GT.Field({
       walletId,
       amount,
       memo,
+      expiresIn,
     })
 
     if (lnInvoice instanceof Error) {

--- a/src/graphql/types/scalar/minutes.ts
+++ b/src/graphql/types/scalar/minutes.ts
@@ -1,0 +1,36 @@
+import { GT } from "@graphql/index"
+import { InputValidationError } from "@graphql/error"
+
+const Minutes = GT.Scalar({
+  name: "Minutes",
+  description: "(Positive) amount of minutes",
+  parseValue(value) {
+    if (typeof value !== "string" && typeof value !== "number") {
+      return new InputValidationError({ message: "Invalid type for Minutes" })
+    }
+    return validMinutesAmount(value)
+  },
+  parseLiteral(ast) {
+    if (ast.kind === GT.Kind.INT) {
+      return validMinutesAmount(ast.value)
+    }
+    return new InputValidationError({ message: "Invalid type for Minutes" })
+  },
+})
+
+function validMinutesAmount(value: string | number) {
+  let intValue: number
+  if (typeof value === "number") {
+    intValue = value
+  } else {
+    intValue = Number.parseInt(value, 10)
+  }
+
+  if (!(Number.isInteger(intValue) && intValue >= 0)) {
+    return new InputValidationError({ message: "Invalid value for Minutes" })
+  }
+
+  return intValue
+}
+
+export default Minutes

--- a/test/unit/domain/bitcoin/lightning/invoice-expiration.spec.ts
+++ b/test/unit/domain/bitcoin/lightning/invoice-expiration.spec.ts
@@ -1,15 +1,63 @@
+import { SECS_PER_10_MINS, SECS_PER_DAY } from "@config"
+
+import { toSeconds } from "@domain/primitives"
+import { WalletCurrency } from "@domain/shared"
 import { invoiceExpirationForCurrency } from "@domain/bitcoin/lightning"
 
-describe("invoice-expiration", () => {
-  it("BTC invoice expires in 1 days", () => {
-    const creationDate = new Date("2000-01-01T00:00:00.000Z")
-    const expiresAt = invoiceExpirationForCurrency("BTC", creationDate)
-    expect(expiresAt).toEqual(new Date("2000-01-02T00:00:00.000Z"))
+describe("invoiceExpirationForCurrency", () => {
+  const BTC = WalletCurrency.Btc
+  const USD = WalletCurrency.Usd
+  const now = new Date("2000-01-01T00:00:00Z")
+
+  it("should return expiration for BTC currency with default delay", () => {
+    const expectedExpiration = new Date("2000-01-02T00:00:00.000Z")
+    let expiresAt = invoiceExpirationForCurrency(BTC, now)
+    expect(expiresAt).toEqual(expectedExpiration)
+
+    let delay = toSeconds(59)
+    expiresAt = invoiceExpirationForCurrency(BTC, now, delay)
+    expect(expiresAt).toEqual(expectedExpiration)
+
+    delay = toSeconds(0)
+    expiresAt = invoiceExpirationForCurrency(BTC, now, delay)
+    expect(expiresAt).toEqual(expectedExpiration)
+
+    delay = toSeconds(2 * SECS_PER_DAY)
+    expiresAt = invoiceExpirationForCurrency(BTC, now, delay)
+    expect(expiresAt).toEqual(expectedExpiration)
   })
 
-  it("USD invoice expires in 5 minutes", () => {
-    const creationDate = new Date("2000-01-01T00:00:00.000Z")
-    const expiresAt = invoiceExpirationForCurrency("USD", creationDate)
-    expect(expiresAt).toEqual(new Date("2000-01-01T00:05:00.000Z"))
+  it("should return expiration for USD currency with default delay", () => {
+    const expectedExpiration = new Date("2000-01-01T00:05:00.000Z")
+    let expiresAt = invoiceExpirationForCurrency(USD, now)
+    expect(expiresAt).toEqual(expectedExpiration)
+
+    let delay = toSeconds(59)
+    expiresAt = invoiceExpirationForCurrency(USD, now, delay)
+    expect(expiresAt).toEqual(expectedExpiration)
+
+    delay = toSeconds(0)
+    expiresAt = invoiceExpirationForCurrency(USD, now, delay)
+    expect(expiresAt).toEqual(expectedExpiration)
+
+    delay = toSeconds(SECS_PER_10_MINS)
+    expiresAt = invoiceExpirationForCurrency(USD, now, delay)
+    expect(expiresAt).toEqual(expectedExpiration)
+  })
+
+  it("should return expiration for BTC currency with provided delay", () => {
+    const delay = toSeconds(30 * 60)
+    const currency = BTC
+    const expiration = invoiceExpirationForCurrency(currency, now, delay)
+    const expectedExpiration = new Date("2000-01-01T00:30:00Z")
+    expect(expiration).toEqual(expectedExpiration)
+  })
+
+  it("should return expiration for USD currency with provided delay", () => {
+    const delay = toSeconds(3 * 60)
+    const currency = USD
+    const expiration = invoiceExpirationForCurrency(currency, now, delay)
+    const expectedExpiration = new Date("2000-01-01T00:03:00Z")
+    expect(expiration).toEqual(expectedExpiration)
   })
 })


### PR DESCRIPTION
Use case from mattermost

> we want to add lightning to our list of crypto/fiat options available for customers to make payments for services/products via a generated QR code.  For a payment, a fixed amount is generated which must be paid before a set time (e.g. 10mins) elapses. If it is not paid, we invalidate it and regenerate an updated amount if the user is still interested in paying. Now because an expired payment has been invalidated, a customer will not be able to make a successful payment even if they somehow still have the initial QR code.
> 
> However, because we cannot set an expiry for an lnInvoice, a customer that still has a QR code generated from the lightning's payment request will be able to make payment way past our desired expiry time.

- Update invoice builder (including tests)
- Update public and private create invoice mutations
- Update tests + domain validations