### PR TITLE
chore: remove mongoose resolution

### DIFF
--- a/core/api/package.json
+++ b/core/api/package.json
@@ -193,8 +193,7 @@
   "resolutions": {
     "protobufjs": "7.2.5",
     "http-cache-semantics": "4.1.1",
-    "import-in-the-middle": "1.4.2",
-    "**/**/mongoose": "~7.5.1"
+    "import-in-the-middle": "1.4.2"
   },
   "private": true
 }


### PR DESCRIPTION
This removes a resolution that was first introduced while we waited for medici to upgrade their deps to address an upstream vulnerability.

See https://github.com/GaloyMoney/galoy/pull/2912