### PR TITLE
test: add missing public e2e bats checks

### DIFF
--- a/src/debug/gqlsubscribe.ts
+++ b/src/debug/gqlsubscribe.ts
@@ -11,8 +11,10 @@ if (process.argv.length <= 3) {
 
 const url = process.argv[2]
 const filePath = process.argv[3]
+const authToken = process.argv[4]
 const client = createClient({
   url,
+  connectionParams: authToken ? { Authorization: `Bearer ${authToken}` } : undefined,
   webSocketImpl: WebSocket,
 })
 
@@ -26,9 +28,9 @@ const startSubscription = async () => {
         // May need to add variables
       },
       {
-        next: (data) => console.log(`Data: ${JSON.stringify(data)}\n`),
-        error: (err) => console.log(`Error: ${JSON.stringify(err)}\n`),
-        complete: () => console.log("Completed\n"),
+        next: (data) => console.log(`Data: ${JSON.stringify(data)}`),
+        error: (err) => console.log(err, `Error: ${JSON.stringify(err)}`),
+        complete: () => console.log("Completed"),
       },
     )
   } catch (err) {

--- a/src/debug/gqlsubscribe.ts
+++ b/src/debug/gqlsubscribe.ts
@@ -12,6 +12,7 @@ if (process.argv.length <= 3) {
 const url = process.argv[2]
 const filePath = process.argv[3]
 const authToken = process.argv[4]
+const variablesString = process.argv[5] || "{}"
 const client = createClient({
   url,
   connectionParams: authToken ? { Authorization: `Bearer ${authToken}` } : undefined,
@@ -22,10 +23,17 @@ const startSubscription = async () => {
   try {
     const data = await fsPromises.readFile(filePath, "utf8")
 
+    let variables = undefined
+    try {
+      variables = JSON.parse(variablesString)
+    } catch (err) {
+      console.log(err)
+    }
+
     await client.subscribe(
       {
         query: data,
-        // May need to add variables
+        variables,
       },
       {
         next: (data) => console.log(`Data: ${JSON.stringify(data)}`),

--- a/test/bats/gql/real-time-price-sub.gql
+++ b/test/bats/gql/real-time-price-sub.gql
@@ -1,0 +1,22 @@
+subscription realtimePrice($currency: DisplayCurrency!) {
+  realtimePrice(input: { currency: $currency }) {
+    errors {
+      message
+    }
+    realtimePrice {
+      id
+      timestamp
+      denominatorCurrency
+      btcSatPrice {
+        base
+        offset
+        currencyUnit
+      }
+      usdCentPrice {
+        base
+        offset
+        currencyUnit
+      }
+    }
+  }
+}

--- a/test/bats/helpers/setup-and-teardown.bash
+++ b/test/bats/helpers/setup-and-teardown.bash
@@ -31,7 +31,13 @@ start_server() {
 }
 
 subscribe_to() {
-  background ${REPO_ROOT}/node_modules/.bin/ts-node "${REPO_ROOT}/src/debug/gqlsubscribe.ts" "ws://${GALOY_ENDPOINT}/graphqlws" "$(gql_file $1)" > .e2e-subscriber.log
+  token_name=$1
+  if [[ -n "$token_name" && "$token_name" != 'anon' ]]; then
+     token="$(read_value $token_name)"
+  fi
+  gql_filename=$2
+
+  background ${REPO_ROOT}/node_modules/.bin/ts-node "${REPO_ROOT}/src/debug/gqlsubscribe.ts" "ws://${GALOY_ENDPOINT}/graphqlws" "$(gql_file $gql_filename)" "$token" > .e2e-subscriber.log
   echo $! > $SUBSCRIBER_PID_FILE
 }
 

--- a/test/bats/helpers/setup-and-teardown.bash
+++ b/test/bats/helpers/setup-and-teardown.bash
@@ -36,8 +36,15 @@ subscribe_to() {
      token="$(read_value $token_name)"
   fi
   gql_filename=$2
+  variables=$3
 
-  background ${REPO_ROOT}/node_modules/.bin/ts-node "${REPO_ROOT}/src/debug/gqlsubscribe.ts" "ws://${GALOY_ENDPOINT}/graphqlws" "$(gql_file $gql_filename)" "$token" > .e2e-subscriber.log
+  background \
+    ${REPO_ROOT}/node_modules/.bin/ts-node "${REPO_ROOT}/src/debug/gqlsubscribe.ts" \
+    "ws://${GALOY_ENDPOINT}/graphqlws" \
+    "$(gql_file $gql_filename)" \
+    "$token" \
+    "$variables" \
+    > .e2e-subscriber.log
   echo $! > $SUBSCRIBER_PID_FILE
 }
 

--- a/test/bats/public.bats
+++ b/test/bats/public.bats
@@ -20,6 +20,12 @@ teardown_file() {
 
 @test "public: can subscribe to price" {
   subscribe_to 'anon' price-sub
-  retry 10 1 grep 'Data:' .e2e-subscriber.log
+  retry 10 1 grep 'Data.*\bprice\b' .e2e-subscriber.log
+  stop_subscriber
+}
+
+@test "public: can subscribe to realtime price" {
+  subscribe_to 'anon' real-time-price-sub '{"currency": "EUR"}'
+  retry 10 1 grep 'Data.*\brealtimePrice\b.*EUR' .e2e-subscriber.log
   stop_subscriber
 }

--- a/test/bats/public.bats
+++ b/test/bats/public.bats
@@ -19,7 +19,7 @@ teardown_file() {
 }
 
 @test "public: can subscribe to price" {
-  subscribe_to price-sub
+  subscribe_to 'anon' price-sub
   retry 10 1 grep 'Data:' .e2e-subscriber.log
   stop_subscriber
 }


### PR DESCRIPTION
## Description

This PR is to remove the `no-auth-requests.spec.ts` file. 

### Open questions
- [ ] should we test the detail that current e2e tests go into for the returned data for `price` and `realtimePrice`, or is a simple presence response good enough?
- [ ] do we still need to test the `main` query here?