### PR TITLE
chore: unskip test after adding 'xxd' to CI

### DIFF
--- a/test/bats/ln-send.bats
+++ b/test/bats/ln-send.bats
@@ -363,8 +363,6 @@ usd_amount=50
 }
 
 @test "ln-send: ln settled - settle failed and then pending-to-failed payment" {
-  skip "failing on concourse"
-
   token_name="$ALICE_TOKEN_NAME"
   btc_wallet_name="$token_name.btc_wallet_id"
 


### PR DESCRIPTION
## Description

Is unlocked by https://github.com/GaloyMoney/galoy-deployments/pull/4614
