### PR TITLE
fix: properly handle null walletIds

### DIFF
--- a/src/graphql/public/types/object/business-account.ts
+++ b/src/graphql/public/types/object/business-account.ts
@@ -130,7 +130,7 @@ const BusinessAccount = GT.Object({
 
         let { walletIds } = args
 
-        if (walletIds === undefined) {
+        if (!walletIds) {
           const wallets = await WalletsRepository().listByAccountId(source.id)
           if (wallets instanceof Error) {
             throw mapError(wallets)

--- a/src/graphql/public/types/object/consumer-account.ts
+++ b/src/graphql/public/types/object/consumer-account.ts
@@ -152,7 +152,7 @@ const ConsumerAccount = GT.Object<Account, GraphQLPublicContextAuth>({
 
         let { walletIds } = args
 
-        if (walletIds === undefined) {
+        if (!walletIds) {
           const wallets = await WalletsRepository().listByAccountId(source.id)
           if (wallets instanceof Error) {
             throw mapError(wallets)


### PR DESCRIPTION
WalletIds is a nullable field, but currently we only check if it is undefined.