### PR TITLE
chore: add event details to tracing

### DIFF
--- a/src/servers/event-handlers/bria.ts
+++ b/src/servers/event-handlers/bria.ts
@@ -12,12 +12,18 @@ import * as LedgerFacade from "@services/ledger/facade"
 import { baseLogger } from "@services/logger"
 import { BriaPayloadType } from "@services/bria"
 import { EventAugmentationMissingError } from "@services/bria/errors"
+import { addAttributesToCurrentSpan } from "@services/tracing"
 
 export const briaEventHandler = async (event: BriaEvent): Promise<true | DomainError> => {
   baseLogger.info(
     { sequence: event.sequence, type: event.payload.type },
     "bria event handler",
   )
+  addAttributesToCurrentSpan({
+    ["event.sequence"]: event.sequence,
+    ["event.type"]: event.payload.type,
+  })
+
   switch (event.payload.type) {
     case BriaPayloadType.UtxoDetected:
       return utxoDetectedEventHandler({ event: event.payload })


### PR DESCRIPTION
## Description

I'm planning to use these to create an easily accessible honeycomb view for our event queue that looks like: https://ui.honeycomb.io/galoy/datasets/arvin-dev/result/3v7BM4QcYVz