### PR TITLE
test: add connects-to-bria check

### DIFF
--- a/test/helpers/shared.ts
+++ b/test/helpers/shared.ts
@@ -5,3 +5,13 @@ export const waitFor = async (f) => {
   while (!(res = await f())) await sleep(500)
   return res
 }
+
+export const waitForWithCount = async (f, max) => {
+  let count = 0
+  let res
+  while (!(res = await f()) && count < max) {
+    await sleep(500)
+    count++
+  }
+  return res
+}

--- a/test/legacy-integration/01-setup/01-connection.spec.ts
+++ b/test/legacy-integration/01-setup/01-connection.spec.ts
@@ -1,3 +1,4 @@
+import { NewOnChainService } from "@services/bria"
 import { redis } from "@services/redis"
 import { Account } from "@services/mongoose/schema"
 
@@ -12,6 +13,7 @@ import {
   resetLnds,
   getChannels,
   getChainBalance,
+  waitForWithCount,
 } from "test/helpers"
 
 it("connects to bitcoind", async () => {
@@ -63,4 +65,13 @@ it("connects to redis", async () => {
   await redis.set("key", value)
   const result = await redis.get("key")
   expect(result).toBe(value)
+})
+
+it("connects to bria", async () => {
+  let res
+  await waitForWithCount(async () => {
+    const res = await NewOnChainService().getBalance()
+    return !(res instanceof Error)
+  }, 20)
+  expect(res).not.toBeInstanceOf(Error)
 })


### PR DESCRIPTION
## Description

Bria gets bootstrapped on container startup. This adds a test with a wait to check for bria successful bootstrap.