### PR TITLE
tests: fix timeout 90s in galoy-pay

### DIFF
--- a/src/domain/pubsub/index.types.d.ts
+++ b/src/domain/pubsub/index.types.d.ts
@@ -21,5 +21,8 @@ interface IPubSubService {
     trigger,
   }: AsyncIteratorArgs) => AsyncIterator<T> | PubSubServiceError
   publish: <T>({ trigger, payload }: PublishArgs<T>) => Promise<void | PubSubServiceError>
-  publishImmediate: <T>({ trigger, payload }: PublishArgs<T>) => NodeJS.Immediate
+  publishDelayed: <T>({
+    trigger,
+    payload,
+  }: PublishArgs<T>) => Promise<void | PubSubServiceError>
 }

--- a/src/graphql/root/subscription/my-updates.ts
+++ b/src/graphql/root/subscription/my-updates.ts
@@ -270,12 +270,12 @@ const MeSubscription = {
         pricePerUsdCent: pricePerUsdCent.price,
       }
       if (displayCurrency === DisplayCurrency.Usd) {
-        pubsub.publishImmediate({
+        pubsub.publishDelayed({
           trigger: accountUpdatedTrigger,
           payload: { price: priceData },
         })
       }
-      pubsub.publishImmediate({
+      pubsub.publishDelayed({
         trigger: accountUpdatedTrigger,
         payload: { realtimePrice: priceData },
       })

--- a/src/graphql/root/subscription/price.ts
+++ b/src/graphql/root/subscription/price.ts
@@ -101,7 +101,7 @@ const PriceSubscription = {
     })
 
     if (amount instanceof Error) {
-      pubsub.publishImmediate({
+      pubsub.publishDelayed({
         trigger: immediateTrigger,
         payload: { errors: [{ message: amount.message }] },
       })
@@ -110,7 +110,7 @@ const PriceSubscription = {
 
     for (const input of [amountCurrencyUnit, priceCurrencyUnit]) {
       if (input instanceof Error) {
-        pubsub.publishImmediate({
+        pubsub.publishDelayed({
           trigger: immediateTrigger,
           payload: { errors: [{ message: input.message }] },
         })
@@ -120,7 +120,7 @@ const PriceSubscription = {
 
     const currencies = await Prices.listCurrencies()
     if (currencies instanceof Error) {
-      pubsub.publishImmediate({
+      pubsub.publishDelayed({
         trigger: immediateTrigger,
         payload: { errors: [{ message: currencies.message }] },
       })
@@ -132,20 +132,20 @@ const PriceSubscription = {
 
     if (amountCurrencyUnit !== "BTCSAT" || displayCurrency instanceof Error) {
       // For now, keep the only supported exchange price as SAT -> USD
-      pubsub.publishImmediate({
+      pubsub.publishDelayed({
         trigger: immediateTrigger,
         payload: { errors: [{ message: "Unsupported exchange unit" }] },
       })
     } else if (amount >= 1000000) {
       // SafeInt limit, reject for now
-      pubsub.publishImmediate({
+      pubsub.publishDelayed({
         trigger: immediateTrigger,
         payload: { errors: [{ message: "Unsupported exchange amount" }] },
       })
     } else {
       const pricePerSat = await Prices.getCurrentSatPrice({ currency: displayCurrency })
       if (!(pricePerSat instanceof Error)) {
-        pubsub.publishImmediate({
+        pubsub.publishDelayed({
           trigger: immediateTrigger,
           payload: { pricePerSat: pricePerSat.price, displayCurrency },
         })

--- a/src/graphql/root/subscription/realtime-price.ts
+++ b/src/graphql/root/subscription/realtime-price.ts
@@ -118,7 +118,7 @@ const RealtimePriceSubscription = {
     })
 
     if (displayCurrency instanceof Error) {
-      pubsub.publishImmediate({
+      pubsub.publishDelayed({
         trigger: immediateTrigger,
         payload: { errors: [{ message: displayCurrency.message }] },
       })
@@ -127,7 +127,7 @@ const RealtimePriceSubscription = {
 
     const currencies = await Prices.listCurrencies()
     if (currencies instanceof Error) {
-      pubsub.publishImmediate({
+      pubsub.publishDelayed({
         trigger: immediateTrigger,
         payload: { errors: [mapAndParseErrorForGqlResponse(currencies)] },
       })
@@ -138,7 +138,7 @@ const RealtimePriceSubscription = {
     const checkedDisplayCurrency = checkedToDisplayCurrency(priceCurrency?.code)
 
     if (checkedDisplayCurrency instanceof Error) {
-      pubsub.publishImmediate({
+      pubsub.publishDelayed({
         trigger: immediateTrigger,
         payload: { errors: [{ message: "Unsupported exchange unit" }] },
       })
@@ -153,7 +153,7 @@ const RealtimePriceSubscription = {
     })
     if (!(pricePerSat instanceof Error) && !(pricePerUsdCent instanceof Error)) {
       const { timestamp } = pricePerSat
-      pubsub.publishImmediate({
+      pubsub.publishDelayed({
         trigger: immediateTrigger,
         payload: {
           timestamp,

--- a/src/services/pubsub.ts
+++ b/src/services/pubsub.ts
@@ -1,5 +1,7 @@
 import { PubSubServiceError, UnknownPubSubError } from "@domain/pubsub"
 
+import { sleep } from "@utils"
+
 import { redisPubSub } from "./redis"
 
 export const PubSubService = (): IPubSubService => {
@@ -24,16 +26,21 @@ export const PubSubService = (): IPubSubService => {
     }
   }
 
-  const publishImmediate = <T>({
+  const publishDelayed = async <T>({
     trigger,
     payload,
-  }: PublishArgs<T>): NodeJS.Immediate => {
-    return setImmediate(() => setImmediate(() => publish({ trigger, payload })))
+  }: PublishArgs<T>): Promise<void | PubSubServiceError> => {
+    // this is a "hack" to make sure the subscription is created before publishing
+    // this is because we rely on subscription (as an alternative to query)
+    // to know if some events (like payment) are successful or not
+    // this bring down some complexity on the client side but addomg some quirks here
+    await sleep(10)
+    publish({ trigger, payload })
   }
 
   return {
     createAsyncIterator,
     publish,
-    publishImmediate,
+    publishDelayed,
   }
 }


### PR DESCRIPTION
the test is failing on galoy-pay because it uses the subscription to get the status of an invoice, and the result never comes. 

this is because the `publishImmediate` (now renamed publishDelayed) was trigger because the listener was in place.

this fix one of the many flacky issues in the current e2e test,

unfortunately the fix is still a hack but I don't see a good way to solve this issue otherwise (except a broader change of design)