### PR TITLE
fix: remove title and coordinates on account deletion

### DIFF
--- a/src/app/accounts/mark-account-for-deletion.ts
+++ b/src/app/accounts/mark-account-for-deletion.ts
@@ -58,6 +58,8 @@ export const markAccountForDeletion = async ({
     status: AccountStatus.Closed,
     updatedByUserId,
   })
+  account.title = null
+  account.coordinates = null
 
   const newAccount = await accountsRepo.update(account)
   if (newAccount instanceof Error) return newAccount


### PR DESCRIPTION
small fix to remove deleted accounts from businessMapMarkers query