### PR TITLE
feat(old): switch to btc wallet for sub 1 cent usd receipts

### DIFF
--- a/src/app/payments/helpers.ts
+++ b/src/app/payments/helpers.ts
@@ -13,8 +13,8 @@ import {
   SelfPaymentError,
 } from "@domain/errors"
 import {
-  InvalidZeroAmountPriceRatioInputError,
   LightningPaymentFlowBuilder,
+  SubOneCentSatAmountForUsdSelfSendError,
   WalletPriceRatio,
   ZeroAmountForUsdRecipientError,
 } from "@domain/payments"
@@ -74,8 +74,8 @@ export const constructPaymentFlowBuilder = async <
     const builderWithConversion = builderWithSenderWallet
       .withRecipientWallet<R>(recipientDetails)
       .withConversion(withConversionArgs)
-    const check = await builderWithConversion.usdPaymentAmount()
-    if (!(check instanceof InvalidZeroAmountPriceRatioInputError)) {
+    const check = await builderWithConversion.checkForBuilderError()
+    if (!(check instanceof ZeroAmountForUsdRecipientError)) {
       return builderWithConversion
     }
 
@@ -100,9 +100,9 @@ export const constructPaymentFlowBuilder = async <
       .withRecipientWallet<R>(recipientBtcDetails)
       .withConversion(withConversionArgs)
 
-    const postCheck = await redoneBuilderWithConversion.usdPaymentAmount()
+    const postCheck = await redoneBuilderWithConversion.checkForBuilderError()
     if (postCheck instanceof SelfPaymentError) {
-      return new ZeroAmountForUsdRecipientError()
+      return new SubOneCentSatAmountForUsdSelfSendError()
     }
 
     return redoneBuilderWithConversion

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -42,6 +42,7 @@ export class CouldNotFindWalletFromIdError extends CouldNotFindError {}
 export class CouldNotListWalletsFromAccountIdError extends CouldNotFindError {}
 export class CouldNotFindWalletFromUsernameError extends CouldNotFindError {}
 export class CouldNotFindWalletFromUsernameAndCurrencyError extends CouldNotFindError {}
+export class CouldNotFindWalletFromAccountIdAndCurrencyError extends CouldNotFindError {}
 export class CouldNotFindWalletFromOnChainAddressError extends CouldNotFindError {}
 export class CouldNotFindWalletFromOnChainAddressesError extends CouldNotFindError {}
 export class CouldNotListWalletsFromWalletCurrencyError extends CouldNotFindError {}

--- a/src/domain/payments/errors.ts
+++ b/src/domain/payments/errors.ts
@@ -2,6 +2,7 @@ import { ValidationError, ErrorLevel } from "@domain/shared"
 
 export class InvalidZeroAmountPriceRatioInputError extends ValidationError {}
 export class ZeroAmountForUsdRecipientError extends ValidationError {}
+export class SubOneCentSatAmountForUsdSelfSendError extends ValidationError {}
 export class LnPaymentRequestNonZeroAmountRequiredError extends ValidationError {}
 export class LnPaymentRequestZeroAmountRequiredError extends ValidationError {}
 export class LnPaymentRequestInTransitError extends ValidationError {}

--- a/src/domain/payments/index.types.d.ts
+++ b/src/domain/payments/index.types.d.ts
@@ -225,12 +225,18 @@ type LPFBWithConversion<S extends WalletCurrency, R extends WalletCurrency> = {
   }): Promise<PaymentFlow<S, R> | ValidationError | DealerPriceServiceError>
   withoutRoute(): Promise<PaymentFlow<S, R> | ValidationError | DealerPriceServiceError>
 
