### PR TITLE
ci: exit gracefully on no proto diff

### DIFF
--- a/ci/tasks/open-bump-proto-pr.sh
+++ b/ci/tasks/open-bump-proto-pr.sh
@@ -11,4 +11,4 @@ gh pr create \
   --body "" \
   --base ${BRANCH} \
   --head ${BOT_BRANCH} \
-  --label galoybot
+  --label galoybot || true

--- a/ci/tasks/sync-proto.sh
+++ b/ci/tasks/sync-proto.sh
@@ -27,5 +27,5 @@ fi
   git merge --no-edit ${BRANCH}
   git add -A
   git status
-  git commit -m "chore(deps): bump ${MODULE} proto to '${ref}'"
+  git commit -m "chore(deps): bump ${MODULE} proto to '${ref}'" || true
 )


### PR DESCRIPTION
The combination of tag_regex and paths seems to not be working correctly and the sync job is being triggered on each tagged commit, instead of only on the tagged commits that change the proto files. 