### PR TITLE
refactor: change how escrow amount is calculated from channel

### DIFF
--- a/src/services/lnd/utils.ts
+++ b/src/services/lnd/utils.ts
@@ -268,7 +268,10 @@ export const updateEscrows = async () => {
   )
   const escrowInLnd = toSats(
     selfInitiatedChannels.reduce(
-      (acc, chan) => acc + (chan.capacity - (chan.local_balance + chan.remote_balance)),
+      (acc, chan) =>
+        acc +
+        (chan.capacity -
+          (chan.local_balance + chan.remote_balance + chan.unsettled_balance)),
       0,
     ),
   )


### PR DESCRIPTION
## Description

We currently calculate the escrow amount for internal channel opens based on some combination of channel's `commit_fee` and deriving the anchor output amount. These 2 value can change depending on the state of the channel though:
- when there are pending htlcs
- when there is either 0 remote or local balance

This makes the accounting and check balance code go off when the channel changes states, and it can even result in incorrect accounting if the channel is in a state where the "commit_fee + single anchor output fee" does not equal the total amount held back in the channel for a force close.

The more stable estimation of this value is to calculate the diff between the channel's capacity and it local + remote balance. This value never changes, and is usually made up of the stated `commit_fee` + the fees from the number of anchor outputs committed for the channel.

### Manual testing

I added some bats cases in the 2nd commit (and reverted as demo) to illustrate how the balance reacts to different states. From the test cases:
- these new changes help to cover the case where escrow is recorded after some balance has been sent to remote
- these changes still don't work if there are pending htlcs
- a test is needed to double-check that non-self-initiated channels are unaffected