### PR TITLE
refactor: simplify display currency hybrid

### DIFF
--- a/src/app/accounts/active-accounts.ts
+++ b/src/app/accounts/active-accounts.ts
@@ -2,12 +2,13 @@ import { USER_ACTIVENESS_MONTHLY_VOLUME_THRESHOLD } from "@config"
 
 import { getCurrentPriceAsWalletPriceRatio } from "@app/prices"
 
-import { ErrorLevel, WalletCurrency } from "@domain/shared"
+import { ErrorLevel } from "@domain/shared"
 import { ActivityChecker } from "@domain/ledger"
 
 import { LedgerService } from "@services/ledger"
 import { recordExceptionInCurrentSpan } from "@services/tracing"
 import { WalletsRepository, AccountsRepository } from "@services/mongoose"
+import { UsdDisplayCurrency } from "@domain/fiat"
 
 export const getRecentlyActiveAccounts = async function* ():
   | AsyncGenerator<Account>
@@ -16,7 +17,7 @@ export const getRecentlyActiveAccounts = async function* ():
   if (unlockedAccounts instanceof Error) return unlockedAccounts
 
   const walletPriceRatio = await getCurrentPriceAsWalletPriceRatio({
-    currency: WalletCurrency.Usd,
+    currency: UsdDisplayCurrency,
   })
   if (walletPriceRatio instanceof Error) return walletPriceRatio
 

--- a/src/app/accounts/send-default-wallet-balance-to-users.ts
+++ b/src/app/accounts/send-default-wallet-balance-to-users.ts
@@ -4,7 +4,7 @@ import {
 } from "@app/prices"
 import { removeDeviceTokens } from "@app/users/remove-device-tokens"
 
-import { DisplayCurrency } from "@domain/fiat"
+import { UsdDisplayCurrency } from "@domain/fiat"
 import { WalletCurrency } from "@domain/shared"
 import { DeviceTokensNotRegisteredNotificationsServiceError } from "@domain/notifications"
 
