### PR TITLE
temp: investigate containers logging to github action log

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -388,14 +388,10 @@ services:
       - -d
       - m/84h/0h/0h
     depends_on:
-      bitcoind-signer:
-        condition: service_started
-      otel-agent:
-        condition: service_started
-      fulcrum:
-        condition: service_started
-      postgres-bria:
-        condition: service_healthy
+      - bitcoind-signer
+      - otel-agent
+      - fulcrum
+      - postgres-bria
     restart: on-failure:10
     volumes:
       - ${HOST_PROJECT_PATH:-.}/:/repo


### PR DESCRIPTION
## Description

It looks like the extra logs started popping up between these two commits on `main` branch:
ed9a154a1e2fd5758b0490e344aa1e4f63e60bdd -> 17089ac034f825131c40cc9e2e105e0dd4721a46

From initial exploration, it looks like nothing material was changed on our end, and it's possible that a change was made to upstream `docker compose` that introduced this behaviour.

Potential path forward is to figure out how to explicitly silence these logs somehow.