### PR TITLE
feat: switch to btc wallet for sub 1 cent usd receipts

### DIFF
--- a/src/app/payments/get-protocol-fee.ts
+++ b/src/app/payments/get-protocol-fee.ts
@@ -230,6 +230,10 @@ const estimateLightningFee = async ({
   }
   if (paymentFlow instanceof Error) return PartialResult.err(paymentFlow)
 
+  addAttributesToCurrentSpan({
+    "payment.finalRecipient": JSON.stringify(paymentFlow.recipientWalletDescriptor()),
+  })
+
   const persistedPayment = await PaymentFlowStateRepository(
     defaultTimeToExpiryInSeconds,
   ).persistNew(paymentFlow)

--- a/src/app/payments/helpers.ts
+++ b/src/app/payments/helpers.ts
@@ -8,12 +8,7 @@ import {
 } from "@config"
 import { AccountLimitsChecker } from "@domain/accounts"
 import { AlreadyPaidError } from "@domain/errors"
-import {
-  InvalidZeroAmountPriceRatioInputError,
-  LightningPaymentFlowBuilder,
-  WalletPriceRatio,
-  ZeroAmountForUsdRecipientError,
-} from "@domain/payments"
+import { LightningPaymentFlowBuilder, WalletPriceRatio } from "@domain/payments"
 import { WalletCurrency } from "@domain/shared"
 import { LedgerService } from "@services/ledger"
 import { LndService } from "@services/lnd"
@@ -68,21 +63,11 @@ export const constructPaymentFlowBuilder = async <
     builderAfterRecipientStep = builderWithSenderWallet.withoutRecipientWallet()
   }
 
