### PR TITLE
chore: add walletId as onchain create requestId on 1st create

### DIFF
--- a/src/app/wallets/get-last-on-chain-address.ts
+++ b/src/app/wallets/get-last-on-chain-address.ts
@@ -9,9 +9,13 @@ export const getLastOnChainAddress = async (
   const onChainAddressesRepo = WalletOnChainAddressesRepository()
   const lastOnChainAddress = await onChainAddressesRepo.findLastByWalletId(walletId)
 
-  if (lastOnChainAddress instanceof CouldNotFindError)
-    return createOnChainAddressForBtcWallet({ walletId })
-
+  if (lastOnChainAddress instanceof CouldNotFindError) {
+    const requestId = walletId as unknown as OnChainAddressRequestId
+    return createOnChainAddressForBtcWallet({
+      walletId,
+      requestId,
+    })
+  }
   if (lastOnChainAddress instanceof Error) return lastOnChainAddress
 
   return lastOnChainAddress.address


### PR DESCRIPTION
## Description

We call the `createOnChainAddress` function from the `lastOnChainAddress` method if no previous address was recorded. This PR makes it so that the first address that is created for a wallet has a `requestId` with the value of the wallet's `walletId` to help with idempotency of this specific call.