### PR TITLE
fix: channels outbound balance

### DIFF
--- a/src/app/lightning/get-balances.ts
+++ b/src/app/lightning/get-balances.ts
@@ -26,8 +26,6 @@ export const getTotalBalance = async (): Promise<Satoshis | ApplicationError> =>
 export const getInboundBalance = async (): Promise<Satoshis | ApplicationError> => {
   const offChainService = LndService()
   if (offChainService instanceof Error) return offChainService
-  const offChainChannelBalances = await offChainService.getInboundOutboundBalance()
-  if (offChainChannelBalances instanceof Error) return offChainChannelBalances
 
   const inboundOutboundBalance = await Promise.all(
     offChainService
@@ -46,8 +44,6 @@ export const getInboundBalance = async (): Promise<Satoshis | ApplicationError> 
 export const getOutboundBalance = async (): Promise<Satoshis | ApplicationError> => {
   const offChainService = LndService()
   if (offChainService instanceof Error) return offChainService
-  const offChainChannelBalances = await offChainService.getInboundOutboundBalance()
-  if (offChainChannelBalances instanceof Error) return offChainChannelBalances
 
   const inboundOutboundBalance = await Promise.all(
     offChainService

--- a/src/domain/bitcoin/lightning/index.types.d.ts
+++ b/src/domain/bitcoin/lightning/index.types.d.ts
@@ -171,10 +171,7 @@ interface ILightningService {
   getBalance(pubkey?: Pubkey): Promise<Satoshis | LightningServiceError>
   getInboundOutboundBalance(
     pubkey?: Pubkey,
-  ): Promise<
-    | { channelBalance: Satoshis; inbound: Satoshis; outbound: Satoshis }
-    | LightningServiceError
-  >
+  ): Promise<{ inbound: Satoshis; outbound: Satoshis } | LightningServiceError>
   getOpeningChannelsBalance(pubkey?: Pubkey): Promise<Satoshis | LightningServiceError>
   getClosingChannelsBalance(pubkey?: Pubkey): Promise<Satoshis | LightningServiceError>
 

--- a/src/services/lnd/index.ts
+++ b/src/services/lnd/index.ts
@@ -103,18 +103,17 @@ export const LndService = (): ILightningService | LightningServiceError => {
     }
   }
 
-  const getInboundOutboundBalance = async (pubkey?: Pubkey) => {
+  const getInboundOutboundBalance = async (
+    pubkey?: Pubkey,
+  ): Promise<{ inbound: Satoshis; outbound: Satoshis } | LightningServiceError> => {
     try {
       const lnd = pubkey ? getLndFromPubkey({ pubkey }) : defaultLnd
       if (lnd instanceof Error) return lnd
       const { channel_balance, inbound } = await getChannelBalance({ lnd })
-      const inboundBal = inbound ?? 0
-      const outbound = channel_balance - inboundBal
 
       return {
-        channelBalance: toSats(channel_balance),
-        inbound: toSats(inboundBal),
-        outbound: toSats(outbound),
+        outbound: toSats(channel_balance),
+        inbound: toSats(inbound || 0),
       }
     } catch (err) {
       const errDetails = parseLndErrorDetails(err)


### PR DESCRIPTION
return from lightning library
```
return cbk(null, {
          channel_balance: Number(getSummary.local_balance.sat),
          channel_balance_mtokens: getSummary.local_balance.msat,
          inbound: Number(getSummary.remote_balance.sat),
          inbound_mtokens: getSummary.remote_balance.msat,
          pending_balance: Number(getSummary.pending_open_local_balance.sat),
          pending_inbound: Number(getSummary.pending_open_remote_balance.sat),
          unsettled_balance: Number(getSummary.unsettled_local_balance.sat),
          unsettled_balance_mtokens: getSummary.unsettled_local_balance.msat,
        });
```
so channel_balance is local balance and not channel capacity