### PR TITLE
fix: switching to serbian language fixed

### DIFF
--- a/src/domain/users/languages.ts
+++ b/src/domain/users/languages.ts
@@ -193,6 +193,7 @@ export const Languages = [
   "sl-SI",
   "sq",
   "sq-AL",
+  "sr",
   "sr-BA",
   "sr-BA",
   "sr-SP",


### PR DESCRIPTION
It was an error on the server side
I discovered it when I added a try-catch block to the language screen, when we update the language - 
```
<ListItem
  key={language}
  bottomDivider
  containerStyle={styles.container}
  onPress={async () => { 
    if (language !== languageFromServer) {
      try {
        const { data } = await updateLanguage({
          variables: { input: { language } },
        })

        if (data.userUpdateLanguage.errors && data.userUpdateLanguage.errors.length > 0) {
          console.log('Error updating language: ', data.userUpdateLanguage.errors)
        } else {
          setNewLanguage(language)
        }
      } catch (err) {
        console.error('Error updating language: ', err)
      }
    }
  }}
>

```
This logged: Error updating language: Invalid value for language
