### PR TITLE
feat: add held invoices count to exporter

### DIFF
--- a/src/app/lightning/get-held-invoices.ts
+++ b/src/app/lightning/get-held-invoices.ts
@@ -9,7 +9,7 @@ export const getHeldInvoicesCount = async (): Promise<number | ApplicationError>
   if (offChainService instanceof Error) return offChainService
 
   const { delay } = DEFAULT_EXPIRATIONS[WalletCurrency.Btc]
-  const createdAfter = new Date(new Date().getTime() - delay * 1000)
+  const createdAfter = new Date(new Date().getTime() - delay * 2 * 1000)
 
   const invoices = await Promise.all(
     offChainService.listActivePubkeys().map(async (pubkey) => {

--- a/src/app/lightning/get-held-invoices.ts
+++ b/src/app/lightning/get-held-invoices.ts
@@ -1,0 +1,26 @@
+import { ErrorLevel, WalletCurrency } from "@domain/shared"
+import { DEFAULT_EXPIRATIONS } from "@domain/bitcoin/lightning/invoice-expiration"
+
+import { LndService } from "@services/lnd"
+import { recordExceptionInCurrentSpan } from "@services/tracing"
+
+export const getHeldInvoicesCount = async (): Promise<number | ApplicationError> => {
+  const offChainService = LndService()
+  if (offChainService instanceof Error) return offChainService
+
+  const { delay } = DEFAULT_EXPIRATIONS[WalletCurrency.Btc]
+  const createdAfter = new Date(new Date().getTime() - delay * 1000)
+
+  const invoices = await Promise.all(
+    offChainService.listActivePubkeys().map(async (pubkey) => {
+      const result = await offChainService.listInvoices({ pubkey, createdAfter })
+      if (result instanceof Error) {
+        recordExceptionInCurrentSpan({ error: result, level: ErrorLevel.Critical })
+        return []
+      }
+      return result
+    }),
+  )
+
+  return invoices.flat().filter((i) => i.isHeld).length
+}

--- a/src/app/lightning/index.ts
+++ b/src/app/lightning/index.ts
@@ -1,5 +1,6 @@
 export * from "./delete-ln-payments"
 export * from "./get-balances"
+export * from "./get-held-invoices"
 export * from "./get-pending-htlc"
 export * from "./list-nodes-pubkeys"
 export * from "./lookup-invoice-by-hash"

--- a/src/domain/bitcoin/lightning/index.types.d.ts
+++ b/src/domain/bitcoin/lightning/index.types.d.ts
@@ -159,6 +159,11 @@ type LightningServiceConfig = {
   feeCapPercent: number
 }
 
+type ListLnInvoicesArgs = {
+  pubkey?: Pubkey
+  createdAfter?: Date
+}
+
 interface ILightningService {
   isLocal(pubkey: Pubkey): boolean | LightningServiceError
 
@@ -241,7 +246,9 @@ interface ILightningService {
 
   listFailedPayments: ListLnPayments
 
-  listInvoices(lnd: AuthenticatedLnd): Promise<LnInvoiceLookup[] | LightningServiceError>
+  listInvoices(
+    args: ListLnInvoicesArgs,
+  ): Promise<LnInvoiceLookup[] | LightningServiceError>
 
   deletePaymentByHash({
     paymentHash,

--- a/src/servers/exporter.ts
+++ b/src/servers/exporter.ts
@@ -378,6 +378,16 @@ createGauge({
 })
 
 createGauge({
+  name: "getHeldInvoicesCount",
+  description: "How many hold invoices are not settled or declined",
+  collect: async () => {
+    const heldInvoicesCount = await Lightning.getHeldInvoicesCount()
+    if (heldInvoicesCount instanceof Error) return NaN
+    return heldInvoicesCount
+  },
+})
+
+createGauge({
   name: "activeChannels",
   description: "How many active channels there are on the active nodes",
   collect: async () => {

--- a/src/servers/trigger.ts
+++ b/src/servers/trigger.ts
@@ -275,7 +275,7 @@ const listenerExistingHodlInvoices = async ({
   if (lndService instanceof Error) return lndService
 
   const { delay } = DEFAULT_EXPIRATIONS[WalletCurrency.Btc]
-  const createdAfter = new Date(new Date().getTime() - delay * 1000)
+  const createdAfter = new Date(new Date().getTime() - delay * 2 * 1000)
 
   const invoices = await lndService.listInvoices({ pubkey, createdAfter })
   if (invoices instanceof Error) return invoices

--- a/src/servers/trigger.ts
+++ b/src/servers/trigger.ts
@@ -36,9 +36,10 @@ import {
   CouldNotFindWalletFromOnChainAddressError,
   CouldNotFindWalletInvoiceError,
 } from "@domain/errors"
-import { checkedToDisplayCurrency } from "@domain/fiat"
-import { ErrorLevel, paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
 import { SwapTriggerError } from "@domain/swap/errors"
+import { checkedToDisplayCurrency } from "@domain/fiat"
+import { DEFAULT_EXPIRATIONS } from "@domain/bitcoin/lightning/invoice-expiration"
+import { ErrorLevel, paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
 
 import { BriaSubscriber } from "@services/bria"
 import { RedisCacheService } from "@services/cache"
@@ -273,7 +274,10 @@ const listenerExistingHodlInvoices = async ({
   const lndService = LndService()
   if (lndService instanceof Error) return lndService
 
-  const invoices = await lndService.listInvoices(lnd)
+  const { delay } = DEFAULT_EXPIRATIONS[WalletCurrency.Btc]
+  const createdAfter = new Date(new Date().getTime() - delay * 1000)
+
+  const invoices = await lndService.listInvoices({ pubkey, createdAfter })
   if (invoices instanceof Error) return invoices
 
   for (const lnInvoice of invoices) {


### PR DESCRIPTION
- Add held invoices count to exporter
- Refactor listInvoices in lnd service to get only invoices in the last 24h (default value for btc invoices) -> impact in performance https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/wYkcvsJ3AyP/trace/FRQFckMZxLo?fields[]=c_name&fields[]=c_service.name&span=f60e2dd69019c170 (if it is only used in trigger start up is not a problem but in exporter can impact performance)