### PR TITLE
chore: remove a critical kratos alert

### DIFF
--- a/src/services/kratos/errors.ts
+++ b/src/services/kratos/errors.ts
@@ -29,9 +29,7 @@ export class MissingTotpKratosError extends KratosError {
   level = ErrorLevel.Critical
 }
 
-export class IncompatibleSchemaUpgradeError extends KratosError {
-  level = ErrorLevel.Critical
-}
+export class IncompatibleSchemaUpgradeError extends KratosError {}
 
 export class UnknownKratosError extends KratosError {
   level = ErrorLevel.Critical


### PR DESCRIPTION
this is trigger on staging because we try to remove the email, even it doesn't exist.

this action is intended in order to make sure the email is not set, as otherwise the mobile e2e test would fail.

the e2e tests assumes the email is not set and set it on its own