### PR TITLE
fix: add journalId valiation to payoutSubmittedEventHandler

### DIFF
--- a/src/servers/event-handlers/bria.ts
+++ b/src/servers/event-handlers/bria.ts
@@ -83,7 +83,7 @@ export const payoutSubmittedEventHandler = async ({
   event: PayoutSubmitted
   payoutInfo: PayoutAugmentation
 }): Promise<true | ApplicationError> => {
-  const res = LedgerFacade.setOnChainTxPayoutId({
+  const res = await LedgerFacade.setOnChainTxPayoutId({
     journalId: payoutInfo.externalId as LedgerJournalId,
     payoutId: event.id,
   })

--- a/src/services/ledger/facade/onchain-send.ts
+++ b/src/services/ledger/facade/onchain-send.ts
@@ -10,7 +10,7 @@ import {
   NoTransactionToUpdateError,
 } from "@domain/errors"
 
-import { toObjectId } from "@services/mongoose/utils"
+import { isValidObjectId, toObjectId } from "@services/mongoose/utils"
 
 import { MainBook, Transaction } from "../books"
 
@@ -82,6 +82,10 @@ export const setOnChainTxPayoutId = async ({
   payoutId,
 }: SetOnChainTxPayoutIdArgs): Promise<true | LedgerServiceError> => {
   try {
+    if (!isValidObjectId(journalId)) {
+      return new NoTransactionToUpdateError()
+    }
+
     const result = await Transaction.updateMany(
       { _journal: toObjectId(journalId) },
       { payout_id: payoutId },
@@ -92,10 +96,7 @@ export const setOnChainTxPayoutId = async ({
     }
     return true
   } catch (err) {
-    if (err.message.includes("BSONTypeError")) {
-      return new NoTransactionToUpdateError()
-    }
-    return new UnknownLedgerError(err)
+    return new UnknownLedgerError(err.message || err)
   }
 }
 

--- a/src/services/mongoose/utils.ts
+++ b/src/services/mongoose/utils.ts
@@ -7,6 +7,10 @@ import {
 } from "@domain/errors"
 import { Types } from "mongoose"
 
+export const isValidObjectId = <T extends string>(id: T): boolean => {
+  return Types.ObjectId.isValid(id)
+}
+
 export const toObjectId = <T extends string>(id: T): Types.ObjectId => {
   return new Types.ObjectId(id)
 }


### PR DESCRIPTION
2 issues:
- Error handling was assuming `BSONTypeError: Argument passed in must be a string of 12 bytes or a string of 24 hex characters or an integer` but at least in my environment it was only returning `Argument passed in must be a string of 12 bytes or a string of 24 hex characters or an integer`
- LedgerFacade.setOnChainTxPayoutId without await, this returned a promise so it never was a NoTransactionToUpdateError 