### PR TITLE
fix: crash on error in sessionPublicContext

### DIFF
--- a/src/servers/graphql-main-server.ts
+++ b/src/servers/graphql-main-server.ts
@@ -15,6 +15,7 @@ import {
   ACCOUNT_USERNAME,
   SemanticAttributes,
   addAttributesToCurrentSpanAndPropagate,
+  recordExceptionInCurrentSpan,
 } from "@services/tracing"
 
 import { NextFunction, Request, Response } from "express"
@@ -44,6 +45,15 @@ const setGqlContext = async (
     tokenPayload,
     ip,
   })
+
+  if (gqlContext instanceof Error) {
+    recordExceptionInCurrentSpan({
+      error: gqlContext,
+      fallbackMsg: "error executing sessionPublicContext",
+    })
+    next(gqlContext)
+    return
+  }
 
   req.gqlContext = gqlContext
 

--- a/src/servers/ws-server.ts
+++ b/src/servers/ws-server.ts
@@ -82,10 +82,13 @@ const getContext = async (
           sub: kratosCookieRes.kratosUserId,
         }
 
-        return sessionPublicContext({
+        const context = await sessionPublicContext({
           tokenPayload,
           ip,
         })
+
+        if (context instanceof Error) throw context
+        return context
       }
 
       const kratosToken = authz?.slice(7) as AuthToken
@@ -106,10 +109,13 @@ const getContext = async (
         return false
       }
 
-      return sessionPublicContext({
+      const context = await sessionPublicContext({
         tokenPayload,
         ip,
       })
+
+      if (context instanceof Error) throw context
+      return context
     },
   })()
 }


### PR DESCRIPTION
- I don't think it make sense to throw in the middleware
- I don't think it make sense to wrap the error in `mapError`
- passing the error to next when it arise. 