### PR TITLE
fix: call sync updateLightningPaymentFlow + update error level

### DIFF
--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -699,7 +699,10 @@ const executePaymentViaLn = async ({
     }
     if (payResult instanceof LnPaymentPendingError) {
       paymentFlow.paymentSentAndPending = true
-      paymentFlowRepo.updateLightningPaymentFlow(paymentFlow)
+      const updateResult = await paymentFlowRepo.updateLightningPaymentFlow(paymentFlow)
+      if (updateResult instanceof Error) {
+        recordExceptionInCurrentSpan({ error: updateResult })
+      }
       return PaymentSendStatus.Pending
     }
 

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -45,7 +45,9 @@ export class CouldNotListWalletsFromWalletCurrencyError extends CouldNotFindErro
 export class CouldNotFindWalletOnChainPendingReceiveError extends CouldNotFindError {}
 export class NoTransactionToUpdateError extends CouldNotFindError {}
 export class CouldNotFindLightningPaymentFlowError extends CouldNotFindError {}
-export class CouldNotUpdateLightningPaymentFlowError extends CouldNotFindError {}
+export class CouldNotUpdateLightningPaymentFlowError extends CouldNotFindError {
+  level = ErrorLevel.Critical
+}
 export class NoExpiredLightningPaymentFlowsError extends CouldNotFindError {}
 export class CouldNotFindBtcWalletForAccountError extends CouldNotFindError {
   level = ErrorLevel.Critical


### PR DESCRIPTION
fix keybase://chat/galoymoney#incident/6029

-  call updateLightningPaymentFlow synchronously 
- Update CouldNotUpdateLightningPaymentFlowError level