### PR TITLE
fix: shift limit check in create address function

### DIFF
--- a/src/domain/wallet-on-chain/index.types.d.ts
+++ b/src/domain/wallet-on-chain/index.types.d.ts
@@ -19,6 +19,13 @@ interface IWalletOnChainAddressesRepository {
   findLastByWalletId(
     walletId: WalletId,
   ): Promise<OnChainAddressIdentifier | RepositoryError>
+  isRecorded({
+    walletId,
+    onChainAddress,
+  }: {
+    walletId: WalletId
+    onChainAddress: OnChainAddressIdentifier
+  }): Promise<boolean | RepositoryError>
 }
 
 type ListWalletOnChainPendingReceiveArgs = {

--- a/src/services/mongoose/wallet-on-chain-addresses.ts
+++ b/src/services/mongoose/wallet-on-chain-addresses.ts
@@ -57,8 +57,31 @@ export const WalletOnChainAddressesRepository = (): IWalletOnChainAddressesRepos
     }
   }
 
+  const isRecorded = async ({
+    walletId,
+    onChainAddress,
+  }: {
+    walletId: WalletId
+    onChainAddress: OnChainAddressIdentifier
+  }) => {
+    try {
+      const result = await Wallet.countDocuments({
+        id: walletId,
+        onchain: {
+          $elemMatch: {
+            address: onChainAddress.address,
+          },
+        },
+      })
+
+      return result > 0
+    } catch (err) {
+      return parseRepositoryError(err)
+    }
+  }
   return {
     persistNew,
     findLastByWalletId,
+    isRecorded,
   }
 }

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -81,7 +81,6 @@ import {
   subscribeToTransactions,
   getUsdWalletIdByTestUserRef,
   amountByPriceAsMajor,
-  resetOnChainAddressAccountIdLimits,
 } from "test/helpers"
 
 let accountA: Account