-  const builderWithConversion = await builderAfterRecipientStep.withConversion({
+  return builderAfterRecipientStep.withConversion({
     mid: { usdFromBtc: usdFromBtcMidPriceFn, btcFromUsd: btcFromUsdMidPriceFn },
     hedgeBuyUsd,
     hedgeSellUsd,
   })
-
-  const check = await builderWithConversion.usdPaymentAmount()
-  if (
-    check instanceof InvalidZeroAmountPriceRatioInputError &&
-    builderWithSenderWallet.isIntraLedger() === true
-  ) {
-    return new ZeroAmountForUsdRecipientError()
-  }
-
-  return builderWithConversion
 }
 
 const recipientDetailsFromInvoice = async <R extends WalletCurrency>(

--- a/src/app/payments/helpers.ts
+++ b/src/app/payments/helpers.ts
@@ -89,9 +89,8 @@ const recipientDetailsFromInvoice = async <R extends WalletCurrency>(
   invoice: LnInvoice,
 ): Promise<
   | {
-      id: WalletId
-      currency: R
-      accountId: AccountId
+      recipientWalletDescriptor: WalletDescriptor<R>
+      recipientWalletDescriptorsForAccount: WalletDescriptor<WalletCurrency>[]
       pubkey: Pubkey
       usdPaymentAmount: UsdPaymentAmount | undefined
       username: Username
@@ -118,14 +117,20 @@ const recipientDetailsFromInvoice = async <R extends WalletCurrency>(
   if (recipientWallet instanceof Error) return recipientWallet
   const { accountId } = recipientWallet
 
+  const wallets = await WalletsRepository().listByAccountId(accountId)
+  if (wallets instanceof Error) return wallets
+
   const recipientAccount = await AccountsRepository().findById(accountId)
   if (recipientAccount instanceof Error) return recipientAccount
   const { username: recipientUsername, kratosUserId: recipientUserId } = recipientAccount
 
   return {
-    id: recipientWalletId,
-    currency: recipientsWalletCurrency as R,
-    accountId: recipientAccount.id,
+    recipientWalletDescriptor: {
+      id: recipientWalletId,
+      currency: recipientsWalletCurrency as R,
+      accountId: recipientAccount.id,
+    },
+    recipientWalletDescriptorsForAccount: wallets,
     pubkey: recipientPubkey,
     usdPaymentAmount,
     username: recipientUsername,

--- a/src/app/payments/send-intraledger.ts
+++ b/src/app/payments/send-intraledger.ts
@@ -84,10 +84,15 @@ const intraledgerPaymentSendWalletId = async ({
 
   const builderWithSenderWallet = builderWithInvoice.withSenderWallet(senderWallet)
 
-  const recipientDetailsForBuilder = {
-    id: recipientWalletId,
-    currency: recipientWalletCurrency,
-    accountId: recipientAccountId,
+  const wallets = await WalletsRepository().listByAccountId(recipientAccountId)
+  if (wallets instanceof Error) return wallets
+  const recipientArgsForBuilder = {
+    recipientWalletDescriptor: {
+      id: recipientWalletId,
+      currency: recipientWalletCurrency,
+      accountId: recipientAccountId,
+    },
+    recipientWalletDescriptorsForAccount: wallets,
     username: recipientUsername,
     userId: recipientUserId,
     pubkey: undefined,
@@ -95,7 +100,7 @@ const intraledgerPaymentSendWalletId = async ({
   }
 
   const builderAfterRecipientStep = builderWithSenderWallet.withRecipientWallet(
-    recipientDetailsForBuilder,
+    recipientArgsForBuilder,
   )
 
   const builderWithConversion = builderAfterRecipientStep.withConversion({

--- a/src/app/payments/send-intraledger.ts
+++ b/src/app/payments/send-intraledger.ts
@@ -121,6 +121,7 @@ const intraledgerPaymentSendWalletId = async ({
     "payment.intraLedger.inputAmount": paymentFlow.inputAmount.toString(),
     "payment.intraLedger.hash": paymentFlow.intraLedgerHash,
     "payment.intraLedger.description": memo || "",
+    "payment.finalRecipient": JSON.stringify(paymentFlow.recipientWalletDescriptor()),
   })
 
   const paymentSendStatus = await executePaymentViaIntraledger({

--- a/src/app/payments/send-intraledger.ts
+++ b/src/app/payments/send-intraledger.ts
@@ -10,9 +10,7 @@ import { validateIsBtcWallet, validateIsUsdWallet } from "@app/wallets"
 
 import {
   InvalidLightningPaymentFlowBuilderStateError,
-  InvalidZeroAmountPriceRatioInputError,
   LightningPaymentFlowBuilder,
-  ZeroAmountForUsdRecipientError,
   toDisplayBaseAmount,
 } from "@domain/payments"
 import { AccountLevel, AccountValidator } from "@domain/accounts"
@@ -117,9 +115,6 @@ const intraledgerPaymentSendWalletId = async ({
   if (builderWithConversion instanceof Error) return builderWithConversion
 
   const paymentFlow = await builderWithConversion.withoutRoute()
-  if (paymentFlow instanceof InvalidZeroAmountPriceRatioInputError) {
-    return new ZeroAmountForUsdRecipientError()
-  }
   if (paymentFlow instanceof Error) return paymentFlow
 
   addAttributesToCurrentSpan({

--- a/src/app/payments/send-lightning.ts
+++ b/src/app/payments/send-lightning.ts
@@ -335,6 +335,7 @@ const getPaymentFlow = async <S extends WalletCurrency, R extends WalletCurrency
 
   addAttributesToCurrentSpan({
     "payment.amount": paymentFlow.btcPaymentAmount.amount.toString(),
+    "payment.finalRecipient": JSON.stringify(paymentFlow.recipientWalletDescriptor()),
   })
 
   return paymentFlow

--- a/src/app/wallets/get-on-chain-fee.ts
+++ b/src/app/wallets/get-on-chain-fee.ts
@@ -99,6 +99,9 @@ const getOnChainFee = async <S extends WalletCurrency, R extends WalletCurrency>
       accountId: recipientWallet.accountId,
     }
 
+    const wallets = await WalletsRepository().listByAccountId(recipientWallet.accountId)
+    if (wallets instanceof Error) return wallets
+
     const recipientAccount = await AccountsRepository().findById(
       recipientWallet.accountId,
     )
@@ -106,7 +109,8 @@ const getOnChainFee = async <S extends WalletCurrency, R extends WalletCurrency>
 
     const paymentFlow = await withSenderBuilder
       .withRecipientWallet({
-        ...recipientWalletDescriptor,
+        recipientWalletDescriptor,
+        recipientWalletDescriptorsForAccount: wallets,
         userId: recipientAccount.kratosUserId,
         username: recipientAccount.username,
       })

--- a/src/app/wallets/send-on-chain.ts
+++ b/src/app/wallets/send-on-chain.ts
@@ -147,6 +147,9 @@ const payOnChainByWalletId = async <R extends WalletCurrency>({
       accountId: recipientWallet.accountId,
     }
 
+    const wallets = await WalletsRepository().listByAccountId(recipientWallet.accountId)
+    if (wallets instanceof Error) return wallets
+
     const recipientAccount = await AccountsRepository().findById(
       recipientWallet.accountId,
     )
@@ -154,7 +157,8 @@ const payOnChainByWalletId = async <R extends WalletCurrency>({
 
     const builder = withSenderBuilder
       .withRecipientWallet({
-        ...recipientWalletDescriptor,
+        recipientWalletDescriptor,
+        recipientWalletDescriptorsForAccount: wallets,
         userId: recipientAccount.kratosUserId,
         username: recipientAccount.username,
       })

--- a/src/app/wallets/send-on-chain.ts
+++ b/src/app/wallets/send-on-chain.ts
@@ -147,6 +147,10 @@ const payOnChainByWalletId = async <R extends WalletCurrency>({
       accountId: recipientWallet.accountId,
     }
 
+    addAttributesToCurrentSpan({
+      "payment.originalRecipient": JSON.stringify(recipientWalletDescriptor),
+    })
+
     const wallets = await WalletsRepository().listByAccountId(recipientWallet.accountId)
     if (wallets instanceof Error) return wallets
 
@@ -257,6 +261,7 @@ const executePaymentViaIntraledger = async <
 
   addAttributesToCurrentSpan({
     "payment.settlement_method": SettlementMethod.IntraLedger,
+    "payment.finalRecipient": JSON.stringify(paymentFlow.recipientWalletDescriptor()),
   })
 
   const {

--- a/src/app/wallets/update-pending-invoices.ts
+++ b/src/app/wallets/update-pending-invoices.ts
@@ -186,8 +186,9 @@ const updatePendingInvoiceBeforeFinally = async ({
       walletInvoice,
       recipientAccountId: recipientWallet.accountId,
       receivedBtc,
-      usdFromBtc: dealer.getCentsFromSatsForImmediateBuy,
-      usdFromBtcMidPrice: usdFromBtcMidPriceFn,
+    }).withConversion({
+      mid: { usdFromBtc: usdFromBtcMidPriceFn },
+      hedgeBuyUsd: { usdFromBtc: dealer.getCentsFromSatsForImmediateBuy },
     })
     if (walletInvoiceReceiver instanceof Error) return walletInvoiceReceiver
     const {

--- a/src/app/wallets/update-pending-invoices.ts
+++ b/src/app/wallets/update-pending-invoices.ts
@@ -112,6 +112,10 @@ const updatePendingInvoiceBeforeFinally = async ({
     recipientWalletDescriptor: recipientInvoiceWalletDescriptor,
   } = walletInvoice
 
+  addAttributesToCurrentSpan({
+    "invoices.originalRecipient": JSON.stringify(recipientInvoiceWalletDescriptor),
+  })
+
   const pendingInvoiceLogger = logger.child({
     hash: paymentHash,
     walletId: recipientInvoiceWalletDescriptor.id,
@@ -209,6 +213,10 @@ const updatePendingInvoiceBeforeFinally = async ({
       usdToCreditReceiver,
       usdBankFee,
     } = receivedWalletInvoice
+
+    addAttributesToCurrentSpan({
+      "invoices.finalRecipient": JSON.stringify(recipientWalletDescriptor),
+    })
 
     if (!lnInvoiceLookup.isSettled) {
       const invoiceSettled = await lndService.settleInvoice({ pubkey, secret })

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -42,6 +42,7 @@ export class CouldNotFindWalletFromIdError extends CouldNotFindError {}
 export class CouldNotListWalletsFromAccountIdError extends CouldNotFindError {}
 export class CouldNotFindWalletFromUsernameError extends CouldNotFindError {}
 export class CouldNotFindWalletFromUsernameAndCurrencyError extends CouldNotFindError {}
+export class CouldNotFindWalletFromAccountIdAndCurrencyError extends CouldNotFindError {}
 export class CouldNotFindWalletFromOnChainAddressError extends CouldNotFindError {}
 export class CouldNotFindWalletFromOnChainAddressesError extends CouldNotFindError {}
 export class CouldNotListWalletsFromWalletCurrencyError extends CouldNotFindError {}

--- a/src/domain/payments/errors.ts
+++ b/src/domain/payments/errors.ts
@@ -1,7 +1,6 @@
 import { ValidationError, ErrorLevel } from "@domain/shared"
 
 export class InvalidZeroAmountPriceRatioInputError extends ValidationError {}
-export class ZeroAmountForUsdRecipientError extends ValidationError {}
 export class SubOneCentSatAmountForUsdSelfSendError extends ValidationError {}
 export class LnPaymentRequestNonZeroAmountRequiredError extends ValidationError {}
 export class LnPaymentRequestZeroAmountRequiredError extends ValidationError {}

--- a/src/domain/payments/errors.ts
+++ b/src/domain/payments/errors.ts
@@ -2,6 +2,7 @@ import { ValidationError, ErrorLevel } from "@domain/shared"
 
 export class InvalidZeroAmountPriceRatioInputError extends ValidationError {}
 export class ZeroAmountForUsdRecipientError extends ValidationError {}
+export class SubOneCentSatAmountForUsdSelfSendError extends ValidationError {}
 export class LnPaymentRequestNonZeroAmountRequiredError extends ValidationError {}
 export class LnPaymentRequestZeroAmountRequiredError extends ValidationError {}
 export class LnPaymentRequestInTransitError extends ValidationError {}

--- a/src/domain/payments/index.types.d.ts
+++ b/src/domain/payments/index.types.d.ts
@@ -37,6 +37,16 @@ type AmountsAndFees = {
   usdProtocolAndBankFee: UsdPaymentAmount
 }
 
+type BtcAmountsAndFees = {
+  btcPaymentAmount: BtcPaymentAmount
+  btcProtocolAndBankFee: BtcPaymentAmount
+}
+
+type UsdAmountsAndFees = {
+  usdPaymentAmount: UsdPaymentAmount
+  usdProtocolAndBankFee: UsdPaymentAmount
+}
+
 type PaymentFlowCommonState<
   S extends WalletCurrency,
   R extends WalletCurrency,

--- a/src/domain/payments/index.types.d.ts
+++ b/src/domain/payments/index.types.d.ts
@@ -159,18 +159,22 @@ type OPFBWithAddress<S extends WalletCurrency> = {
   }): OPFBWithSenderWalletAndAccount<S> | OPFBWithError
 }
 
+type LPFBWithRecipientArgs<R extends WalletCurrency> = {
+  recipientWalletDescriptor: WalletDescriptor<R>
+  recipientWalletDescriptorsForAccount: WalletDescriptor<WalletCurrency>[]
+  userId: UserId
+  pubkey?: Pubkey
+  usdPaymentAmount?: UsdPaymentAmount
+  username?: Username
+}
+
 type LPFBWithSenderWallet<S extends WalletCurrency> = {
   isIntraLedger(): boolean
   withoutRecipientWallet<R extends WalletCurrency>():
     | LPFBWithRecipientWallet<S, R>
     | LPFBWithError
   withRecipientWallet<R extends WalletCurrency>(
-    args: WalletDescriptor<R> & {
-      userId: UserId
-      pubkey?: Pubkey
-      usdPaymentAmount?: UsdPaymentAmount
-      username?: Username
-    },
+    args: LPFBWithRecipientArgs<R>,
   ): LPFBWithRecipientWallet<S, R> | LPFBWithError
 }
 
@@ -359,6 +363,7 @@ type LPFBWithRecipientWalletState<
   recipientUsername?: Username
   recipientUserId?: UserId
   recipientAccountId?: AccountId
+  recipientWalletDescriptorsForAccount?: WalletDescriptor<WalletCurrency>[]
 }
 
 type LPFBWithConversionState<

--- a/src/domain/payments/index.types.d.ts
+++ b/src/domain/payments/index.types.d.ts
@@ -203,16 +203,20 @@ type WithConversionArgs = {
   mid: ConversionFns
 }
 
+type OPFBWithRecipientArgs<R extends WalletCurrency> = {
+  recipientWalletDescriptor: WalletDescriptor<R>
+  recipientWalletDescriptorsForAccount: WalletDescriptor<WalletCurrency>[]
+  userId: UserId
+  usdProposedAmount?: UsdPaymentAmount
+  username?: Username
+}
+
 type OPFBWithSenderWalletAndAccount<S extends WalletCurrency> = {
   withoutRecipientWallet<R extends WalletCurrency>():
     | OPFBWithRecipientWallet<S, R>
     | OPFBWithError
   withRecipientWallet<R extends WalletCurrency>(
-    args: WalletDescriptor<R> & {
-      userId: UserId
-      usdProposedAmount?: UsdPaymentAmount
-      username?: Username
-    },
+    args: OPFBWithRecipientArgs<R>,
   ): OPFBWithRecipientWallet<S, R> | OPFBWithError
   isIntraLedger(): Promise<boolean | DealerPriceServiceError>
 }
@@ -411,6 +415,7 @@ type OPFBWithRecipientWalletState<
   recipientUsername?: Username
   recipientUserId?: UserId
   recipientAccountId?: AccountId
+  recipientWalletDescriptorsForAccount?: WalletDescriptor<WalletCurrency>[]
 }
 
 type OPFBWithAmountState<

--- a/src/domain/payments/onchain-payment-flow-builder.ts
+++ b/src/domain/payments/onchain-payment-flow-builder.ts
@@ -85,16 +85,15 @@ const OPFBWithSenderWalletAndAccount = <S extends WalletCurrency>(
   }
 
   const withRecipientWallet = <R extends WalletCurrency>({
-    id: recipientWalletId,
-    currency: recipientWalletCurrency,
+    recipientWalletDescriptor: {
+      id: recipientWalletId,
+      currency: recipientWalletCurrency,
+      accountId: recipientAccountId,
+    },
+    recipientWalletDescriptorsForAccount,
     username: recipientUsername,
-    accountId: recipientAccountId,
     userId: recipientUserId,
-  }: WalletDescriptor<R> & {
-    userId: UserId
-    usdProposedAmount?: UsdPaymentAmount
-    username?: Username
-  }): OPFBWithRecipientWallet<S, R> | OPFBWithError => {
+  }: OPFBWithRecipientArgs<R>): OPFBWithRecipientWallet<S, R> | OPFBWithError => {
     if (recipientWalletId === state.senderWalletId) {
       return OPFBWithError(new SelfPaymentError())
     }
@@ -106,6 +105,7 @@ const OPFBWithSenderWalletAndAccount = <S extends WalletCurrency>(
       recipientAccountId,
       recipientUserId,
       recipientUsername,
+      recipientWalletDescriptorsForAccount,
     })
   }
 

--- a/src/domain/payments/payment-flow-builder.ts
+++ b/src/domain/payments/payment-flow-builder.ts
@@ -221,19 +221,17 @@ const LPFBWithSenderWallet = <S extends WalletCurrency>(
   }
 
   const withRecipientWallet = <R extends WalletCurrency>({
-    id: recipientWalletId,
-    currency: recipientWalletCurrency,
+    recipientWalletDescriptor: {
+      id: recipientWalletId,
+      currency: recipientWalletCurrency,
+      accountId: recipientAccountId,
+    },
+    recipientWalletDescriptorsForAccount,
     pubkey: recipientPubkey,
     usdPaymentAmount,
     username: recipientUsername,
-    accountId: recipientAccountId,
     userId: recipientUserId,
-  }: WalletDescriptor<R> & {
-    userId: UserId
-    pubkey?: Pubkey
-    usdPaymentAmount?: UsdPaymentAmount
-    username?: Username
-  }): LPFBWithRecipientWallet<S, R> | LPFBWithError => {
+  }: LPFBWithRecipientArgs<R>): LPFBWithRecipientWallet<S, R> | LPFBWithError => {
     if (recipientWalletId === state.senderWalletId) {
       return LPFBWithError(new SelfPaymentError())
     }
@@ -258,6 +256,7 @@ const LPFBWithSenderWallet = <S extends WalletCurrency>(
       recipientAccountId,
       recipientUsername,
       recipientUserId,
+      recipientWalletDescriptorsForAccount,
       usdPaymentAmount: usdPaymentAmount || state.usdPaymentAmount,
     })
   }

--- a/src/domain/payments/payment-flow-builder.ts
+++ b/src/domain/payments/payment-flow-builder.ts
@@ -286,85 +286,164 @@ const LPFBWithRecipientWallet = <S extends WalletCurrency, R extends WalletCurre
       usdProtocolAndBankFee,
     } = state
 
-    // Use mid price when no buy / sell required
+    // Setup conditions
     const noConversionRequired =
       (state.senderWalletCurrency === WalletCurrency.Btc &&
         state.settlementMethod === SettlementMethod.Lightning) ||
       (state.senderWalletCurrency as WalletCurrency) ===
         (state.recipientWalletCurrency as WalletCurrency)
 
+    const hasBtcAmounts = !!(btcPaymentAmount && btcProtocolAndBankFee)
+    const hasUsdAmounts = !!(usdPaymentAmount && usdProtocolAndBankFee)
+    const isUsdRecipient = !!(state.recipientWalletCurrency === WalletCurrency.Usd)
+
+    // Define conversion methods
+    const currentStateFromAllAmountsPresent = async (amounts: AmountsAndFees) => ({
+      ...stateWithCreatedAt,
+      ...amounts,
+    })
+
+    const updatedStateFromBtcPaymentAmountMid = async ({
+      btcPaymentAmount,
+      btcProtocolAndBankFee,
+    }: BtcAmountsAndFees): Promise<
+      LPFBWithConversionState<S, R> | DealerPriceServiceError
+    > => {
+      const convertedAmount = await mid.usdFromBtc(btcPaymentAmount)
+      if (convertedAmount instanceof Error) return convertedAmount
+
+      const priceRatio = WalletPriceRatio({
+        usd: convertedAmount,
+        btc: btcPaymentAmount,
+      })
+      if (priceRatio instanceof Error) return priceRatio
+
+      const usdProtocolAndBankFee = priceRatio.convertFromBtcToCeil(btcProtocolAndBankFee)
+      return {
+        ...stateWithCreatedAt,
+        btcPaymentAmount,
+        usdPaymentAmount: convertedAmount,
+        btcProtocolAndBankFee,
+        usdProtocolAndBankFee,
+      }
+    }
+
+    const updatedStateFromBtcPaymentAmountDealer = async ({
+      btcPaymentAmount,
+      btcProtocolAndBankFee,
+    }: BtcAmountsAndFees): Promise<
+      LPFBWithConversionState<S, R> | DealerPriceServiceError
+    > => {
+      const usdFromBtc =
+        state.senderWalletCurrency === WalletCurrency.Btc
+          ? hedgeBuyUsd.usdFromBtc
+          : hedgeSellUsd.usdFromBtc
+
+      const convertedAmount = await usdFromBtc(btcPaymentAmount)
+      if (convertedAmount instanceof Error) return convertedAmount
+
+      const priceRatio = WalletPriceRatio({
+        usd: convertedAmount,
+        btc: btcPaymentAmount,
+      })
+      if (priceRatio instanceof Error) return priceRatio
+
+      const usdProtocolAndBankFee = priceRatio.convertFromBtcToCeil(btcProtocolAndBankFee)
+      return {
+        ...stateWithCreatedAt,
+        btcPaymentAmount,
+        usdPaymentAmount: convertedAmount,
+        btcProtocolAndBankFee,
+        usdProtocolAndBankFee,
+      }
+    }
+
+    const updatedStateFromUsdPaymentAmountMid = async ({
+      usdPaymentAmount,
+      usdProtocolAndBankFee,
+    }: UsdAmountsAndFees): Promise<
+      LPFBWithConversionState<S, R> | DealerPriceServiceError
+    > => {
+      const convertedAmount = await mid.btcFromUsd(usdPaymentAmount)
+      if (convertedAmount instanceof Error) return convertedAmount
+
+      const priceRatio = WalletPriceRatio({
+        btc: convertedAmount,
+        usd: usdPaymentAmount,
+      })
+      if (priceRatio instanceof Error) return priceRatio
+
+      const btcProtocolAndBankFee = priceRatio.convertFromUsd(usdProtocolAndBankFee)
+      return {
+        ...stateWithCreatedAt,
+        btcPaymentAmount: convertedAmount,
+        usdPaymentAmount,
+        btcProtocolAndBankFee,
+        usdProtocolAndBankFee,
+      }
+    }
+
+    const updatedStateFromUsdPaymentAmountDealer = async ({
+      usdPaymentAmount,
+      usdProtocolAndBankFee,
+    }: UsdAmountsAndFees): Promise<
+      LPFBWithConversionState<S, R> | DealerPriceServiceError
+    > => {
+      const btcFromUsd =
+        state.senderWalletCurrency === WalletCurrency.Btc
+          ? hedgeBuyUsd.btcFromUsd
+          : hedgeSellUsd.btcFromUsd
+
+      const convertedAmount = await btcFromUsd(usdPaymentAmount)
+      if (convertedAmount instanceof Error) return convertedAmount
+
+      const priceRatio = WalletPriceRatio({
+        btc: convertedAmount,
+        usd: usdPaymentAmount,
+      })
+      if (priceRatio instanceof Error) return priceRatio
+
+      const btcProtocolAndBankFee = priceRatio.convertFromUsd(usdProtocolAndBankFee)
+      return {
+        ...stateWithCreatedAt,
+        btcPaymentAmount: convertedAmount,
+        usdPaymentAmount,
+        btcProtocolAndBankFee,
+        usdProtocolAndBankFee,
+      }
+    }
+
+    // Apply conversion methods based on conditional checks
+    if (noConversionRequired && hasBtcAmounts && hasUsdAmounts) {
+      return LPFBWithConversion(
+        currentStateFromAllAmountsPresent({
+          btcPaymentAmount,
+          usdPaymentAmount,
+          btcProtocolAndBankFee,
+          usdProtocolAndBankFee,
+        }),
+      )
+    }
+
+    if (noConversionRequired && hasBtcAmounts) {
+      return LPFBWithConversion(
+        updatedStateFromBtcPaymentAmountMid({
+          btcPaymentAmount,
+          btcProtocolAndBankFee,
+        }),
+      )
+    }
+
+    if (noConversionRequired && hasUsdAmounts) {
+      return LPFBWithConversion(
+        updatedStateFromUsdPaymentAmountMid({
+          usdPaymentAmount,
+          usdProtocolAndBankFee,
+        }),
+      )
+    }
+
     if (noConversionRequired) {
-      if (
-        btcPaymentAmount &&
-        btcProtocolAndBankFee &&
-        usdPaymentAmount &&
-        usdProtocolAndBankFee
-      ) {
-        return LPFBWithConversion(
-          new Promise((res) =>
-            res({
-              ...stateWithCreatedAt,
-              btcPaymentAmount,
-              usdPaymentAmount,
-              btcProtocolAndBankFee,
-              usdProtocolAndBankFee,
-            }),
-          ),
-        )
-      }
-
-      if (btcPaymentAmount && btcProtocolAndBankFee) {
-        const updatedStateFromBtcPaymentAmount = async (
-          btcPaymentAmount: BtcPaymentAmount,
-        ): Promise<LPFBWithConversionState<S, R> | DealerPriceServiceError> => {
-          const convertedAmount = await mid.usdFromBtc(btcPaymentAmount)
-          if (convertedAmount instanceof Error) return convertedAmount
-
-          const priceRatio = WalletPriceRatio({
-            usd: convertedAmount,
-            btc: btcPaymentAmount,
-          })
-          if (priceRatio instanceof Error) return priceRatio
-
-          const usdProtocolAndBankFee =
-            priceRatio.convertFromBtcToCeil(btcProtocolAndBankFee)
-          return {
-            ...stateWithCreatedAt,
-            btcPaymentAmount,
-            usdPaymentAmount: convertedAmount,
-            btcProtocolAndBankFee,
-            usdProtocolAndBankFee,
-          }
-        }
-
-        return LPFBWithConversion(updatedStateFromBtcPaymentAmount(btcPaymentAmount))
-      }
-      if (usdPaymentAmount && usdProtocolAndBankFee) {
-        const updatedStateFromUsdPaymentAmount = async (
-          usdPaymentAmount: UsdPaymentAmount,
-        ): Promise<LPFBWithConversionState<S, R> | DealerPriceServiceError> => {
-          const convertedAmount = await mid.btcFromUsd(usdPaymentAmount)
-          if (convertedAmount instanceof Error) return convertedAmount
-
-          const priceRatio = WalletPriceRatio({
-            btc: convertedAmount,
-            usd: usdPaymentAmount,
-          })
-          if (priceRatio instanceof Error) return priceRatio
-
-          const btcProtocolAndBankFee = priceRatio.convertFromUsd(usdProtocolAndBankFee)
-          return {
-            ...stateWithCreatedAt,
-            btcPaymentAmount: convertedAmount,
-            usdPaymentAmount,
-            btcProtocolAndBankFee,
-            usdProtocolAndBankFee,
-          }
-        }
-
-        return LPFBWithConversion(updatedStateFromUsdPaymentAmount(usdPaymentAmount))
-      }
-
       return LPFBWithError(
         new InvalidLightningPaymentFlowBuilderStateError(
           "withConversion - btcPaymentAmount || btcProtocolAndBankFee not set",
@@ -372,85 +451,33 @@ const LPFBWithRecipientWallet = <S extends WalletCurrency, R extends WalletCurre
       )
     }
 
-    // Convert to usd if necessary
-    if (btcPaymentAmount && btcProtocolAndBankFee) {
-      // We already know usd amount from the recipient invoice
-      if (
-        state.recipientWalletCurrency === WalletCurrency.Usd &&
-        usdPaymentAmount &&
-        usdProtocolAndBankFee
-      ) {
-        return LPFBWithConversion(
-          Promise.resolve({
-            ...stateWithCreatedAt,
-            btcPaymentAmount,
-            usdPaymentAmount,
-            btcProtocolAndBankFee,
-            usdProtocolAndBankFee,
-          }),
-        )
-      }
-
-      const updatedStateFromBtcPaymentAmount = async (
-        btcPaymentAmount: BtcPaymentAmount,
-      ): Promise<LPFBWithConversionState<S, R> | DealerPriceServiceError> => {
-        const usdFromBtc =
-          state.senderWalletCurrency === WalletCurrency.Btc
-            ? hedgeBuyUsd.usdFromBtc
-            : hedgeSellUsd.usdFromBtc
-
-        const convertedAmount = await usdFromBtc(btcPaymentAmount)
-        if (convertedAmount instanceof Error) return convertedAmount
-
-        const priceRatio = WalletPriceRatio({
-          usd: convertedAmount,
-          btc: btcPaymentAmount,
-        })
-        if (priceRatio instanceof Error) return priceRatio
-
-        const usdProtocolAndBankFee =
-          priceRatio.convertFromBtcToCeil(btcProtocolAndBankFee)
-        return {
-          ...stateWithCreatedAt,
+    if (hasBtcAmounts && hasUsdAmounts && isUsdRecipient) {
+      return LPFBWithConversion(
+        currentStateFromAllAmountsPresent({
           btcPaymentAmount,
-          usdPaymentAmount: convertedAmount,
-          btcProtocolAndBankFee,
-          usdProtocolAndBankFee,
-        }
-      }
-
-      return LPFBWithConversion(updatedStateFromBtcPaymentAmount(btcPaymentAmount))
-    }
-
-    if (usdPaymentAmount && usdProtocolAndBankFee) {
-      const updatedStateFromUsdPaymentAmount = async (
-        usdPaymentAmount: UsdPaymentAmount,
-      ): Promise<LPFBWithConversionState<S, R> | DealerPriceServiceError> => {
-        const btcFromUsd =
-          state.senderWalletCurrency === WalletCurrency.Btc
-            ? hedgeBuyUsd.btcFromUsd
-            : hedgeSellUsd.btcFromUsd
-
-        const convertedAmount = await btcFromUsd(usdPaymentAmount)
-        if (convertedAmount instanceof Error) return convertedAmount
-
-        const priceRatio = WalletPriceRatio({
-          btc: convertedAmount,
-          usd: usdPaymentAmount,
-        })
-        if (priceRatio instanceof Error) return priceRatio
-
-        const btcProtocolAndBankFee = priceRatio.convertFromUsd(usdProtocolAndBankFee)
-        return {
-          ...stateWithCreatedAt,
-          btcPaymentAmount: convertedAmount,
           usdPaymentAmount,
           btcProtocolAndBankFee,
           usdProtocolAndBankFee,
-        }
-      }
+        }),
+      )
+    }
 
-      return LPFBWithConversion(updatedStateFromUsdPaymentAmount(usdPaymentAmount))
+    if (hasBtcAmounts) {
+      return LPFBWithConversion(
+        updatedStateFromBtcPaymentAmountDealer({
+          btcPaymentAmount,
+          btcProtocolAndBankFee,
+        }),
+      )
+    }
+
+    if (hasUsdAmounts) {
+      return LPFBWithConversion(
+        updatedStateFromUsdPaymentAmountDealer({
+          usdPaymentAmount,
+          usdProtocolAndBankFee,
+        }),
+      )
     }
 
     return LPFBWithError(

--- a/src/domain/wallet-invoices/index.types.d.ts
+++ b/src/domain/wallet-invoices/index.types.d.ts
@@ -93,6 +93,7 @@ type WalletInvoiceReceiver = {
   btcToCreditReceiver: BtcPaymentAmount
   usdBankFee: UsdPaymentAmount
   btcBankFee: BtcPaymentAmount
+  recipientWalletDescriptor: WalletDescriptor<WalletCurrency>
   receivedAmount: () => BtcPaymentAmount | UsdPaymentAmount
 }
 
@@ -120,6 +121,7 @@ type WalletReceiverArgs = {
 
 type WalletInvoiceReceiverArgs = WalletReceiverArgs & {
   walletInvoice: WalletInvoice
+  recipientAccountId: AccountId
 }
 
 type WalletAddressReceiverArgs<S extends WalletCurrency> = WalletReceiverArgs & {

--- a/src/domain/wallet-invoices/index.types.d.ts
+++ b/src/domain/wallet-invoices/index.types.d.ts
@@ -131,6 +131,7 @@ type WalletInvoiceReceiverArgs = {
 
   walletInvoice: WalletInvoice
   recipientAccountId: AccountId
+  recipientWalletDescriptorsForAccount: WalletDescriptor<WalletCurrency>[]
 }
 
 type WalletAddressReceiverArgs<S extends WalletCurrency> = {

--- a/src/domain/wallet-invoices/index.types.d.ts
+++ b/src/domain/wallet-invoices/index.types.d.ts
@@ -88,7 +88,24 @@ type WalletAddress<S extends WalletCurrency> = {
   recipientWalletDescriptor: WalletDescriptor<S>
 }
 
+type WalletInvoiceConversionFns = {
+  usdFromBtc(
+    amount: BtcPaymentAmount,
+  ): Promise<UsdPaymentAmount | DealerPriceServiceError>
+}
+
+type WalletInvoiceWithConversionArgs = {
+  hedgeBuyUsd: WalletInvoiceConversionFns
+  mid: WalletInvoiceConversionFns
+}
+
 type WalletInvoiceReceiver = {
+  withConversion(
+    args: WalletInvoiceWithConversionArgs,
+  ): Promise<ReceivedWalletInvoice | ValidationError | DealerPriceServiceError>
+}
+
+type ReceivedWalletInvoice = {
   usdToCreditReceiver: UsdPaymentAmount
   btcToCreditReceiver: BtcPaymentAmount
   usdBankFee: UsdPaymentAmount
@@ -108,7 +125,15 @@ type WalletAddressReceiver = {
     | { amountToCreditReceiver: UsdPaymentAmount; bankFee: UsdPaymentAmount }
 }
 
-type WalletReceiverArgs = {
+type WalletInvoiceReceiverArgs = {
+  receivedBtc: BtcPaymentAmount
+  satsFee?: BtcPaymentAmount
+
+  walletInvoice: WalletInvoice
+  recipientAccountId: AccountId
+}
+
+type WalletAddressReceiverArgs<S extends WalletCurrency> = {
   receivedBtc: BtcPaymentAmount
   satsFee?: BtcPaymentAmount
   usdFromBtc(
@@ -117,14 +142,7 @@ type WalletReceiverArgs = {
   usdFromBtcMidPrice(
     amount: BtcPaymentAmount,
   ): Promise<UsdPaymentAmount | DealerPriceServiceError>
-}
 
-type WalletInvoiceReceiverArgs = WalletReceiverArgs & {
-  walletInvoice: WalletInvoice
-  recipientAccountId: AccountId
-}
-
-type WalletAddressReceiverArgs<S extends WalletCurrency> = WalletReceiverArgs & {
   walletAddress: WalletAddress<S>
 }
 

--- a/src/domain/wallet-invoices/wallet-invoice-receiver.ts
+++ b/src/domain/wallet-invoices/wallet-invoice-receiver.ts
@@ -3,16 +3,12 @@ import { AmountCalculator, WalletCurrency, ZERO_BANK_FEE } from "@domain/shared"
 
 const calc = AmountCalculator()
 
-export const WalletInvoiceReceiver = async ({
+export const WalletInvoiceReceiver = ({
   walletInvoice,
   recipientAccountId,
   receivedBtc,
   satsFee = ZERO_BANK_FEE.btcBankFee,
-  usdFromBtc,
-  usdFromBtcMidPrice,
-}: WalletInvoiceReceiverArgs): Promise<
-  WalletInvoiceReceiver | DealerPriceServiceError | ValidationError
-> => {
+}: WalletInvoiceReceiverArgs): WalletInvoiceReceiver => {
   const {
     recipientWalletDescriptor: partialWalletDescriptor,
     usdAmount: usdAmountFromInvoice,
@@ -22,69 +18,96 @@ export const WalletInvoiceReceiver = async ({
     ...partialWalletDescriptor,
     accountId: recipientAccountId,
   }
-  if (recipientWalletDescriptor.currency === WalletCurrency.Btc) {
-    const receivedUsd = await usdFromBtcMidPrice(receivedBtc)
-    if (receivedUsd instanceof Error) return receivedUsd
 
-    const priceRatio = WalletPriceRatio({ usd: receivedUsd, btc: receivedBtc })
-    if (priceRatio instanceof Error) return priceRatio
+  const withConversion = async ({
+    hedgeBuyUsd,
+    mid,
+  }: WalletInvoiceWithConversionArgs): Promise<
+    ReceivedWalletInvoice | ValidationError | DealerPriceServiceError
+  > => {
+    // Setup conditions
+    const isBtcRecipient = recipientWalletDescriptor.currency === WalletCurrency.Btc
 
-    const btcBankFee = satsFee
-    const usdBankFee = priceRatio.convertFromBtcToCeil(btcBankFee)
+    // Define conversion methods
+    const receivedWalletInvoiceFromBtcAmountMid = async () => {
+      const receivedUsd = await mid.usdFromBtc(receivedBtc)
+      if (receivedUsd instanceof Error) return receivedUsd
 
-    return {
-      btcToCreditReceiver: calc.sub(receivedBtc, btcBankFee),
-      usdToCreditReceiver: calc.sub(receivedUsd, usdBankFee),
-      usdBankFee,
-      btcBankFee,
-      recipientWalletDescriptor,
-      receivedAmount: () =>
-        recipientWalletDescriptor.currency === WalletCurrency.Btc
-          ? receivedBtc
-          : receivedUsd,
+      const priceRatio = WalletPriceRatio({ usd: receivedUsd, btc: receivedBtc })
+      if (priceRatio instanceof Error) return priceRatio
+
+      const btcBankFee = satsFee
+      const usdBankFee = priceRatio.convertFromBtcToCeil(btcBankFee)
+
+      return {
+        btcToCreditReceiver: calc.sub(receivedBtc, btcBankFee),
+        usdToCreditReceiver: calc.sub(receivedUsd, usdBankFee),
+        usdBankFee,
+        btcBankFee,
+        recipientWalletDescriptor,
+        receivedAmount: () =>
+          recipientWalletDescriptor.currency === WalletCurrency.Btc
+            ? receivedBtc
+            : receivedUsd,
+      }
     }
-  }
 
-  if (usdAmountFromInvoice) {
-    const receivedUsd = usdAmountFromInvoice
+    const receivedWalletInvoiceFromUsdAmountMid = async (
+      receivedUsd: UsdPaymentAmount,
+    ) => {
+      const priceRatio = WalletPriceRatio({ usd: receivedUsd, btc: receivedBtc })
+      if (priceRatio instanceof Error) return priceRatio
 
-    const priceRatio = WalletPriceRatio({ usd: receivedUsd, btc: receivedBtc })
-    if (priceRatio instanceof Error) return priceRatio
+      const btcBankFee = satsFee
+      const usdBankFee = priceRatio.convertFromBtcToCeil(btcBankFee)
 
-    const btcBankFee = satsFee
-    const usdBankFee = priceRatio.convertFromBtcToCeil(btcBankFee)
-
-    return {
-      btcToCreditReceiver: calc.sub(receivedBtc, btcBankFee),
-      usdToCreditReceiver: calc.sub(receivedUsd, usdBankFee),
-      usdBankFee,
-      btcBankFee,
-      recipientWalletDescriptor,
-      receivedAmount: () =>
-        recipientWalletDescriptor.currency === WalletCurrency.Btc
-          ? receivedBtc
-          : receivedUsd,
+      return {
+        btcToCreditReceiver: calc.sub(receivedBtc, btcBankFee),
+        usdToCreditReceiver: calc.sub(receivedUsd, usdBankFee),
+        usdBankFee,
+        btcBankFee,
+        recipientWalletDescriptor,
+        receivedAmount: () =>
+          recipientWalletDescriptor.currency === WalletCurrency.Btc
+            ? receivedBtc
+            : receivedUsd,
+      }
     }
+
+    const receivedWalletInvoiceFromBtcAmountDealer = async () => {
+      const receivedUsd = await hedgeBuyUsd.usdFromBtc(receivedBtc)
+      if (receivedUsd instanceof Error) return receivedUsd
+
+      const priceRatio = WalletPriceRatio({ usd: receivedUsd, btc: receivedBtc })
+      if (priceRatio instanceof Error) return priceRatio
+
+      const btcBankFee = satsFee
+      const usdBankFee = priceRatio.convertFromBtcToCeil(btcBankFee)
+
+      return {
+        btcToCreditReceiver: calc.sub(receivedBtc, btcBankFee),
+        usdToCreditReceiver: calc.sub(receivedUsd, usdBankFee),
+        usdBankFee,
+        btcBankFee,
+        recipientWalletDescriptor,
+        receivedAmount: () =>
+          recipientWalletDescriptor.currency === WalletCurrency.Btc
+            ? receivedBtc
+            : receivedUsd,
+      }
+    }
+
+    // Apply conversion methods based on conditional checks
+    if (isBtcRecipient) {
+      return receivedWalletInvoiceFromBtcAmountMid()
+    }
+
+    if (usdAmountFromInvoice) {
+      return receivedWalletInvoiceFromUsdAmountMid(usdAmountFromInvoice)
+    }
+
+    return receivedWalletInvoiceFromBtcAmountDealer()
   }
 
-  const receivedUsd = await usdFromBtc(receivedBtc)
-  if (receivedUsd instanceof Error) return receivedUsd
-
-  const priceRatio = WalletPriceRatio({ usd: receivedUsd, btc: receivedBtc })
-  if (priceRatio instanceof Error) return priceRatio
-
-  const btcBankFee = satsFee
-  const usdBankFee = priceRatio.convertFromBtcToCeil(btcBankFee)
-
-  return {
-    btcToCreditReceiver: calc.sub(receivedBtc, btcBankFee),
-    usdToCreditReceiver: calc.sub(receivedUsd, usdBankFee),
-    usdBankFee,
-    btcBankFee,
-    recipientWalletDescriptor,
-    receivedAmount: () =>
-      recipientWalletDescriptor.currency === WalletCurrency.Btc
-        ? receivedBtc
-        : receivedUsd,
-  }
+  return { withConversion }
 }

--- a/src/domain/wallet-invoices/wallet-invoice-receiver.ts
+++ b/src/domain/wallet-invoices/wallet-invoice-receiver.ts
@@ -6,6 +6,7 @@ const calc = AmountCalculator()
 export const WalletInvoiceReceiver = ({
   walletInvoice,
   recipientAccountId,
+  recipientWalletDescriptorsForAccount,
   receivedBtc,
   satsFee = ZERO_BANK_FEE.btcBankFee,
 }: WalletInvoiceReceiverArgs): WalletInvoiceReceiver => {

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -256,7 +256,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       message = "Reward for quiz question was already claimed."
       return new ValidationInternalError({ message, logger: baseLogger })
 
-    case "ZeroAmountForUsdRecipientError":
+    case "SubOneCentSatAmountForUsdSelfSendError":
       message = "Amount sent was too low for recipient's usd wallet."
       return new ValidationInternalError({ message, logger: baseLogger })
 
@@ -622,6 +622,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "InvalidUrlError":
     case "SvixEventError":
     case "UnknownSvixError":
+    case "ZeroAmountForUsdRecipientError":
       message = `Unexpected error occurred, please try again or contact support if it persists (code: ${
         error.name
       }${error.message ? ": " + error.message : ""})`

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -483,6 +483,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "CouldNotListWalletsFromAccountIdError":
     case "CouldNotFindWalletFromUsernameError":
     case "CouldNotFindWalletFromUsernameAndCurrencyError":
+    case "CouldNotFindWalletFromAccountIdAndCurrencyError":
     case "CouldNotFindWalletFromOnChainAddressError":
     case "CouldNotFindWalletFromOnChainAddressesError":
     case "CouldNotFindBtcWalletForAccountError":

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -623,7 +623,6 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "InvalidUrlError":
     case "SvixEventError":
     case "UnknownSvixError":
-    case "ZeroAmountForUsdRecipientError":
       message = `Unexpected error occurred, please try again or contact support if it persists (code: ${
         error.name
       }${error.message ? ": " + error.message : ""})`

--- a/test/integration/app/wallets/send-intraledger.spec.ts
+++ b/test/integration/app/wallets/send-intraledger.spec.ts
@@ -4,7 +4,6 @@ import { AccountStatus } from "@domain/accounts"
 import { toSats } from "@domain/bitcoin"
 import { PaymentSendStatus } from "@domain/bitcoin/lightning"
 import { DisplayCurrency, toCents } from "@domain/fiat"
-import { ZeroAmountForUsdRecipientError } from "@domain/payments"
 import {
   InactiveAccountError,
   IntraledgerLimitsExceededError,
@@ -195,34 +194,6 @@ describe("intraLedgerPay", () => {
       senderAccount: newAccount,
     })
     expect(paymentResult).toBeInstanceOf(SelfPaymentError)
-  })
-
-  it("fails to send less-than-1-cent amount to usd recipient", async () => {
-    // Create users
-    const { btcWalletDescriptor: newWalletDescriptor, usdWalletDescriptor } =
-      await createRandomUserAndWallets()
-    const newAccount = await AccountsRepository().findById(newWalletDescriptor.accountId)
-    if (newAccount instanceof Error) throw newAccount
-
-    // Fund balance for send
-    const receive = await recordReceiveLnPayment({
-      walletDescriptor: usdWalletDescriptor,
-      paymentAmount: receiveAmounts,
-      bankFee: receiveBankFee,
-      displayAmounts: receiveDisplayAmounts,
-      memo,
-    })
-    if (receive instanceof Error) throw receive
-
-    // Pay intraledger
-    const paymentResult = await Payments.intraledgerPaymentSendWalletIdForBtcWallet({
-      recipientWalletId: usdWalletDescriptor.id,
-      memo,
-      amount: 1,
-      senderWalletId: newWalletDescriptor.id,
-      senderAccount: newAccount,
-    })
-    expect(paymentResult).toBeInstanceOf(ZeroAmountForUsdRecipientError)
   })
 
   it("fails if amount greater than trade-intra-account limit", async () => {

--- a/test/integration/app/wallets/send-onchain.spec.ts
+++ b/test/integration/app/wallets/send-onchain.spec.ts
@@ -12,7 +12,7 @@ import {
   LimitsExceededError,
   SelfPaymentError,
 } from "@domain/errors"
-import { InvalidZeroAmountPriceRatioInputError } from "@domain/payments"
+import { SubOneCentSatAmountForUsdSelfSendError } from "@domain/payments"
 import {
   AmountCalculator,
   WalletCurrency,
@@ -333,18 +333,14 @@ describe("onChainPay", () => {
     })
 
     it("fails if builder 'withConversion' step fails", async () => {
-      const newWalletDescriptor = await createRandomUserAndBtcWallet()
+      const {
+        btcWalletDescriptor: newWalletDescriptor,
+        usdWalletDescriptor: recipientUsdWalletDescriptor,
+      } = await createRandomUserAndWallets()
       const newAccount = await AccountsRepository().findById(
         newWalletDescriptor.accountId,
       )
       if (newAccount instanceof Error) throw newAccount
-
-      const { usdWalletDescriptor: recipientUsdWalletDescriptor } =
-        await createRandomUserAndWallets()
-      const recipientAccount = await AccountsRepository().findById(
-        recipientUsdWalletDescriptor.accountId,
-      )
-      if (recipientAccount instanceof Error) throw recipientAccount
 
       // Fund balance for send
       const receive = await recordReceiveLnPayment({
@@ -381,7 +377,7 @@ describe("onChainPay", () => {
         speed: PayoutSpeed.Fast,
         memo,
       })
-      expect(res).toBeInstanceOf(InvalidZeroAmountPriceRatioInputError)
+      expect(res).toBeInstanceOf(SubOneCentSatAmountForUsdSelfSendError)
     })
 
     it("fails if recipient account is locked", async () => {

--- a/test/legacy-integration/services/dealer/hedge-price.spec.ts
+++ b/test/legacy-integration/services/dealer/hedge-price.spec.ts
@@ -96,13 +96,18 @@ const getBtcEquivalentForIntraledgerSendToUsd = async ({
   }
 
   const beforeBtc = await getBalanceHelper(newBtcWallet.id)
+  const beforeRecipientUsd = await getBalanceHelper(newUsdWallet.id)
 
   const result = await Payments.intraledgerPaymentSendWalletIdForBtcWallet({
     amount: Number(btcPaymentAmount.amount),
     ...sendArgs,
   })
-  if (result instanceof ZeroAmountForUsdRecipientError) return result
   if (result instanceof Error) throw result
+
+  const afterRecipientUsd = await getBalanceHelper(newUsdWallet.id)
+  if (beforeRecipientUsd === afterRecipientUsd) {
+    return new ZeroAmountForUsdRecipientError()
+  }
 
   const afterBtc = await getBalanceHelper(newBtcWallet.id)
   return (beforeBtc - afterBtc) as CurrencyBaseAmount
@@ -175,6 +180,7 @@ const getBtcEquivalentForNoAmountInvoiceSendToUsd = async ({
 }): Promise<CurrencyBaseAmount | ZeroAmountForUsdRecipientError> => {
   const { newBtcWallet, newUsdWallet, newAccount } = accountAndWallets
 
+  const beforeRecipientUsd = await getBalanceHelper(newUsdWallet.id)
   const lnInvoice = await Wallets.addInvoiceNoAmountForSelf({
     walletId: newUsdWallet.id,
   })
@@ -188,8 +194,12 @@ const getBtcEquivalentForNoAmountInvoiceSendToUsd = async ({
     senderWalletId: newBtcWallet.id,
     senderAccount: newAccount,
   })
-  if (result instanceof ZeroAmountForUsdRecipientError) return result
   if (result instanceof Error) throw result
+
+  const afterRecipientUsd = await getBalanceHelper(newUsdWallet.id)
+  if (beforeRecipientUsd === afterRecipientUsd) {
+    return new ZeroAmountForUsdRecipientError()
+  }
 
   const afterBtc = await getBalanceHelper(newBtcWallet.id)
   return (beforeBtc - afterBtc) as CurrencyBaseAmount
@@ -204,6 +214,7 @@ const getBtcEquivalentForNoAmountInvoiceProbeAndSendToUsd = async ({
 }): Promise<CurrencyBaseAmount | ZeroAmountForUsdRecipientError> => {
   const { newBtcWallet, newUsdWallet, newAccount } = accountAndWallets
 
+  const beforeRecipientUsd = await getBalanceHelper(newUsdWallet.id)
   const lnInvoice = await Wallets.addInvoiceNoAmountForSelf({
     walletId: newUsdWallet.id,
   })
@@ -228,8 +239,12 @@ const getBtcEquivalentForNoAmountInvoiceProbeAndSendToUsd = async ({
     senderWalletId: newBtcWallet.id,
     senderAccount: newAccount,
   })
-  if (result instanceof ZeroAmountForUsdRecipientError) return result
   if (result instanceof Error) throw result
+
+  const afterRecipientUsd = await getBalanceHelper(newUsdWallet.id)
+  if (beforeRecipientUsd === afterRecipientUsd) {
+    return new ZeroAmountForUsdRecipientError()
+  }
 
   const afterBtc = await getBalanceHelper(newBtcWallet.id)
   return (beforeBtc - afterBtc) as CurrencyBaseAmount

--- a/test/legacy-integration/services/dealer/hedge-price.spec.ts
+++ b/test/legacy-integration/services/dealer/hedge-price.spec.ts
@@ -4,12 +4,13 @@ import { getDealerConfig } from "@config"
 
 import { toSats } from "@domain/bitcoin"
 import { toCents } from "@domain/fiat"
-import { ZeroAmountForUsdRecipientError } from "@domain/payments"
 import { AmountCalculator, paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
 import { baseLogger } from "@services/logger"
 import { AccountsRepository } from "@services/mongoose"
 
 import { createAccount, createAndFundNewWallet, getBalanceHelper } from "test/helpers"
+
+class ZeroAmountForUsdRecipientError extends Error {}
 
 jest.mock("@config", () => {
   const config = jest.requireActual("@config")

--- a/test/unit/domain/wallet-invoices/wallet-invoice-receiver.spec.ts
+++ b/test/unit/domain/wallet-invoices/wallet-invoice-receiver.spec.ts
@@ -26,18 +26,26 @@ describe("WalletInvoiceReceiver", () => {
   }
 
   const receivedBtc = BtcPaymentAmount(1200n)
-  const recipientBtcWallet = {
-    id: "recipientWalletId" as WalletId,
-    currency: WalletCurrency.Btc,
-    username: "Username" as Username,
-  }
-  const recipientUsdWallet = {
-    id: "recipientWalletId" as WalletId,
-    currency: WalletCurrency.Usd,
-    username: "Username" as Username,
-  }
 
   const recipientAccountId = "recipientAccountId" as AccountId
+
+  const partialRecipientBtcWalletDescriptor = {
+    id: "recipientBtcWalletId" as WalletId,
+    currency: WalletCurrency.Btc,
+  }
+  const recipientBtcWalletDescriptor = {
+    ...partialRecipientBtcWalletDescriptor,
+    accountId: recipientAccountId,
+  }
+
+  const partialRecipientUsdWalletDescriptor = {
+    id: "recipientUsdWalletId" as WalletId,
+    currency: WalletCurrency.Usd,
+  }
+  const recipientUsdWalletDescriptor = {
+    ...partialRecipientUsdWalletDescriptor,
+    accountId: recipientAccountId,
+  }
 
   describe("for btc invoice", () => {
     const btcInvoice: WalletInvoice = {
@@ -47,14 +55,18 @@ describe("WalletInvoiceReceiver", () => {
       pubkey: "pubkey" as Pubkey,
       usdAmount: undefined,
       paid: false,
-      recipientWalletDescriptor: recipientBtcWallet,
+      recipientWalletDescriptor: partialRecipientBtcWalletDescriptor,
     }
 
     it("returns correct amounts", async () => {
       const walletInvoiceAmounts = await WalletInvoiceReceiver({
         walletInvoice: btcInvoice,
-        recipientAccountId,
         receivedBtc,
+        recipientAccountId,
+        recipientWalletDescriptorsForAccount: [
+          recipientBtcWalletDescriptor,
+          recipientUsdWalletDescriptor,
+        ],
       }).withConversion({
         mid: { usdFromBtc: usdFromBtcMidPrice },
         hedgeBuyUsd: { usdFromBtc },
@@ -82,7 +94,7 @@ describe("WalletInvoiceReceiver", () => {
       const amountUsdInvoice: WalletInvoice = {
         paymentHash: "paymentHash" as PaymentHash,
         secret: "secret" as SecretPreImage,
-        recipientWalletDescriptor: recipientUsdWallet,
+        recipientWalletDescriptor: partialRecipientUsdWalletDescriptor,
         selfGenerated: false,
         pubkey: "pubkey" as Pubkey,
         usdAmount: UsdPaymentAmount(BigInt(100)),
@@ -92,8 +104,12 @@ describe("WalletInvoiceReceiver", () => {
       it("returns correct amounts", async () => {
         const walletInvoiceAmounts = await WalletInvoiceReceiver({
           walletInvoice: amountUsdInvoice,
-          recipientAccountId,
           receivedBtc,
+          recipientAccountId,
+          recipientWalletDescriptorsForAccount: [
+            recipientBtcWalletDescriptor,
+            recipientUsdWalletDescriptor,
+          ],
         }).withConversion({
           mid: { usdFromBtc: usdFromBtcMidPrice },
           hedgeBuyUsd: { usdFromBtc },
@@ -115,7 +131,7 @@ describe("WalletInvoiceReceiver", () => {
       const noAmountUsdInvoice: WalletInvoice = {
         paymentHash: "paymentHash" as PaymentHash,
         secret: "secret" as SecretPreImage,
-        recipientWalletDescriptor: recipientUsdWallet,
+        recipientWalletDescriptor: partialRecipientUsdWalletDescriptor,
         selfGenerated: false,
         pubkey: "pubkey" as Pubkey,
         paid: false,
@@ -124,8 +140,12 @@ describe("WalletInvoiceReceiver", () => {
       it("returns correct amounts", async () => {
         const walletInvoiceAmounts = await WalletInvoiceReceiver({
           walletInvoice: noAmountUsdInvoice,
-          recipientAccountId,
           receivedBtc,
+          recipientAccountId,
+          recipientWalletDescriptorsForAccount: [
+            recipientBtcWalletDescriptor,
+            recipientUsdWalletDescriptor,
+          ],
         }).withConversion({
           mid: { usdFromBtc: usdFromBtcMidPrice },
           hedgeBuyUsd: { usdFromBtc },

--- a/test/unit/domain/wallet-invoices/wallet-invoice-receiver.spec.ts
+++ b/test/unit/domain/wallet-invoices/wallet-invoice-receiver.spec.ts
@@ -37,6 +37,8 @@ describe("WalletInvoiceReceiver", () => {
     username: "Username" as Username,
   }
 
+  const recipientAccountId = "recipientAccountId" as AccountId
+
   describe("for btc invoice", () => {
     const btcInvoice: WalletInvoice = {
       paymentHash: "paymentHash" as PaymentHash,
@@ -51,6 +53,7 @@ describe("WalletInvoiceReceiver", () => {
     it("returns correct amounts", async () => {
       const walletInvoiceAmounts = await WalletInvoiceReceiver({
         walletInvoice: btcInvoice,
+        recipientAccountId,
         receivedBtc,
         usdFromBtcMidPrice,
         usdFromBtc,
@@ -88,6 +91,7 @@ describe("WalletInvoiceReceiver", () => {
       it("returns correct amounts", async () => {
         const walletInvoiceAmounts = await WalletInvoiceReceiver({
           walletInvoice: amountUsdInvoice,
+          recipientAccountId,
           receivedBtc,
           usdFromBtcMidPrice,
           usdFromBtc,
@@ -118,6 +122,7 @@ describe("WalletInvoiceReceiver", () => {
       it("returns correct amounts", async () => {
         const walletInvoiceAmounts = await WalletInvoiceReceiver({
           walletInvoice: noAmountUsdInvoice,
+          recipientAccountId,
           receivedBtc,
           usdFromBtcMidPrice,
           usdFromBtc,

--- a/test/unit/domain/wallet-invoices/wallet-invoice-receiver.spec.ts
+++ b/test/unit/domain/wallet-invoices/wallet-invoice-receiver.spec.ts
@@ -12,7 +12,7 @@ describe("WalletInvoiceReceiver", () => {
   const midPriceRatio = 2n
   const usdFromBtcMidPrice = async (amount: BtcPaymentAmount) => {
     return Promise.resolve({
-      amount: amount.amount * midPriceRatio,
+      amount: amount.amount / midPriceRatio,
       currency: WalletCurrency.Usd,
     })
   }
@@ -20,7 +20,7 @@ describe("WalletInvoiceReceiver", () => {
   const immediatePriceRation = 3n
   const usdFromBtc = async (amount: BtcPaymentAmount) => {
     return Promise.resolve({
-      amount: amount.amount * immediatePriceRation,
+      amount: amount.amount / immediatePriceRation,
       currency: WalletCurrency.Usd,
     })
   }

--- a/test/unit/domain/wallet-invoices/wallet-invoice-receiver.spec.ts
+++ b/test/unit/domain/wallet-invoices/wallet-invoice-receiver.spec.ts
@@ -55,8 +55,9 @@ describe("WalletInvoiceReceiver", () => {
         walletInvoice: btcInvoice,
         recipientAccountId,
         receivedBtc,
-        usdFromBtcMidPrice,
-        usdFromBtc,
+      }).withConversion({
+        mid: { usdFromBtc: usdFromBtcMidPrice },
+        hedgeBuyUsd: { usdFromBtc },
       })
 
       if (walletInvoiceAmounts instanceof Error) throw walletInvoiceAmounts
@@ -93,8 +94,9 @@ describe("WalletInvoiceReceiver", () => {
           walletInvoice: amountUsdInvoice,
           recipientAccountId,
           receivedBtc,
-          usdFromBtcMidPrice,
-          usdFromBtc,
+        }).withConversion({
+          mid: { usdFromBtc: usdFromBtcMidPrice },
+          hedgeBuyUsd: { usdFromBtc },
         })
 
         if (walletInvoiceAmounts instanceof Error) throw walletInvoiceAmounts
@@ -124,8 +126,9 @@ describe("WalletInvoiceReceiver", () => {
           walletInvoice: noAmountUsdInvoice,
           recipientAccountId,
           receivedBtc,
-          usdFromBtcMidPrice,
-          usdFromBtc,
+        }).withConversion({
+          mid: { usdFromBtc: usdFromBtcMidPrice },
+          hedgeBuyUsd: { usdFromBtc },
         })
 
         if (walletInvoiceAmounts instanceof Error) throw walletInvoiceAmounts

--- a/test/unit/payments/onchain-payment-flow-builder.spec.ts
+++ b/test/unit/payments/onchain-payment-flow-builder.spec.ts
@@ -383,58 +383,134 @@ describe("OnChainPaymentFlowBuilder", () => {
               )
             }
 
-            const withAmountDescribes = [
-              { name: "with amount", amount: uncheckedAmount },
-              { name: "with dust amount", amount: dustAmount },
-              { name: "with min amount", amount: 51 }, // Close to 1 cent
-            ]
+            const withBtcRecipientBuilder =
+              withBtcWalletBuilder.withRecipientWallet(recipientBtcArgs)
 
-            const describeWithAmount = ({ name, amount }) => {
-              describe(`${name}`, () => {
-                const withAmountBuilder = withBtcWalletBuilder
-                  .withRecipientWallet(recipientBtcArgs)
-                  .withAmount({ amount: BigInt(amount), currency: amountCurrency })
-                const checkInputAmount = (payment) => {
-                  expect(payment).toEqual(
-                    expect.objectContaining({
-                      inputAmount: BigInt(amount),
-                    }),
-                  )
-                }
-
-                it("correctly applies no fees", async () => {
-                  const payment = await withAmountBuilder
-                    .withConversion(withConversionArgs)
-                    .withoutMinerFee()
-                  if (payment instanceof Error) throw payment
-
-                  const btcPaymentAmount = {
-                    amount: BigInt(amount),
-                    currency: WalletCurrency.Btc,
-                  }
-                  const usdPaymentAmount =
-                    await convertForBtcWalletToBtcWallet.usdFromBtc(btcPaymentAmount)
-
-                  checkAddress(payment)
-                  checkSettlementMethod(payment)
-                  checkInputAmount(payment)
-                  checkSenderWallet(payment)
-                  checkRecipientWallet(payment)
-                  expect(payment).toEqual(
-                    expect.objectContaining({
-                      btcPaymentAmount,
-                      usdPaymentAmount,
-                      btcProtocolAndBankFee: onChainFees.intraLedgerFees().btc,
-                      usdProtocolAndBankFee: onChainFees.intraLedgerFees().usd,
-                    }),
-                  )
-                })
+            it("correctly applies no fees, with normal amount", async () => {
+              const amount = uncheckedAmount
+              const withAmountBuilder = withBtcRecipientBuilder.withAmount({
+                amount: BigInt(amount),
+                currency: amountCurrency,
               })
-            }
 
-            for (const args of withAmountDescribes) {
-              describeWithAmount(args)
-            }
+              const checkInputAmount = (payment) => {
+                expect(payment).toEqual(
+                  expect.objectContaining({
+                    inputAmount: BigInt(amount),
+                  }),
+                )
+              }
+
+              const payment = await withAmountBuilder
+                .withConversion(withConversionArgs)
+                .withoutMinerFee()
+              if (payment instanceof Error) throw payment
+
+              const btcPaymentAmount = {
+                amount: BigInt(amount),
+                currency: WalletCurrency.Btc,
+              }
+              const usdPaymentAmount =
+                await convertForBtcWalletToBtcWallet.usdFromBtc(btcPaymentAmount)
+
+              checkAddress(payment)
+              checkSettlementMethod(payment)
+              checkInputAmount(payment)
+              checkSenderWallet(payment)
+              checkRecipientWallet(payment)
+              expect(payment).toEqual(
+                expect.objectContaining({
+                  btcPaymentAmount,
+                  usdPaymentAmount,
+                  btcProtocolAndBankFee: onChainFees.intraLedgerFees().btc,
+                  usdProtocolAndBankFee: onChainFees.intraLedgerFees().usd,
+                }),
+              )
+            })
+
+            it("correctly applies no fees, with dust amount", async () => {
+              const amount = dustAmount
+              const withAmountBuilder = withBtcRecipientBuilder.withAmount({
+                amount: BigInt(amount),
+                currency: amountCurrency,
+              })
+
+              const checkInputAmount = (payment) => {
+                expect(payment).toEqual(
+                  expect.objectContaining({
+                    inputAmount: BigInt(amount),
+                  }),
+                )
+              }
+
+              const payment = await withAmountBuilder
+                .withConversion(withConversionArgs)
+                .withoutMinerFee()
+              if (payment instanceof Error) throw payment
+
+              const btcPaymentAmount = {
+                amount: BigInt(amount),
+                currency: WalletCurrency.Btc,
+              }
+              const usdPaymentAmount =
+                await convertForBtcWalletToBtcWallet.usdFromBtc(btcPaymentAmount)
+
+              checkAddress(payment)
+              checkSettlementMethod(payment)
+              checkInputAmount(payment)
+              checkSenderWallet(payment)
+              checkRecipientWallet(payment)
+              expect(payment).toEqual(
+                expect.objectContaining({
+                  btcPaymentAmount,
+                  usdPaymentAmount,
+                  btcProtocolAndBankFee: onChainFees.intraLedgerFees().btc,
+                  usdProtocolAndBankFee: onChainFees.intraLedgerFees().usd,
+                }),
+              )
+            })
+
+            it("correctly applies no fees, with min amount", async () => {
+              const amount = 51 // Close to 1 cent
+              const withAmountBuilder = withBtcRecipientBuilder.withAmount({
+                amount: BigInt(amount),
+                currency: amountCurrency,
+              })
+
+              const checkInputAmount = (payment) => {
+                expect(payment).toEqual(
+                  expect.objectContaining({
+                    inputAmount: BigInt(amount),
+                  }),
+                )
+              }
+
+              const payment = await withAmountBuilder
+                .withConversion(withConversionArgs)
+                .withoutMinerFee()
+              if (payment instanceof Error) throw payment
+
+              const btcPaymentAmount = {
+                amount: BigInt(amount),
+                currency: WalletCurrency.Btc,
+              }
+              const usdPaymentAmount =
+                await convertForBtcWalletToBtcWallet.usdFromBtc(btcPaymentAmount)
+
+              checkAddress(payment)
+              checkSettlementMethod(payment)
+              checkInputAmount(payment)
+              checkSenderWallet(payment)
+              checkRecipientWallet(payment)
+              expect(payment).toEqual(
+                expect.objectContaining({
+                  btcPaymentAmount,
+                  usdPaymentAmount,
+                  btcProtocolAndBankFee: onChainFees.intraLedgerFees().btc,
+                  usdProtocolAndBankFee: onChainFees.intraLedgerFees().usd,
+                }),
+              )
+            })
           })
 
           describe("with usd recipient wallet", () => {
@@ -450,58 +526,131 @@ describe("OnChainPaymentFlowBuilder", () => {
               )
             }
 
-            const withAmountDescribes = [
-              { name: "with amount", amount: uncheckedAmount },
-              { name: "with dust amount", amount: dustAmount },
-              { name: "with min amount", amount: 51 }, // Close to 1 cent
-            ]
+            const withUsdRecipientBuilder =
+              withBtcWalletBuilder.withRecipientWallet(recipientUsdArgs)
 
-            const describeWithAmount = ({ name, amount }) => {
-              describe(`${name}`, () => {
-                const withAmountBuilder = withBtcWalletBuilder
-                  .withRecipientWallet(recipientUsdArgs)
-                  .withAmount({ amount: BigInt(amount), currency: amountCurrency })
-                const checkInputAmount = (payment) => {
-                  expect(payment).toEqual(
-                    expect.objectContaining({
-                      inputAmount: BigInt(amount),
-                    }),
-                  )
-                }
-
-                it("correctly applies no fees", async () => {
-                  const payment = await withAmountBuilder
-                    .withConversion(withConversionArgs)
-                    .withoutMinerFee()
-                  if (payment instanceof Error) throw payment
-
-                  const btcPaymentAmount = {
-                    amount: BigInt(amount),
-                    currency: WalletCurrency.Btc,
-                  }
-                  const usdPaymentAmount =
-                    await convertForBtcWalletToUsdWallet.usdFromBtc(btcPaymentAmount)
-
-                  checkAddress(payment)
-                  checkSettlementMethod(payment)
-                  checkInputAmount(payment)
-                  checkSenderWallet(payment)
-                  checkRecipientWallet(payment)
-                  expect(payment).toEqual(
-                    expect.objectContaining({
-                      btcPaymentAmount,
-                      usdPaymentAmount,
-                      btcProtocolAndBankFee: onChainFees.intraLedgerFees().btc,
-                      usdProtocolAndBankFee: onChainFees.intraLedgerFees().usd,
-                    }),
-                  )
-                })
+            it("correctly applies no fees, with normal amount", async () => {
+              const amount = uncheckedAmount
+              const withAmountBuilder = withUsdRecipientBuilder.withAmount({
+                amount: BigInt(amount),
+                currency: amountCurrency,
               })
-            }
+              const checkInputAmount = (payment) => {
+                expect(payment).toEqual(
+                  expect.objectContaining({
+                    inputAmount: BigInt(amount),
+                  }),
+                )
+              }
 
-            for (const args of withAmountDescribes) {
-              describeWithAmount(args)
-            }
+              const payment = await withAmountBuilder
+                .withConversion(withConversionArgs)
+                .withoutMinerFee()
+              if (payment instanceof Error) throw payment
+
+              const btcPaymentAmount = {
+                amount: BigInt(amount),
+                currency: WalletCurrency.Btc,
+              }
+              const usdPaymentAmount =
+                await convertForBtcWalletToUsdWallet.usdFromBtc(btcPaymentAmount)
+
+              checkAddress(payment)
+              checkSettlementMethod(payment)
+              checkInputAmount(payment)
+              checkSenderWallet(payment)
+              checkRecipientWallet(payment)
+              expect(payment).toEqual(
+                expect.objectContaining({
+                  btcPaymentAmount,
+                  usdPaymentAmount,
+                  btcProtocolAndBankFee: onChainFees.intraLedgerFees().btc,
+                  usdProtocolAndBankFee: onChainFees.intraLedgerFees().usd,
+                }),
+              )
+            })
+
+            it("correctly applies no fees, with dust amount", async () => {
+              const amount = dustAmount
+              const withAmountBuilder = withUsdRecipientBuilder.withAmount({
+                amount: BigInt(amount),
+                currency: amountCurrency,
+              })
+              const checkInputAmount = (payment) => {
+                expect(payment).toEqual(
+                  expect.objectContaining({
+                    inputAmount: BigInt(amount),
+                  }),
+                )
+              }
+
+              const payment = await withAmountBuilder
+                .withConversion(withConversionArgs)
+                .withoutMinerFee()
+              if (payment instanceof Error) throw payment
+
+              const btcPaymentAmount = {
+                amount: BigInt(amount),
+                currency: WalletCurrency.Btc,
+              }
+              const usdPaymentAmount =
+                await convertForBtcWalletToUsdWallet.usdFromBtc(btcPaymentAmount)
+
+              checkAddress(payment)
+              checkSettlementMethod(payment)
+              checkInputAmount(payment)
+              checkSenderWallet(payment)
+              checkRecipientWallet(payment)
+              expect(payment).toEqual(
+                expect.objectContaining({
+                  btcPaymentAmount,
+                  usdPaymentAmount,
+                  btcProtocolAndBankFee: onChainFees.intraLedgerFees().btc,
+                  usdProtocolAndBankFee: onChainFees.intraLedgerFees().usd,
+                }),
+              )
+            })
+
+            it("correctly applies no fees, with min amount", async () => {
+              const amount = 51 // Close to 1 cent
+              const withAmountBuilder = withUsdRecipientBuilder.withAmount({
+                amount: BigInt(amount),
+                currency: amountCurrency,
+              })
+              const checkInputAmount = (payment) => {
+                expect(payment).toEqual(
+                  expect.objectContaining({
+                    inputAmount: BigInt(amount),
+                  }),
+                )
+              }
+
+              const payment = await withAmountBuilder
+                .withConversion(withConversionArgs)
+                .withoutMinerFee()
+              if (payment instanceof Error) throw payment
+
+              const btcPaymentAmount = {
+                amount: BigInt(amount),
+                currency: WalletCurrency.Btc,
+              }
+              const usdPaymentAmount =
+                await convertForBtcWalletToUsdWallet.usdFromBtc(btcPaymentAmount)
+
+              checkAddress(payment)
+              checkSettlementMethod(payment)
+              checkInputAmount(payment)
+              checkSenderWallet(payment)
+              checkRecipientWallet(payment)
+              expect(payment).toEqual(
+                expect.objectContaining({
+                  btcPaymentAmount,
+                  usdPaymentAmount,
+                  btcProtocolAndBankFee: onChainFees.intraLedgerFees().btc,
+                  usdProtocolAndBankFee: onChainFees.intraLedgerFees().usd,
+                }),
+              )
+            })
           })
         })
       })
@@ -724,70 +873,116 @@ describe("OnChainPaymentFlowBuilder", () => {
                   )
                 }
 
-                const withAmountDescribes = [
-                  { name: "with amount", amount: uncheckedAmount },
-                  { name: "with dust amount", amount: 1 },
-                ]
+                const withBtcRecipientBuilder =
+                  withUsdWalletBuilder.withRecipientWallet(recipientBtcArgs)
 
-                const describeWithAmount = ({ name, amount }) => {
-                  describe(`${name}`, () => {
-                    const withAmountBuilder = withUsdWalletBuilder
-                      .withRecipientWallet(recipientBtcArgs)
-                      .withAmount({ amount: BigInt(amount), currency: amountCurrency })
-                    const checkInputAmount = (payment) => {
-                      expect(payment).toEqual(
-                        expect.objectContaining({
-                          inputAmount: BigInt(amount),
-                        }),
-                      )
-                    }
-
-                    it("correctly applies no fees", async () => {
-                      const payment = await withAmountBuilder
-                        .withConversion(withConversionArgs)
-                        .withoutMinerFee()
-                      if (payment instanceof Error) throw payment
-
-                      const sendAmount = paymentAmountFromNumber({
-                        amount,
-                        currency: amountCurrency,
-                      })
-                      if (sendAmount instanceof Error) throw sendAmount
-
-                      const btcPaymentAmount =
-                        amountCurrency === WalletCurrency.Btc
-                          ? (sendAmount as BtcPaymentAmount)
-                          : await convertForUsdWalletToBtcWallet.btcFromUsd(
-                              sendAmount as UsdPaymentAmount,
-                            )
-
-                      const usdPaymentAmount =
-                        amountCurrency === WalletCurrency.Usd
-                          ? (sendAmount as UsdPaymentAmount)
-                          : await convertForUsdWalletToBtcWallet.usdFromBtc(
-                              sendAmount as BtcPaymentAmount,
-                            )
-
-                      checkAddress(payment)
-                      checkSettlementMethod(payment)
-                      checkInputAmount(payment)
-                      checkSenderWallet(payment)
-                      checkRecipientWallet(payment)
-                      expect(payment).toEqual(
-                        expect.objectContaining({
-                          btcPaymentAmount,
-                          usdPaymentAmount,
-                          btcProtocolAndBankFee: onChainFees.intraLedgerFees().btc,
-                          usdProtocolAndBankFee: onChainFees.intraLedgerFees().usd,
-                        }),
-                      )
-                    })
+                it("correctly applies no fees, with normal amount", async () => {
+                  const amount = uncheckedAmount
+                  const withAmountBuilder = withBtcRecipientBuilder.withAmount({
+                    amount: BigInt(amount),
+                    currency: amountCurrency,
                   })
-                }
+                  const checkInputAmount = (payment) => {
+                    expect(payment).toEqual(
+                      expect.objectContaining({
+                        inputAmount: BigInt(amount),
+                      }),
+                    )
+                  }
 
-                for (const args of withAmountDescribes) {
-                  describeWithAmount(args)
-                }
+                  const payment = await withAmountBuilder
+                    .withConversion(withConversionArgs)
+                    .withoutMinerFee()
+                  if (payment instanceof Error) throw payment
+
+                  const sendAmount = paymentAmountFromNumber({
+                    amount,
+                    currency: amountCurrency,
+                  })
+                  if (sendAmount instanceof Error) throw sendAmount
+
+                  const btcPaymentAmount =
+                    amountCurrency === WalletCurrency.Btc
+                      ? (sendAmount as BtcPaymentAmount)
+                      : await convertForUsdWalletToBtcWallet.btcFromUsd(
+                          sendAmount as UsdPaymentAmount,
+                        )
+
+                  const usdPaymentAmount =
+                    amountCurrency === WalletCurrency.Usd
+                      ? (sendAmount as UsdPaymentAmount)
+                      : await convertForUsdWalletToBtcWallet.usdFromBtc(
+                          sendAmount as BtcPaymentAmount,
+                        )
+
+                  checkAddress(payment)
+                  checkSettlementMethod(payment)
+                  checkInputAmount(payment)
+                  checkSenderWallet(payment)
+                  checkRecipientWallet(payment)
+                  expect(payment).toEqual(
+                    expect.objectContaining({
+                      btcPaymentAmount,
+                      usdPaymentAmount,
+                      btcProtocolAndBankFee: onChainFees.intraLedgerFees().btc,
+                      usdProtocolAndBankFee: onChainFees.intraLedgerFees().usd,
+                    }),
+                  )
+                })
+
+                it("correctly applies no fees, with dust amount", async () => {
+                  const amount = 1
+                  const withAmountBuilder = withBtcRecipientBuilder.withAmount({
+                    amount: BigInt(amount),
+                    currency: amountCurrency,
+                  })
+                  const checkInputAmount = (payment) => {
+                    expect(payment).toEqual(
+                      expect.objectContaining({
+                        inputAmount: BigInt(amount),
+                      }),
+                    )
+                  }
+
+                  const payment = await withAmountBuilder
+                    .withConversion(withConversionArgs)
+                    .withoutMinerFee()
+                  if (payment instanceof Error) throw payment
+
+                  const sendAmount = paymentAmountFromNumber({
+                    amount,
+                    currency: amountCurrency,
+                  })
+                  if (sendAmount instanceof Error) throw sendAmount
+
+                  const btcPaymentAmount =
+                    amountCurrency === WalletCurrency.Btc
+                      ? (sendAmount as BtcPaymentAmount)
+                      : await convertForUsdWalletToBtcWallet.btcFromUsd(
+                          sendAmount as UsdPaymentAmount,
+                        )
+
+                  const usdPaymentAmount =
+                    amountCurrency === WalletCurrency.Usd
+                      ? (sendAmount as UsdPaymentAmount)
+                      : await convertForUsdWalletToBtcWallet.usdFromBtc(
+                          sendAmount as BtcPaymentAmount,
+                        )
+
+                  checkAddress(payment)
+                  checkSettlementMethod(payment)
+                  checkInputAmount(payment)
+                  checkSenderWallet(payment)
+                  checkRecipientWallet(payment)
+                  expect(payment).toEqual(
+                    expect.objectContaining({
+                      btcPaymentAmount,
+                      usdPaymentAmount,
+                      btcProtocolAndBankFee: onChainFees.intraLedgerFees().btc,
+                      usdProtocolAndBankFee: onChainFees.intraLedgerFees().usd,
+                    }),
+                  )
+                })
               })
 
               describe("with usd recipient wallet", () => {
@@ -803,72 +998,120 @@ describe("OnChainPaymentFlowBuilder", () => {
                   )
                 }
 
-                const withAmountDescribes = [
-                  { name: "with amount", amount: uncheckedAmount },
-                  { name: "with dust amount", amount: 1 },
-                ]
+                const withUsdRecipientBuilder =
+                  withUsdWalletBuilder.withRecipientWallet(recipientUsdArgs)
 
-                const describeWithAmount = ({ name, amount }) => {
-                  describe(`${name}`, () => {
-                    const withAmountBuilder = withUsdWalletBuilder
-                      .withRecipientWallet(recipientUsdArgs)
-                      .withAmount({ amount: BigInt(amount), currency: amountCurrency })
-                    const checkInputAmount = (payment) => {
-                      expect(payment).toEqual(
-                        expect.objectContaining({
-                          inputAmount: BigInt(amount),
-                        }),
-                      )
-                    }
-
-                    it("correctly applies no fees", async () => {
-                      const payment = await withAmountBuilder
-                        .withConversion(withConversionArgs)
-                        .withoutMinerFee()
-                      if (payment instanceof Error) throw payment
-
-                      const sendAmount = paymentAmountFromNumber({
-                        amount,
-                        currency: amountCurrency,
-                      })
-                      if (sendAmount instanceof Error) throw sendAmount
-
-                      const btcPaymentAmount =
-                        amountCurrency === WalletCurrency.Btc
-                          ? (sendAmount as BtcPaymentAmount)
-                          : await convertForUsdWalletToUsdWallet.btcFromUsd(
-                              sendAmount as UsdPaymentAmount,
-                            )
-
-                      const usdPaymentAmount =
-                        amountCurrency === WalletCurrency.Usd
-                          ? (sendAmount as UsdPaymentAmount)
-                          : sendAmount.amount === 1n
-                          ? ONE_CENT
-                          : await convertForUsdWalletToUsdWallet.usdFromBtc(
-                              sendAmount as BtcPaymentAmount,
-                            )
-
-                      checkAddress(payment)
-                      checkSettlementMethod(payment)
-                      checkInputAmount(payment)
-                      checkSenderWallet(payment)
-                      checkRecipientWallet(payment)
-                      expect(payment).toEqual(
-                        expect.objectContaining({
-                          btcPaymentAmount,
-                          usdPaymentAmount,
-                          btcProtocolAndBankFee: onChainFees.intraLedgerFees().btc,
-                          usdProtocolAndBankFee: onChainFees.intraLedgerFees().usd,
-                        }),
-                      )
-                    })
+                it("correctly applies no fees, with normal amount", async () => {
+                  const amount = uncheckedAmount
+                  const withAmountBuilder = withUsdRecipientBuilder.withAmount({
+                    amount: BigInt(amount),
+                    currency: amountCurrency,
                   })
-                }
+                  const checkInputAmount = (payment) => {
+                    expect(payment).toEqual(
+                      expect.objectContaining({
+                        inputAmount: BigInt(amount),
+                      }),
+                    )
+                  }
 
-                for (const args of withAmountDescribes) {
-                  describeWithAmount(args)
-                }
+                  const payment = await withAmountBuilder
+                    .withConversion(withConversionArgs)
+                    .withoutMinerFee()
+                  if (payment instanceof Error) throw payment
+
+                  const sendAmount = paymentAmountFromNumber({
+                    amount,
+                    currency: amountCurrency,
+                  })
+                  if (sendAmount instanceof Error) throw sendAmount
+
+                  const btcPaymentAmount =
+                    amountCurrency === WalletCurrency.Btc
+                      ? (sendAmount as BtcPaymentAmount)
+                      : await convertForUsdWalletToUsdWallet.btcFromUsd(
+                          sendAmount as UsdPaymentAmount,
+                        )
+
+                  const usdPaymentAmount =
+                    amountCurrency === WalletCurrency.Usd
+                      ? (sendAmount as UsdPaymentAmount)
+                      : sendAmount.amount === 1n
+                      ? ONE_CENT
+                      : await convertForUsdWalletToUsdWallet.usdFromBtc(
+                          sendAmount as BtcPaymentAmount,
+                        )
+
+                  checkAddress(payment)
+                  checkSettlementMethod(payment)
+                  checkInputAmount(payment)
+                  checkSenderWallet(payment)
+                  checkRecipientWallet(payment)
+                  expect(payment).toEqual(
+                    expect.objectContaining({
+                      btcPaymentAmount,
+                      usdPaymentAmount,
+                      btcProtocolAndBankFee: onChainFees.intraLedgerFees().btc,
+                      usdProtocolAndBankFee: onChainFees.intraLedgerFees().usd,
+                    }),
+                  )
+                })
+
+                it("correctly applies no fees, with dust amount", async () => {
+                  const amount = 1
+                  const withAmountBuilder = withUsdRecipientBuilder.withAmount({
+                    amount: BigInt(amount),
+                    currency: amountCurrency,
+                  })
+                  const checkInputAmount = (payment) => {
+                    expect(payment).toEqual(
+                      expect.objectContaining({
+                        inputAmount: BigInt(amount),
+                      }),
+                    )
+                  }
+
+                  const payment = await withAmountBuilder
+                    .withConversion(withConversionArgs)
+                    .withoutMinerFee()
+                  if (payment instanceof Error) throw payment
+
+                  const sendAmount = paymentAmountFromNumber({
+                    amount,
+                    currency: amountCurrency,
+                  })
+                  if (sendAmount instanceof Error) throw sendAmount
+
+                  const btcPaymentAmount =
+                    amountCurrency === WalletCurrency.Btc
+                      ? (sendAmount as BtcPaymentAmount)
+                      : await convertForUsdWalletToUsdWallet.btcFromUsd(
+                          sendAmount as UsdPaymentAmount,
+                        )
+
+                  const usdPaymentAmount =
+                    amountCurrency === WalletCurrency.Usd
+                      ? (sendAmount as UsdPaymentAmount)
+                      : sendAmount.amount === 1n
+                      ? ONE_CENT
+                      : await convertForUsdWalletToUsdWallet.usdFromBtc(
+                          sendAmount as BtcPaymentAmount,
+                        )
+
+                  checkAddress(payment)
+                  checkSettlementMethod(payment)
+                  checkInputAmount(payment)
+                  checkSenderWallet(payment)
+                  checkRecipientWallet(payment)
+                  expect(payment).toEqual(
+                    expect.objectContaining({
+                      btcPaymentAmount,
+                      usdPaymentAmount,
+                      btcProtocolAndBankFee: onChainFees.intraLedgerFees().btc,
+                      usdProtocolAndBankFee: onChainFees.intraLedgerFees().usd,
+                    }),
+                  )
+                })
               })
             })
           })

--- a/test/unit/payments/payment-flow-builder.spec.ts
+++ b/test/unit/payments/payment-flow-builder.spec.ts
@@ -36,33 +36,66 @@ describe("LightningPaymentFlowBuilder", () => {
   const paymentRequestWithNoAmount =
     "lnbc1p3zn402pp54skf32qeal5jnfm73u5e3d9h5448l4yutszy0kr9l56vdsy8jefsdqqcqzpuxqyz5vqsp5c6z7a4lrey4ejvhx5q4l83jm9fhy34dsqgxnceem4dgz6fmh456s9qyyssqkxkg6ke6nt39dusdhpansu8j0r5f7gadwcampnw2g8ap0fccteer7hzjc8tgat9m5wxd98nxjxhwx0ha6g95v9edmgd30f0m8kujslgpxtzt6w" as EncodedPaymentRequest
   const invoiceWithNoAmount = decodeInvoice(paymentRequestWithNoAmount) as LnInvoice
-  const senderBtcWallet = {
-    id: "senderWalletId" as WalletId,
+
+  const senderBtcWalletDescriptor = {
+    id: "senderBtcWalletId" as WalletId,
     currency: WalletCurrency.Btc,
     accountId: "senderAccountId" as AccountId,
-    userId: "senderUserId" as UserId,
   }
 
-  const recipientBtcWallet = {
-    id: "recipientWalletId" as WalletId,
-    currency: WalletCurrency.Btc,
-    accountId: "recipientAccountId" as AccountId,
-    username: "Username" as Username,
-    userId: "recipientUserId" as UserId,
-  }
-  const senderUsdWallet = {
-    id: "walletId" as WalletId,
+  const senderUsdWalletDescriptor = {
+    id: "senderUsdWalletId" as WalletId,
     currency: WalletCurrency.Usd,
     accountId: "senderAccountId" as AccountId,
-    userId: "senderUserId" as UserId,
   }
-  const recipientUsdWallet = {
-    id: "recipientWalletId" as WalletId,
+
+  const senderAsRecipientCommonArgs = {
+    userId: "senderUserId" as UserId,
+    recipientWalletDescriptorsForAccount: [
+      senderBtcWalletDescriptor,
+      senderUsdWalletDescriptor,
+    ],
+  }
+  const senderBtcAsRecipientArgs = {
+    ...senderAsRecipientCommonArgs,
+    recipientWalletDescriptor: senderBtcWalletDescriptor,
+  }
+
+  const senderUsdAsRecipientArgs = {
+    ...senderAsRecipientCommonArgs,
+    recipientWalletDescriptor: senderUsdWalletDescriptor,
+  }
+
+  const recipientBtcWalletDescriptor = {
+    id: "recipientBtcWalletId" as WalletId,
+    currency: WalletCurrency.Btc,
+    accountId: "recipientAccountId" as AccountId,
+  }
+  const recipientUsdWalletDescriptor = {
+    id: "recipientUsdWalletId" as WalletId,
     currency: WalletCurrency.Usd,
     accountId: "recipientAccountId" as AccountId,
+  }
+
+  const recipientCommonArgs = {
+    recipientWalletDescriptorsForAccount: [
+      recipientBtcWalletDescriptor,
+      recipientUsdWalletDescriptor,
+    ],
     username: "Username" as Username,
     userId: "recipientUserId" as UserId,
   }
+
+  const recipientBtcArgs = {
+    ...recipientCommonArgs,
+    recipientWalletDescriptor: recipientBtcWalletDescriptor,
+  }
+
+  const recipientUsdArgs = {
+    ...recipientCommonArgs,
+    recipientWalletDescriptor: recipientUsdWalletDescriptor,
+  }
+
   const pubkey = "pubkey" as Pubkey
   const rawRoute = { total_mtokens: "21000000", safe_fee: 210 } as RawRoute
 
@@ -188,22 +221,22 @@ describe("LightningPaymentFlowBuilder", () => {
 
       describe("with btc wallet", () => {
         const withBtcWalletBuilder = withAmountBuilder
-          .withSenderWallet(senderBtcWallet)
+          .withSenderWallet(senderBtcWalletDescriptor)
           .withoutRecipientWallet()
 
         const withSkippedPubkeyBtcWalletBuilder = withSkippedPubkeyAmountBuilder
-          .withSenderWallet(senderBtcWallet)
+          .withSenderWallet(senderBtcWalletDescriptor)
           .withoutRecipientWallet()
 
         const withSkippedChanIdBtcWalletBuilder = withSkippedChanIdAmountBuilder
-          .withSenderWallet(senderBtcWallet)
+          .withSenderWallet(senderBtcWalletDescriptor)
           .withoutRecipientWallet()
 
         const checkSenderWallet = (payment) => {
           expect(payment).toEqual(
             expect.objectContaining({
-              senderWalletId: senderBtcWallet.id,
-              senderWalletCurrency: senderBtcWallet.currency,
+              senderWalletId: senderBtcWalletDescriptor.id,
+              senderWalletCurrency: senderBtcWalletDescriptor.currency,
             }),
           )
         }
@@ -309,14 +342,14 @@ describe("LightningPaymentFlowBuilder", () => {
 
       describe("with usd wallet", () => {
         const withUsdWalletBuilder = withAmountBuilder
-          .withSenderWallet(senderUsdWallet)
+          .withSenderWallet(senderUsdWalletDescriptor)
           .withoutRecipientWallet()
 
         const checkSenderWallet = (payment) => {
           expect(payment).toEqual(
             expect.objectContaining({
-              senderWalletId: senderUsdWallet.id,
-              senderWalletCurrency: senderUsdWallet.currency,
+              senderWalletId: senderUsdWalletDescriptor.id,
+              senderWalletCurrency: senderUsdWalletDescriptor.currency,
               skipProbeForDestination: false,
             }),
           )
@@ -414,14 +447,14 @@ describe("LightningPaymentFlowBuilder", () => {
 
       describe("with btc wallet", () => {
         const withBtcWalletBuilder = withAmountBuilder
-          .withSenderWallet(senderBtcWallet)
+          .withSenderWallet(senderBtcWalletDescriptor)
           .withoutRecipientWallet()
 
         const checkSenderWallet = (payment) => {
           expect(payment).toEqual(
             expect.objectContaining({
-              senderWalletId: senderBtcWallet.id,
-              senderWalletCurrency: senderBtcWallet.currency,
+              senderWalletId: senderBtcWalletDescriptor.id,
+              senderWalletCurrency: senderBtcWalletDescriptor.currency,
               btcPaymentAmount: {
                 amount: uncheckedAmount,
                 currency: WalletCurrency.Btc,
@@ -477,14 +510,14 @@ describe("LightningPaymentFlowBuilder", () => {
 
       describe("with usd wallet", () => {
         const withUsdWalletBuilder = withAmountBuilder
-          .withSenderWallet(senderUsdWallet)
+          .withSenderWallet(senderUsdWalletDescriptor)
           .withoutRecipientWallet()
 
         const checkSenderWallet = (payment) => {
           expect(payment).toEqual(
             expect.objectContaining({
-              senderWalletId: senderUsdWallet.id,
-              senderWalletCurrency: senderUsdWallet.currency,
+              senderWalletId: senderUsdWalletDescriptor.id,
+              senderWalletCurrency: senderUsdWalletDescriptor.currency,
               usdPaymentAmount: {
                 amount: uncheckedAmount,
                 currency: WalletCurrency.Usd,
@@ -550,26 +583,28 @@ describe("LightningPaymentFlowBuilder", () => {
         )
       }
       describe("with btc wallet", () => {
-        const withBtcWalletBuilder = withAmountBuilder.withSenderWallet(senderBtcWallet)
+        const withBtcWalletBuilder = withAmountBuilder.withSenderWallet(
+          senderBtcWalletDescriptor,
+        )
 
         const checkSenderWallet = (payment) => {
           expect(payment).toEqual(
             expect.objectContaining({
-              senderWalletId: senderBtcWallet.id,
-              senderWalletCurrency: senderBtcWallet.currency,
+              senderWalletId: senderBtcWalletDescriptor.id,
+              senderWalletCurrency: senderBtcWalletDescriptor.currency,
             }),
           )
         }
 
         describe("with btc recipient", () => {
           const withBtcRecipientBuilder =
-            withBtcWalletBuilder.withRecipientWallet(recipientBtcWallet)
+            withBtcWalletBuilder.withRecipientWallet(recipientBtcArgs)
           const checkRecipientWallet = (payment) => {
             expect(payment).toEqual(
               expect.objectContaining({
-                recipientWalletId: recipientBtcWallet.id,
-                recipientWalletCurrency: recipientBtcWallet.currency,
-                recipientUsername: recipientBtcWallet.username,
+                recipientWalletId: recipientBtcWalletDescriptor.id,
+                recipientWalletCurrency: recipientBtcWalletDescriptor.currency,
+                recipientUsername: recipientBtcArgs.username,
               }),
             )
           }
@@ -613,15 +648,15 @@ describe("LightningPaymentFlowBuilder", () => {
             currency: WalletCurrency.Usd,
           }
           const withUsdRecipientBuilder = withBtcWalletBuilder.withRecipientWallet({
-            ...recipientUsdWallet,
+            ...recipientUsdArgs,
             usdPaymentAmount,
           })
           const checkRecipientWallet = (payment) => {
             expect(payment).toEqual(
               expect.objectContaining({
-                recipientWalletId: recipientUsdWallet.id,
-                recipientWalletCurrency: recipientUsdWallet.currency,
-                recipientUsername: recipientUsdWallet.username,
+                recipientWalletId: recipientUsdWalletDescriptor.id,
+                recipientWalletCurrency: recipientUsdWalletDescriptor.currency,
+                recipientUsername: recipientUsdArgs.username,
                 usdPaymentAmount,
               }),
             )
@@ -654,26 +689,28 @@ describe("LightningPaymentFlowBuilder", () => {
         })
       })
       describe("with usd wallet", () => {
-        const withUsdWalletBuilder = withAmountBuilder.withSenderWallet(senderUsdWallet)
+        const withUsdWalletBuilder = withAmountBuilder.withSenderWallet(
+          senderUsdWalletDescriptor,
+        )
 
         const checkSenderWallet = (payment) => {
           expect(payment).toEqual(
             expect.objectContaining({
-              senderWalletId: senderUsdWallet.id,
-              senderWalletCurrency: senderUsdWallet.currency,
+              senderWalletId: senderUsdWalletDescriptor.id,
+              senderWalletCurrency: senderUsdWalletDescriptor.currency,
             }),
           )
         }
 
         describe("with btc recipient", () => {
           const withBtcRecipientBuilder =
-            withUsdWalletBuilder.withRecipientWallet(recipientBtcWallet)
+            withUsdWalletBuilder.withRecipientWallet(recipientBtcArgs)
           const checkRecipientWallet = (payment) => {
             expect(payment).toEqual(
               expect.objectContaining({
-                recipientWalletId: recipientBtcWallet.id,
-                recipientWalletCurrency: recipientBtcWallet.currency,
-                recipientUsername: recipientBtcWallet.username,
+                recipientWalletId: recipientBtcWalletDescriptor.id,
+                recipientWalletCurrency: recipientBtcWalletDescriptor.currency,
+                recipientUsername: recipientBtcArgs.username,
               }),
             )
           }
@@ -717,15 +754,15 @@ describe("LightningPaymentFlowBuilder", () => {
             currency: WalletCurrency.Usd,
           }
           const withUsdRecipientBuilder = withUsdWalletBuilder.withRecipientWallet({
-            ...recipientUsdWallet,
+            ...recipientUsdArgs,
             usdPaymentAmount,
           })
           const checkRecipientWallet = (payment) => {
             expect(payment).toEqual(
               expect.objectContaining({
-                recipientWalletId: recipientUsdWallet.id,
-                recipientWalletCurrency: recipientUsdWallet.currency,
-                recipientUsername: recipientUsdWallet.username,
+                recipientWalletId: recipientUsdWalletDescriptor.id,
+                recipientWalletCurrency: recipientUsdWalletDescriptor.currency,
+                recipientUsername: recipientUsdArgs.username,
                 usdPaymentAmount,
               }),
             )
@@ -781,15 +818,17 @@ describe("LightningPaymentFlowBuilder", () => {
       }
 
       describe("with btc wallet", () => {
-        const withBtcWalletBuilder = withAmountBuilder.withSenderWallet(senderBtcWallet)
+        const withBtcWalletBuilder = withAmountBuilder.withSenderWallet(
+          senderBtcWalletDescriptor,
+        )
         const lessThan1CentWithBtcWalletBuilder =
-          lessThan1CentWithAmountBuilder.withSenderWallet(senderBtcWallet)
+          lessThan1CentWithAmountBuilder.withSenderWallet(senderBtcWalletDescriptor)
 
         const checkSenderWallet = (payment) => {
           expect(payment).toEqual(
             expect.objectContaining({
-              senderWalletId: senderBtcWallet.id,
-              senderWalletCurrency: senderBtcWallet.currency,
+              senderWalletId: senderBtcWalletDescriptor.id,
+              senderWalletCurrency: senderBtcWalletDescriptor.currency,
               btcPaymentAmount: {
                 amount: uncheckedAmount,
                 currency: WalletCurrency.Btc,
@@ -800,16 +839,16 @@ describe("LightningPaymentFlowBuilder", () => {
 
         describe("with btc recipient", () => {
           const withBtcRecipientBuilder =
-            withBtcWalletBuilder.withRecipientWallet(recipientBtcWallet)
+            withBtcWalletBuilder.withRecipientWallet(recipientBtcArgs)
           const lessThan1CentWithBtcRecipientBuilder =
-            lessThan1CentWithBtcWalletBuilder.withRecipientWallet(recipientBtcWallet)
+            lessThan1CentWithBtcWalletBuilder.withRecipientWallet(recipientBtcArgs)
 
           const checkRecipientWallet = (payment) => {
             expect(payment).toEqual(
               expect.objectContaining({
-                recipientWalletId: recipientBtcWallet.id,
-                recipientWalletCurrency: recipientBtcWallet.currency,
-                recipientUsername: recipientBtcWallet.username,
+                recipientWalletId: recipientBtcWalletDescriptor.id,
+                recipientWalletCurrency: recipientBtcWalletDescriptor.currency,
+                recipientUsername: recipientBtcArgs.username,
               }),
             )
           }
@@ -878,16 +917,16 @@ describe("LightningPaymentFlowBuilder", () => {
 
         describe("with usd recipient", () => {
           const withUsdRecipientBuilder =
-            withBtcWalletBuilder.withRecipientWallet(recipientUsdWallet)
+            withBtcWalletBuilder.withRecipientWallet(recipientUsdArgs)
           const lessThan1CentWithUsdRecipientBuilder =
-            lessThan1CentWithBtcWalletBuilder.withRecipientWallet(recipientUsdWallet)
+            lessThan1CentWithBtcWalletBuilder.withRecipientWallet(recipientUsdArgs)
 
           const checkRecipientWallet = (payment) => {
             expect(payment).toEqual(
               expect.objectContaining({
-                recipientWalletId: recipientUsdWallet.id,
-                recipientWalletCurrency: recipientUsdWallet.currency,
-                recipientUsername: recipientUsdWallet.username,
+                recipientWalletId: recipientUsdWalletDescriptor.id,
+                recipientWalletCurrency: recipientUsdWalletDescriptor.currency,
+                recipientUsername: recipientUsdArgs.username,
               }),
             )
           }
@@ -950,13 +989,15 @@ describe("LightningPaymentFlowBuilder", () => {
       })
 
       describe("with usd wallet", () => {
-        const withUsdWalletBuilder = withAmountBuilder.withSenderWallet(senderUsdWallet)
+        const withUsdWalletBuilder = withAmountBuilder.withSenderWallet(
+          senderUsdWalletDescriptor,
+        )
 
         const checkSenderWallet = (payment) => {
           expect(payment).toEqual(
             expect.objectContaining({
-              senderWalletId: senderUsdWallet.id,
-              senderWalletCurrency: senderUsdWallet.currency,
+              senderWalletId: senderUsdWalletDescriptor.id,
+              senderWalletCurrency: senderUsdWalletDescriptor.currency,
               usdPaymentAmount: {
                 amount: uncheckedAmount,
                 currency: WalletCurrency.Usd,
@@ -967,13 +1008,13 @@ describe("LightningPaymentFlowBuilder", () => {
 
         describe("with btc recipient", () => {
           const withBtcRecipientBuilder =
-            withUsdWalletBuilder.withRecipientWallet(recipientBtcWallet)
+            withUsdWalletBuilder.withRecipientWallet(recipientBtcArgs)
           const checkRecipientWallet = (payment) => {
             expect(payment).toEqual(
               expect.objectContaining({
-                recipientWalletId: recipientBtcWallet.id,
-                recipientWalletCurrency: recipientBtcWallet.currency,
-                recipientUsername: recipientUsdWallet.username,
+                recipientWalletId: recipientBtcWalletDescriptor.id,
+                recipientWalletCurrency: recipientBtcWalletDescriptor.currency,
+                recipientUsername: recipientBtcArgs.username,
               }),
             )
           }
@@ -1014,13 +1055,13 @@ describe("LightningPaymentFlowBuilder", () => {
         })
         describe("with usd recipient", () => {
           const withUsdRecipientBuilder =
-            withUsdWalletBuilder.withRecipientWallet(recipientUsdWallet)
+            withUsdWalletBuilder.withRecipientWallet(recipientUsdArgs)
           const checkRecipientWallet = (payment) => {
             expect(payment).toEqual(
               expect.objectContaining({
-                recipientWalletId: recipientUsdWallet.id,
-                recipientWalletCurrency: recipientUsdWallet.currency,
-                recipientUsername: recipientUsdWallet.username,
+                recipientWalletId: recipientUsdWalletDescriptor.id,
+                recipientWalletCurrency: recipientUsdWalletDescriptor.currency,
+                recipientUsername: recipientUsdArgs.username,
               }),
             )
           }
@@ -1101,15 +1142,17 @@ describe("LightningPaymentFlowBuilder", () => {
       }
 
       describe("with btc wallet", () => {
-        const withBtcWalletBuilder = withAmountBuilder.withSenderWallet(senderBtcWallet)
+        const withBtcWalletBuilder = withAmountBuilder.withSenderWallet(
+          senderBtcWalletDescriptor,
+        )
         const lessThan1CentWithBtcWalletBuilder =
-          lessThan1CentWithAmountBuilder.withSenderWallet(senderBtcWallet)
+          lessThan1CentWithAmountBuilder.withSenderWallet(senderBtcWalletDescriptor)
 
         const checkSenderWallet = (payment) => {
           expect(payment).toEqual(
             expect.objectContaining({
-              senderWalletId: senderBtcWallet.id,
-              senderWalletCurrency: senderBtcWallet.currency,
+              senderWalletId: senderBtcWalletDescriptor.id,
+              senderWalletCurrency: senderBtcWalletDescriptor.currency,
               btcPaymentAmount: {
                 amount: uncheckedAmount,
                 currency: WalletCurrency.Btc,
@@ -1120,17 +1163,17 @@ describe("LightningPaymentFlowBuilder", () => {
 
         describe("with btc recipient", () => {
           const withBtcRecipientBuilder =
-            withBtcWalletBuilder.withRecipientWallet(recipientBtcWallet)
+            withBtcWalletBuilder.withRecipientWallet(recipientBtcArgs)
 
           const lessThan1CentWithBtcRecipientBuilder =
-            lessThan1CentWithBtcWalletBuilder.withRecipientWallet(recipientBtcWallet)
+            lessThan1CentWithBtcWalletBuilder.withRecipientWallet(recipientBtcArgs)
 
           const checkRecipientWallet = (payment) => {
             expect(payment).toEqual(
               expect.objectContaining({
-                recipientWalletId: recipientBtcWallet.id,
-                recipientWalletCurrency: recipientBtcWallet.currency,
-                recipientUsername: recipientBtcWallet.username,
+                recipientWalletId: recipientBtcWalletDescriptor.id,
+                recipientWalletCurrency: recipientBtcWalletDescriptor.currency,
+                recipientUsername: recipientBtcArgs.username,
               }),
             )
           }
@@ -1199,16 +1242,16 @@ describe("LightningPaymentFlowBuilder", () => {
 
         describe("with usd recipient", () => {
           const withUsdRecipientBuilder =
-            withBtcWalletBuilder.withRecipientWallet(recipientUsdWallet)
+            withBtcWalletBuilder.withRecipientWallet(recipientUsdArgs)
           const lessThan1CentWithUsdRecipientBuilder =
-            lessThan1CentWithBtcWalletBuilder.withRecipientWallet(recipientUsdWallet)
+            lessThan1CentWithBtcWalletBuilder.withRecipientWallet(recipientUsdArgs)
 
           const checkRecipientWallet = (payment) => {
             expect(payment).toEqual(
               expect.objectContaining({
-                recipientWalletId: recipientUsdWallet.id,
-                recipientWalletCurrency: recipientUsdWallet.currency,
-                recipientUsername: recipientUsdWallet.username,
+                recipientWalletId: recipientUsdWalletDescriptor.id,
+                recipientWalletCurrency: recipientUsdWalletDescriptor.currency,
+                recipientUsername: recipientUsdArgs.username,
               }),
             )
           }
@@ -1271,13 +1314,15 @@ describe("LightningPaymentFlowBuilder", () => {
       })
 
       describe("with usd wallet", () => {
-        const withUsdWalletBuilder = withAmountBuilder.withSenderWallet(senderUsdWallet)
+        const withUsdWalletBuilder = withAmountBuilder.withSenderWallet(
+          senderUsdWalletDescriptor,
+        )
 
         const checkSenderWallet = (payment) => {
           expect(payment).toEqual(
             expect.objectContaining({
-              senderWalletId: senderUsdWallet.id,
-              senderWalletCurrency: senderUsdWallet.currency,
+              senderWalletId: senderUsdWalletDescriptor.id,
+              senderWalletCurrency: senderUsdWalletDescriptor.currency,
               usdPaymentAmount: {
                 amount: uncheckedAmount,
                 currency: WalletCurrency.Usd,
@@ -1288,13 +1333,13 @@ describe("LightningPaymentFlowBuilder", () => {
 
         describe("with btc recipient", () => {
           const withBtcRecipientBuilder =
-            withUsdWalletBuilder.withRecipientWallet(recipientBtcWallet)
+            withUsdWalletBuilder.withRecipientWallet(recipientBtcArgs)
           const checkRecipientWallet = (payment) => {
             expect(payment).toEqual(
               expect.objectContaining({
-                recipientWalletId: recipientBtcWallet.id,
-                recipientWalletCurrency: recipientBtcWallet.currency,
-                recipientUsername: recipientUsdWallet.username,
+                recipientWalletId: recipientBtcWalletDescriptor.id,
+                recipientWalletCurrency: recipientBtcWalletDescriptor.currency,
+                recipientUsername: recipientBtcArgs.username,
               }),
             )
           }
@@ -1335,13 +1380,13 @@ describe("LightningPaymentFlowBuilder", () => {
         })
         describe("with usd recipient", () => {
           const withUsdRecipientBuilder =
-            withUsdWalletBuilder.withRecipientWallet(recipientUsdWallet)
+            withUsdWalletBuilder.withRecipientWallet(recipientUsdArgs)
           const checkRecipientWallet = (payment) => {
             expect(payment).toEqual(
               expect.objectContaining({
-                recipientWalletId: recipientUsdWallet.id,
-                recipientWalletCurrency: recipientUsdWallet.currency,
-                recipientUsername: recipientUsdWallet.username,
+                recipientWalletId: recipientUsdWalletDescriptor.id,
+                recipientWalletCurrency: recipientUsdWalletDescriptor.currency,
+                recipientUsername: recipientUsdArgs.username,
               }),
             )
           }
@@ -1393,7 +1438,7 @@ describe("LightningPaymentFlowBuilder", () => {
           skipProbe,
         })
           .withInvoice(invoiceWithNoAmount)
-          .withSenderWallet(senderBtcWallet)
+          .withSenderWallet(senderBtcWalletDescriptor)
           .withoutRecipientWallet()
           .withConversion({
             mid,
@@ -1412,7 +1457,7 @@ describe("LightningPaymentFlowBuilder", () => {
           skipProbe,
         })
           .withNoAmountInvoice({ invoice: invoiceWithNoAmount, uncheckedAmount: 0.4 })
-          .withSenderWallet(senderBtcWallet)
+          .withSenderWallet(senderBtcWalletDescriptor)
           .withoutRecipientWallet()
           .withConversion({
             mid,
@@ -1431,7 +1476,7 @@ describe("LightningPaymentFlowBuilder", () => {
           skipProbe,
         })
           .withNoAmountInvoice({ invoice: invoiceWithNoAmount, uncheckedAmount: 0 })
-          .withSenderWallet(senderBtcWallet)
+          .withSenderWallet(senderBtcWalletDescriptor)
           .withoutRecipientWallet()
           .withConversion({
             mid,
@@ -1450,7 +1495,7 @@ describe("LightningPaymentFlowBuilder", () => {
           skipProbe,
         })
           .withInvoice(invoiceWithAmount)
-          .withSenderWallet(senderBtcWallet)
+          .withSenderWallet(senderBtcWalletDescriptor)
           .withoutRecipientWallet()
           .withConversion({
             mid,
@@ -1470,8 +1515,8 @@ describe("LightningPaymentFlowBuilder", () => {
           skipProbe,
         })
           .withInvoice(invoiceWithAmount)
-          .withSenderWallet(senderBtcWallet)
-          .withRecipientWallet(senderUsdWallet)
+          .withSenderWallet(senderBtcWalletDescriptor)
+          .withRecipientWallet(senderUsdAsRecipientArgs)
           .withConversion({
             mid,
             hedgeBuyUsd,
@@ -1490,9 +1535,9 @@ describe("LightningPaymentFlowBuilder", () => {
           skipProbe,
         })
           .withNoAmountInvoice({ invoice: invoiceWithNoAmount, uncheckedAmount: 1000 })
-          .withSenderWallet(senderBtcWallet)
+          .withSenderWallet(senderBtcWalletDescriptor)
           .withRecipientWallet({
-            ...senderUsdWallet,
+            ...senderUsdAsRecipientArgs,
             usdPaymentAmount: { amount: 1000n, currency: WalletCurrency.Usd },
           })
           .withConversion({
@@ -1513,8 +1558,8 @@ describe("LightningPaymentFlowBuilder", () => {
           skipProbe,
         })
           .withInvoice(invoiceWithAmount)
-          .withSenderWallet(senderBtcWallet)
-          .withRecipientWallet(senderBtcWallet)
+          .withSenderWallet(senderBtcWalletDescriptor)
+          .withRecipientWallet(senderBtcAsRecipientArgs)
           .withConversion({
             mid,
             hedgeBuyUsd,


### PR DESCRIPTION
### Description

This is the 2nd iteration on handling sub-1-cent incoming transactions to usd wallets (see #3158). The 1st iteration implemented the logic to switch recipient wallets to btc in use-cases, with integration & e2e tests. This iteration instead does this switching inside builder objects, with unit tests.

We currently return an error and don't credit the USD wallet or settle the invoice. This PR is to instead settle the sats to BTC wallet instead of returning an error in the following cases:
- [x] ln-initiated intraledger receive to USD wallet
- [x] walletId-initiated intraledger receive to USD wallet
- [x] no-amount invoice receive from external source
- [x] onchain-initiated intraledger receive to USD wallet
