### PR TITLE
chore: make 'phone' nullable in admin schema

### DIFF
--- a/src/graphql/admin/schema.graphql
+++ b/src/graphql/admin/schema.graphql
@@ -476,7 +476,7 @@ type User {
   email: Email
   id: ID!
   language: Language!
-  phone: Phone!
+  phone: Phone
 }
 
 input UserLoginInput {

--- a/src/graphql/admin/types/object/user.ts
+++ b/src/graphql/admin/types/object/user.ts
@@ -13,7 +13,7 @@ const User = GT.Object<User>({
 
   fields: () => ({
     id: { type: GT.NonNullID },
-    phone: { type: GT.NonNull(Phone) },
+    phone: { type: Phone },
 
     email: {
       type: GraphQLEmail,


### PR DESCRIPTION
## Description

`phone` is now an optional user field with the introduction of device accounts. This was trigger by [these alerts](https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/zA8QVC4hfva).