@@ -126,7 +125,6 @@ beforeAll(async () => {
   accountG = await getAccountByTestUserRef("G")
 
   await bitcoindClient.loadWallet({ filename: "outside" })
-  await resetOnChainAddressAccountIdLimits(accountA.id)
 })
 
 afterEach(async () => {
@@ -1138,7 +1136,6 @@ describe("BtcWallet - onChainPay", () => {
   )
 
   it("fails if try to send a transaction to self", async () => {
-    await resetOnChainAddressAccountIdLimits(accountA.id)
     const res = await testInternalSend({
       senderAccount: accountA,
       senderWalletId: walletIdA,
@@ -1351,7 +1348,6 @@ describe("UsdWallet - onChainPay", () => {
     amountCases.forEach(({ amountCurrency, senderAmount }) => {
       describe(`with ${amountCurrency} amount currency`, () => {
         it("sends from usd wallet to usd wallet", async () => {
-          await resetOnChainAddressAccountIdLimits(accountA.id)
           const res = await testInternalSend({
             senderAccount: accountB,
             senderWalletId: walletIdUsdB,
@@ -1363,7 +1359,6 @@ describe("UsdWallet - onChainPay", () => {
         })
 
         it("sends from usd wallet to btc wallet", async () => {
-          await resetOnChainAddressAccountIdLimits(accountA.id)
           const res = await testInternalSend({
             senderAccount: accountB,
             senderWalletId: walletIdUsdB,

--- a/test/integration/02-user-wallet/02-tx-display.spec.ts
+++ b/test/integration/02-user-wallet/02-tx-display.spec.ts
@@ -45,7 +45,6 @@ import {
   lndOutside1,
   onceBriaSubscribe,
   RANDOM_ADDRESS,
-  resetOnChainAddressAccountIdLimits,
   safePay,
   sendToAddressAndConfirm,
   subscribeToTransactions,
@@ -840,8 +839,6 @@ describe("Display properties on transactions", () => {
       it("(OnChainIntraledgerLedgerMetadata) pays another galoy user via onchain address", async () => {
         // TxMetadata:
         // - OnChainIntraledgerLedgerMetadata
-        await resetOnChainAddressAccountIdLimits(accountC.id)
-
         const amountSats = toSats(20_000)
 
         const senderWalletId = walletIdB

--- a/test/integration/02-user-wallet/02-tx-onchain-fees.spec.ts
+++ b/test/integration/02-user-wallet/02-tx-onchain-fees.spec.ts
@@ -21,7 +21,6 @@ import {
   getDefaultWalletIdByTestUserRef,
   getUsdWalletIdByTestUserRef,
   lndonchain,
-  resetOnChainAddressAccountIdLimits,
   sendToAddressAndConfirm,
   subscribeToChainAddress,
   waitUntilBlockHeight,
@@ -36,7 +35,6 @@ let walletIdA: WalletId
 let walletIdB: WalletId
 let walletIdUsdA: WalletId
 let accountA: Account
-let accountB: Account
 
 const dealerFns = DealerPriceService()
 
@@ -49,11 +47,9 @@ beforeAll(async () => {
   walletIdA = await getDefaultWalletIdByTestUserRef("A")
   walletIdUsdA = await getUsdWalletIdByTestUserRef("A")
   accountA = await getAccountByTestUserRef("A")
-  accountB = await getAccountByTestUserRef("B")
   walletIdB = await getDefaultWalletIdByTestUserRef("B")
 
   // Fund walletIdA
-  await resetOnChainAddressAccountIdLimits(accountA.id)
   await sendToLndWalletTestWrapper({
     amountSats: toSats(defaultAmount * 5),
     walletId: walletIdA,
@@ -61,9 +57,6 @@ beforeAll(async () => {
 
   // Fund lnd
   const funderWalletId = await getFunderWalletId()
-  const funderWallet = await WalletsRepository().findById(funderWalletId)
-  if (funderWallet instanceof Error) throw funderWallet
-  await resetOnChainAddressAccountIdLimits(funderWallet.accountId)
   await sendToLndWalletTestWrapper({
     amountSats: toSats(2_000_000_000),
     walletId: funderWalletId,
@@ -136,7 +129,6 @@ describe("UserWallet - getOnchainFee", () => {
     })
 
     it("returns zero for an on us address", async () => {
-      await resetOnChainAddressAccountIdLimits(accountB.id)
       const address = await Wallets.createOnChainAddressForBtcWallet({
         walletId: walletIdB,
       })
@@ -297,7 +289,6 @@ describe("UserWallet - getOnchainFee", () => {
         })
 
         it("returns zero for an on us address", async () => {
-          await resetOnChainAddressAccountIdLimits(accountB.id)
           const address = await Wallets.createOnChainAddressForBtcWallet({
             walletId: walletIdB,
           })

--- a/test/integration/app/trigger/trigger.fn.spec.ts
+++ b/test/integration/app/trigger/trigger.fn.spec.ts
@@ -5,7 +5,6 @@ import { Wallets } from "@app"
 import { TxStatus } from "@domain/wallets"
 import { sat2btc, toSats } from "@domain/bitcoin"
 
-import { WalletsRepository } from "@services/mongoose"
 import { onchainBlockEventHandler } from "@servers/trigger"
 
 import { baseLogger } from "@services/logger"
@@ -23,7 +22,6 @@ import {
   lnd1,
   mineBlockAndSyncAll,
   RANDOM_ADDRESS,
-  resetOnChainAddressAccountIdLimits,
   subscribeToBlocks,
   waitFor,
   waitUntilSyncAll,
@@ -86,14 +84,6 @@ const getWalletState = async (walletId: WalletId): Promise<WalletState> => {
 
 describe("onchainBlockEventHandler", () => {
   it("should process block for incoming transactions from lnd", async () => {
-    const walletA = await WalletsRepository().findById(walletIdA)
-    if (walletA instanceof Error) throw walletA
-    await resetOnChainAddressAccountIdLimits(walletA.accountId)
-
-    const walletD = await WalletsRepository().findById(walletIdD)
-    if (walletD instanceof Error) throw walletD
-    await resetOnChainAddressAccountIdLimits(walletD.accountId)
-
     const amount = toSats(10_000)
     const amount2 = toSats(20_000)
     const blocksToMine = ONCHAIN_MIN_CONFIRMATIONS


### PR DESCRIPTION
## Description

With the introduction of `requestId` and the usage of `createAddress` in the finally section of our add-settled use-case now, the limiter in the createAddress function was badly placed and being wrongly triggered after many expected createAddress re-runs resulting in `OnChainAddressCreateRateLimiterExceededError` errors being thrown.

This PR fixes the limiter placement to accommodate for this, and it also adds a change to prevent multiple address values from being pushed to the addresses array in persistence.