### PR TITLE
fix: add sparse to uuid index

### DIFF
--- a/src/services/mongoose/schema.ts
+++ b/src/services/mongoose/schema.ts
@@ -136,6 +136,7 @@ const AccountSchema = new Schema<AccountRecord>(
       type: String,
       index: true,
       unique: true,
+      sparse: true,
       // TODO: uncomment after migration
       // required: true,
       default: () => crypto.randomUUID(),


### PR DESCRIPTION
fix index to include only documents that have uuid