-  btcPaymentAmount(): Promise<BtcPaymentAmount | DealerPriceServiceError>
-  usdPaymentAmount(): Promise<UsdPaymentAmount | DealerPriceServiceError>
-  skipProbeForDestination(): Promise<boolean | DealerPriceServiceError>
+  btcPaymentAmount(): Promise<
+    BtcPaymentAmount | ValidationError | DealerPriceServiceError
+  >
+  usdPaymentAmount(): Promise<
+    UsdPaymentAmount | ValidationError | DealerPriceServiceError
+  >
+  skipProbeForDestination(): Promise<boolean | ValidationError | DealerPriceServiceError>
 
-  isIntraLedger(): Promise<boolean | DealerPriceServiceError>
-  isTradeIntraAccount(): Promise<boolean | DealerPriceServiceError>
+  isIntraLedger(): Promise<boolean | ValidationError | DealerPriceServiceError>
+  isTradeIntraAccount(): Promise<boolean | ValidationError | DealerPriceServiceError>
+
+  checkForBuilderError(): Promise<false | ValidationError | DealerPriceServiceError>
 }
 
 type OPFBWithConversion<S extends WalletCurrency, R extends WalletCurrency> = {
@@ -271,6 +277,7 @@ type LPFBWithError = {
   skipProbeForDestination(): Promise<ValidationError | DealerPriceServiceError>
   isIntraLedger(): Promise<ValidationError | DealerPriceServiceError>
   isTradeIntraAccount(): Promise<ValidationError | DealerPriceServiceError>
+  checkForBuilderError(): Promise<ValidationError | DealerPriceServiceError>
 }
 
 type OPFBWithError = {

--- a/src/domain/payments/index.types.d.ts
+++ b/src/domain/payments/index.types.d.ts
@@ -259,6 +259,8 @@ type OPFBWithConversion<S extends WalletCurrency, R extends WalletCurrency> = {
 
   addressForFlow(): Promise<OnChainAddress | DealerPriceServiceError>
   senderWalletDescriptor(): Promise<WalletDescriptor<S> | DealerPriceServiceError>
+
+  checkForBuilderError(): Promise<false | ValidationError | DealerPriceServiceError>
 }
 
 type LPFBTest = {
@@ -294,6 +296,7 @@ type OPFBWithError = {
   proposedAmounts(): Promise<ValidationError | DealerPriceServiceError>
   addressForFlow(): Promise<ValidationError | DealerPriceServiceError>
   senderWalletDescriptor(): Promise<ValidationError | DealerPriceServiceError>
+  checkForBuilderError(): Promise<ValidationError | DealerPriceServiceError>
 }
 
 interface IPaymentFlowRepository {

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -253,7 +253,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       message = "Reward for quiz question was already claimed."
       return new ValidationInternalError({ message, logger: baseLogger })
 
-    case "ZeroAmountForUsdRecipientError":
+    case "SubOneCentSatAmountForUsdSelfSendError":
       message = "Amount sent was too low for recipient's usd wallet."
       return new ValidationInternalError({ message, logger: baseLogger })
 
@@ -609,6 +609,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "MattermostError":
     case "CouldNotFindAccountIpError":
     case "InvalidFlowId":
+    case "ZeroAmountForUsdRecipientError":
       message = `Unexpected error occurred, please try again or contact support if it persists (code: ${
         error.name
       }${error.message ? ": " + error.message : ""})`

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -471,6 +471,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "CouldNotListWalletsFromAccountIdError":
     case "CouldNotFindWalletFromUsernameError":
     case "CouldNotFindWalletFromUsernameAndCurrencyError":
+    case "CouldNotFindWalletFromAccountIdAndCurrencyError":
     case "CouldNotFindWalletFromOnChainAddressError":
     case "CouldNotFindWalletFromOnChainAddressesError":
     case "CouldNotFindBtcWalletForAccountError":

--- a/test/integration/app/wallets/send-intraledger.spec.ts
+++ b/test/integration/app/wallets/send-intraledger.spec.ts
@@ -4,7 +4,7 @@ import { AccountStatus } from "@domain/accounts"
 import { toSats } from "@domain/bitcoin"
 import { PaymentSendStatus } from "@domain/bitcoin/lightning"
 import { DisplayCurrency, toCents } from "@domain/fiat"
-import { ZeroAmountForUsdRecipientError } from "@domain/payments"
+import { SubOneCentSatAmountForUsdSelfSendError } from "@domain/payments"
 import {
   InactiveAccountError,
   IntraledgerLimitsExceededError,
@@ -222,7 +222,7 @@ describe("intraLedgerPay", () => {
       senderWalletId: newWalletDescriptor.id,
       senderAccount: newAccount,
     })
-    expect(paymentResult).toBeInstanceOf(ZeroAmountForUsdRecipientError)
+    expect(paymentResult).toBeInstanceOf(SubOneCentSatAmountForUsdSelfSendError)
   })
 
   it("fails if amount greater than trade-intra-account limit", async () => {

--- a/test/integration/app/wallets/send-intraledger.spec.ts
+++ b/test/integration/app/wallets/send-intraledger.spec.ts
@@ -197,7 +197,7 @@ describe("intraLedgerPay", () => {
     expect(paymentResult).toBeInstanceOf(SelfPaymentError)
   })
 
-  it("fails to send less-than-1-cent amount to usd recipient", async () => {
+  it("fails to send less-than-1-cent amount from self btc to usd", async () => {
     // Create users
     const { btcWalletDescriptor: newWalletDescriptor, usdWalletDescriptor } =
       await createRandomUserAndWallets()
@@ -206,7 +206,7 @@ describe("intraLedgerPay", () => {
 
     // Fund balance for send
     const receive = await recordReceiveLnPayment({
-      walletDescriptor: usdWalletDescriptor,
+      walletDescriptor: newWalletDescriptor,
       paymentAmount: receiveAmounts,
       bankFee: receiveBankFee,
       displayAmounts: receiveDisplayAmounts,

--- a/test/integration/app/wallets/send-lightning.spec.ts
+++ b/test/integration/app/wallets/send-lightning.spec.ts
@@ -10,7 +10,7 @@ import {
 import { DisplayCurrency, toCents } from "@domain/fiat"
 import {
   LnPaymentRequestNonZeroAmountRequiredError,
-  ZeroAmountForUsdRecipientError,
+  SubOneCentSatAmountForUsdSelfSendError,
 } from "@domain/payments"
 import {
   InactiveAccountError,
@@ -631,7 +631,7 @@ describe("initiated via lightning", () => {
         senderAccount: newAccount,
         amount: 1,
       })
-      expect(paymentResult).toBeInstanceOf(ZeroAmountForUsdRecipientError)
+      expect(paymentResult).toBeInstanceOf(SubOneCentSatAmountForUsdSelfSendError)
 
       // Restore system state
       lndServiceSpy.mockRestore()

--- a/test/integration/app/wallets/send-lightning.spec.ts
+++ b/test/integration/app/wallets/send-lightning.spec.ts
@@ -586,7 +586,7 @@ describe("initiated via lightning", () => {
       lndServiceSpy.mockRestore()
     })
 
-    it("fails to send less-than-1-cent amount to usd recipient", async () => {
+    it("fails to send less-than-1-cent amount from self btc to usd", async () => {
       // Setup mocks
       const { LndService: LnServiceOrig } = jest.requireActual("@services/lnd")
       const lndServiceSpy = jest.spyOn(LndImpl, "LndService").mockReturnValue({

--- a/test/integration/app/wallets/send-onchain.spec.ts
+++ b/test/integration/app/wallets/send-onchain.spec.ts
@@ -12,10 +12,7 @@ import {
   LimitsExceededError,
   SelfPaymentError,
 } from "@domain/errors"
-import {
-  InvalidZeroAmountPriceRatioInputError,
-  SubOneCentSatAmountForUsdSelfSendError,
-} from "@domain/payments"
+import { SubOneCentSatAmountForUsdSelfSendError } from "@domain/payments"
 import {
   AmountCalculator,
   WalletCurrency,
@@ -336,14 +333,15 @@ describe("onChainPay", () => {
     })
 
     it("fails if builder 'withConversion' step fails", async () => {
-      const newWalletDescriptor = await createRandomUserAndBtcWallet()
+      const {
+        btcWalletDescriptor: newWalletDescriptor,
+        usdWalletDescriptor: recipientUsdWalletDescriptor,
+      } = await createRandomUserAndWallets()
       const newAccount = await AccountsRepository().findById(
         newWalletDescriptor.accountId,
       )
       if (newAccount instanceof Error) throw newAccount
 
-      const { usdWalletDescriptor: recipientUsdWalletDescriptor } =
-        await createRandomUserAndWallets()
       const recipientAccount = await AccountsRepository().findById(
         recipientUsdWalletDescriptor.accountId,
       )
@@ -384,7 +382,7 @@ describe("onChainPay", () => {
         speed: PayoutSpeed.Fast,
         memo,
       })
-      expect(res).toBeInstanceOf(InvalidZeroAmountPriceRatioInputError)
+      expect(res).toBeInstanceOf(SubOneCentSatAmountForUsdSelfSendError)
     })
 
     it("fails if recipient account is locked", async () => {

--- a/test/legacy-integration/services/dealer/hedge-price.spec.ts
+++ b/test/legacy-integration/services/dealer/hedge-price.spec.ts
@@ -96,13 +96,18 @@ const getBtcEquivalentForIntraledgerSendToUsd = async ({
   }
 
   const beforeBtc = await getBalanceHelper(newBtcWallet.id)
+  const beforeRecipientUsd = await getBalanceHelper(newUsdWallet.id)
 
   const result = await Payments.intraledgerPaymentSendWalletIdForBtcWallet({
     amount: Number(btcPaymentAmount.amount),
     ...sendArgs,
   })
-  if (result instanceof ZeroAmountForUsdRecipientError) return result
   if (result instanceof Error) throw result
+
+  const afterRecipientUsd = await getBalanceHelper(newUsdWallet.id)
+  if (beforeRecipientUsd === afterRecipientUsd) {
+    return new ZeroAmountForUsdRecipientError()
+  }
 
   const afterBtc = await getBalanceHelper(newBtcWallet.id)
   return (beforeBtc - afterBtc) as CurrencyBaseAmount
@@ -175,6 +180,7 @@ const getBtcEquivalentForNoAmountInvoiceSendToUsd = async ({
 }): Promise<CurrencyBaseAmount | ZeroAmountForUsdRecipientError> => {
   const { newBtcWallet, newUsdWallet, newAccount } = accountAndWallets
 
+  const beforeRecipientUsd = await getBalanceHelper(newUsdWallet.id)
   const lnInvoice = await Wallets.addInvoiceNoAmountForSelf({
     walletId: newUsdWallet.id,
   })
@@ -188,8 +194,12 @@ const getBtcEquivalentForNoAmountInvoiceSendToUsd = async ({
     senderWalletId: newBtcWallet.id,
     senderAccount: newAccount,
   })
-  if (result instanceof ZeroAmountForUsdRecipientError) return result
   if (result instanceof Error) throw result
+
+  const afterRecipientUsd = await getBalanceHelper(newUsdWallet.id)
+  if (beforeRecipientUsd === afterRecipientUsd) {
+    return new ZeroAmountForUsdRecipientError()
+  }
 
   const afterBtc = await getBalanceHelper(newBtcWallet.id)
   return (beforeBtc - afterBtc) as CurrencyBaseAmount
@@ -204,6 +214,7 @@ const getBtcEquivalentForNoAmountInvoiceProbeAndSendToUsd = async ({
 }): Promise<CurrencyBaseAmount | ZeroAmountForUsdRecipientError> => {
   const { newBtcWallet, newUsdWallet, newAccount } = accountAndWallets
 
+  const beforeRecipientUsd = await getBalanceHelper(newUsdWallet.id)
   const lnInvoice = await Wallets.addInvoiceNoAmountForSelf({
     walletId: newUsdWallet.id,
   })
@@ -228,8 +239,12 @@ const getBtcEquivalentForNoAmountInvoiceProbeAndSendToUsd = async ({
     senderWalletId: newBtcWallet.id,
     senderAccount: newAccount,
   })
-  if (result instanceof ZeroAmountForUsdRecipientError) return result
   if (result instanceof Error) throw result
+
+  const afterRecipientUsd = await getBalanceHelper(newUsdWallet.id)
+  if (beforeRecipientUsd === afterRecipientUsd) {
+    return new ZeroAmountForUsdRecipientError()
+  }
 
   const afterBtc = await getBalanceHelper(newBtcWallet.id)
   return (beforeBtc - afterBtc) as CurrencyBaseAmount

--- a/test/unit/payments/onchain-payment-flow-builder.spec.ts
+++ b/test/unit/payments/onchain-payment-flow-builder.spec.ts
@@ -4,7 +4,7 @@ import { SettlementMethod, PaymentInitiationMethod, OnChainFees } from "@domain/
 import { LessThanDustThresholdError, SelfPaymentError } from "@domain/errors"
 import {
   InvalidOnChainPaymentFlowBuilderStateError,
-  InvalidZeroAmountPriceRatioInputError,
+  ZeroAmountForUsdRecipientError,
   WalletPriceRatio,
 } from "@domain/payments"
 import {
@@ -964,10 +964,10 @@ describe("OnChainPaymentFlowBuilder", () => {
             .withConversion(withConversionArgs)
 
           const proposedBtcAmount = await builder.btcProposedAmount()
-          expect(proposedBtcAmount).toBeInstanceOf(InvalidZeroAmountPriceRatioInputError)
+          expect(proposedBtcAmount).toBeInstanceOf(ZeroAmountForUsdRecipientError)
 
           const proposedAmounts = await builder.proposedAmounts()
-          expect(proposedAmounts).toBeInstanceOf(InvalidZeroAmountPriceRatioInputError)
+          expect(proposedAmounts).toBeInstanceOf(ZeroAmountForUsdRecipientError)
         })
       })
     })

--- a/test/unit/payments/payment-flow-builder.spec.ts
+++ b/test/unit/payments/payment-flow-builder.spec.ts
@@ -7,7 +7,7 @@ import {
   LnFees,
   InvalidLightningPaymentFlowBuilderStateError,
   WalletPriceRatio,
-  InvalidZeroAmountPriceRatioInputError,
+  ZeroAmountForUsdRecipientError,
 } from "@domain/payments"
 import { ONE_CENT, ValidationError, WalletCurrency } from "@domain/shared"
 
@@ -944,7 +944,7 @@ describe("LightningPaymentFlowBuilder", () => {
                 },
               })
               .withoutRoute()
-            expect(payment).toBeInstanceOf(InvalidZeroAmountPriceRatioInputError)
+            expect(payment).toBeInstanceOf(ZeroAmountForUsdRecipientError)
           })
         })
       })
@@ -1265,7 +1265,7 @@ describe("LightningPaymentFlowBuilder", () => {
                 },
               })
               .withoutRoute()
-            expect(payment).toBeInstanceOf(InvalidZeroAmountPriceRatioInputError)
+            expect(payment).toBeInstanceOf(ZeroAmountForUsdRecipientError)
           })
         })
       })


### PR DESCRIPTION
## Description

For incoming transactions to USD wallets where the sats amount is less than 1 cent, we currently return an error and don't credit the USD wallet or settle the invoice. This PR is to instead settle the sats to BTC wallet instead of returning an error in the following cases:
- [x] ln-initiated intraledger receive to USD wallet
- [x] walletId-initiated intraledger receive to USD wallet
- [x] no-amount invoice receive from external source
- [x] onchain-initiated intraledger receive to USD wallet
