### PR TITLE
fix: accommodate dealer onchain send events

### DIFF
--- a/src/app/wallets/settle-payout-txn.ts
+++ b/src/app/wallets/settle-payout-txn.ts
@@ -13,10 +13,13 @@ import { NotificationsService } from "@services/notifications"
 export const settlePayout = async (
   payoutId: PayoutId,
 ): Promise<true | ApplicationError> => {
+  // Settle transaction in ledger
   const ledgerTxn = await LedgerFacade.settlePendingOnChainPayment(payoutId)
   if (ledgerTxn instanceof Error) return ledgerTxn
-  if (ledgerTxn.walletId === undefined) return new InvalidLedgerTransactionStateError()
+  if (ledgerTxn === undefined) return true
 
+  // Send notification to end user
+  if (ledgerTxn.walletId === undefined) return new InvalidLedgerTransactionStateError()
   const wallet = await WalletsRepository().findById(ledgerTxn.walletId)
   if (wallet instanceof Error) return wallet
   const account = await AccountsRepository().findById(wallet.accountId)

--- a/src/services/ledger/facade/onchain-send.ts
+++ b/src/services/ledger/facade/onchain-send.ts
@@ -154,7 +154,7 @@ export const setOnChainTxIdByPayoutId = async ({
 
 export const settlePendingOnChainPayment = async (
   payoutId: PayoutId,
-): Promise<LedgerTransaction<WalletCurrency> | LedgerServiceError> => {
+): Promise<LedgerTransaction<WalletCurrency> | undefined | LedgerServiceError> => {
   try {
     const result = await Transaction.updateMany(
       { payout_id: payoutId },
@@ -176,7 +176,9 @@ export const settlePendingOnChainPayment = async (
     (txn) => txn.walletId && !nonUserWalletIds.includes(txn.walletId),
   )
 
-  if (userLedgerTxn === undefined) return new InvalidLedgerTransactionStateError()
+  if (userLedgerTxn === undefined && txns.length === 0) {
+    return new InvalidLedgerTransactionStateError()
+  }
 
   return userLedgerTxn
 }


### PR DESCRIPTION
## Discussion

This PR accommodates ledger states where the dealer (or any non-end-user) wallet is the one sending an onchain payment.