### PR TITLE
feat: add uuid to account schema

### DIFF
--- a/src/domain/accounts/index.types.d.ts
+++ b/src/domain/accounts/index.types.d.ts
@@ -62,6 +62,7 @@ type AccountStatusHistory = Array<{
 
 type Account = {
   readonly id: AccountId
+  readonly uuid: AccountUUID
   readonly createdAt: Date
   username: Username
   defaultWalletId: WalletId

--- a/src/domain/primitives/index.types.d.ts
+++ b/src/domain/primitives/index.types.d.ts
@@ -4,6 +4,7 @@ type Username = string & { readonly brand: unique symbol }
 type Pubkey = string & { readonly brand: unique symbol }
 type WalletId = string & { readonly brand: unique symbol }
 type AccountId = string & { readonly brand: unique symbol }
+type AccountUUID = string & { readonly brand: unique symbol }
 type Seconds = number & { readonly brand: unique symbol }
 type Minutes = number & { readonly brand: unique symbol }
 type MilliSeconds = number & { readonly brand: unique symbol }

--- a/src/graphql/types/object/business-account.ts
+++ b/src/graphql/types/object/business-account.ts
@@ -1,5 +1,3 @@
-import getUuidByString from "uuid-by-string"
-
 import { Accounts, Prices, Wallets } from "@app"
 
 import {
@@ -37,7 +35,7 @@ const BusinessAccount = GT.Object({
   fields: () => ({
     id: {
       type: GT.NonNullID,
-      resolve: (source) => getUuidByString(source.id),
+      resolve: (source) => source.uuid,
     },
 
     wallets: {

--- a/src/graphql/types/object/consumer-account.ts
+++ b/src/graphql/types/object/consumer-account.ts
@@ -1,5 +1,3 @@
-import getUuidByString from "uuid-by-string"
-
 import { Accounts, Prices, Wallets } from "@app"
 
 import {
@@ -39,7 +37,7 @@ const ConsumerAccount = GT.Object<Account>({
   fields: () => ({
     id: {
       type: GT.NonNullID,
-      resolve: (source) => getUuidByString(source.id),
+      resolve: (source) => source.uuid,
     },
 
     wallets: {

--- a/src/services/mongoose/accounts.ts
+++ b/src/services/mongoose/accounts.ts
@@ -1,5 +1,8 @@
+import getUuidByString from "uuid-by-string"
+
 import { OnboardingEarn } from "@config"
-import { AccountLevel, AccountStatus } from "@domain/accounts"
+
+import { AccountStatus } from "@domain/accounts"
 import {
   CouldNotFindAccountFromKratosIdError,
   CouldNotFindAccountFromUsernameError,
@@ -182,6 +185,9 @@ export const AccountsRepository = (): IAccountsRepository => {
 
 const translateToAccount = (result: AccountRecord): Account => ({
   id: fromObjectId<AccountId>(result._id),
+  // TODO: remove default value after migration
+  uuid: (result.uuid ||
+    getUuidByString(fromObjectId<AccountId>(result._id))) as AccountUUID,
   createdAt: new Date(result.created_at),
   defaultWalletId: result.defaultWalletId as WalletId,
   username: result.username as Username,

--- a/src/services/mongoose/schema.ts
+++ b/src/services/mongoose/schema.ts
@@ -132,6 +132,15 @@ export const Wallet = mongoose.model<WalletRecord>("Wallet", WalletSchema)
 
 const AccountSchema = new Schema<AccountRecord>(
   {
+    uuid: {
+      type: String,
+      index: true,
+      unique: true,
+      // TODO: uncomment after migration
+      // required: true,
+      default: () => crypto.randomUUID(),
+    },
+
     withdrawFee: {
       type: Number,
       default: feesConfig.withdrawDefaultMin,

--- a/src/services/mongoose/schema.types.d.ts
+++ b/src/services/mongoose/schema.types.d.ts
@@ -67,6 +67,8 @@ interface WalletInvoiceRecord {
 
 interface AccountRecord {
   _id: ObjectId
+  // TODO: remove optional after migration
+  uuid?: string
   kratosUserId: string
 
   username: string | null

--- a/test/unit/domain/wallets/payment-input-validator.spec.ts
+++ b/test/unit/domain/wallets/payment-input-validator.spec.ts
@@ -9,6 +9,7 @@ import { WalletCurrency, InvalidBtcPaymentAmountError } from "@domain/shared"
 describe("PaymentInputValidator", () => {
   const dummyAccount: Account = {
     id: crypto.randomUUID() as AccountId,
+    uuid: crypto.randomUUID() as AccountUUID,
     createdAt: new Date(),
     username: "username" as Username,
     defaultWalletId: "senderWalletId" as WalletId,


### PR DESCRIPTION
Add uuid to account schema before uuid migration.

- Add uuid to mongoose schema with default value (random UUID)
- Add default value to translateToAccount using `uuid-by-string`. This avoids a 3rd PR to update graphql.
- After migration the new field can be required (including field type in schema record type)