### PR TITLE
feat: email cookie login

### DIFF
--- a/dev/ory/oathkeeper_rules.yaml
+++ b/dev/ory/oathkeeper_rules.yaml
@@ -2,7 +2,7 @@
   upstream:
     url: "http://e2e-tests:4012"
   match:
-    url: "<(http|https)>://<[a-zA-Z0-9-.:]+>/auth/<(clearCookies|login|logout|email/code|email/login|totp/validate)>"
+    url: "<(http|https)>://<[a-zA-Z0-9-.:]+>/auth/<(clearCookies|login|logout|email/code|email/login|totp/validate|email/login/cookie)>"
     methods: ["GET", "POST", "OPTIONS"]
   authenticators:
     - handler: anonymous

--- a/src/app/authentication/index.types.d.ts
+++ b/src/app/authentication/index.types.d.ts
@@ -30,6 +30,6 @@ type LoginWithPhoneResult = {
 
 type LoginWithEmailCookieResult = {
   cookiesToSendBackToClient: Array<SessionCookie>
-  kratosUserId: UserId
+  kratosUserId?: UserId
   totpRequired: boolean
 }

--- a/src/app/authentication/index.types.d.ts
+++ b/src/app/authentication/index.types.d.ts
@@ -27,3 +27,9 @@ type LoginWithPhoneResult = {
   authToken: AuthToken
   totpRequired: boolean
 }
+
+type LoginWithEmailCookieResult = {
+  cookiesToSendBackToClient: Array<SessionCookie>
+  kratosUserId: UserId
+  totpRequired: boolean
+}

--- a/src/app/authentication/login.ts
+++ b/src/app/authentication/login.ts
@@ -182,6 +182,45 @@ export const loginWithEmail = async ({
   return { authToken: res.authToken, totpRequired }
 }
 
+export const loginWithEmailCookie = async ({
+  emailFlowId,
+  code: codeRaw,
+  ip,
+}: {
+  emailFlowId: EmailFlowId
+  code: EmailCode
+  ip: IpAddress
+}): Promise<LoginWithEmailCookieResult | ApplicationError> => {
+  {
+    const limitOk = await checkFailedLoginAttemptPerIpLimits(ip)
+    if (limitOk instanceof Error) return limitOk
+  }
+
+  const code = checkedToEmailCode(codeRaw)
+  if (code instanceof Error) return code
+
+  const authServiceEmail = AuthWithEmailPasswordlessService()
+
+  const validateCodeRes = await authServiceEmail.validateCode({
+    code,
+    emailFlowId,
+  })
+  if (validateCodeRes instanceof Error) return validateCodeRes
+
+  const email = validateCodeRes.email
+  const totpRequired = validateCodeRes.totpRequired
+
+  const isEmailVerified = await authServiceEmail.isEmailVerified({ email })
+  if (isEmailVerified instanceof Error) return isEmailVerified
+  if (isEmailVerified === false) return new EmailUnverifiedError()
+
+  await rewardFailedLoginAttemptPerIpLimits(ip)
+
+  const kratosResult = await authServiceEmail.loginCookie({ email })
+  if (kratosResult instanceof Error) return kratosResult
+  return { ...kratosResult, totpRequired }
+}
+
 export const loginDeviceUpgradeWithPhone = async ({
   phone,
   code,

--- a/src/app/authentication/login.ts
+++ b/src/app/authentication/login.ts
@@ -157,11 +157,6 @@ export const loginWithEmail = async ({
     if (limitOk instanceof Error) return limitOk
   }
 
-  {
-    const limitOk = await checkFailedLoginAttemptPerLoginIdentifierLimits(emailFlowId)
-    if (limitOk instanceof Error) return limitOk
-  }
-
   const code = checkedToEmailCode(codeRaw)
   if (code instanceof Error) return code
 
@@ -181,7 +176,6 @@ export const loginWithEmail = async ({
   if (isEmailVerified === false) return new EmailUnverifiedError()
 
   await rewardFailedLoginAttemptPerIpLimits(ip)
-  await rewardFailedLoginAttemptPerLoginIdentifierLimits(emailFlowId)
 
   const res = await authServiceEmail.loginToken({ email })
   if (res instanceof Error) throw res
@@ -202,11 +196,6 @@ export const loginWithEmailCookie = async ({
     if (limitOk instanceof Error) return limitOk
   }
 
-  {
-    const limitOk = await checkFailedLoginAttemptPerLoginIdentifierLimits(emailFlowId)
-    if (limitOk instanceof Error) return limitOk
-  }
-
   const code = checkedToEmailCode(codeRaw)
   if (code instanceof Error) return code
 
@@ -226,7 +215,6 @@ export const loginWithEmailCookie = async ({
   if (isEmailVerified === false) return new EmailUnverifiedError()
 
   await rewardFailedLoginAttemptPerIpLimits(ip)
-  await rewardFailedLoginAttemptPerLoginIdentifierLimits(emailFlowId)
 
   const kratosResult = await authServiceEmail.loginCookie({ email })
   if (kratosResult instanceof Error) return kratosResult

--- a/src/app/authentication/login.ts
+++ b/src/app/authentication/login.ts
@@ -97,7 +97,7 @@ export const loginWithPhoneCookie = async ({
   phone: PhoneNumber
   code: PhoneCode
   ip: IpAddress
-}): Promise<WithCookieResponse | ApplicationError> => {
+}): Promise<LoginWithPhoneCookieSchemaResponse | ApplicationError> => {
   {
     const limitOk = await checkFailedLoginAttemptPerIpLimits(ip)
     if (limitOk instanceof Error) return limitOk

--- a/src/app/authentication/ratelimits.ts
+++ b/src/app/authentication/ratelimits.ts
@@ -27,20 +27,20 @@ export const rewardFailedLoginAttemptPerIpLimits = async (
 }
 
 export const checkFailedLoginAttemptPerLoginIdentifierLimits = async (
-  phone: PhoneNumber,
+  loginIdentifier: LoginIdentifier,
 ): Promise<true | RateLimiterExceededError> =>
   consumeLimiter({
     rateLimitConfig: RateLimitConfig.failedLoginAttemptPerLoginIdentifier,
-    keyToConsume: phone,
+    keyToConsume: loginIdentifier,
   })
 
 export const rewardFailedLoginAttemptPerLoginIdentifierLimits = async (
-  phone: PhoneNumber,
+  loginIdentifier: LoginIdentifier,
 ): Promise<true | RateLimiterExceededError> => {
   const limiter = RedisRateLimitService({
     keyPrefix: RateLimitPrefix.failedLoginAttemptPerLoginIdentifier,
     limitOptions: getFailedLoginAttemptPerLoginIdentifierLimits(),
   })
 
-  return limiter.reward(phone)
+  return limiter.reward(loginIdentifier)
 }

--- a/src/domain/authentication/cookie.ts
+++ b/src/domain/authentication/cookie.ts
@@ -1,0 +1,11 @@
+export interface ICookieOptions {
+  maxAge?: number | undefined
+  signed?: boolean | undefined
+  expires?: Date | undefined
+  httpOnly?: boolean | undefined
+  path?: string | undefined
+  domain?: string | undefined
+  secure?: boolean | undefined
+  encode?: ((val: string) => string) | undefined
+  sameSite?: boolean | "lax" | "strict" | "none" | undefined
+}

--- a/src/domain/authentication/index.types.d.ts
+++ b/src/domain/authentication/index.types.d.ts
@@ -124,6 +124,9 @@ interface IAuthWithEmailPasswordlessService {
   loginToken(args: {
     email: EmailAddress
   }): Promise<LoginWithPhoneNoPasswordSchemaResponse | KratosError>
+  loginCookie(args: {
+    email: EmailAddress
+  }): Promise<LoginWithPhoneCookieSchemaResponse | KratosError>
 }
 
 type CreateIdentityWithSessionResult = WithSessionResponse & {

--- a/src/domain/authentication/index.types.d.ts
+++ b/src/domain/authentication/index.types.d.ts
@@ -59,7 +59,10 @@ type LoginWithPhoneNoPasswordSchemaResponse = {
   authToken: AuthToken
   kratosUserId?: UserId
 }
-type LoginWithPhoneCookieSchemaResponse = WithCookieResponse
+type LoginWithPhoneCookieSchemaResponse = {
+  cookiesToSendBackToClient: Array<SessionCookie>
+  kratosUserId?: UserId
+}
 type CreateKratosUserForPhoneNoPasswordSchemaResponse = WithSessionResponse
 type CreateKratosUserForPhoneNoPasswordSchemaCookieResponse = WithCookieResponse
 

--- a/src/domain/users/index.types.d.ts
+++ b/src/domain/users/index.types.d.ts
@@ -4,7 +4,7 @@ type PhoneCode = string & { readonly brand: unique symbol }
 type EmailAddress = string & { readonly brand: unique symbol }
 type EmailCode = string & { readonly brand: unique symbol }
 
-type LoginIdentifier = PhoneNumber | EmailAddress
+type LoginIdentifier = PhoneNumber | EmailAddress | DeviceId | EmailFlowId
 
 type DeviceId = string & { readonly brand: unique symbol }
 

--- a/src/domain/users/index.types.d.ts
+++ b/src/domain/users/index.types.d.ts
@@ -4,7 +4,7 @@ type PhoneCode = string & { readonly brand: unique symbol }
 type EmailAddress = string & { readonly brand: unique symbol }
 type EmailCode = string & { readonly brand: unique symbol }
 
-type LoginIdentifier = PhoneNumber | EmailAddress | DeviceId | EmailFlowId
+type LoginIdentifier = PhoneNumber | EmailAddress
 
 type DeviceId = string & { readonly brand: unique symbol }
 

--- a/src/servers/authorization/cookies.ts
+++ b/src/servers/authorization/cookies.ts
@@ -11,12 +11,12 @@ import { logoutCookie } from "@app/authentication"
 import { parseIps } from "@domain/accounts-ips"
 import { checkedToPhoneNumber } from "@domain/users"
 import bodyParser from "body-parser"
-import libCookie from "cookie"
 
 import cookieParser from "cookie-parser"
-import setCookie from "set-cookie-parser"
 
 import { validateKratosCookie } from "@services/kratos"
+
+import { parseKratosCookies } from "@services/kratos/cookie"
 
 import { authRouter } from "./router"
 
@@ -50,73 +50,42 @@ authRouter.post(
         return res.status(500).send({ error: mapError(loginResp).message })
       }
 
-      let cookies: setCookie.Cookie[]
-      let kratosUserId: UserId
       try {
-        cookies = setCookie.parse(loginResp.cookiesToSendBackToClient)
-        kratosUserId = loginResp.kratosUserId
-      } catch (error) {
-        recordExceptionInCurrentSpan({ error })
-        return res.status(500).send({ error: "Error parsing cookies" })
-      }
-
-      try {
-        const csrfCookie = cookies?.find((c) => c.name.includes("csrf"))
-        const kratosSessionCookie = cookies?.find((c) =>
-          c.name.includes("ory_kratos_session"),
-        )
+        const kratosCookies = parseKratosCookies(loginResp.cookiesToSendBackToClient)
+        const kratosUserId: UserId = loginResp.kratosUserId
+        const csrfCookie = kratosCookies.csrf()
+        const kratosSessionCookie = kratosCookies.kratosSession()
         if (!csrfCookie || !kratosSessionCookie) {
           return res
             .status(500)
             .send({ error: "Missing csrf or ory_kratos_session cookie" })
         }
-        const kratosCookieStr = libCookie.serialize(
-          kratosSessionCookie.name,
-          kratosSessionCookie.value,
-          {
-            expires: kratosSessionCookie.expires,
-            maxAge: kratosSessionCookie.maxAge,
-            sameSite: "none",
-            secure: kratosSessionCookie.secure,
-            httpOnly: kratosSessionCookie.httpOnly,
-            path: kratosSessionCookie.path,
-          },
-        )
+        const kratosCookieStr = kratosCookies.kratosSessionAsString()
         const result = await validateKratosCookie(kratosCookieStr)
         if (result instanceof Error) {
           return res.status(500).send({ error: result.message })
         }
-        const thirtyDaysFromNow = new Date(new Date().setDate(new Date().getDate() + 30))
-        const expiresAt = result.session.expiresAt
-          ? result.session.expiresAt
-          : thirtyDaysFromNow
-        const maxAge = expiresAt.getTime() - new Date().getTime()
-        res.cookie(kratosSessionCookie.name, kratosSessionCookie.value, {
-          maxAge,
-          sameSite: "none",
-          secure: kratosSessionCookie.secure,
-          httpOnly: kratosSessionCookie.httpOnly,
-          path: kratosSessionCookie.path,
-        })
-        res.cookie(csrfCookie.name, csrfCookie.value, {
-          maxAge,
-          sameSite: "none",
-          secure: csrfCookie.secure,
-          httpOnly: csrfCookie.httpOnly,
-          path: csrfCookie.path,
+        res.cookie(
+          kratosSessionCookie.name,
+          kratosSessionCookie.value,
+          kratosCookies.formatCookieOptions(kratosSessionCookie),
+        )
+        res.cookie(
+          csrfCookie.name,
+          csrfCookie.value,
+          kratosCookies.formatCookieOptions(csrfCookie),
+        )
+        return res.send({
+          identity: {
+            id: kratosUserId,
+            uid: kratosUserId,
+            phoneNumber: phone,
+          },
         })
       } catch (error) {
         recordExceptionInCurrentSpan({ error })
         return res.status(500).send({ result: "Error parsing cookies" })
       }
-
-      res.send({
-        identity: {
-          id: kratosUserId,
-          uid: kratosUserId,
-          phoneNumber: phone,
-        },
-      })
     },
   }),
 )

--- a/src/servers/authorization/cookies.ts
+++ b/src/servers/authorization/cookies.ts
@@ -36,6 +36,7 @@ authRouter.post(
       const ipString = isProd ? req?.headers["x-real-ip"] : req?.ip
       const ip = parseIps(ipString)
       if (!ip) {
+        recordExceptionInCurrentSpan({ error: "IP is not defined" })
         return res.status(500).send({ error: "IP is not defined" })
       }
       const code = req.body.authCode
@@ -52,7 +53,7 @@ authRouter.post(
 
       try {
         const kratosCookies = parseKratosCookies(loginResp.cookiesToSendBackToClient)
-        const kratosUserId: UserId = loginResp.kratosUserId
+        const kratosUserId: UserId | undefined = loginResp.kratosUserId
         const csrfCookie = kratosCookies.csrf()
         const kratosSessionCookie = kratosCookies.kratosSession()
         if (!csrfCookie || !kratosSessionCookie) {

--- a/src/servers/authorization/email.ts
+++ b/src/servers/authorization/email.ts
@@ -1,3 +1,4 @@
+import cors from "cors"
 import express from "express"
 
 import { isProd } from "@config"
@@ -11,6 +12,7 @@ import {
   elevatingSessionWithTotp,
   loginWithEmail,
   requestEmailCode,
+  loginWithEmailCookie,
 } from "@app/authentication"
 
 import { parseErrorMessageFromUnknown } from "@domain/shared"
@@ -30,8 +32,18 @@ import {
 } from "@domain/authentication/errors"
 
 import { UserLoginIpRateLimiterExceededError } from "@domain/rate-limit/errors"
+import { parseKratosCookies } from "@services/kratos/cookie"
+
+import bodyParser from "body-parser"
+
+import cookieParser from "cookie-parser"
 
 import { authRouter } from "./router"
+
+authRouter.use(cors({ origin: true, credentials: true }))
+authRouter.use(bodyParser.urlencoded({ extended: true }))
+authRouter.use(bodyParser.json())
+authRouter.use(cookieParser())
 
 // TODO: should code request behind captcha or device token?
 authRouter.post(
@@ -202,6 +214,99 @@ authRouter.post(
         recordExceptionInCurrentSpan({ error: err })
         return res.status(500).send({ error: parseErrorMessageFromUnknown(err) })
       }
+    },
+  }),
+)
+
+authRouter.post(
+  "/email/login/cookie",
+  wrapAsyncToRunInSpan({
+    namespace: "servers.middlewares.authRouter",
+    fnName: "emailLoginCookie",
+    fn: async (req: express.Request, res: express.Response) => {
+      baseLogger.info("/email/login/cookie")
+
+      const ipString = isProd ? req?.headers["x-real-ip"] : req?.ip
+      const ip = parseIps(ipString)
+
+      if (!ip) {
+        return res.status(500).send({ error: "IP is not defined" })
+      }
+
+      const emailLoginIdRaw = req.body.emailLoginId
+      if (!emailLoginIdRaw) {
+        return res.status(422).send({ error: "Missing input" })
+      }
+
+      const emailLoginId = checkedToEmailLoginId(emailLoginIdRaw)
+      if (emailLoginId instanceof Error) {
+        return res.status(422).send({ error: emailLoginId.message })
+      }
+
+      const codeRaw = req.body.code
+      if (!codeRaw) {
+        return res.status(422).send({ error: "Missing input" })
+      }
+
+      const code = checkedToEmailCode(codeRaw)
+      if (code instanceof Error) {
+        return res.status(422).send({ error: code.message })
+      }
+
+      let loginResult
+      try {
+        loginResult = await loginWithEmailCookie({ ip, emailFlowId: emailLoginId, code })
+        if (loginResult instanceof EmailCodeInvalidError) {
+          recordExceptionInCurrentSpan({ error: loginResult })
+          return res.status(401).send({ error: "invalid code" })
+        }
+        if (
+          loginResult instanceof EmailValidationSubmittedTooOftenError ||
+          loginResult instanceof UserLoginIpRateLimiterExceededError
+        ) {
+          recordExceptionInCurrentSpan({ error: loginResult })
+          return res.status(429).send({ error: "too many requests" })
+        }
+        if (loginResult instanceof Error) {
+          recordExceptionInCurrentSpan({ error: loginResult })
+          return res.status(500).send({ error: loginResult.message })
+        }
+      } catch (err) {
+        recordExceptionInCurrentSpan({ error: err })
+        return res.status(500).send({ error: parseErrorMessageFromUnknown(err) })
+      }
+
+      const { cookiesToSendBackToClient, kratosUserId, totpRequired } = loginResult
+      try {
+        const kratosCookies = parseKratosCookies(cookiesToSendBackToClient)
+        const csrfCookie = kratosCookies.csrf()
+        const kratosSessionCookie = kratosCookies.kratosSession()
+        if (!csrfCookie || !kratosSessionCookie) {
+          return res
+            .status(500)
+            .send({ error: "Missing csrf or ory_kratos_session cookie" })
+        }
+        res.cookie(
+          kratosSessionCookie.name,
+          kratosSessionCookie.value,
+          kratosCookies.formatCookieOptions(kratosSessionCookie),
+        )
+        res.cookie(
+          csrfCookie.name,
+          csrfCookie.value,
+          kratosCookies.formatCookieOptions(csrfCookie),
+        )
+      } catch (error) {
+        recordExceptionInCurrentSpan({ error })
+        return res.status(500).send({ result: "Error parsing cookies" })
+      }
+
+      return res.status(200).send({
+        identity: {
+          kratosUserId,
+          totpRequired,
+        },
+      })
     },
   }),
 )

--- a/src/servers/authorization/email.ts
+++ b/src/servers/authorization/email.ts
@@ -58,6 +58,7 @@ authRouter.post(
       const ip = parseIps(ipString)
 
       if (!ip) {
+        recordExceptionInCurrentSpan({ error: "IP is not defined" })
         return res.status(500).send({ error: "IP is not defined" })
       }
 
@@ -100,6 +101,7 @@ authRouter.post(
       const ip = parseIps(ipString)
 
       if (!ip) {
+        recordExceptionInCurrentSpan({ error: "IP is not defined" })
         return res.status(500).send({ error: "IP is not defined" })
       }
 
@@ -164,6 +166,7 @@ authRouter.post(
       const ip = parseIps(ipString)
 
       if (!ip) {
+        recordExceptionInCurrentSpan({ error: "IP is not defined" })
         return res.status(500).send({ error: "IP is not defined" })
       }
 
@@ -230,6 +233,7 @@ authRouter.post(
       const ip = parseIps(ipString)
 
       if (!ip) {
+        recordExceptionInCurrentSpan({ error: "IP is not defined" })
         return res.status(500).send({ error: "IP is not defined" })
       }
 
@@ -277,30 +281,30 @@ authRouter.post(
       }
 
       const { cookiesToSendBackToClient, kratosUserId, totpRequired } = loginResult
+      let kratosCookies
       try {
-        const kratosCookies = parseKratosCookies(cookiesToSendBackToClient)
-        const csrfCookie = kratosCookies.csrf()
-        const kratosSessionCookie = kratosCookies.kratosSession()
-        if (!csrfCookie || !kratosSessionCookie) {
-          return res
-            .status(500)
-            .send({ error: "Missing csrf or ory_kratos_session cookie" })
-        }
-        res.cookie(
-          kratosSessionCookie.name,
-          kratosSessionCookie.value,
-          kratosCookies.formatCookieOptions(kratosSessionCookie),
-        )
-        res.cookie(
-          csrfCookie.name,
-          csrfCookie.value,
-          kratosCookies.formatCookieOptions(csrfCookie),
-        )
+        kratosCookies = parseKratosCookies(cookiesToSendBackToClient)
       } catch (error) {
         recordExceptionInCurrentSpan({ error })
         return res.status(500).send({ result: "Error parsing cookies" })
       }
-
+      const csrfCookie = kratosCookies.csrf()
+      const kratosSessionCookie = kratosCookies.kratosSession()
+      if (!csrfCookie || !kratosSessionCookie) {
+        return res
+          .status(500)
+          .send({ error: "Missing csrf or ory_kratos_session cookie" })
+      }
+      res.cookie(
+        kratosSessionCookie.name,
+        kratosSessionCookie.value,
+        kratosCookies.formatCookieOptions(kratosSessionCookie),
+      )
+      res.cookie(
+        csrfCookie.name,
+        csrfCookie.value,
+        kratosCookies.formatCookieOptions(csrfCookie),
+      )
       return res.status(200).send({
         identity: {
           kratosUserId,

--- a/src/services/kratos/auth-email-no-password.ts
+++ b/src/services/kratos/auth-email-no-password.ts
@@ -25,6 +25,7 @@ import {
 } from "./errors"
 import { kratosAdmin, kratosPublic, toDomainIdentityEmailPhone } from "./private"
 import { SchemaIdType } from "./schema"
+import { createCookieLoginFlow } from "./cookie"
 
 const getKratosKnex = () =>
   knex({
@@ -226,6 +227,35 @@ export const AuthWithEmailPasswordlessService = (): IAuthWithEmailPasswordlessSe
       const kratosUserId = result.data.session.identity?.id as UserId | undefined
 
       return { authToken, kratosUserId }
+    } catch (err) {
+      return new UnknownKratosError(err)
+    }
+  }
+
+  const loginCookie = async ({
+    email,
+  }: {
+    email: EmailAddress
+  }): Promise<LoginWithPhoneCookieSchemaResponse | KratosError> => {
+    const identifier = email
+    const method = "password"
+    try {
+      const cookieFlow = await createCookieLoginFlow()
+      if (cookieFlow instanceof Error) return cookieFlow
+      const result = await kratosPublic.updateLoginFlow({
+        flow: cookieFlow.flowId,
+        cookie: cookieFlow.cookie,
+        updateLoginFlowBody: {
+          identifier,
+          method,
+          password,
+          csrf_token: cookieFlow.csrf,
+        },
+      })
+      const cookiesToSendBackToClient: Array<SessionCookie> = result.headers["set-cookie"]
+      // note: this only works when whoami: required_aal = aal1
+      const kratosUserId = result.data.session.identity.id as UserId
+      return { cookiesToSendBackToClient, kratosUserId }
     } catch (err) {
       return new UnknownKratosError(err)
     }
@@ -452,6 +482,7 @@ export const AuthWithEmailPasswordlessService = (): IAuthWithEmailPasswordlessSe
       hasEmail,
       isEmailVerified,
       loginToken,
+      loginCookie,
     },
   })
 }

--- a/src/services/kratos/auth-email-no-password.ts
+++ b/src/services/kratos/auth-email-no-password.ts
@@ -253,8 +253,8 @@ export const AuthWithEmailPasswordlessService = (): IAuthWithEmailPasswordlessSe
         },
       })
       const cookiesToSendBackToClient: Array<SessionCookie> = result.headers["set-cookie"]
-      // note: this only works when whoami: required_aal = aal1
-      const kratosUserId = result.data.session.identity.id as UserId
+      // identity is only defined when identity has not enabled totp
+      const kratosUserId = result.data.session.identity.id as UserId | undefined
       return { cookiesToSendBackToClient, kratosUserId }
     } catch (err) {
       return new UnknownKratosError(err)

--- a/src/services/kratos/cookie.ts
+++ b/src/services/kratos/cookie.ts
@@ -1,0 +1,96 @@
+import libCookie from "cookie"
+import setCookie, { Cookie } from "set-cookie-parser"
+
+import { ICookieOptions } from "@domain/authentication/cookie"
+
+import { kratosPublic } from "./private"
+import { KratosError } from "./errors"
+
+export const createCookieLoginFlow = async (): Promise<
+  | {
+      flowId: string
+      cookie: string
+      csrf: string
+    }
+  | KratosError
+> => {
+  const flow = await kratosPublic.createBrowserLoginFlow()
+  const parsedCookies = setCookie.parse(flow.headers["set-cookie"])
+  const csrfCookie = parsedCookies?.find((c) => c.name.includes("csrf"))
+  if (!csrfCookie) return new KratosError("Could not find csrf cookie")
+  const cookie = libCookie.serialize(csrfCookie.name, csrfCookie.value, {
+    expires: csrfCookie.expires,
+    maxAge: csrfCookie.maxAge,
+    sameSite: "none",
+    secure: csrfCookie.secure,
+    httpOnly: csrfCookie.httpOnly,
+    path: csrfCookie.path,
+  })
+  return {
+    flowId: flow.data.id,
+    cookie: decodeURIComponent(cookie),
+    csrf: csrfCookie.value,
+  }
+}
+
+export const parseKratosCookies = (
+  cookie: string | Array<SessionCookie>,
+): {
+  asString: () => string | SessionCookie[]
+  asArray: () => setCookie.Cookie[]
+  csrf: () => setCookie.Cookie | undefined
+  kratosSession: () => setCookie.Cookie | undefined
+  kratosSessionAsString: () => string
+  formatCookieOptions: (cookieVal: Cookie) => ICookieOptions
+} => {
+  let cookiesStr = ""
+  if (cookie instanceof Array) {
+    for (const cookieVal of cookie) {
+      cookiesStr = cookiesStr + cookieVal + "; "
+    }
+  }
+  const cookies: setCookie.Cookie[] = setCookie.parse(cookie)
+
+  return {
+    asString: () => {
+      if (cookie instanceof String) return cookie
+      return cookiesStr
+    },
+    asArray: (): setCookie.Cookie[] => {
+      return cookies
+    },
+    csrf: () => {
+      return cookies?.find((c) => c.name.includes("csrf"))
+    },
+    kratosSession: () => {
+      return cookies?.find((c) => c.name.includes("ory_kratos_session"))
+    },
+    kratosSessionAsString: () => {
+      const kratosSessionCookie = cookies?.find((c) =>
+        c.name.includes("ory_kratos_session"),
+      )
+      if (!kratosSessionCookie) return ""
+      return libCookie.serialize(kratosSessionCookie.name, kratosSessionCookie.value, {
+        expires: kratosSessionCookie.expires,
+        maxAge: kratosSessionCookie.maxAge,
+        sameSite: "none",
+        secure: kratosSessionCookie.secure,
+        httpOnly: kratosSessionCookie.httpOnly,
+        path: kratosSessionCookie.path,
+      })
+    },
+    formatCookieOptions: (cookieVal: Cookie) => {
+      const thirtyDaysFromNow = new Date(new Date().setDate(new Date().getDate() + 30))
+      const expiresAt = cookieVal.expires ? cookieVal.expires : thirtyDaysFromNow
+      const maxAge = expiresAt.getTime() - new Date().getTime()
+      const cookieOpts: ICookieOptions = {
+        maxAge,
+        sameSite: "none",
+        secure: cookieVal.secure ? Boolean(cookieVal.secure) : true,
+        httpOnly: cookieVal.httpOnly ? Boolean(cookieVal.httpOnly) : true,
+        path: cookieVal.path ? String(cookieVal.path) : "/",
+      }
+      return cookieOpts
+    },
+  }
+}

--- a/test/e2e/servers/ory/kratos.spec.ts
+++ b/test/e2e/servers/ory/kratos.spec.ts
@@ -498,7 +498,7 @@ describe("phone+email schema", () => {
     }
   })
 
-  it("login back to an email account using cookies", async () => {
+  it("login back to an email account using cookies auth", async () => {
     const emailFlowId = await authServiceEmail.sendEmailWithCode({ email })
     if (emailFlowId instanceof Error) throw emailFlowId
 

--- a/test/e2e/servers/ory/kratos.spec.ts
+++ b/test/e2e/servers/ory/kratos.spec.ts
@@ -498,6 +498,40 @@ describe("phone+email schema", () => {
     }
   })
 
+  it("login back to an email account using cookies", async () => {
+    const emailFlowId = await authServiceEmail.sendEmailWithCode({ email })
+    if (emailFlowId instanceof Error) throw emailFlowId
+
+    const code = await getEmailCode(email)
+
+    {
+      const wrongCode = "000000" as EmailCode
+      const res = await authServiceEmail.validateCode({
+        code: wrongCode,
+        emailFlowId: emailFlowId,
+      })
+      expect(res).toBeInstanceOf(EmailCodeInvalidError)
+    }
+
+    {
+      const res = await authServiceEmail.validateCode({
+        code,
+        emailFlowId: emailFlowId,
+      })
+      if (res instanceof Error) throw res
+      expect(res.email).toBe(email)
+    }
+
+    {
+      const res = await authServiceEmail.loginCookie({ email })
+      if (res instanceof Error) throw res
+      const cookie1 = res.cookiesToSendBackToClient[0]
+      const cookie2 = res.cookiesToSendBackToClient[1]
+      expect(cookie1).toContain("ory" || "csrf")
+      expect(cookie2).toContain("ory" || "csrf")
+    }
+  })
+
   // TODO: verification code expired
 
   it("login back to an phone+email account by phone", async () => {

--- a/test/e2e/servers/ory/kratos.spec.ts
+++ b/test/e2e/servers/ory/kratos.spec.ts
@@ -525,10 +525,7 @@ describe("phone+email schema", () => {
     {
       const res = await authServiceEmail.loginCookie({ email })
       if (res instanceof Error) throw res
-      const cookie1 = res.cookiesToSendBackToClient[0]
-      const cookie2 = res.cookiesToSendBackToClient[1]
-      expect(cookie1).toContain("ory" || "csrf")
-      expect(cookie2).toContain("ory" || "csrf")
+      expect(res.cookiesToSendBackToClient.length).toBe(2)
     }
   })
 


### PR DESCRIPTION
Enables email cookie login at this new rest endpoint `/email/login/cookie`

```
const session = await ajax.post(config.galoyAuthEndpoint + "/email/login/cookie", {
  emailLoginId,
  code,
})
```

TODO
- [x] chart and config for new oathkeeper rule https://github.com/GaloyMoney/charts/pull/3902