### PR TITLE
fix: avoid duplicate pending tx ids by deriving from 'txHash:vout'

### DIFF
--- a/src/app/wallets/update-on-chain-receipt.ts
+++ b/src/app/wallets/update-on-chain-receipt.ts
@@ -11,7 +11,10 @@ import { toSats } from "@domain/bitcoin"
 import { OnChainError, TxDecoder } from "@domain/bitcoin/onchain"
 import { CacheKeys } from "@domain/cache"
 import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
-import { CouldNotFindWalletFromOnChainAddressesError } from "@domain/errors"
+import {
+  CouldNotFindWalletFromOnChainAddressError,
+  CouldNotFindWalletFromOnChainAddressesError,
+} from "@domain/errors"
 import { DisplayCurrency } from "@domain/fiat"
 
 import { LockService } from "@services/lock"
@@ -122,7 +125,10 @@ const processTxForWallet = async ({
       satoshis,
       address,
     })
-    if (result instanceof Error) {
+    if (
+      result instanceof Error &&
+      !(result instanceof CouldNotFindWalletFromOnChainAddressError)
+    ) {
       logger.error({ error: result }, "Error adding settled transaction")
       recordExceptionInCurrentSpan({ error: result })
     }

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -74,7 +74,7 @@ type BaseWalletTransaction = {
   >
   readonly createdAt: Date
 
-  readonly id: LedgerTransactionId | OnChainTxHash
+  readonly id: LedgerTransactionId
   readonly status: TxStatus
   readonly memo: string | null
 }

--- a/src/graphql/types/object/transaction.ts
+++ b/src/graphql/types/object/transaction.ts
@@ -1,4 +1,5 @@
 import dedent from "dedent"
+import getUuidByString from "uuid-by-string"
 
 import { GT } from "@graphql/index"
 import { mapError } from "@graphql/error-map"
@@ -46,7 +47,8 @@ const Transaction = GT.Object<WalletTransaction>({
         // Filter out source.id as OnChainTxHash
         if (
           settlementVia.type === "onchain" &&
-          source.id === settlementVia.transactionHash &&
+          source.id ===
+            getUuidByString(`${settlementVia.transactionHash}:${settlementVia.vout}`) &&
           // If not pending, we would like this to error in the next step with invalid source.id
           source.status === DomainTxStatus.Pending
         ) {

--- a/src/services/mongoose/wallet-onchain-pending-receive.ts
+++ b/src/services/mongoose/wallet-onchain-pending-receive.ts
@@ -1,3 +1,5 @@
+import getUuidByString from "uuid-by-string"
+
 import { toSats } from "@domain/bitcoin"
 import { toCents } from "@domain/fiat"
 import { TxStatus } from "@domain/wallets"
@@ -100,7 +102,9 @@ const translateToWalletOnChainTransaction = (
   const walletCurrency = result.walletCurrency as WalletCurrency
   const toCurrency = walletCurrency === WalletCurrency.Btc ? toSats : toCents
   return {
-    id: result.transactionHash as OnChainTxHash,
+    id: getUuidByString(
+      `${result.transactionHash}:${result.vout}`,
+    ) as LedgerTransactionId,
     walletId: result.walletId as WalletId,
     settlementAmount: toCurrency(result.walletAmount),
     settlementFee: toCurrency(result.walletFee),

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -309,7 +309,8 @@ const testExternalSend = async ({
       )
     }
 
-    pendingTxHash = pendingTx.id as OnChainTxHash
+    pendingTxHash = (pendingTx as WalletOnChainSettledTransaction).settlementVia
+      .transactionHash
 
     await checkIsBalanced()
   }
@@ -334,10 +335,11 @@ const testExternalSend = async ({
     expect(pendingTxs.length).toBe(0)
 
     const settledTxs = txResult.result.slice.filter(
-      ({ status, initiationVia, id }) =>
+      ({ status, initiationVia, settlementVia }) =>
         status === TxStatus.Success &&
         initiationVia.type === PaymentInitiationMethod.OnChain &&
-        id === pendingTxHash,
+        "transactionHash" in settlementVia &&
+        settlementVia.transactionHash === pendingTxHash,
     )
     expect(settledTxs.length).toBe(1)
     const settledTx = settledTxs[0]


### PR DESCRIPTION
## Description

We derived from just `transactionHash` before which is no longer unique as we parse each vout as a unique transaction now. This PR fixes that.