### PR TITLE
chore: remove keep alive timeout

### DIFF
--- a/src/config/process.ts
+++ b/src/config/process.ts
@@ -8,9 +8,6 @@ type TwilioConfig = {
   verifyService: string
 }
 
-export const GALOY_API_KEEPALIVE_TIMEOUT_MS = process.env.GALOY_API_KEEPALIVE_TIMEOUT
-  ? parseInt(process.env.GALOY_API_KEEPALIVE_TIMEOUT, 10)
-  : (3600 + 600) * 1000 // 1 hour + 10 minutes
 export const GALOY_API_PORT = process.env.GALOY_API_PORT || 4012
 export const GALOY_ADMIN_PORT = process.env.GALOY_ADMIN_PORT || 4001
 

--- a/src/servers/graphql-server.ts
+++ b/src/servers/graphql-server.ts
@@ -4,12 +4,7 @@ import DataLoader from "dataloader"
 import express, { NextFunction, Request, Response } from "express"
 
 import { Accounts, Transactions } from "@app"
-import {
-  GALOY_API_KEEPALIVE_TIMEOUT_MS,
-  getApolloConfig,
-  getJwksArgs,
-  isProd,
-} from "@config"
+import { getApolloConfig, getJwksArgs, isProd } from "@config"
 import { baseLogger } from "@services/logger"
 import {
   ACCOUNT_USERNAME,
@@ -209,7 +204,6 @@ export const startApolloServer = async ({
 }): Promise<Record<string, unknown>> => {
   const app = express()
   const httpServer = createServer(app)
-  httpServer.keepAliveTimeout = GALOY_API_KEEPALIVE_TIMEOUT_MS
 
   const apolloPlugins = [
     createComplexityPlugin({


### PR DESCRIPTION
I think this was an artefact of the websocket integrated in the main backend. not sure this is needed any more. we can deploy and see if this generate new errors regarding to timeout or websocket