### PR TITLE
chore: remove temporary onchain transaction hash

### DIFF
--- a/src/app/wallets/send-on-chain.ts
+++ b/src/app/wallets/send-on-chain.ts
@@ -1,5 +1,3 @@
-import crypto from "crypto"
-
 import { BTC_NETWORK, getOnChainWalletConfig } from "@config"
 
 import {
@@ -521,8 +519,6 @@ const executePaymentViaOnChain = async <
       debitAccountAdditionalMetadata,
       internalAccountsAdditionalMetadata,
     } = LedgerFacade.OnChainSendLedgerMetadata({
-      // we need a temporary hash to be able to search in admin panel
-      onChainTxHash: crypto.randomBytes(32).toString("hex") as OnChainTxHash,
       paymentAmounts: paymentFlow,
 
       amountDisplayCurrency: amountDisplayCurrencyAsNumber,

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -41,11 +41,19 @@ type SettlementViaLn = {
   readonly revealedPreImage: undefined // is added by dataloader in resolver
 }
 
-type SettlementViaOnChain = {
+type SettlementViaOnChainIncoming = {
   readonly type: "onchain"
   transactionHash: OnChainTxHash
   vout?: OnChainTxVout
 }
+
+type SettlementViaOnChainOutgoing = {
+  readonly type: "onchain"
+  transactionHash?: OnChainTxHash
+  vout?: OnChainTxVout
+}
+
+type SettlementViaOnChain = SettlementViaOnChainIncoming | SettlementViaOnChainOutgoing
 
 type PartialBaseWalletTransaction = {
   readonly walletId: WalletId | undefined
@@ -91,12 +99,12 @@ type WalletOnChainIntraledgerTransaction = BaseWalletTransaction & {
 
 type WalletOnChainPendingTransaction = PartialBaseWalletTransaction & {
   readonly initiationVia: InitiationViaOnChain
-  readonly settlementVia: SettlementViaOnChain
+  readonly settlementVia: SettlementViaOnChainIncoming
 }
 
 type WalletOnChainSettledTransaction = BaseWalletTransaction & {
   readonly initiationVia: InitiationViaOnChain
-  readonly settlementVia: SettlementViaOnChain
+  readonly settlementVia: SettlementViaOnChainIncoming
 }
 
 type WalletLegacyOnChainIntraledgerTransaction = BaseWalletTransaction & {

--- a/src/services/ledger/facade/tx-metadata.ts
+++ b/src/services/ledger/facade/tx-metadata.ts
@@ -178,7 +178,6 @@ export const LnSendLedgerMetadata = ({
 }
 
 export const OnChainSendLedgerMetadata = ({
-  onChainTxHash,
   paymentAmounts,
   feeDisplayCurrency: displayFee,
   amountDisplayCurrency: displayAmount,
@@ -187,7 +186,6 @@ export const OnChainSendLedgerMetadata = ({
   sendAll,
   memoOfPayer,
 }: {
-  onChainTxHash: OnChainTxHash
   paymentAmounts: AmountsAndFees
 
   feeDisplayCurrency: DisplayCurrencyBaseAmount
@@ -208,7 +206,7 @@ export const OnChainSendLedgerMetadata = ({
   const metadata: AddOnchainSendLedgerMetadata = {
     type: LedgerTransactionType.OnchainPayment,
     pending: true,
-    hash: onChainTxHash,
+    hash: undefined,
     payee_addresses: payeeAddresses,
     sendAll,
     memoPayer: memoOfPayer,

--- a/src/services/ledger/index.types.d.ts
+++ b/src/services/ledger/index.types.d.ts
@@ -96,7 +96,7 @@ type AddLnSendLedgerMetadata = LedgerMetadata &
 type AddOnchainSendLedgerMetadata = LedgerMetadata &
   LedgerSendMetadata &
   SendAmountsMetadata & {
-    hash: OnChainTxHash
+    hash: undefined
     payee_addresses: OnChainAddress[]
     sendAll: boolean
   }

--- a/test/integration/02-user-wallet/02-bria-handlers.spec.ts
+++ b/test/integration/02-user-wallet/02-bria-handlers.spec.ts
@@ -368,8 +368,6 @@ describe("Bria Event Handlers", () => {
         debitAccountAdditionalMetadata,
         internalAccountsAdditionalMetadata,
       } = LedgerFacade.OnChainSendLedgerMetadata({
-        // we need a temporary hash to be able to search in admin panel
-        onChainTxHash: crypto.randomBytes(32).toString("hex") as OnChainTxHash,
         paymentAmounts: {
           btcPaymentAmount,
           btcProtocolAndBankFee,

--- a/test/integration/02-user-wallet/02-receive-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-onchain.spec.ts
@@ -216,7 +216,7 @@ describe("With Bria", () => {
     // Check ledger transaction metadata for BTC 'LedgerTransactionType.OnchainReceipt'
     // ===
     const ledgerTxs = await LedgerService().getTransactionsByHash(
-      (txn.settlementVia as SettlementViaOnChain).transactionHash,
+      (txn.settlementVia as SettlementViaOnChainIncoming).transactionHash,
     )
     if (ledgerTxs instanceof Error) throw ledgerTxs
     const ledgerTx = ledgerTxs.find((tx) => tx.walletId === walletId)
@@ -369,7 +369,7 @@ describe("With Bria", () => {
       settledTxns.slice
         .filter((txn) =>
           settledTxIds.includes(
-            (txn.settlementVia as SettlementViaOnChain).transactionHash,
+            (txn.settlementVia as SettlementViaOnChainIncoming).transactionHash,
           ),
         )
         .map((txn) => (txn.initiationVia as InitiationViaOnChain).address)
@@ -1025,7 +1025,7 @@ describe("With Lnd", () => {
     // Check ledger transaction metadata for BTC 'LedgerTransactionType.OnchainReceipt'
     // ===
     const ledgerTxs = await LedgerService().getTransactionsByHash(
-      (txn.settlementVia as SettlementViaOnChain).transactionHash,
+      (txn.settlementVia as SettlementViaOnChainIncoming).transactionHash,
     )
     if (ledgerTxs instanceof Error) throw ledgerTxs
     const ledgerTx = ledgerTxs.find((tx) => tx.walletId === walletId)

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -412,7 +412,9 @@ const testExternalSend = async ({
 
     // Check ledger transaction metadata for USD & BTC 'LedgerTransactionType.OnchainPayment'
     // ===
-    const txHash = (settledTx.settlementVia as SettlementViaOnChain).transactionHash
+    const txHash = (settledTx.settlementVia as SettlementViaOnChainOutgoing)
+      .transactionHash
+    if (txHash === undefined) throw new Error("txHash is undefined")
     const txns = await LedgerService().getTransactionsByHash(txHash)
     if (txns instanceof Error) throw txns
     const txnPayment = txns.find(

--- a/test/integration/services/ledger/helpers.ts
+++ b/test/integration/services/ledger/helpers.ts
@@ -132,7 +132,6 @@ export const recordSendOnChainPayment = async <S extends WalletCurrency>({
 }: RecordExternalTxTestArgs<S>) => {
   const { metadata, debitAccountAdditionalMetadata, internalAccountsAdditionalMetadata } =
     LedgerFacade.OnChainSendLedgerMetadata({
-      onChainTxHash: crypto.randomUUID() as OnChainTxHash,
       paymentAmounts: {
         btcPaymentAmount: paymentAmount.btc,
         usdPaymentAmount: paymentAmount.usd,

--- a/test/unit/services/ledger/domain/tx-metadata.spec.ts
+++ b/test/unit/services/ledger/domain/tx-metadata.spec.ts
@@ -406,9 +406,13 @@ describe("Tx metadata", () => {
       payeeAddresses,
       newAddressRequestId,
     }
-    const expectedOnChainMetadataArgs = {
-      hash: onchainMetadataArgs.onChainTxHash,
+    const expectedOnChainSendMetadataArgs = {
       payee_addresses: onchainMetadataArgs.payeeAddresses,
+    }
+
+    const expectedOnChainReceiveMetadataArgs = {
+      payee_addresses: onchainMetadataArgs.payeeAddresses,
+      hash: onChainTxHash,
     }
 
     const lnMetadataArgs = {
@@ -461,7 +465,7 @@ describe("Tx metadata", () => {
                 expect.objectContaining({
                   type: LedgerTransactionType.OnchainPayment,
                   ...expectedMetadata,
-                  ...expectedOnChainMetadataArgs,
+                  ...expectedOnChainSendMetadataArgs,
                   sendAll: true,
                 }),
               )
@@ -563,7 +567,7 @@ describe("Tx metadata", () => {
                 expect.objectContaining({
                   type: LedgerTransactionType.OnchainReceipt,
                   ...expectedMetadata,
-                  ...expectedOnChainMetadataArgs,
+                  ...expectedOnChainReceiveMetadataArgs,
                 }),
               )
 


### PR DESCRIPTION
## Description

This PR removes the temporary transaction hash we set for onchain payments and it allows that field to be `undefined` until an actual transaction hash is available.