@@ -47,7 +47,7 @@ export const sendDefaultWalletBalanceToAccounts = async () => {
 
         if (balanceAmount.currency === WalletCurrency.Usd) {
           const usdWalletPriceRatio = await getCurrentPriceAsWalletPriceRatio({
-            currency: DisplayCurrency.Usd,
+            currency: UsdDisplayCurrency,
           })
 
           if (!(usdWalletPriceRatio instanceof Error)) {

--- a/src/app/on-chain/rebalance-to-cold-wallet.ts
+++ b/src/app/on-chain/rebalance-to-cold-wallet.ts
@@ -3,7 +3,7 @@ import { getColdStorageConfig } from "@config"
 import { getCurrentPriceAsDisplayPriceRatio } from "@app/prices"
 
 import { toSats } from "@domain/bitcoin"
-import { DisplayCurrency } from "@domain/fiat"
+import { UsdDisplayCurrency } from "@domain/fiat"
 import { RebalanceChecker } from "@domain/bitcoin/onchain"
 import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
 
@@ -22,7 +22,7 @@ export const rebalanceToColdWallet = async (): Promise<boolean | ApplicationErro
   if (offChainService instanceof Error) return offChainService
 
   const displayPriceRatio = await getCurrentPriceAsDisplayPriceRatio({
-    currency: DisplayCurrency.Usd,
+    currency: UsdDisplayCurrency,
   })
   if (displayPriceRatio instanceof Error) return displayPriceRatio
 

--- a/src/app/on-chain/record-hot-to-cold-transfer.ts
+++ b/src/app/on-chain/record-hot-to-cold-transfer.ts
@@ -1,7 +1,7 @@
 import { toSats } from "@domain/bitcoin"
 import { LedgerService } from "@services/ledger"
 import { getCurrentPriceAsDisplayPriceRatio } from "@app/prices"
-import { DisplayCurrency } from "@domain/fiat"
+import { UsdDisplayCurrency } from "@domain/fiat"
 
 export const recordHotToColdTransfer = async ({
   satoshis,
@@ -17,7 +17,7 @@ export const recordHotToColdTransfer = async ({
   const description = `deposit of ${satoshis.amount} sats to the cold storage wallet`
 
   const displayPriceRatio = await getCurrentPriceAsDisplayPriceRatio({
-    currency: DisplayCurrency.Usd,
+    currency: UsdDisplayCurrency,
   })
   if (displayPriceRatio instanceof Error) return displayPriceRatio
   const amountDisplayCurrency = displayPriceRatio.convertFromWallet(satoshis)

--- a/src/app/prices/mid-price.ts
+++ b/src/app/prices/mid-price.ts
@@ -1,6 +1,6 @@
 import { getDealerConfig } from "@config"
 
-import { DisplayCurrency } from "@domain/fiat"
+import { UsdDisplayCurrency } from "@domain/fiat"
 import { ErrorLevel, ExchangeCurrencyUnit, WalletCurrency } from "@domain/shared"
 
 import {
@@ -96,10 +96,10 @@ export const getMidPriceRatio = async (
         error: priceRatio,
         level: ErrorLevel.Warn,
       })
-      return getCurrentPriceAsWalletPriceRatio({ currency: DisplayCurrency.Usd })
+      return getCurrentPriceAsWalletPriceRatio({ currency: UsdDisplayCurrency })
     }
     return priceRatio
   }
 
-  return getCurrentPriceAsWalletPriceRatio({ currency: DisplayCurrency.Usd })
+  return getCurrentPriceAsWalletPriceRatio({ currency: UsdDisplayCurrency })
 }

--- a/src/app/wallets/update-legacy-on-chain-receipt.ts
+++ b/src/app/wallets/update-legacy-on-chain-receipt.ts
@@ -14,7 +14,7 @@ import {
   CouldNotFindWalletFromOnChainAddressError,
   CouldNotFindWalletFromOnChainAddressesError,
 } from "@domain/errors"
-import { DisplayCurrency } from "@domain/fiat"
+import { UsdDisplayCurrency } from "@domain/fiat"
 
 import { LockService } from "@services/lock"
 import { LedgerService } from "@services/ledger"
@@ -153,7 +153,7 @@ const processTxForHotWallet = async ({
   const ledger = LedgerService()
 
   const displayPriceRatio = await getCurrentPriceAsDisplayPriceRatio({
-    currency: DisplayCurrency.Usd,
+    currency: UsdDisplayCurrency,
   })
   if (displayPriceRatio instanceof Error) return displayPriceRatio
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,11 +1,10 @@
 import { AccountStatus } from "@domain/accounts/primitives"
-import { DisplayCurrency } from "@domain/fiat"
 import { WalletCurrency } from "@domain/shared"
 
 const displayCurrencyConfigSchema = {
   type: "object",
   properties: {
-    code: { type: "string", enum: Object.values(DisplayCurrency) },
+    code: { type: "string" },
     symbol: { type: "string" },
   },
   required: ["code", "symbol"],

--- a/src/domain/fiat/display-amounts-converter.ts
+++ b/src/domain/fiat/display-amounts-converter.ts
@@ -2,7 +2,8 @@ import {
   displayAmountFromWalletAmount,
   priceAmountFromDisplayPriceRatio,
 } from "./display-currency"
-import { DisplayCurrency } from "./primitives"
+
+import { UsdDisplayCurrency } from "./primitives"
 
 export const DisplayAmountsConverter = <D extends DisplayCurrency>(
   displayPriceRatio: DisplayPriceRatio<"BTC", D>,
@@ -12,7 +13,7 @@ export const DisplayAmountsConverter = <D extends DisplayCurrency>(
 
     let displayAmount = displayPriceRatio.convertFromWallet(args.btcPaymentAmount)
     let displayFee = displayPriceRatio.convertFromWalletToCeil(args.btcProtocolAndBankFee)
-    if (displayCurrency === DisplayCurrency.Usd) {
+    if (displayCurrency === UsdDisplayCurrency) {
       displayAmount = displayAmountFromWalletAmount<D>(args.usdPaymentAmount)
       displayFee = displayAmountFromWalletAmount<D>(args.usdProtocolAndBankFee)
     }

--- a/src/domain/fiat/display-currency.ts
+++ b/src/domain/fiat/display-currency.ts
@@ -81,7 +81,7 @@ export const displayAmountFromWalletAmount = <D extends DisplayCurrency>(
 ): DisplayAmount<D> => {
   const { amount: amountInMinor, currency } = walletAmount
 
-  const displayMajorExponent = getCurrencyMajorExponent(walletAmount.currency)
+  const displayMajorExponent = getCurrencyMajorExponent(currency as D)
 
   return {
     amountInMinor,

--- a/src/domain/fiat/index.types.d.ts
+++ b/src/domain/fiat/index.types.d.ts
@@ -1,9 +1,7 @@
 type UsdCents = number & { readonly brand: unique symbol }
 type CentsPerSatsRatio = number & { readonly brand: unique symbol }
 type DisplayCurrencyBaseAmount = number & { readonly brand: unique symbol }
-type DisplayCurrency =
-  | (typeof import("./primitives").DisplayCurrency)[keyof typeof import("./primitives").DisplayCurrency]
-  | (string & { readonly brand: unique symbol })
+type DisplayCurrency = string & { readonly brand: unique symbol }
 type CurrencyMajorExponent =
   (typeof import("./index").MajorExponent)[keyof typeof import("./index").MajorExponent]
 

--- a/src/domain/fiat/primitives.ts
+++ b/src/domain/fiat/primitives.ts
@@ -1,4 +1,1 @@
-export const DisplayCurrency = {
-  Usd: "USD",
-  Btc: "BTC",
-} as const
+export const UsdDisplayCurrency = "USD" as DisplayCurrency

--- a/src/domain/wallets/settlement-amounts.ts
+++ b/src/domain/wallets/settlement-amounts.ts
@@ -1,9 +1,9 @@
 import { toSats } from "@domain/bitcoin"
 import {
-  DisplayCurrency,
   getCurrencyMajorExponent,
   displayAmountFromNumber,
   toCents,
+  UsdDisplayCurrency,
 } from "@domain/fiat"
 import { ErrorLevel, WalletCurrency } from "@domain/shared"
 
@@ -22,7 +22,7 @@ export const SettlementAmounts = () => {
     // ======
 
     const { debit, credit, currency, displayCurrency: displayCurrencyRaw } = txn
-    const displayCurrency = displayCurrencyRaw || DisplayCurrency.Usd
+    const displayCurrency = displayCurrencyRaw || UsdDisplayCurrency
     const settlementAmount =
       currency === WalletCurrency.Btc ? toSats(credit - debit) : toCents(credit - debit)
 

--- a/src/domain/wallets/tx-history.ts
+++ b/src/domain/wallets/tx-history.ts
@@ -1,4 +1,4 @@
-import { DisplayCurrency, priceAmountFromNumber, toCents } from "@domain/fiat"
+import { UsdDisplayCurrency, priceAmountFromNumber, toCents } from "@domain/fiat"
 import { toSats } from "@domain/bitcoin"
 import { WalletCurrency } from "@domain/shared"
 import { AdminLedgerTransactionType, LedgerTransactionType } from "@domain/ledger"
@@ -33,7 +33,7 @@ const translateLedgerTxnToWalletTxn = <S extends WalletCurrency>({
     walletId,
   } = txn
 
-  const displayCurrency = displayCurrencyRaw || DisplayCurrency.Usd
+  const displayCurrency = displayCurrencyRaw || UsdDisplayCurrency
 
   const isAdmin = Object.values(AdminLedgerTransactionType).includes(
     type as AdminLedgerTransactionType,

--- a/src/graphql/public/root/query/btc-price-list.ts
+++ b/src/graphql/public/root/query/btc-price-list.ts
@@ -1,7 +1,7 @@
 import { Prices } from "@app"
 
 import { SATS_PER_BTC } from "@domain/bitcoin"
-import { DisplayCurrency, BTC_PRICE_PRECISION_OFFSET } from "@domain/fiat"
+import { BTC_PRICE_PRECISION_OFFSET, UsdDisplayCurrency } from "@domain/fiat"
 import { PriceInterval, PriceRange } from "@domain/price"
 
 import { GT } from "@graphql/index"
@@ -85,7 +85,7 @@ const BtcPriceListQuery = GT.Field({
     // Add the current price as the last item in the array
     // This is used by the mobile app to convert prices
     const currentPrice = await Prices.getCurrentSatPrice({
-      currency: DisplayCurrency.Usd,
+      currency: UsdDisplayCurrency,
     })
     if (!(currentPrice instanceof Error)) {
       const currentBtcPriceInCents = currentPrice.price * 100 * SATS_PER_BTC

--- a/src/graphql/public/root/query/btc-price.ts
+++ b/src/graphql/public/root/query/btc-price.ts
@@ -1,6 +1,6 @@
 import { Prices } from "@app"
 
-import { DisplayCurrency, SAT_PRICE_PRECISION_OFFSET } from "@domain/fiat"
+import { SAT_PRICE_PRECISION_OFFSET, UsdDisplayCurrency } from "@domain/fiat"
 
 import { GT } from "@graphql/index"
 import { mapError } from "@graphql/error-map"
@@ -11,7 +11,10 @@ const BtcPriceQuery = GT.Field({
   deprecationReason: "Deprecated in favor of realtimePrice",
   type: Price,
   args: {
-    currency: { type: GT.NonNull(DisplayCurrencyGT), defaultValue: DisplayCurrency.Usd },
+    currency: {
+      type: GT.NonNull(DisplayCurrencyGT),
+      defaultValue: UsdDisplayCurrency,
+    },
   },
   resolve: async (_, args) => {
     const { currency } = args

--- a/src/graphql/public/root/query/realtime-price.ts
+++ b/src/graphql/public/root/query/realtime-price.ts
@@ -2,9 +2,9 @@ import { Prices } from "@app"
 
 import {
   majorToMinorUnit,
-  DisplayCurrency,
   USD_PRICE_PRECISION_OFFSET,
   SAT_PRICE_PRECISION_OFFSET,
+  UsdDisplayCurrency,
 } from "@domain/fiat"
 
 import { GT } from "@graphql/index"
@@ -18,7 +18,7 @@ const RealtimePriceQuery = GT.Field({
   args: {
     currency: {
       type: DisplayCurrencyGT,
-      defaultValue: DisplayCurrency.Usd,
+      defaultValue: UsdDisplayCurrency,
     },
   },
   resolve: async (_, args) => {

--- a/src/graphql/public/root/subscription/my-updates.ts
+++ b/src/graphql/public/root/subscription/my-updates.ts
@@ -2,9 +2,9 @@ import { Prices } from "@app"
 
 import {
   majorToMinorUnit,
-  DisplayCurrency,
   SAT_PRICE_PRECISION_OFFSET,
   USD_PRICE_PRECISION_OFFSET,
+  UsdDisplayCurrency,
 } from "@domain/fiat"
 import { customPubSubTrigger, PubSubDefaultTriggers } from "@domain/pubsub"
 
@@ -167,7 +167,7 @@ const MeSubscription = {
 
     // This will be deprecated but while we update the app must return only USD updates
     if (source.price) {
-      if (source.price.displayCurrency !== DisplayCurrency.Usd) {
+      if (source.price.displayCurrency !== UsdDisplayCurrency) {
         return {
           errors: [{ message: "Price is deprecated, please use realtimePrice event" }],
         }
@@ -269,7 +269,7 @@ const MeSubscription = {
         pricePerSat: pricePerSat.price,
         pricePerUsdCent: pricePerUsdCent.price,
       }
-      if (displayCurrency === DisplayCurrency.Usd) {
+      if (displayCurrency === UsdDisplayCurrency) {
         pubsub.publishDelayed({
           trigger: accountUpdatedTrigger,
           payload: { price: priceData },

--- a/src/graphql/public/root/subscription/price.ts
+++ b/src/graphql/public/root/subscription/price.ts
@@ -5,9 +5,9 @@ import { Prices } from "@app"
 import { customPubSubTrigger, PubSubDefaultTriggers } from "@domain/pubsub"
 import {
   checkedToDisplayCurrency,
-  DisplayCurrency,
   majorToMinorUnit,
   SAT_PRICE_PRECISION_OFFSET,
+  UsdDisplayCurrency,
 } from "@domain/fiat"
 
 import { GT } from "@graphql/index"
@@ -67,7 +67,7 @@ const PriceSubscription = {
     }
 
     if (source.errors) return { errors: source.errors }
-    if (source.displayCurrency !== DisplayCurrency.Usd) {
+    if (source.displayCurrency !== UsdDisplayCurrency) {
       return {
         errors: [{ message: "Price is deprecated, please use realtimePrice event" }],
       }

--- a/src/graphql/public/root/subscription/realtime-price.ts
+++ b/src/graphql/public/root/subscription/realtime-price.ts
@@ -6,9 +6,9 @@ import { customPubSubTrigger, PubSubDefaultTriggers } from "@domain/pubsub"
 import {
   checkedToDisplayCurrency,
   majorToMinorUnit,
-  DisplayCurrency,
   SAT_PRICE_PRECISION_OFFSET,
   USD_PRICE_PRECISION_OFFSET,
+  UsdDisplayCurrency,
 } from "@domain/fiat"
 
 import { GT } from "@graphql/index"
@@ -27,7 +27,7 @@ const RealtimePriceInput = GT.Input({
   fields: () => ({
     currency: {
       type: DisplayCurrencyGT,
-      defaultValue: DisplayCurrency.Usd,
+      defaultValue: UsdDisplayCurrency,
     },
   }),
 })

--- a/src/services/ledger/facade/tx-metadata.ts
+++ b/src/services/ledger/facade/tx-metadata.ts
@@ -1,5 +1,5 @@
 import { toSats } from "@domain/bitcoin"
-import { DisplayCurrency, toCents } from "@domain/fiat"
+import { UsdDisplayCurrency, toCents } from "@domain/fiat"
 import { LedgerTransactionType } from "@domain/ledger"
 
 const displayArgsFromArgs = ({
@@ -40,7 +40,7 @@ const internalMetadataAmounts = ({
 }): DisplayTxnAmounts => ({
   displayAmount: Number(centsAmount) as DisplayCurrencyBaseAmount,
   displayFee: Number(centsFee) as DisplayCurrencyBaseAmount,
-  displayCurrency: DisplayCurrency.Usd,
+  displayCurrency: UsdDisplayCurrency,
 })
 
 const debitOrCreditMetadataAmounts = ({
@@ -61,9 +61,9 @@ const debitOrCreditMetadataAmounts = ({
   const walletUsdFee = Number(centsFee) as DisplayCurrencyBaseAmount
 
   const resultDisplayAmount =
-    displayCurrency === DisplayCurrency.Usd ? walletUsdAmount : displayAmount
+    displayCurrency === UsdDisplayCurrency ? walletUsdAmount : displayAmount
   const resultDisplayFee =
-    displayCurrency === DisplayCurrency.Usd ? walletUsdFee : displayFee
+    displayCurrency === UsdDisplayCurrency ? walletUsdFee : displayFee
 
   return {
     debitOrCreditAdditionalMetadata: {

--- a/src/services/mongoose/accounts.ts
+++ b/src/services/mongoose/accounts.ts
@@ -7,7 +7,7 @@ import {
   CouldNotFindAccountFromUsernameError,
   RepositoryError,
 } from "@domain/errors"
-import { DisplayCurrency } from "@domain/fiat"
+import { UsdDisplayCurrency } from "@domain/fiat"
 
 import { Account } from "@services/mongoose/schema"
 
@@ -244,5 +244,5 @@ const translateToAccount = (result: AccountRecord): Account => ({
   })),
 
   kratosUserId: result.kratosUserId as UserId,
-  displayCurrency: (result.displayCurrency || DisplayCurrency.Usd) as DisplayCurrency,
+  displayCurrency: (result.displayCurrency || UsdDisplayCurrency) as DisplayCurrency,
 })

--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -1,6 +1,6 @@
 import { toSats } from "@domain/bitcoin"
 import { WalletCurrency } from "@domain/shared"
-import { DisplayCurrency, toCents } from "@domain/fiat"
+import { toCents, UsdDisplayCurrency } from "@domain/fiat"
 import { customPubSubTrigger, PubSubDefaultTriggers } from "@domain/pubsub"
 import { NotificationsServiceError, NotificationType } from "@domain/notifications"
 
@@ -283,7 +283,7 @@ export const NotificationsService = (): INotificationsService => {
       event: PubSubDefaultTriggers.UserPriceUpdate,
       suffix: displayCurrency,
     })
-    if (displayCurrency === DisplayCurrency.Usd) {
+    if (displayCurrency === UsdDisplayCurrency) {
       pubsub.publish({ trigger: userPriceUpdateTrigger, payload: { price: payload } })
     }
     pubsub.publish({

--- a/src/services/price/index.ts
+++ b/src/services/price/index.ts
@@ -12,7 +12,7 @@ import { SATS_PER_BTC } from "@domain/bitcoin"
 
 import { WalletCurrency } from "@domain/shared"
 
-import { CENTS_PER_USD, DisplayCurrency } from "@domain/fiat"
+import { CENTS_PER_USD, UsdDisplayCurrency } from "@domain/fiat"
 
 import { PRICE_HISTORY_HOST, PRICE_HISTORY_PORT, PRICE_HOST, PRICE_PORT } from "@config"
 
@@ -69,7 +69,7 @@ export const PriceService = (): IPriceService => {
     try {
       if (walletCurrency === displayCurrency) {
         const offset =
-          displayCurrency === DisplayCurrency.Usd ? CENTS_PER_USD : SATS_PER_BTC
+          displayCurrency === UsdDisplayCurrency ? CENTS_PER_USD : SATS_PER_BTC
         return {
           timestamp: new Date(Date.now()),
           price: 1 / offset,
@@ -83,7 +83,9 @@ export const PriceService = (): IPriceService => {
 
       let displayCurrencyPrice = price / SATS_PER_BTC
       if (walletCurrency === WalletCurrency.Usd) {
-        const { price: usdBtcPrice } = await getPrice({ currency: DisplayCurrency.Usd })
+        const { price: usdBtcPrice } = await getPrice({
+          currency: UsdDisplayCurrency,
+        })
         if (!usdBtcPrice) return new PriceNotAvailableError()
 
         displayCurrencyPrice = price / usdBtcPrice / CENTS_PER_USD

--- a/test/integration/app/accounts/get-transactions-for-accounts.spec.ts
+++ b/test/integration/app/accounts/get-transactions-for-accounts.spec.ts
@@ -1,7 +1,7 @@
 import { Accounts } from "@app"
 
 import { toSats } from "@domain/bitcoin"
-import { DisplayCurrency, toCents } from "@domain/fiat"
+import { UsdDisplayCurrency, toCents } from "@domain/fiat"
 import { InvalidWalletId } from "@domain/errors"
 
 import { AccountsRepository } from "@services/mongoose"
@@ -43,7 +43,7 @@ const receiveBankFee = {
 const receiveDisplayAmounts = {
   amountDisplayCurrency: Number(receiveAmounts.usd.amount) as DisplayCurrencyBaseAmount,
   feeDisplayCurrency: Number(receiveBankFee.usd.amount) as DisplayCurrencyBaseAmount,
-  displayCurrency: DisplayCurrency.Usd,
+  displayCurrency: UsdDisplayCurrency,
 }
 
 const randomMemo = () => "this is my memo #" + (Math.random() * 1_000_000).toFixed()

--- a/test/integration/app/wallets/send-intraledger.spec.ts
+++ b/test/integration/app/wallets/send-intraledger.spec.ts
@@ -3,7 +3,7 @@ import { Accounts, Payments } from "@app"
 import { AccountStatus } from "@domain/accounts"
 import { toSats } from "@domain/bitcoin"
 import { PaymentSendStatus } from "@domain/bitcoin/lightning"
-import { DisplayCurrency, toCents } from "@domain/fiat"
+import { UsdDisplayCurrency, toCents } from "@domain/fiat"
 import {
   InactiveAccountError,
   IntraledgerLimitsExceededError,
@@ -63,7 +63,7 @@ const receiveBankFee = {
 const receiveDisplayAmounts = {
   amountDisplayCurrency: Number(receiveAmounts.usd.amount) as DisplayCurrencyBaseAmount,
   feeDisplayCurrency: Number(receiveBankFee.usd.amount) as DisplayCurrencyBaseAmount,
-  displayCurrency: DisplayCurrency.Usd,
+  displayCurrency: UsdDisplayCurrency,
 }
 
 const receiveAboveLimitAmounts = {
@@ -75,7 +75,7 @@ const receiveAboveLimitDisplayAmounts = {
     receiveAboveLimitAmounts.usd.amount,
   ) as DisplayCurrencyBaseAmount,
   feeDisplayCurrency: Number(receiveBankFee.usd.amount) as DisplayCurrencyBaseAmount,
-  displayCurrency: DisplayCurrency.Usd,
+  displayCurrency: UsdDisplayCurrency,
 }
 
 const randomIntraLedgerMemo = () =>

--- a/test/integration/app/wallets/send-lightning.spec.ts
+++ b/test/integration/app/wallets/send-lightning.spec.ts
@@ -7,7 +7,7 @@ import {
   PaymentSendStatus,
   decodeInvoice,
 } from "@domain/bitcoin/lightning"
-import { DisplayCurrency, toCents } from "@domain/fiat"
+import { UsdDisplayCurrency, toCents } from "@domain/fiat"
 import { LnPaymentRequestNonZeroAmountRequiredError } from "@domain/payments"
 import {
   InactiveAccountError,
@@ -106,7 +106,7 @@ const receiveBankFee = {
 const receiveDisplayAmounts = {
   amountDisplayCurrency: Number(receiveAmounts.usd.amount) as DisplayCurrencyBaseAmount,
   feeDisplayCurrency: Number(receiveBankFee.usd.amount) as DisplayCurrencyBaseAmount,
-  displayCurrency: DisplayCurrency.Usd,
+  displayCurrency: UsdDisplayCurrency,
 }
 
 const receiveAboveLimitAmounts = {
@@ -118,7 +118,7 @@ const receiveAboveLimitDisplayAmounts = {
     receiveAboveLimitAmounts.usd.amount,
   ) as DisplayCurrencyBaseAmount,
   feeDisplayCurrency: Number(receiveBankFee.usd.amount) as DisplayCurrencyBaseAmount,
-  displayCurrency: DisplayCurrency.Usd,
+  displayCurrency: UsdDisplayCurrency,
 }
 
 const randomLightningMemo = () =>

--- a/test/integration/app/wallets/send-onchain.spec.ts
+++ b/test/integration/app/wallets/send-onchain.spec.ts
@@ -4,7 +4,7 @@ import { getAccountLimits, getOnChainWalletConfig, ONE_DAY } from "@config"
 
 import { AccountStatus } from "@domain/accounts"
 import { toSats } from "@domain/bitcoin"
-import { DisplayCurrency, toCents } from "@domain/fiat"
+import { toCents, UsdDisplayCurrency } from "@domain/fiat"
 import {
   InactiveAccountError,
   InsufficientBalanceError,
@@ -81,7 +81,7 @@ const receiveBankFee = {
 const receiveDisplayAmounts = {
   amountDisplayCurrency: Number(receiveAmounts.usd.amount) as DisplayCurrencyBaseAmount,
   feeDisplayCurrency: Number(receiveBankFee.usd.amount) as DisplayCurrencyBaseAmount,
-  displayCurrency: DisplayCurrency.Usd,
+  displayCurrency: UsdDisplayCurrency,
 }
 
 const amountBelowDustThreshold = getOnChainWalletConfig().dustThreshold - 1
@@ -191,7 +191,7 @@ describe("onChainPay", () => {
         currency: WalletCurrency.Usd,
       }
       const walletPriceRatio = await Prices.getCurrentPriceAsWalletPriceRatio({
-        currency: WalletCurrency.Usd,
+        currency: UsdDisplayCurrency,
       })
       if (walletPriceRatio instanceof Error) throw walletPriceRatio
       const withdrawalLimitBtcAmount = walletPriceRatio.convertFromUsd(

--- a/test/integration/services/ledger-facade.spec.ts
+++ b/test/integration/services/ledger-facade.spec.ts
@@ -2,7 +2,7 @@ import crypto from "crypto"
 
 import { BtcWalletDescriptor, UsdWalletDescriptor, WalletCurrency } from "@domain/shared"
 import { LedgerTransactionType } from "@domain/ledger"
-import { DisplayCurrency } from "@domain/fiat"
+import { UsdDisplayCurrency } from "@domain/fiat"
 import { CouldNotFindError } from "@domain/errors"
 
 import { LedgerService } from "@services/ledger"
@@ -45,7 +45,7 @@ describe("Facade", () => {
   const displayReceiveUsdAmounts = {
     amountDisplayCurrency: Number(receiveAmount.usd.amount) as DisplayCurrencyBaseAmount,
     feeDisplayCurrency: Number(bankFee.usd.amount) as DisplayCurrencyBaseAmount,
-    displayCurrency: DisplayCurrency.Usd,
+    displayCurrency: UsdDisplayCurrency,
   }
 
   const displayReceiveEurAmounts = {

--- a/test/legacy-integration/02-user-wallet/02-bria-handlers.spec.ts
+++ b/test/legacy-integration/02-user-wallet/02-bria-handlers.spec.ts
@@ -13,7 +13,11 @@ import {
 import { AmountCalculator, WalletCurrency, ZERO_SATS } from "@domain/shared"
 import { UnknownLedgerError, toLiabilitiesWalletId } from "@domain/ledger"
 import { DisplayPriceRatio, WalletPriceRatio } from "@domain/payments"
-import { DisplayAmountsConverter, displayAmountFromNumber } from "@domain/fiat"
+import {
+  DisplayAmountsConverter,
+  UsdDisplayCurrency,
+  displayAmountFromNumber,
+} from "@domain/fiat"
 
 import { WalletOnChainPendingReceive } from "@services/mongoose/schema"
 import { Transaction } from "@services/ledger/schema"
@@ -389,7 +393,10 @@ describe("Bria Event Handlers", () => {
       })
       if (priceRatio instanceof Error) throw priceRatio
 
-      const displayAmount = displayAmountFromNumber({ amount: 20, currency: "USD" })
+      const displayAmount = displayAmountFromNumber({
+        amount: 20,
+        currency: UsdDisplayCurrency,
+      })
       if (displayAmount instanceof Error) throw displayAmount
       const displayPriceRatio = DisplayPriceRatio({
         displayAmount,

--- a/test/legacy-integration/02-user-wallet/02-receive-lightning.spec.ts
+++ b/test/legacy-integration/02-user-wallet/02-receive-lightning.spec.ts
@@ -10,7 +10,7 @@ import { handleHeldInvoices } from "@app/wallets"
 import { toSats } from "@domain/bitcoin"
 import { InvoiceNotFoundError } from "@domain/bitcoin/lightning"
 import { defaultTimeToExpiryInSeconds } from "@domain/bitcoin/lightning/invoice-expiration"
-import { DisplayCurrency, toCents } from "@domain/fiat"
+import { UsdDisplayCurrency, toCents } from "@domain/fiat"
 import { PaymentInitiationMethod, WithdrawalFeePriceMethod } from "@domain/wallets"
 import { WalletCurrency } from "@domain/shared"
 import { CouldNotFindWalletInvoiceError } from "@domain/errors"
@@ -212,7 +212,7 @@ describe("UserWallet - Lightning", () => {
       displayAmount: centsAmount,
       displayFee: 0,
 
-      displayCurrency: DisplayCurrency.Usd,
+      displayCurrency: UsdDisplayCurrency,
     }
     expect(ledgerTx).toEqual(expect.objectContaining(expectedFields))
   })
@@ -469,7 +469,7 @@ describe("UserWallet - Lightning", () => {
       displayAmount: cents,
       displayFee: 0,
 
-      displayCurrency: DisplayCurrency.Usd,
+      displayCurrency: UsdDisplayCurrency,
     }
     expect(ledgerTx).toEqual(expect.objectContaining(expectedFields))
   })

--- a/test/legacy-integration/02-user-wallet/02-receive-onchain.spec.ts
+++ b/test/legacy-integration/02-user-wallet/02-receive-onchain.spec.ts
@@ -15,11 +15,11 @@ import {
 
 import { sat2btc, toSats } from "@domain/bitcoin"
 import {
-  DisplayCurrency,
   getCurrencyMajorExponent,
   displayAmountFromNumber,
   toCents,
   DisplayAmountsConverter,
+  UsdDisplayCurrency,
 } from "@domain/fiat"
 import { LedgerTransactionType } from "@domain/ledger"
 import { NotificationType } from "@domain/notifications"
@@ -291,7 +291,7 @@ describe("With Bria", () => {
       displayAmount: centsAmount - centsFee,
       displayFee: centsFee,
 
-      displayCurrency: DisplayCurrency.Usd,
+      displayCurrency: UsdDisplayCurrency,
     }
     expect(ledgerTx).toEqual(expect.objectContaining(expectedFields))
 
@@ -513,7 +513,7 @@ describe("With Bria", () => {
 
       const displayAmountForMajor = displayAmountFromNumber({
         amount: displayAmountRaw || 0,
-        currency: displayCurrency || DisplayCurrency.Usd,
+        currency: displayCurrency || UsdDisplayCurrency,
       })
       if (displayAmountForMajor instanceof Error) throw displayAmountForMajor
 
@@ -643,7 +643,7 @@ describe("With Bria", () => {
       if (wallet instanceof Error) throw wallet
 
       const walletPriceRatio = await Prices.getCurrentPriceAsWalletPriceRatio({
-        currency: WalletCurrency.Usd,
+        currency: UsdDisplayCurrency,
       })
       if (walletPriceRatio instanceof Error) throw walletPriceRatio
       const satsAmount = walletPriceRatio.convertFromUsd({
@@ -667,7 +667,7 @@ describe("With Bria", () => {
       if (wallet instanceof Error) throw wallet
 
       const walletPriceRatio = await Prices.getCurrentPriceAsWalletPriceRatio({
-        currency: WalletCurrency.Usd,
+        currency: UsdDisplayCurrency,
       })
       if (walletPriceRatio instanceof Error) throw walletPriceRatio
       const satsAmount = walletPriceRatio.convertFromUsd({
@@ -1089,7 +1089,7 @@ describe("With Lnd", () => {
       displayAmount: centsAmount - centsFee,
       displayFee: centsFee,
 
-      displayCurrency: DisplayCurrency.Usd,
+      displayCurrency: UsdDisplayCurrency,
     }
     expect(ledgerTx).toEqual(expect.objectContaining(expectedFields))
 
@@ -1401,7 +1401,7 @@ describe("With Lnd", () => {
 
       const displayAmountForMajor = displayAmountFromNumber({
         amount: displayAmountRaw || 0,
-        currency: displayCurrency || DisplayCurrency.Usd,
+        currency: displayCurrency || UsdDisplayCurrency,
       })
       if (displayAmountForMajor instanceof Error) throw displayAmountForMajor
 
@@ -1482,7 +1482,7 @@ describe("With Lnd", () => {
       const walletIdG = await getDefaultWalletIdByPhone(phoneG)
 
       const walletPriceRatio = await Prices.getCurrentPriceAsWalletPriceRatio({
-        currency: WalletCurrency.Usd,
+        currency: UsdDisplayCurrency,
       })
       if (walletPriceRatio instanceof Error) throw walletPriceRatio
       const satsAmount = walletPriceRatio.convertFromUsd({
@@ -1507,7 +1507,7 @@ describe("With Lnd", () => {
       const walletId = await getDefaultWalletIdByPhone(phoneF)
 
       const walletPriceRatio = await Prices.getCurrentPriceAsWalletPriceRatio({
-        currency: WalletCurrency.Usd,
+        currency: UsdDisplayCurrency,
       })
       if (walletPriceRatio instanceof Error) throw walletPriceRatio
       const satsAmount = walletPriceRatio.convertFromUsd({

--- a/test/legacy-integration/02-user-wallet/02-tx-display.spec.ts
+++ b/test/legacy-integration/02-user-wallet/02-tx-display.spec.ts
@@ -10,7 +10,7 @@ import { LedgerTransactionType, UnknownLedgerError } from "@domain/ledger"
 import * as LnFeesImpl from "@domain/payments"
 import { paymentAmountFromNumber, WalletCurrency } from "@domain/shared"
 import { TxStatus } from "@domain/wallets"
-import { DisplayCurrency, displayAmountFromNumber } from "@domain/fiat"
+import { UsdDisplayCurrency, displayAmountFromNumber } from "@domain/fiat"
 
 import { updateDisplayCurrency } from "@app/accounts"
 
@@ -264,7 +264,7 @@ describe("Display properties on transactions", () => {
             expect.objectContaining({
               displayAmount: recipientTxn.centsAmount,
               displayFee: recipientTxn.centsFee,
-              displayCurrency: DisplayCurrency.Usd,
+              displayCurrency: UsdDisplayCurrency,
             }),
           )
         }
@@ -400,7 +400,7 @@ describe("Display properties on transactions", () => {
             expect.objectContaining({
               displayAmount: senderTxn.centsAmount,
               displayFee: senderTxn.centsFee,
-              displayCurrency: DisplayCurrency.Usd,
+              displayCurrency: UsdDisplayCurrency,
             }),
           )
         }
@@ -469,7 +469,7 @@ describe("Display properties on transactions", () => {
             expect.objectContaining({
               displayAmount: senderTxn.centsAmount,
               displayFee: senderTxn.centsFee,
-              displayCurrency: DisplayCurrency.Usd,
+              displayCurrency: UsdDisplayCurrency,
             }),
           )
         }
@@ -554,13 +554,13 @@ describe("Display properties on transactions", () => {
             expect.objectContaining({
               displayAmount: senderTxn.centsAmount,
               displayFee: senderTxn.centsFee,
-              displayCurrency: DisplayCurrency.Usd,
+              displayCurrency: UsdDisplayCurrency,
               type: LedgerTransactionType.Payment,
             }),
             expect.objectContaining({
               displayAmount: reimbursementTxn.centsAmount,
               displayFee: reimbursementTxn.centsFee,
-              displayCurrency: DisplayCurrency.Usd,
+              displayCurrency: UsdDisplayCurrency,
               type: LedgerTransactionType.LnFeeReimbursement,
             }),
           ]),
@@ -634,7 +634,7 @@ describe("Display properties on transactions", () => {
             expect.objectContaining({
               displayAmount: senderTxn.centsAmount,
               displayFee: senderTxn.centsFee,
-              displayCurrency: DisplayCurrency.Usd,
+              displayCurrency: UsdDisplayCurrency,
             }),
           )
         }
@@ -735,7 +735,7 @@ describe("Display properties on transactions", () => {
             expect.objectContaining({
               displayAmount: recipientTxn.centsAmount,
               displayFee: recipientTxn.centsFee,
-              displayCurrency: DisplayCurrency.Usd,
+              displayCurrency: UsdDisplayCurrency,
             }),
           )
         }
@@ -981,7 +981,7 @@ describe("Display properties on transactions", () => {
             expect.objectContaining({
               displayAmount: senderTxn.centsAmount,
               displayFee: senderTxn.centsFee,
-              displayCurrency: DisplayCurrency.Usd,
+              displayCurrency: UsdDisplayCurrency,
             }),
           )
         }
@@ -1054,7 +1054,7 @@ describe("Display properties on transactions", () => {
             expect.objectContaining({
               displayAmount: senderTxn.centsAmount,
               displayFee: senderTxn.centsFee,
-              displayCurrency: DisplayCurrency.Usd,
+              displayCurrency: UsdDisplayCurrency,
             }),
           )
         }
@@ -1193,7 +1193,7 @@ describe("Display properties on transactions", () => {
             expect.objectContaining({
               displayAmount: senderTxn.centsAmount,
               displayFee: senderTxn.centsFee,
-              displayCurrency: DisplayCurrency.Usd,
+              displayCurrency: UsdDisplayCurrency,
             }),
           )
         }

--- a/test/legacy-integration/notifications/notification.spec.ts
+++ b/test/legacy-integration/notifications/notification.spec.ts
@@ -2,7 +2,7 @@ import { getRecentlyActiveAccounts } from "@app/accounts/active-accounts"
 import { sendDefaultWalletBalanceToAccounts } from "@app/accounts/send-default-wallet-balance-to-users"
 
 import { toSats } from "@domain/bitcoin"
-import { DisplayCurrency } from "@domain/fiat"
+import { UsdDisplayCurrency } from "@domain/fiat"
 import { LedgerService } from "@services/ledger"
 import * as serviceLedger from "@services/ledger"
 import {
@@ -45,7 +45,7 @@ const crcDisplayPaymentAmount = {
 
 beforeAll(async () => {
   const usdDisplayPriceRatio = await getCurrentPriceAsDisplayPriceRatio({
-    currency: DisplayCurrency.Usd,
+    currency: UsdDisplayCurrency,
   })
   if (usdDisplayPriceRatio instanceof Error) throw usdDisplayPriceRatio
 
@@ -154,7 +154,7 @@ describe("notification", () => {
           displayPaymentAmount = displayAmount
         } else {
           const walletPriceRatio = await getCurrentPriceAsWalletPriceRatio({
-            currency: WalletCurrency.Usd,
+            currency: UsdDisplayCurrency,
           })
           if (walletPriceRatio instanceof Error) throw walletPriceRatio
           const btcBalanceAmount = walletPriceRatio.convertFromUsd(

--- a/test/legacy-integration/services/dealer/mid-price.spec.ts
+++ b/test/legacy-integration/services/dealer/mid-price.spec.ts
@@ -1,5 +1,5 @@
 import { getCurrentPriceAsWalletPriceRatio, getMidPriceRatio } from "@app/prices"
-import { DisplayCurrency } from "@domain/fiat"
+import { UsdDisplayCurrency } from "@domain/fiat"
 
 import { DealerPriceService } from "@services/dealer-price"
 
@@ -10,7 +10,7 @@ describe("getMidPriceRatio", () => {
     if (dealerMidPriceRatio instanceof Error) throw dealerMidPriceRatio
 
     const priceMidPriceRatio = await getCurrentPriceAsWalletPriceRatio({
-      currency: DisplayCurrency.Usd,
+      currency: UsdDisplayCurrency,
     })
     if (priceMidPriceRatio instanceof Error) throw priceMidPriceRatio
 

--- a/test/legacy-integration/services/mongoose/wallet-onchain-pending-receive.spec.ts
+++ b/test/legacy-integration/services/mongoose/wallet-onchain-pending-receive.spec.ts
@@ -1,4 +1,4 @@
-import { DisplayCurrency } from "@domain/fiat"
+import { UsdDisplayCurrency } from "@domain/fiat"
 import { WalletCurrency } from "@domain/shared"
 import {
   CouldNotFindWalletOnChainPendingReceiveError,
@@ -39,18 +39,18 @@ describe("WalletOnChainPendingReceiveRepository", () => {
     settlementCurrency: WalletCurrency.Btc,
     settlementDisplayAmount: {
       amountInMinor: 100n,
-      currency: DisplayCurrency.Usd,
+      currency: UsdDisplayCurrency,
       displayInMajor: "1.00",
     },
     settlementDisplayFee: {
       amountInMinor: 2n,
-      currency: DisplayCurrency.Usd,
+      currency: UsdDisplayCurrency,
       displayInMajor: "0.02",
     },
     settlementDisplayPrice: {
       base: 27454545454n,
       offset: 12n,
-      displayCurrency: DisplayCurrency.Usd,
+      displayCurrency: UsdDisplayCurrency,
       walletCurrency: WalletCurrency.Btc,
     },
     createdAt: new Date(Date.now()),

--- a/test/mocks/get-current-price.ts
+++ b/test/mocks/get-current-price.ts
@@ -53,7 +53,7 @@ export const getCurrentPriceAsWalletPriceRatio = async ({
   return toWalletPriceRatio(price.price * 10 ** exponent)
 }
 
-export const getCurrentPriceAsDisplayPriceRatio = async <T extends WalletCurrency>({
+export const getCurrentPriceAsDisplayPriceRatio = async <T extends DisplayCurrency>({
   currency,
 }: GetCurrentSatPriceArgs): Promise<DisplayPriceRatio<"BTC", T> | PriceServiceError> => {
   const price = await getCurrentSatPrice({ currency })

--- a/test/unit/app/prices/get-current-price.spec.ts
+++ b/test/unit/app/prices/get-current-price.spec.ts
@@ -1,5 +1,5 @@
 import { CacheKeys } from "@domain/cache"
-import { DisplayCurrency } from "@domain/fiat"
+import { UsdDisplayCurrency } from "@domain/fiat"
 import { PriceNotAvailableError } from "@domain/price"
 
 import * as PriceServiceImpl from "@services/price"
@@ -33,7 +33,7 @@ describe("Prices", () => {
             Promise.resolve({
               timestamp: new Date(Date.now()),
               price: 0.05,
-              currency: DisplayCurrency.Usd,
+              currency: UsdDisplayCurrency,
             }),
           listCurrencies: jest.fn(),
         }))
@@ -44,11 +44,11 @@ describe("Prices", () => {
           listCurrencies: jest.fn(),
         }))
 
-      let satPrice = await getCurrentSatPrice({ currency: DisplayCurrency.Usd })
+      let satPrice = await getCurrentSatPrice({ currency: UsdDisplayCurrency })
       if (satPrice instanceof Error) throw satPrice
       expect(satPrice.price).toEqual(0.05)
 
-      satPrice = await getCurrentSatPrice({ currency: DisplayCurrency.Usd })
+      satPrice = await getCurrentSatPrice({ currency: UsdDisplayCurrency })
       if (satPrice instanceof Error) throw satPrice
       expect(satPrice.price).toEqual(0.05)
     })
@@ -61,7 +61,7 @@ describe("Prices", () => {
         listCurrencies: jest.fn(),
       }))
 
-      const price = await getCurrentSatPrice({ currency: DisplayCurrency.Usd })
+      const price = await getCurrentSatPrice({ currency: UsdDisplayCurrency })
       expect(price).toBeInstanceOf(PriceNotAvailableError)
     })
   })

--- a/test/unit/domain/fiat/display-amounts-converter.spec.ts
+++ b/test/unit/domain/fiat/display-amounts-converter.spec.ts
@@ -1,4 +1,4 @@
-import { DisplayAmountsConverter, DisplayCurrency } from "@domain/fiat"
+import { DisplayAmountsConverter, UsdDisplayCurrency } from "@domain/fiat"
 
 import { WalletCurrency, ZERO_CENTS, ZERO_SATS } from "@domain/shared"
 import { DisplayPriceRatio } from "@domain/payments"
@@ -54,7 +54,7 @@ describe("DisplayAmountsConverter", () => {
   }
 
   const expectedResultForUsd = () => {
-    const expectedResult = expectedResultForCurrency(DisplayCurrency.Usd)
+    const expectedResult = expectedResultForCurrency(UsdDisplayCurrency)
     return {
       ...expectedResult,
       displayAmount: {
@@ -103,7 +103,7 @@ describe("DisplayAmountsConverter", () => {
   })
 
   describe("usd display currency", () => {
-    const currency = DisplayCurrency.Usd
+    const currency = UsdDisplayCurrency
 
     const displayUsdPriceRatio = DisplayPriceRatio({
       displayAmount: { ...displayQuoteAmount, currency },

--- a/test/unit/domain/payments/price-ratio.spec.ts
+++ b/test/unit/domain/payments/price-ratio.spec.ts
@@ -7,7 +7,7 @@ import {
   toWalletPriceRatio,
   WalletPriceRatio,
 } from "@domain/payments"
-import { DisplayCurrency } from "@domain/fiat"
+import { UsdDisplayCurrency } from "@domain/fiat"
 
 describe("PriceRatio", () => {
   const otherQuoteAmount = 100n
@@ -388,7 +388,7 @@ describe("WalletPriceRatio", () => {
 describe("DisplayPriceRatio", () => {
   const displayQuoteAmount = {
     amountInMinor: 100n,
-    currency: DisplayCurrency.Usd,
+    currency: UsdDisplayCurrency,
     displayInMajor: "1.00" as DisplayCurrencyMajorAmount,
   }
   const btcQuoteAmount = {
@@ -404,7 +404,7 @@ describe("DisplayPriceRatio", () => {
   it("convertFromDisplayMinorUnit", () => {
     const result = displayPriceRatio.convertFromDisplayMinorUnit({
       amountInMinor: 40n,
-      currency: DisplayCurrency.Usd,
+      currency: UsdDisplayCurrency,
       displayInMajor: "0.40" as DisplayCurrencyMajorAmount,
     })
 
@@ -422,7 +422,7 @@ describe("DisplayPriceRatio", () => {
 
     expect(result).toStrictEqual({
       amountInMinor: 40n,
-      currency: DisplayCurrency.Usd,
+      currency: UsdDisplayCurrency,
       displayInMajor: "0.40",
     })
   })
@@ -435,7 +435,7 @@ describe("DisplayPriceRatio", () => {
 
     expect(result).toStrictEqual({
       amountInMinor: 40n,
-      currency: DisplayCurrency.Usd,
+      currency: UsdDisplayCurrency,
       displayInMajor: "0.40",
     })
   })
@@ -448,7 +448,7 @@ describe("DisplayPriceRatio", () => {
 
     expect(result).toStrictEqual({
       amountInMinor: 41n,
-      currency: DisplayCurrency.Usd,
+      currency: UsdDisplayCurrency,
       displayInMajor: "0.41",
     })
   })
@@ -475,7 +475,7 @@ describe("to DisplayPriceRatio from float ratio", () => {
 
     const priceRatio = toDisplayPriceRatio({
       ratio,
-      displayCurrency: DisplayCurrency.Usd,
+      displayCurrency: UsdDisplayCurrency,
     })
     expect(priceRatio).not.toBeInstanceOf(Error)
     if (priceRatio instanceof Error) throw priceRatio

--- a/test/unit/domain/wallets/payment-input-validator.spec.ts
+++ b/test/unit/domain/wallets/payment-input-validator.spec.ts
@@ -1,6 +1,6 @@
 import crypto from "crypto"
 
-import { DisplayCurrency } from "@domain/fiat"
+import { UsdDisplayCurrency } from "@domain/fiat"
 import { AccountLevel, AccountStatus } from "@domain/accounts"
 import { InvalidAccountStatusError, SelfPaymentError } from "@domain/errors"
 import { PaymentInputValidator, WalletType } from "@domain/wallets"
@@ -28,7 +28,7 @@ describe("PaymentInputValidator", () => {
     quizQuestions: [],
     quiz: [],
     kratosUserId: "kratosUserId" as UserId,
-    displayCurrency: DisplayCurrency.Usd,
+    displayCurrency: UsdDisplayCurrency,
   }
 
   const dummySenderWallet: Wallet = {

--- a/test/unit/domain/wallets/settlement-amounts.spec.ts
+++ b/test/unit/domain/wallets/settlement-amounts.spec.ts
@@ -1,5 +1,5 @@
 import { toSats } from "@domain/bitcoin"
-import { DisplayCurrency, displayAmountFromNumber, toCents } from "@domain/fiat"
+import { UsdDisplayCurrency, displayAmountFromNumber, toCents } from "@domain/fiat"
 import { WalletCurrency } from "@domain/shared"
 import { SettlementAmounts } from "@domain/wallets/settlement-amounts"
 
@@ -93,7 +93,7 @@ describe("SettlementAmounts", () => {
 
           const expectedDisplayAmountForDebitObj = displayAmountFromNumber({
             amount: expectedDisplayAmount,
-            currency: txnDebit.displayCurrency || DisplayCurrency.Usd,
+            currency: txnDebit.displayCurrency || UsdDisplayCurrency,
           })
           if (expectedDisplayAmountForDebitObj instanceof Error) {
             throw expectedDisplayAmountForDebitObj
@@ -128,7 +128,7 @@ describe("SettlementAmounts", () => {
 
           const expectedDisplayAmountForCreditObj = displayAmountFromNumber({
             amount: expectedDisplayAmount,
-            currency: txnCredit.displayCurrency || DisplayCurrency.Usd,
+            currency: txnCredit.displayCurrency || UsdDisplayCurrency,
           })
           if (expectedDisplayAmountForCreditObj instanceof Error) {
             throw expectedDisplayAmountForCreditObj
@@ -171,7 +171,7 @@ describe("SettlementAmounts", () => {
 
           const expectedDisplayAmountForDebitObj = displayAmountFromNumber({
             amount: expectedDisplayAmount,
-            currency: txnDebit.displayCurrency || DisplayCurrency.Usd,
+            currency: txnDebit.displayCurrency || UsdDisplayCurrency,
           })
           if (expectedDisplayAmountForDebitObj instanceof Error) {
             throw expectedDisplayAmountForDebitObj
@@ -206,7 +206,7 @@ describe("SettlementAmounts", () => {
 
           const expectedDisplayAmountForCreditObj = displayAmountFromNumber({
             amount: expectedDisplayAmount,
-            currency: txnCredit.displayCurrency || DisplayCurrency.Usd,
+            currency: txnCredit.displayCurrency || UsdDisplayCurrency,
           })
           if (expectedDisplayAmountForCreditObj instanceof Error) {
             throw expectedDisplayAmountForCreditObj

--- a/test/unit/domain/wallets/tx-history.spec.ts
+++ b/test/unit/domain/wallets/tx-history.spec.ts
@@ -14,7 +14,7 @@ import {
   MEMO_SHARING_SATS_THRESHOLD,
 } from "@config"
 import { WalletCurrency } from "@domain/shared"
-import { DisplayCurrency, priceAmountFromNumber, toCents } from "@domain/fiat"
+import { UsdDisplayCurrency, priceAmountFromNumber, toCents } from "@domain/fiat"
 
 describe("translates ledger txs to wallet txs", () => {
   const timestamp = new Date(Date.now())
@@ -30,7 +30,7 @@ describe("translates ledger txs to wallet txs", () => {
     satsFee,
     centsFee,
     displayFee,
-    displayCurrency: DisplayCurrency.Usd,
+    displayCurrency: UsdDisplayCurrency,
     pendingConfirmation: false,
     journalId: "journalId" as LedgerJournalId,
     timestamp,
@@ -128,7 +128,7 @@ describe("translates ledger txs to wallet txs", () => {
     centsAmount: UsdCents
     currency: WalletCurrency
   }): WalletTransaction[] => {
-    const displayCurrency = DisplayCurrency.Usd
+    const displayCurrency = UsdDisplayCurrency
 
     const settlementFee = currency === WalletCurrency.Btc ? satsFee : centsFee
     const settlementDisplayPrice = displayCurrencyPerBaseUnitFromAmounts({
@@ -346,7 +346,7 @@ describe("translates ledger txs to wallet txs", () => {
           settlementDisplayFee: "0.00",
           settlementDisplayPrice: priceAmountFromNumber({
             priceOfOneSatInMinorUnit: 0,
-            displayCurrency: DisplayCurrency.Usd,
+            displayCurrency: UsdDisplayCurrency,
             walletCurrency: tx.settlementCurrency,
           }),
           ...rest,

--- a/test/unit/services/ledger/domain/entry-builder.spec.ts
+++ b/test/unit/services/ledger/domain/entry-builder.spec.ts
@@ -10,7 +10,7 @@ import {
   onChainLedgerAccountId,
 } from "@services/ledger/domain"
 import { MainBook } from "@services/ledger/books"
-import { DisplayCurrency } from "@domain/fiat"
+import { UsdDisplayCurrency } from "@domain/fiat"
 
 const createEntry = () => MainBook.entry("")
 
@@ -169,13 +169,13 @@ describe("EntryBuilder", () => {
   const additionalInternalMetadata = {
     displayAmount: 20 as DisplayCurrencyBaseAmount,
     displayFee: 0 as DisplayCurrencyBaseAmount,
-    displayCurrency: DisplayCurrency.Usd,
+    displayCurrency: UsdDisplayCurrency,
   }
 
   const additionalUserUsdMetadata = {
     displayAmount: 22 as DisplayCurrencyBaseAmount,
     displayFee: 0 as DisplayCurrencyBaseAmount,
-    displayCurrency: DisplayCurrency.Usd,
+    displayCurrency: UsdDisplayCurrency,
   }
 
   const additionalUserEurMetadata = {

--- a/test/unit/services/ledger/domain/tx-metadata.spec.ts
+++ b/test/unit/services/ledger/domain/tx-metadata.spec.ts
@@ -1,5 +1,5 @@
 import { toSats } from "@domain/bitcoin"
-import { DisplayCurrency, toCents } from "@domain/fiat"
+import { UsdDisplayCurrency, toCents } from "@domain/fiat"
 import { LedgerTransactionType } from "@domain/ledger"
 import { WalletCurrency, ZERO_CENTS, ZERO_SATS } from "@domain/shared"
 import {
@@ -71,7 +71,7 @@ describe("Tx metadata", () => {
       displayFee: Number(
         paymentAmounts.usdProtocolAndBankFee.amount,
       ) as DisplayCurrencyBaseAmount,
-      displayCurrency: DisplayCurrency.Usd,
+      displayCurrency: UsdDisplayCurrency,
     },
 
     sender: {
@@ -183,7 +183,7 @@ describe("Tx metadata", () => {
               internalAccountsAdditionalMetadata,
             } = MetadataFn({
               ...metadataArgs,
-              senderDisplayCurrency: DisplayCurrency.Usd,
+              senderDisplayCurrency: UsdDisplayCurrency,
             })
 
             expect(debitAccountAdditionalMetadata).toEqual(
@@ -211,7 +211,7 @@ describe("Tx metadata", () => {
               internalAccountsAdditionalMetadata,
             } = MetadataFn({
               ...metadataArgs,
-              recipientDisplayCurrency: DisplayCurrency.Usd,
+              recipientDisplayCurrency: UsdDisplayCurrency,
             })
 
             expect(debitAccountAdditionalMetadata).toEqual(
@@ -280,7 +280,7 @@ describe("Tx metadata", () => {
               internalAccountsAdditionalMetadata,
             } = MetadataFn({
               ...metadataArgs,
-              senderDisplayCurrency: DisplayCurrency.Usd,
+              senderDisplayCurrency: UsdDisplayCurrency,
             })
 
             expect(metadata).toEqual(

--- a/test/unit/services/notifications/transactions.ts
+++ b/test/unit/services/notifications/transactions.ts
@@ -1,10 +1,10 @@
 import { NotificationType } from "@domain/notifications"
 import { WalletCurrency } from "@domain/shared"
-import { DisplayCurrency } from "@domain/fiat"
+import { UsdDisplayCurrency } from "@domain/fiat"
 
 const usdDisplayPaymentAmount = {
   amountInMinor: 500n,
-  currency: DisplayCurrency.Usd,
+  currency: UsdDisplayCurrency,
   displayInMajor: "5.00",
 }
 


### PR DESCRIPTION
## Description

This is to remove the partial `DisplayCurrency` enum and to have it only be a "unique symbol" type with display currencies loaded dynamically.