### PR TITLE
fix: add handler for invalid or approved verification error

### DIFF
--- a/src/domain/phone-provider/errors.ts
+++ b/src/domain/phone-provider/errors.ts
@@ -8,6 +8,7 @@ export class InvalidPhoneNumberPhoneProviderError extends PhoneProviderServiceEr
 export class RestrictedRegionPhoneProviderError extends PhoneProviderServiceError {}
 export class UnsubscribedRecipientPhoneProviderError extends PhoneProviderServiceError {}
 export class RestrictedRecipientPhoneNumberError extends PhoneProviderServiceError {}
+export class InvalidOrApprovedVerificationError extends PhoneProviderServiceError {}
 
 export class PhoneCodeInvalidError extends PhoneProviderServiceError {}
 

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -160,6 +160,11 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
         "Issue detected with phone number. Please try again later or contact support."
       return new PhoneProviderError({ message, logger: baseLogger })
 
+    case "InvalidOrApprovedVerificationError":
+      message =
+        "Issue detected with verification. Please try again later or contact support."
+      return new PhoneProviderError({ message, logger: baseLogger })
+
     case "UnsubscribedRecipientPhoneProviderError":
       message = "Phone number has opted out of receiving messages"
       return new ValidationInternalError({ message, logger: baseLogger })

--- a/src/services/twilio.ts
+++ b/src/services/twilio.ts
@@ -12,6 +12,7 @@ import {
   PhoneProviderRateLimitExceededError,
   RestrictedRecipientPhoneNumberError,
   PhoneProviderUnavailableError,
+  InvalidOrApprovedVerificationError,
 } from "@domain/phone-provider"
 import { baseLogger } from "@services/logger"
 
@@ -148,6 +149,9 @@ const handleCommonErrors = (err: Error | string | unknown) => {
     case match(KnownTwilioErrorMessages.FraudulentActivityBlock):
       return new RestrictedRecipientPhoneNumberError(errMsg)
 
+    case match(KnownTwilioErrorMessages.InvalidOrApprovedVerification):
+      return new InvalidOrApprovedVerificationError(errMsg)
+
     default:
       return new UnknownPhoneProviderServiceError(errMsg)
   }
@@ -168,6 +172,8 @@ export const KnownTwilioErrorMessages = {
   FraudulentActivityBlock:
     /The destination phone number has been temporarily blocked by Twilio due to fraudulent activities/,
   ServiceUnavailable: /Service is unavailable. Please try again/,
+  InvalidOrApprovedVerification:
+    /The requested resource \/Services\/(.*?)\/VerificationCheck was not found/,
 } as const
 
 export const isPhoneCodeValid = async ({


### PR DESCRIPTION
FIx twilio unhandled error https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/adXD4GaRNqL/a/frwc6qPYuTJ

There is now way to know the details through api so we can only return 1 error for expired, approved or max attemps) https://www.twilio.com/docs/verify/api/verification-check#check-a-verification 