### PR TITLE
chore: refactor display amounts conversion

### DIFF
--- a/src/app/wallets/update-pending-invoices.ts
+++ b/src/app/wallets/update-pending-invoices.ts
@@ -7,7 +7,7 @@ import {
   InvalidNonHodlInvoiceError,
 } from "@domain/errors"
 import { checkedToSats } from "@domain/bitcoin"
-import { displayAmountFromNumber } from "@domain/fiat"
+import { DisplayAmountsConverter } from "@domain/fiat"
 import { InvoiceNotFoundError } from "@domain/bitcoin/lightning"
 import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
 import { WalletInvoiceReceiver } from "@domain/wallet-invoices/wallet-invoice-receiver"
@@ -35,6 +35,7 @@ import { CallbackEventType } from "@domain/callback"
 import { AccountLevel } from "@domain/accounts"
 import { CallbackService } from "@services/callback"
 import { getCallbackServiceConfig } from "@config"
+import { toDisplayBaseAmount } from "@domain/payments"
 
 export const handleHeldInvoices = async (logger: Logger): Promise<void> => {
   const invoicesRepo = WalletInvoicesRepository()
@@ -183,6 +184,12 @@ const updatePendingInvoiceBeforeFinally = async ({
       usdFromBtcMidPrice: usdFromBtcMidPriceFn,
     })
     if (walletInvoiceReceiver instanceof Error) return walletInvoiceReceiver
+    const {
+      btcToCreditReceiver: btcPaymentAmount,
+      btcBankFee: btcProtocolAndBankFee,
+      usdToCreditReceiver: usdPaymentAmount,
+      usdBankFee: usdProtocolAndBankFee,
+    } = walletInvoiceReceiver
 
     if (!lnInvoiceLookup.isSettled) {
       const invoiceSettled = await lndService.settleInvoice({ pubkey, secret })
@@ -208,15 +215,14 @@ const updatePendingInvoiceBeforeFinally = async ({
     })
     if (displayPriceRatio instanceof Error) return displayPriceRatio
 
-    const amountDisplayCurrency = Number(
-      displayPriceRatio.convertFromWallet(walletInvoiceReceiver.btcToCreditReceiver)
-        .amountInMinor,
-    ) as DisplayCurrencyBaseAmount
-
-    const feeDisplayCurrency = Number(
-      displayPriceRatio.convertFromWalletToCeil(walletInvoiceReceiver.btcBankFee)
-        .amountInMinor,
-    ) as DisplayCurrencyBaseAmount
+    const { displayAmount: displayPaymentAmount, displayFee } = DisplayAmountsConverter(
+      displayPriceRatio,
+    ).convert({
+      btcPaymentAmount,
+      btcProtocolAndBankFee,
+      usdPaymentAmount,
+      usdProtocolAndBankFee,
+    })
 
     // TODO: this should be a in a mongodb transaction session with the ledger transaction below
     // markAsPaid could be done after the transaction, but we should in that case not only look
@@ -237,8 +243,8 @@ const updatePendingInvoiceBeforeFinally = async ({
         usdProtocolAndBankFee: walletInvoiceReceiver.usdBankFee,
       },
 
-      feeDisplayCurrency,
-      amountDisplayCurrency,
+      feeDisplayCurrency: toDisplayBaseAmount(displayFee),
+      amountDisplayCurrency: toDisplayBaseAmount(displayPaymentAmount),
       displayCurrency: recipientDisplayCurrency,
     })
 
@@ -268,13 +274,6 @@ const updatePendingInvoiceBeforeFinally = async ({
     if (result instanceof Error) return result
 
     // Prepare and send notification
-    const { displayAmount, displayCurrency } = creditAccountAdditionalMetadata
-    const displayPaymentAmount = displayAmountFromNumber({
-      amount: displayAmount,
-      currency: displayCurrency,
-    })
-    if (displayPaymentAmount instanceof Error) throw displayPaymentAmount
-
     const recipientUser = await UsersRepository().findById(recipientAccount.kratosUserId)
     if (recipientUser instanceof Error) return recipientUser
 

--- a/src/domain/fiat/display-amounts-converter.ts
+++ b/src/domain/fiat/display-amounts-converter.ts
@@ -1,0 +1,32 @@
+import {
+  displayAmountFromWalletAmount,
+  priceAmountFromDisplayPriceRatio,
+} from "./display-currency"
+import { DisplayCurrency } from "./primitives"
+
+export const DisplayAmountsConverter = <D extends DisplayCurrency>(
+  displayPriceRatio: DisplayPriceRatio<"BTC", D>,
+): DisplayAmountsConverter<D> => {
+  const convert = (args: AmountsAndFees) => {
+    const displayCurrency = displayPriceRatio.displayCurrency
+
+    let displayAmount = displayPriceRatio.convertFromWallet(args.btcPaymentAmount)
+    let displayFee = displayPriceRatio.convertFromWalletToCeil(args.btcProtocolAndBankFee)
+    if (displayCurrency === DisplayCurrency.Usd) {
+      displayAmount = displayAmountFromWalletAmount<D>(args.usdPaymentAmount)
+      displayFee = displayAmountFromWalletAmount<D>(args.usdProtocolAndBankFee)
+    }
+
+    return {
+      displayAmount,
+      displayFee,
+      displayCurrency,
+
+      // Note: This should come from the WalletPriceRatio too if currency is USD, but
+      //       this is left as-is for now since we don't have precise wallet ratios yet.
+      displayPrice: priceAmountFromDisplayPriceRatio(displayPriceRatio),
+    }
+  }
+
+  return { convert }
+}

--- a/src/domain/fiat/display-currency.ts
+++ b/src/domain/fiat/display-currency.ts
@@ -49,6 +49,14 @@ export const getCurrencyMajorExponent = (
   }
 }
 
+const displayMinorToMajor = ({
+  amountInMinor,
+  displayMajorExponent,
+}: {
+  amountInMinor: bigint
+  displayMajorExponent: CurrencyMajorExponent
+}) => (Number(amountInMinor) / 10 ** displayMajorExponent).toFixed(displayMajorExponent)
+
 export const displayAmountFromNumber = <T extends DisplayCurrency>({
   amount,
   currency,
@@ -64,9 +72,21 @@ export const displayAmountFromNumber = <T extends DisplayCurrency>({
   return {
     amountInMinor,
     currency,
-    displayInMajor: (Number(amountInMinor) / 10 ** displayMajorExponent).toFixed(
-      displayMajorExponent,
-    ),
+    displayInMajor: displayMinorToMajor({ amountInMinor, displayMajorExponent }),
+  }
+}
+
+export const displayAmountFromWalletAmount = <D extends DisplayCurrency>(
+  walletAmount: PaymentAmount<WalletCurrency>,
+): DisplayAmount<D> => {
+  const { amount: amountInMinor, currency } = walletAmount
+
+  const displayMajorExponent = getCurrencyMajorExponent(walletAmount.currency)
+
+  return {
+    amountInMinor,
+    currency: currency as D,
+    displayInMajor: displayMinorToMajor({ amountInMinor, displayMajorExponent }),
   }
 }
 

--- a/src/domain/fiat/index.ts
+++ b/src/domain/fiat/index.ts
@@ -6,6 +6,8 @@ import {
 } from "@domain/errors"
 
 export * from "./display-currency"
+export * from "./display-amounts-converter"
+export * from "./primitives"
 
 export const toCents = (amount: number | bigint): UsdCents => {
   return Number(amount) as UsdCents
@@ -41,8 +43,3 @@ export const sub = <T extends number>(
   if (result < 0) return new InvalidNegativeAmountError()
   return result as T
 }
-
-export const DisplayCurrency = {
-  Usd: "USD",
-  Btc: "BTC",
-} as const

--- a/src/domain/fiat/index.types.d.ts
+++ b/src/domain/fiat/index.types.d.ts
@@ -2,7 +2,7 @@ type UsdCents = number & { readonly brand: unique symbol }
 type CentsPerSatsRatio = number & { readonly brand: unique symbol }
 type DisplayCurrencyBaseAmount = number & { readonly brand: unique symbol }
 type DisplayCurrency =
-  | (typeof import(".").DisplayCurrency)[keyof typeof import(".").DisplayCurrency]
+  | (typeof import("./primitives").DisplayCurrency)[keyof typeof import("./primitives").DisplayCurrency]
   | (string & { readonly brand: unique symbol })
 type CurrencyMajorExponent =
   (typeof import("./index").MajorExponent)[keyof typeof import("./index").MajorExponent]
@@ -44,3 +44,12 @@ type GetAmountsSendOrReceiveRet =
   | NotReachableError
   | NotImplementedError
   | DealerPriceServiceError
+
+type DisplayAmountsConverter<D extends DisplayCurrency> = {
+  convert: (args: AmountsAndFees) => {
+    displayAmount: DisplayAmount<D>
+    displayFee: DisplayAmount<D>
+    displayCurrency: D
+    displayPrice: WalletMinorUnitDisplayPrice<"BTC", D>
+  }
+}

--- a/src/domain/fiat/primitives.ts
+++ b/src/domain/fiat/primitives.ts
@@ -1,0 +1,4 @@
+export const DisplayCurrency = {
+  Usd: "USD",
+  Btc: "BTC",
+} as const

--- a/src/domain/payments/price-ratio.ts
+++ b/src/domain/payments/price-ratio.ts
@@ -121,6 +121,11 @@ const toDisplayAmount = <T extends DisplayCurrency>({
   }
 }
 
+export const toDisplayBaseAmount = (
+  displayAmount: DisplayAmount<DisplayCurrency>,
+): DisplayCurrencyBaseAmount =>
+  Number(displayAmount.amountInMinor) as DisplayCurrencyBaseAmount
+
 export const DisplayPriceRatio = <S extends WalletCurrency, T extends DisplayCurrency>({
   displayAmount,
   walletAmount,

--- a/test/legacy-integration/02-user-wallet/02-bria-handlers.spec.ts
+++ b/test/legacy-integration/02-user-wallet/02-bria-handlers.spec.ts
@@ -13,7 +13,7 @@ import {
 import { AmountCalculator, WalletCurrency, ZERO_SATS } from "@domain/shared"
 import { UnknownLedgerError, toLiabilitiesWalletId } from "@domain/ledger"
 import { DisplayPriceRatio, WalletPriceRatio } from "@domain/payments"
-import { displayAmountFromNumber } from "@domain/fiat"
+import { DisplayAmountsConverter, displayAmountFromNumber } from "@domain/fiat"
 
 import { WalletOnChainPendingReceive } from "@services/mongoose/schema"
 import { Transaction } from "@services/ledger/schema"
@@ -402,14 +402,21 @@ describe("Bria Event Handlers", () => {
       const usdBankFee = priceRatio.convertFromBtc(btcBankFee)
       const btcProtocolAndBankFee = calc.add(btcMinerFee, btcBankFee)
       const usdProtocolAndBankFee = priceRatio.convertFromBtc(btcProtocolAndBankFee)
-      const displayProtocolAndBankFee =
-        displayPriceRatio.convertFromWallet(btcProtocolAndBankFee)
 
       const btcPaymentAmount = { amount: 10_000n, currency: WalletCurrency.Btc }
       const usdPaymentAmount = priceRatio.convertFromBtc(btcPaymentAmount)
-      const displayPaymentAmount = displayPriceRatio.convertFromWallet(btcPaymentAmount)
       const btcTotalAmount = calc.add(btcProtocolAndBankFee, btcPaymentAmount)
       const usdTotalAmount = priceRatio.convertFromBtc(btcTotalAmount)
+
+      const {
+        displayAmount: displayPaymentAmount,
+        displayFee: displayProtocolAndBankFee,
+      } = DisplayAmountsConverter(displayPriceRatio).convert({
+        btcPaymentAmount,
+        btcProtocolAndBankFee,
+        usdPaymentAmount,
+        usdProtocolAndBankFee,
+      })
 
       const {
         metadata,

--- a/test/unit/domain/fiat/display-amounts-converter.spec.ts
+++ b/test/unit/domain/fiat/display-amounts-converter.spec.ts
@@ -1,0 +1,138 @@
+import { DisplayAmountsConverter, DisplayCurrency } from "@domain/fiat"
+
+import { WalletCurrency, ZERO_CENTS, ZERO_SATS } from "@domain/shared"
+import { DisplayPriceRatio } from "@domain/payments"
+
+describe("DisplayAmountsConverter", () => {
+  const amounts: AmountsAndFees = {
+    btcPaymentAmount: { amount: 50_000n, currency: WalletCurrency.Btc },
+    btcProtocolAndBankFee: { amount: 1_000n, currency: WalletCurrency.Btc },
+    usdPaymentAmount: { amount: 1_250n, currency: WalletCurrency.Usd },
+    usdProtocolAndBankFee: { amount: 25n, currency: WalletCurrency.Usd },
+  }
+
+  const amountsAndZeroFees: AmountsAndFees = {
+    ...amounts,
+    btcProtocolAndBankFee: ZERO_SATS,
+    usdProtocolAndBankFee: ZERO_CENTS,
+  }
+
+  const btcQuoteAmount = {
+    amount: 5000n,
+    currency: WalletCurrency.Btc,
+  }
+
+  const displayQuoteAmount = {
+    amountInMinor: 100n,
+    displayInMajor: "1.00" as DisplayCurrencyMajorAmount,
+  }
+
+  const expectedResultForCurrency = (currency: DisplayCurrency) => {
+    // Based on ratio of `amounts` to `btcQuoteAmount`
+    const expectedResult = {
+      displayAmount: {
+        amountInMinor: 1000n,
+        currency: undefined,
+        displayInMajor: "10.00",
+      },
+      displayFee: { amountInMinor: 20n, currency: undefined, displayInMajor: "0.20" },
+      displayCurrency: undefined,
+      displayPrice: {
+        base: 20000000000n,
+        offset: 12n,
+        displayCurrency: undefined,
+        walletCurrency: "BTC",
+      },
+    }
+
+    return {
+      displayAmount: { ...expectedResult.displayAmount, currency },
+      displayFee: { ...expectedResult.displayFee, currency },
+      displayCurrency: currency,
+      displayPrice: { ...expectedResult.displayPrice, displayCurrency: currency },
+    }
+  }
+
+  const expectedResultForUsd = () => {
+    const expectedResult = expectedResultForCurrency(DisplayCurrency.Usd)
+    return {
+      ...expectedResult,
+      displayAmount: {
+        ...expectedResult.displayAmount,
+        amountInMinor: 1250n,
+        displayInMajor: "12.50",
+      },
+      displayFee: {
+        ...expectedResult.displayFee,
+        amountInMinor: 25n,
+        displayInMajor: "0.25",
+      },
+    }
+  }
+
+  describe("non-usd display currency", () => {
+    const currency = "EUR" as DisplayCurrency
+
+    const displayEurPriceRatio = DisplayPriceRatio({
+      displayAmount: { ...displayQuoteAmount, currency },
+      walletAmount: btcQuoteAmount,
+    })
+    if (displayEurPriceRatio instanceof Error) throw displayEurPriceRatio
+
+    const expectedEurResult = expectedResultForCurrency(currency)
+
+    it("converts amounts to EUR", async () => {
+      const res = DisplayAmountsConverter(displayEurPriceRatio).convert(amounts)
+      expect(res).toStrictEqual(expectedEurResult)
+    })
+
+    it("converts amounts with zero fees to EUR", async () => {
+      const expectedZeroFeeEurResult = {
+        ...expectedEurResult,
+        displayFee: {
+          ...expectedEurResult.displayFee,
+          amountInMinor: 0n,
+          displayInMajor: "0.00",
+        },
+      }
+
+      const res =
+        DisplayAmountsConverter(displayEurPriceRatio).convert(amountsAndZeroFees)
+      expect(res).toStrictEqual(expectedZeroFeeEurResult)
+    })
+  })
+
+  describe("usd display currency", () => {
+    const currency = DisplayCurrency.Usd
+
+    const displayUsdPriceRatio = DisplayPriceRatio({
+      displayAmount: { ...displayQuoteAmount, currency },
+      walletAmount: btcQuoteAmount,
+    })
+    if (displayUsdPriceRatio instanceof Error) throw displayUsdPriceRatio
+
+    const expectedUsdResultFromDisplay = expectedResultForCurrency(currency)
+    const expectedUsdResultFromWallet = expectedResultForUsd()
+
+    it("converts amounts to USD", async () => {
+      const res = DisplayAmountsConverter(displayUsdPriceRatio).convert(amounts)
+      expect(res).not.toStrictEqual(expectedUsdResultFromDisplay)
+      expect(res).toStrictEqual(expectedUsdResultFromWallet)
+    })
+
+    it("converts amounts with zero fees to USD", async () => {
+      const expectedZeroFeeUsdResult = {
+        ...expectedUsdResultFromWallet,
+        displayFee: {
+          ...expectedUsdResultFromWallet.displayFee,
+          amountInMinor: 0n,
+          displayInMajor: "0.00",
+        },
+      }
+
+      const res =
+        DisplayAmountsConverter(displayUsdPriceRatio).convert(amountsAndZeroFees)
+      expect(res).toStrictEqual(expectedZeroFeeUsdResult)
+    })
+  })
+})


### PR DESCRIPTION
## Description

This PR adds a new unit tested `DisplayCurrencyConverter` object and then swaps it into all use-cases that have this conversion implemented in-line.

The prompt for this was to stop explicitly integration testing this conversion for each use-case like we do now, and to instead test it once via a unit test.

It also adds a new switching decision for USD display currencies internally in the converter which will eventually allow removing this from our `Metadata` functions in a follow-on PR.