### PR TITLE
chore: migrate request id in schema

### DIFF
--- a/src/migrations/20230603185541-ledger-request-id.ts
+++ b/src/migrations/20230603185541-ledger-request-id.ts
@@ -1,0 +1,13 @@
+module.exports = {
+  async up(db) {
+    await db
+      .collection("medici_transactions")
+      .updateMany({}, { $rename: { new_address_request_id: "request_id" } })
+  },
+
+  async down(db) {
+    await db
+      .collection("medici_transactions")
+      .updateMany({}, { $rename: { request_id: "new_address_request_id" } })
+  },
+}

--- a/src/services/ledger/index.ts
+++ b/src/services/ledger/index.ts
@@ -459,9 +459,7 @@ export const translateToLedgerTx = <S extends WalletCurrency, T extends DisplayC
       tx.payee_addresses && tx.payee_addresses.length > 0
         ? (tx.payee_addresses[0] as OnChainAddress)
         : undefined,
-    requestId:
-      ((tx.request_id || tx.new_address_request_id) as OnChainAddressRequestId) ||
-      undefined,
+    requestId: (tx.request_id as OnChainAddressRequestId) || undefined,
     txHash: (tx.hash as OnChainTxHash) || undefined,
     vout: (tx.vout as OnChainTxVout) || undefined,
     feeKnownInAdvance: tx.feeKnownInAdvance || false,

--- a/src/services/ledger/schema.ts
+++ b/src/services/ledger/schema.ts
@@ -52,7 +52,6 @@ const transactionSchema = new Schema<ILedgerTransaction>(
 
     // for onchain transactions.
     payee_addresses: [String],
-    new_address_request_id: String,
     request_id: String,
 
     memoPayer: String,

--- a/src/services/ledger/schema.types.d.ts
+++ b/src/services/ledger/schema.types.d.ts
@@ -24,7 +24,6 @@ interface ILedgerTransaction {
   feeKnownInAdvance?: boolean
   related_journal?: ObjectId
   payee_addresses?: string[]
-  new_address_request_id?: string
   request_id?: string
   memoPayer?: string
   sats?: number


### PR DESCRIPTION
## Description 

Second part of `request_id` schema migration (see PR #2711)