### PR TITLE
chore: rename request id in schema

### DIFF
--- a/src/app/wallets/add-settled-on-chain-transaction.ts
+++ b/src/app/wallets/add-settled-on-chain-transaction.ts
@@ -175,7 +175,7 @@ const addSettledTransactionBeforeFinally = async ({
 
     return {
       walletDescriptor: wallet,
-      newAddressRequestId: newAddressRequestId,
+      newAddressRequestId,
     }
   })
 }

--- a/src/domain/ledger/index.types.d.ts
+++ b/src/domain/ledger/index.types.d.ts
@@ -64,7 +64,7 @@ type LedgerTransaction<S extends WalletCurrency> = {
   readonly address?: OnChainAddress
   readonly txHash?: OnChainTxHash
   readonly vout?: OnChainTxVout
-  readonly newAddressRequestId?: OnChainAddressRequestId
+  readonly requestId?: OnChainAddressRequestId
 
   // for admin, to be removed when we switch those to satsAmount props
   readonly fee: number | undefined // Satoshis

--- a/src/services/ledger/index.ts
+++ b/src/services/ledger/index.ts
@@ -319,7 +319,7 @@ export const LedgerService = (): ILedgerService => {
       }
 
       const tx = translateToLedgerTx(entry)
-      return { recorded: true, newAddressRequestId: tx.newAddressRequestId }
+      return { recorded: true, newAddressRequestId: tx.requestId }
     } catch (err) {
       return new UnknownLedgerError(err)
     }
@@ -459,8 +459,9 @@ export const translateToLedgerTx = <S extends WalletCurrency, T extends DisplayC
       tx.payee_addresses && tx.payee_addresses.length > 0
         ? (tx.payee_addresses[0] as OnChainAddress)
         : undefined,
-    newAddressRequestId:
-      (tx.new_address_request_id as OnChainAddressRequestId) || undefined,
+    requestId:
+      ((tx.request_id || tx.new_address_request_id) as OnChainAddressRequestId) ||
+      undefined,
     txHash: (tx.hash as OnChainTxHash) || undefined,
     vout: (tx.vout as OnChainTxVout) || undefined,
     feeKnownInAdvance: tx.feeKnownInAdvance || false,

--- a/src/services/ledger/index.types.d.ts
+++ b/src/services/ledger/index.types.d.ts
@@ -68,7 +68,7 @@ type OnChainReceiveLedgerMetadata = LedgerMetadata &
     hash: OnChainTxHash
     vout: OnChainTxVout
     payee_addresses: OnChainAddress[]
-    new_address_request_id: OnChainAddressRequestId | undefined
+    request_id: OnChainAddressRequestId | undefined
   }
 
 type SendAmountsMetadata = {

--- a/src/services/ledger/schema.ts
+++ b/src/services/ledger/schema.ts
@@ -53,6 +53,7 @@ const transactionSchema = new Schema<ILedgerTransaction>(
     // for onchain transactions.
     payee_addresses: [String],
     new_address_request_id: String,
+    request_id: String,
 
     memoPayer: String,
 

--- a/src/services/ledger/schema.types.d.ts
+++ b/src/services/ledger/schema.types.d.ts
@@ -25,6 +25,7 @@ interface ILedgerTransaction {
   related_journal?: ObjectId
   payee_addresses?: string[]
   new_address_request_id?: string
+  request_id?: string
   memoPayer?: string
   sats?: number
   username?: string

--- a/src/services/ledger/tx-metadata.ts
+++ b/src/services/ledger/tx-metadata.ts
@@ -273,7 +273,7 @@ export const OnChainReceiveLedgerMetadata = ({
     hash: onChainTxHash,
     vout: onChainTxVout,
     payee_addresses: payeeAddresses,
-    new_address_request_id: newAddressRequestId,
+    request_id: newAddressRequestId,
 
     // Amounts are after fee is deducted
     satsAmount: toSats(satsAmount),


### PR DESCRIPTION
## Description

### Part 1
Rename `request_id` in application code to be more generic in or ledger so that it can be re-used for other transaction types like payouts.

### Migration notes
Migration (https://github.com/GaloyMoney/galoy/pull/2711/commits/ac16a837ddd59e9f9528eeda63a6fd8deec5d017) will be added in a follow-up PR for smoother transition.