### PR TITLE
feat: add data field to admin push notification

### DIFF
--- a/src/app/admin/send-admin-push-notification.ts
+++ b/src/app/admin/send-admin-push-notification.ts
@@ -7,10 +7,12 @@ export const sendAdminPushNotification = async ({
   accountId: accountIdRaw,
   title,
   body,
+  data,
 }: {
   accountId: string
   title: string
   body: string
+  data?: { [key: string]: string }
 }): Promise<true | ApplicationError> => {
   const accountId = checkedToAccountUuid(accountIdRaw)
   if (accountId instanceof Error) return accountId
@@ -28,6 +30,7 @@ export const sendAdminPushNotification = async ({
     deviceTokens: user.deviceTokens,
     title,
     body,
+    data,
   })
 
   if (success instanceof Error) return success

--- a/src/domain/notifications/index.types.d.ts
+++ b/src/domain/notifications/index.types.d.ts
@@ -50,12 +50,6 @@ type PriceUpdateArgs<C extends DisplayCurrency> = {
   pricePerUsdCent: RealTimePrice<C>
 }
 
-type AdminPushNotificationSendArgs = {
-  deviceTokens: DeviceToken[]
-  title: string
-  body: string
-}
-
 interface INotificationsService {
   lightningTxReceived: (
     args: LightningTxReceivedArgs,
@@ -76,6 +70,6 @@ interface INotificationsService {
   priceUpdate: <C extends DisplayCurrency>(args: PriceUpdateArgs<C>) => void
   sendBalance(args: SendBalanceArgs): Promise<true | NotificationsServiceError>
   adminPushNotificationSend(
-    args: AdminPushNotificationSendArgs,
+    args: SendPushNotificationArgs,
   ): Promise<true | NotificationsServiceError>
 }

--- a/src/graphql/admin/root/mutation/admin-push-notification-send.ts
+++ b/src/graphql/admin/root/mutation/admin-push-notification-send.ts
@@ -16,12 +16,20 @@ const AdminPushNotificationSendInput = GT.Input({
     body: {
       type: GT.String,
     },
+    data: {
+      type: GT.Scalar(Object),
+    },
   }),
 })
 
 const AdminPushNotificationSendMutation = GT.Field<
   {
-    input: { accountId: string; title: string; body: string }
+    input: {
+      accountId: string
+      title: string
+      body: string
+      data?: { [key: string]: string }
+    }
   },
   null,
   GraphQLContextAuth
@@ -34,9 +42,14 @@ const AdminPushNotificationSendMutation = GT.Field<
     input: { type: GT.NonNull(AdminPushNotificationSendInput) },
   },
   resolve: async (_, args) => {
-    const { accountId, body, title } = args.input
+    const { accountId, body, title, data } = args.input
 
-    const success = await Admin.sendAdminPushNotification({ accountId, title, body })
+    const success = await Admin.sendAdminPushNotification({
+      accountId,
+      title,
+      body,
+      data,
+    })
 
     if (success instanceof Error) {
       return { errors: [mapAndParseErrorForGqlResponse(success)] }

--- a/src/graphql/admin/schema.graphql
+++ b/src/graphql/admin/schema.graphql
@@ -31,6 +31,7 @@ input AccountUpdateStatusInput {
 input AdminPushNotificationSendInput {
   accountId: String
   body: String
+  data: Object
   title: String
 }
 
@@ -250,6 +251,8 @@ type Mutation {
   userLogin(input: UserLoginInput!): AuthTokenPayload!
   userUpdatePhone(input: UserUpdatePhoneInput!): AccountDetailPayload!
 }
+
+scalar Object
 
 """An address for an on-chain bitcoin destination"""
 scalar OnChainAddress

--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -323,7 +323,8 @@ export const NotificationsService = (): INotificationsService => {
     deviceTokens,
     title,
     body,
-  }: AdminPushNotificationSendArgs): Promise<true | NotificationsServiceError> => {
+    data,
+  }: SendPushNotificationArgs): Promise<true | NotificationsServiceError> => {
     const hasDeviceTokens = deviceTokens && deviceTokens.length > 0
     if (!hasDeviceTokens) return true
 
@@ -332,6 +333,7 @@ export const NotificationsService = (): INotificationsService => {
         deviceTokens,
         title,
         body,
+        data,
       })
     } catch (err) {
       return handleCommonNotificationErrors(err)


### PR DESCRIPTION
This PR allows the admin push notification mutation to accept a data payload. This data payload can be used to send to the mobile client for the deep linking use case to navigate to the circles page.

```
mutation AdminPushNotificationSend {
  adminPushNotificationSend(input: {
      accountId: "12345",
      body: "Body",
      title: "Title",
      data: {
        notificationType: "InnerCircleGrew",
      },
    }) {
      errors {
        code
        message
      }
      success
  }
}
```