### PR TITLE
feat: implement account checks

### DIFF
--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -83,7 +83,6 @@ export const payInvoiceByWalletId = async ({
   const validatedPaymentInputs = await validateInvoicePaymentInputs({
     uncheckedPaymentRequest,
     uncheckedSenderWalletId,
-    senderAccount,
   })
   if (validatedPaymentInputs instanceof AlreadyPaidError) {
     return PaymentSendStatus.AlreadyPaid
@@ -175,11 +174,9 @@ export const payNoAmountInvoiceByWalletIdForUsdWallet = async (
 const validateInvoicePaymentInputs = async ({
   uncheckedPaymentRequest,
   uncheckedSenderWalletId,
-  senderAccount,
 }: {
   uncheckedPaymentRequest: string
   uncheckedSenderWalletId: string
-  senderAccount: Account
 }): Promise<
   | {
       senderWallet: Wallet
@@ -209,6 +206,9 @@ const validateInvoicePaymentInputs = async ({
 
   const senderWallet = await WalletsRepository().findById(senderWalletId)
   if (senderWallet instanceof Error) return senderWallet
+
+  const senderAccount = await AccountsRepository().findById(senderWallet.accountId)
+  if (senderAccount instanceof Error) return senderAccount
 
   const accountValidator = AccountValidator(senderAccount)
   if (accountValidator instanceof Error) return accountValidator
@@ -378,6 +378,9 @@ const executePaymentViaIntraledger = async <
 
   const recipientAccount = await AccountsRepository().findById(recipientWallet.accountId)
   if (recipientAccount instanceof Error) return recipientAccount
+
+  const accountValidator = AccountValidator(recipientAccount)
+  if (accountValidator instanceof Error) return accountValidator
 
   const checkLimits =
     senderWallet.accountId === recipientWallet.accountId

--- a/src/app/wallets/get-last-on-chain-address.ts
+++ b/src/app/wallets/get-last-on-chain-address.ts
@@ -1,11 +1,23 @@
+import { AccountValidator } from "@domain/accounts"
 import { CouldNotFindError } from "@domain/errors"
-import { WalletOnChainAddressesRepository } from "@services/mongoose"
+import {
+  AccountsRepository,
+  WalletOnChainAddressesRepository,
+  WalletsRepository,
+} from "@services/mongoose"
 
 import { createOnChainAddressForBtcWallet } from "./create-on-chain-address"
 
 export const getLastOnChainAddress = async (
   walletId: WalletId,
 ): Promise<OnChainAddress | ApplicationError> => {
+  const wallet = await WalletsRepository().findById(walletId)
+  if (wallet instanceof Error) return wallet
+  const account = await AccountsRepository().findById(wallet.accountId)
+  if (account instanceof Error) return account
+  const accountValidator = AccountValidator(account)
+  if (accountValidator instanceof Error) return accountValidator
+
   const onChainAddressesRepo = WalletOnChainAddressesRepository()
   const lastOnChainAddress = await onChainAddressesRepo.findLastByWalletId(walletId)
 

--- a/test/integration/app/wallets/create-on-chain-address.spec.ts
+++ b/test/integration/app/wallets/create-on-chain-address.spec.ts
@@ -1,0 +1,31 @@
+import { Accounts, Wallets } from "@app"
+
+import { AccountStatus } from "@domain/accounts"
+import { InactiveAccountError } from "@domain/errors"
+
+import { AccountsRepository } from "@services/mongoose"
+
+import { createRandomUserAndWallet } from "test/helpers"
+
+describe("onChainAddress", () => {
+  it("fails if account is locked", async () => {
+    const newWalletDescriptor = await createRandomUserAndWallet()
+    const newAccount = await AccountsRepository().findById(newWalletDescriptor.accountId)
+    if (newAccount instanceof Error) throw newAccount
+
+    // Lock account
+    const updatedAccount = await Accounts.updateAccountStatus({
+      id: newAccount.id,
+      status: AccountStatus.Locked,
+      updatedByUserId: newAccount.kratosUserId,
+    })
+    if (updatedAccount instanceof Error) throw updatedAccount
+    expect(updatedAccount.status).toEqual(AccountStatus.Locked)
+
+    // Create address attempt
+    const res = await Wallets.createOnChainAddressForBtcWallet({
+      walletId: newWalletDescriptor.id,
+    })
+    expect(res).toBeInstanceOf(InactiveAccountError)
+  })
+})

--- a/test/integration/app/wallets/get-last-on-chain-address.spec.ts
+++ b/test/integration/app/wallets/get-last-on-chain-address.spec.ts
@@ -1,0 +1,29 @@
+import { Accounts, Wallets } from "@app"
+
+import { AccountStatus } from "@domain/accounts"
+import { InactiveAccountError } from "@domain/errors"
+
+import { AccountsRepository } from "@services/mongoose"
+
+import { createRandomUserAndWallet } from "test/helpers"
+
+describe("onChainAddress", () => {
+  it("fails if account is locked", async () => {
+    const newWalletDescriptor = await createRandomUserAndWallet()
+    const newAccount = await AccountsRepository().findById(newWalletDescriptor.accountId)
+    if (newAccount instanceof Error) throw newAccount
+
+    // Lock account
+    const updatedAccount = await Accounts.updateAccountStatus({
+      id: newAccount.id,
+      status: AccountStatus.Locked,
+      updatedByUserId: newAccount.kratosUserId,
+    })
+    if (updatedAccount instanceof Error) throw updatedAccount
+    expect(updatedAccount.status).toEqual(AccountStatus.Locked)
+
+    // Create address attempt
+    const res = await Wallets.getLastOnChainAddress(newWalletDescriptor.id)
+    expect(res).toBeInstanceOf(InactiveAccountError)
+  })
+})

--- a/test/integration/app/wallets/send-intraledger.spec.ts
+++ b/test/integration/app/wallets/send-intraledger.spec.ts
@@ -1,0 +1,150 @@
+import { Accounts, Payments } from "@app"
+
+import { AccountStatus } from "@domain/accounts"
+import { toSats } from "@domain/bitcoin"
+import { DisplayCurrency, toCents } from "@domain/fiat"
+import { InactiveAccountError } from "@domain/errors"
+
+import { AccountsRepository } from "@services/mongoose"
+import { Transaction } from "@services/ledger/schema"
+
+import { AmountCalculator, WalletCurrency } from "@domain/shared"
+
+import {
+  createMandatoryUsers,
+  createRandomUserAndWallet,
+  recordReceiveLnPayment,
+} from "test/helpers"
+
+const calc = AmountCalculator()
+
+beforeAll(async () => {
+  await createMandatoryUsers()
+})
+
+const amount = toSats(10040)
+const btcPaymentAmount: BtcPaymentAmount = {
+  amount: BigInt(amount),
+  currency: WalletCurrency.Btc,
+}
+
+const usdAmount = toCents(210)
+const usdPaymentAmount: UsdPaymentAmount = {
+  amount: BigInt(usdAmount),
+  currency: WalletCurrency.Usd,
+}
+
+const receiveAmounts = { btc: calc.mul(btcPaymentAmount, 3n), usd: usdPaymentAmount }
+
+const receiveBankFee = {
+  btc: { amount: 100n, currency: WalletCurrency.Btc },
+  usd: { amount: 1n, currency: WalletCurrency.Usd },
+}
+
+const receiveDisplayAmounts = {
+  amountDisplayCurrency: Number(receiveAmounts.usd.amount) as DisplayCurrencyBaseAmount,
+  feeDisplayCurrency: Number(receiveBankFee.usd.amount) as DisplayCurrencyBaseAmount,
+  displayCurrency: DisplayCurrency.Usd,
+}
+
+const randomOnChainMemo = () =>
+  "this is my onchain memo #" + (Math.random() * 1_000_000).toFixed()
+
+describe("intraLedgerPay", () => {
+  it("fails if sender account is locked", async () => {
+    const memo = randomOnChainMemo()
+
+    const senderWalletDescriptor = await createRandomUserAndWallet()
+    const senderAccount = await AccountsRepository().findById(
+      senderWalletDescriptor.accountId,
+    )
+    if (senderAccount instanceof Error) throw senderAccount
+
+    const recipientWalletDescriptor = await createRandomUserAndWallet()
+    const recipientAccount = await AccountsRepository().findById(
+      recipientWalletDescriptor.accountId,
+    )
+    if (recipientAccount instanceof Error) throw recipientAccount
+
+    // Fund balance for send
+    const receive = await recordReceiveLnPayment({
+      walletDescriptor: senderWalletDescriptor,
+      paymentAmount: receiveAmounts,
+      bankFee: receiveBankFee,
+      displayAmounts: receiveDisplayAmounts,
+      memo,
+    })
+    if (receive instanceof Error) throw receive
+
+    // Lock sender account
+    const updatedAccount = await Accounts.updateAccountStatus({
+      id: senderAccount.id,
+      status: AccountStatus.Locked,
+      updatedByUserId: senderAccount.kratosUserId,
+    })
+    if (updatedAccount instanceof Error) throw updatedAccount
+    expect(updatedAccount.status).toEqual(AccountStatus.Locked)
+
+    // Initiate intraledger send
+    const res = await Payments.intraledgerPaymentSendWalletIdForBtcWallet({
+      senderWalletId: senderWalletDescriptor.id,
+      senderAccount: senderAccount,
+      recipientWalletId: recipientWalletDescriptor.id,
+      amount,
+
+      memo,
+    })
+    expect(res).toBeInstanceOf(InactiveAccountError)
+
+    // Restore system state
+    Transaction.deleteMany({ memo })
+  })
+
+  it("fails if recipient account is locked", async () => {
+    const memo = randomOnChainMemo()
+
+    const senderWalletDescriptor = await createRandomUserAndWallet()
+    const senderAccount = await AccountsRepository().findById(
+      senderWalletDescriptor.accountId,
+    )
+    if (senderAccount instanceof Error) throw senderAccount
+
+    const recipientWalletDescriptor = await createRandomUserAndWallet()
+    const recipientAccount = await AccountsRepository().findById(
+      recipientWalletDescriptor.accountId,
+    )
+    if (recipientAccount instanceof Error) throw recipientAccount
+
+    // Lock recipient account
+    const updatedAccount = await Accounts.updateAccountStatus({
+      id: recipientAccount.id,
+      status: AccountStatus.Locked,
+      updatedByUserId: recipientAccount.kratosUserId,
+    })
+    if (updatedAccount instanceof Error) throw updatedAccount
+    expect(updatedAccount.status).toEqual(AccountStatus.Locked)
+
+    // Fund balance for send
+    const receive = await recordReceiveLnPayment({
+      walletDescriptor: senderWalletDescriptor,
+      paymentAmount: receiveAmounts,
+      bankFee: receiveBankFee,
+      displayAmounts: receiveDisplayAmounts,
+      memo,
+    })
+    if (receive instanceof Error) throw receive
+
+    const res = await Payments.intraledgerPaymentSendWalletIdForBtcWallet({
+      senderWalletId: senderWalletDescriptor.id,
+      senderAccount: senderAccount,
+      recipientWalletId: recipientWalletDescriptor.id,
+      amount,
+
+      memo,
+    })
+    expect(res).toBeInstanceOf(InactiveAccountError)
+
+    // Restore system state
+    Transaction.deleteMany({ memo })
+  })
+})

--- a/test/integration/app/wallets/send-lightning.spec.ts
+++ b/test/integration/app/wallets/send-lightning.spec.ts
@@ -1,0 +1,187 @@
+import { Accounts, Payments } from "@app"
+
+import { AccountStatus } from "@domain/accounts"
+import { toSats } from "@domain/bitcoin"
+import { decodeInvoice } from "@domain/bitcoin/lightning"
+import { DisplayCurrency, toCents } from "@domain/fiat"
+import { InactiveAccountError } from "@domain/errors"
+import { AmountCalculator, WalletCurrency } from "@domain/shared"
+
+import { AccountsRepository, WalletInvoicesRepository } from "@services/mongoose"
+import { Transaction } from "@services/ledger/schema"
+import * as LndImpl from "@services/lnd"
+
+import {
+  createMandatoryUsers,
+  createRandomUserAndWallet,
+  recordReceiveLnPayment,
+} from "test/helpers"
+
+let lnInvoice: LnInvoice
+
+const calc = AmountCalculator()
+
+beforeAll(async () => {
+  await createMandatoryUsers()
+
+  const randomRequest =
+    "lnbcrt10n1p39jatkpp5djwv295kunhe5e0e4whj3dcjzwy7cmcxk8cl2a4dquyrp3dqydesdqqcqzpuxqr23ssp56u5m680x7resnvcelmsngc64ljm7g5q9r26zw0qyq5fenuqlcfzq9qyyssqxv4kvltas2qshhmqnjctnqkjpdfzu89e428ga6yk9jsp8rf382f3t03ex4e6x3a4sxkl7ruj6lsfpkuu9u9ee5kgr5zdyj7x2nwdljgq74025p"
+  const invoice = decodeInvoice(randomRequest)
+  if (invoice instanceof Error) throw invoice
+  lnInvoice = invoice
+})
+
+const amount = toSats(10040)
+const btcPaymentAmount: BtcPaymentAmount = {
+  amount: BigInt(amount),
+  currency: WalletCurrency.Btc,
+}
+
+const usdAmount = toCents(210)
+const usdPaymentAmount: UsdPaymentAmount = {
+  amount: BigInt(usdAmount),
+  currency: WalletCurrency.Usd,
+}
+
+const receiveAmounts = { btc: calc.mul(btcPaymentAmount, 3n), usd: usdPaymentAmount }
+
+const receiveBankFee = {
+  btc: { amount: 100n, currency: WalletCurrency.Btc },
+  usd: { amount: 1n, currency: WalletCurrency.Usd },
+}
+
+const receiveDisplayAmounts = {
+  amountDisplayCurrency: Number(receiveAmounts.usd.amount) as DisplayCurrencyBaseAmount,
+  feeDisplayCurrency: Number(receiveBankFee.usd.amount) as DisplayCurrencyBaseAmount,
+  displayCurrency: DisplayCurrency.Usd,
+}
+
+const randomLightningMemo = () =>
+  "this is my lightning memo #" + (Math.random() * 1_000_000).toFixed()
+
+describe("lightningPay", () => {
+  describe("settles via lightning", () => {
+    it("fails if sender account is locked", async () => {
+      const memo = randomLightningMemo()
+
+      // Setup mocks
+      const { LndService: LnServiceOrig } = jest.requireActual("@services/lnd")
+      const lndServiceSpy = jest.spyOn(LndImpl, "LndService").mockReturnValue({
+        ...LnServiceOrig(),
+        listAllPubkeys: () => [],
+      })
+
+      // Create users
+      const newWalletDescriptor = await createRandomUserAndWallet()
+      const newAccount = await AccountsRepository().findById(
+        newWalletDescriptor.accountId,
+      )
+      if (newAccount instanceof Error) throw newAccount
+
+      // Fund balance for send
+      const receive = await recordReceiveLnPayment({
+        walletDescriptor: newWalletDescriptor,
+        paymentAmount: receiveAmounts,
+        bankFee: receiveBankFee,
+        displayAmounts: receiveDisplayAmounts,
+        memo,
+      })
+      if (receive instanceof Error) throw receive
+
+      // Lock sender account
+      const updatedAccount = await Accounts.updateAccountStatus({
+        id: newAccount.id,
+        status: AccountStatus.Locked,
+        updatedByUserId: newAccount.kratosUserId,
+      })
+      if (updatedAccount instanceof Error) throw updatedAccount
+      expect(updatedAccount.status).toEqual(AccountStatus.Locked)
+
+      // Attempt send payment
+      const res = await Payments.payInvoiceByWalletId({
+        senderWalletId: newWalletDescriptor.id,
+        senderAccount: newAccount,
+        uncheckedPaymentRequest: lnInvoice.paymentRequest,
+
+        memo,
+      })
+      expect(res).toBeInstanceOf(InactiveAccountError)
+
+      // Restore system state
+      await Transaction.deleteMany({ memo })
+      lndServiceSpy.mockReset()
+    })
+  })
+
+  describe("settles intraledger", () => {
+    it("fails if recipient account is locked", async () => {
+      const memo = randomLightningMemo()
+      const { paymentHash, destination } = lnInvoice
+
+      // Setup mocks
+      const { LndService: LnServiceOrig } = jest.requireActual("@services/lnd")
+      const lndServiceSpy = jest.spyOn(LndImpl, "LndService").mockReturnValue({
+        ...LnServiceOrig(),
+        listAllPubkeys: () => [destination],
+      })
+
+      // Setup users and wallets
+      const newWalletDescriptor = await createRandomUserAndWallet()
+      const newAccount = await AccountsRepository().findById(
+        newWalletDescriptor.accountId,
+      )
+      if (newAccount instanceof Error) throw newAccount
+
+      const recipientWalletDescriptor = await createRandomUserAndWallet()
+      const recipientAccount = await AccountsRepository().findById(
+        recipientWalletDescriptor.accountId,
+      )
+      if (recipientAccount instanceof Error) throw recipientAccount
+
+      // Fund balance for send
+      const receive = await recordReceiveLnPayment({
+        walletDescriptor: newWalletDescriptor,
+        paymentAmount: receiveAmounts,
+        bankFee: receiveBankFee,
+        displayAmounts: receiveDisplayAmounts,
+        memo,
+      })
+      if (receive instanceof Error) throw receive
+
+      // Add recipient invoice
+      const persisted = await WalletInvoicesRepository().persistNew({
+        paymentHash,
+        secret: "secret" as SecretPreImage,
+        selfGenerated: true,
+        pubkey: destination,
+        recipientWalletDescriptor,
+        paid: false,
+      })
+      if (persisted instanceof Error) throw persisted
+
+      // Lock recipient account
+      const updatedAccount = await Accounts.updateAccountStatus({
+        id: recipientAccount.id,
+        status: AccountStatus.Locked,
+        updatedByUserId: recipientAccount.kratosUserId,
+      })
+      if (updatedAccount instanceof Error) throw updatedAccount
+      expect(updatedAccount.status).toEqual(AccountStatus.Locked)
+
+      // Attempt send payment
+      const res = await Payments.payInvoiceByWalletId({
+        senderWalletId: newWalletDescriptor.id,
+        senderAccount: newAccount,
+        uncheckedPaymentRequest: lnInvoice.paymentRequest,
+
+        memo,
+      })
+      expect(res).toBeInstanceOf(InactiveAccountError)
+
+      // Restore system state
+      await WalletInvoicesRepository().deleteByPaymentHash(paymentHash)
+      await Transaction.deleteMany({ memo })
+      lndServiceSpy.mockReset()
+    })
+  })
+})


### PR DESCRIPTION
## Description

**_Note: This PR felt like the pre-cursor to thinking about introducing authorization in the backend_**

This PR implements various account-locked checks in different use-cases for both senders and recipients.

We now have account checks that block:
- [x] send-onchain
  - [x] for sender
  - [x] for recipient: initiate onchain, settle intraledger
- [x] send-intraledger
  - [x] for sender
  - [x] for recipient
- [x] send-lightning
  - [x] for sender
  - [x] for recipient: initiate ln, settle intraledger
- [x] create new onchain address
- [x] fetch last onchain address
- [x] add invoice
  - [x] for self
  - [x] as recipient
