### PR TITLE
fix: apollo router config for web apps

### DIFF
--- a/dev/apollo-federation/main.rhai
+++ b/dev/apollo-federation/main.rhai
@@ -1,0 +1,23 @@
+fn supergraph_service(service) {
+  let add_cookies_to_response = |response| {
+    if response.context["set_cookie_headers"]?.len > 0 {
+      response.headers["set-cookie"] = response.context["set_cookie_headers"];
+    }
+  };
+
+  service.map_response(add_cookies_to_response);
+}
+
+fn subgraph_service(service, subgraph) {
+  let store_cookies_from_subgraphs = |response| {
+    if "set-cookie" in response.headers {
+      if response.context["set_cookie_headers"] == () {
+        response.context.set_cookie_headers = []
+      }
+
+      response.context.set_cookie_headers += response.headers.values("set-cookie");
+    }
+  };
+
+  service.map_response(store_cookies_from_subgraphs);
+}

--- a/dev/apollo-federation/router.yaml
+++ b/dev/apollo-federation/router.yaml
@@ -7,8 +7,20 @@ supergraph:
   listen: 0.0.0.0:4004
   introspection: true
   path: /graphql
+cors:
+  match_origins:
+    - "^http://([a-z0-9]+[.])*" # http
+    - "^https://([a-z0-9]+[.])*" # https
+  allow_credentials: true # for cookie auth
 telemetry:
   tracing:
     otlp:
       endpoint: http://otel-agent:4318
       protocol: http
+  experimental_logging: # just for local dev env
+    format: json
+    display_filename: true
+    display_line_number: false
+rhai:
+  scripts: "/repo/dev/apollo-federation"
+  main: "main.rhai" # for cookie auth https://www.apollographql.com/docs/router/configuration/header-propagation/#response-header-propagation

--- a/dev/ory/oathkeeper_rules.yaml
+++ b/dev/ory/oathkeeper_rules.yaml
@@ -11,6 +11,21 @@
   mutators:
     - handler: noop
 
+- id: apollo-playground-ui
+  upstream:
+    url: "http://e2e-tests:4012"
+  match:
+    url: "<(http|https)>://<[a-zA-Z0-9-.:]+>/graphql"
+    methods: ["GET"]
+  authenticators:
+    - handler: anonymous
+  authorizer:
+    handler: allow
+  mutators:
+    - handler: id_token
+      config:
+        claims: '{"sub": "{{ print .Subject }}"}'
+
 - id: device-login
   upstream:
     url: "http://bats-tests:4012"
@@ -53,7 +68,7 @@
     url: "http://apollo-router:4004"
   match:
     url: "<(http|https)>://<[a-zA-Z0-9-.:]+>/graphql"
-    methods: ["POST", "GET", "OPTIONS"]
+    methods: ["POST", "OPTIONS"]
   authenticators:
     - handler: cookie_session
       config:


### PR DESCRIPTION
This enables cors via the apollo router docs here (to make admin/web wallet/pay work): https://www.apollographql.com/docs/router/configuration/cors 

It also adds a rhai script to make sure the cookie response headers are passed back (only request header propagate via yaml, a rhai script is needed for response headers). docs here https://www.apollographql.com/docs/router/configuration/header-propagation/#response-header-propagation