### PR TITLE
fix: trigger restart invoices issue

### DIFF
--- a/src/servers/trigger.ts
+++ b/src/servers/trigger.ts
@@ -322,6 +322,20 @@ const listenerExistingHodlInvoices = async ({
   }
 }
 
+export const setupAndProcessInvoiceSubscribe = ({
+  lnd,
+  pubkey,
+  subInvoices,
+}: {
+  lnd: AuthenticatedLnd
+  pubkey: Pubkey
+  subInvoices: EventEmitter
+}) => {
+  setupInvoiceSubscribe({ lnd, pubkey, subInvoices })
+  // Update existing pending invoices
+  Wallets.handleHeldInvoices(logger)
+}
+
 export const setupInvoiceSubscribe = ({
   lnd,
   pubkey,
@@ -348,9 +362,6 @@ export const setupInvoiceSubscribe = ({
   })
 
   listenerExistingHodlInvoices({ lnd, pubkey })
-
-  // Update existing pending invoices
-  Wallets.handleHeldInvoices(logger)
 }
 
 export const setupPaymentSubscribe = async ({
@@ -388,7 +399,7 @@ export const setupPaymentSubscribe = async ({
 
 const listenerOffchain = ({ lnd, pubkey }: { lnd: AuthenticatedLnd; pubkey: Pubkey }) => {
   const subInvoices = subscribeToInvoices({ lnd })
-  setupInvoiceSubscribe({ lnd, pubkey, subInvoices })
+  setupAndProcessInvoiceSubscribe({ lnd, pubkey, subInvoices })
 
   const subPayments = subscribeToPayments({ lnd })
   setupPaymentSubscribe({ subPayments })

--- a/src/servers/trigger.ts
+++ b/src/servers/trigger.ts
@@ -348,6 +348,9 @@ export const setupInvoiceSubscribe = ({
   })
 
   listenerExistingHodlInvoices({ lnd, pubkey })
+
+  // Update existing pending invoices
+  Wallets.handleHeldInvoices(logger)
 }
 
 export const setupPaymentSubscribe = async ({


### PR DESCRIPTION
Uses similar strategy to setupPaymentSubscribe to avoid missing invoices when trigger is restarted/deployed