### PR TITLE
chore: silencing current implicit any in test

### DIFF
--- a/core/api/src/debug/migrate-ln-payments-trackpaymentsv2.ts
+++ b/core/api/src/debug/migrate-ln-payments-trackpaymentsv2.ts
@@ -24,6 +24,8 @@ import {
 } from "@/services/tracing"
 import { setupMongoConnection } from "@/services/mongodb"
 
+/* eslint @typescript-eslint/ban-ts-comment: "off" */
+// @ts-ignore-next-line no-implicit-any error
 let lndService
 
 export const main = async (): Promise<true> => {
@@ -73,7 +75,9 @@ const migrateLnPayment = async (
       }
 
       // Fetch payment from lnd
+      // @ts-ignore-next-line no-implicit-any error
       const payment = await lndService.lookupPayment({
+        // @ts-ignore-next-line no-implicit-any error
         pubkey: lndService.defaultPubkey(),
         paymentHash,
       })
@@ -90,6 +94,7 @@ const migrateLnPayment = async (
       const partialLnPayment = {
         paymentHash,
         paymentRequest: undefined,
+        // @ts-ignore-next-line no-implicit-any error
         sentFromPubkey: lndService.defaultPubkey(),
         createdAt: undefined,
       }

--- a/core/api/src/migrations/20210922002129-add-wallet-public-id.ts
+++ b/core/api/src/migrations/20210922002129-add-wallet-public-id.ts
@@ -2,6 +2,8 @@
 const { randomUUID } = require("crypto")
 
 module.exports = {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   async up(db) {
     console.log("Begin to add wallet public id to users collection")
     const users = db
@@ -24,12 +26,15 @@ module.exports = {
     console.log("Finish to add wallet public id to users collection")
   },
 
+  // @ts-ignore-next-line no-implicit-any error
   async down(db) {
     await removeAttributes(db.collection("users"), ["walletPublicId"])
   },
 }
 
+// @ts-ignore-next-line no-implicit-any error
 const removeAttributes = (collection, attrs) => {
+  // @ts-ignore-next-line no-implicit-any error
   const unsets = attrs.reduce((obj, key) => {
     return { ...obj, [key]: 1 }
   }, {})

--- a/core/api/src/migrations/20211202002129-coordinate-to-coordinates.ts
+++ b/core/api/src/migrations/20211202002129-coordinate-to-coordinates.ts
@@ -1,4 +1,6 @@
 module.exports = {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   async up(db) {
     console.log("Begin up migration coordinates")
     const result = await db

--- a/core/api/src/migrations/20211209211641-use-walletid-for-ledger.ts
+++ b/core/api/src/migrations/20211209211641-use-walletid-for-ledger.ts
@@ -1,4 +1,6 @@
 module.exports = {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   async up(db) {
     {
       const result = await db.collection("users").updateMany({}, [
@@ -70,6 +72,7 @@ module.exports = {
     }
   },
 
+  // @ts-ignore-next-line no-implicit-any error
   async down(db) {
     await db
       .collection("medici_transactions")

--- a/core/api/src/migrations/20220111173335-separate-wallet-collection.ts
+++ b/core/api/src/migrations/20220111173335-separate-wallet-collection.ts
@@ -1,4 +1,6 @@
 module.exports = {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   async up(db) {
     {
       const result = await db.collection("users").updateMany({}, [

--- a/core/api/src/migrations/20220118183759-remove-wallet-id-index.ts
+++ b/core/api/src/migrations/20220118183759-remove-wallet-id-index.ts
@@ -1,4 +1,6 @@
 module.exports = {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   async up(db) {
     {
       try {

--- a/core/api/src/migrations/20220122121713-add-default-currency-walletinvoices.ts
+++ b/core/api/src/migrations/20220122121713-add-default-currency-walletinvoices.ts
@@ -1,4 +1,6 @@
 module.exports = {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   async up(db) {
     console.log("Begin up migration")
 

--- a/core/api/src/migrations/20220203152515-bootstrap_accounts.ts
+++ b/core/api/src/migrations/20220203152515-bootstrap_accounts.ts
@@ -18,7 +18,9 @@ const getRandomInvalidPhone = () => {
 const defaultWallet = { __v: 0, type: "checking", onchain: [] }
 
 module.exports = {
-  async up(db /*, client */) {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
+  async up(db) {
     for (const userMeta of adminUsers) {
       const role = userMeta.role
       let user = await db.collection("users").findOne({ role })

--- a/core/api/src/migrations/20220310000000-add-kratos-user-id.ts
+++ b/core/api/src/migrations/20220310000000-add-kratos-user-id.ts
@@ -1,4 +1,6 @@
 module.exports = {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   async up(db) {
     try {
       let result = await db.collection("users").dropIndex("phone_1")

--- a/core/api/src/migrations/20220406124601-fix-lnpayments-millisats.ts
+++ b/core/api/src/migrations/20220406124601-fix-lnpayments-millisats.ts
@@ -1,4 +1,6 @@
 module.exports = {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   async up(db) {
     try {
       const result = await db

--- a/core/api/src/migrations/20220422000000-add-status-history.ts
+++ b/core/api/src/migrations/20220422000000-add-status-history.ts
@@ -1,4 +1,6 @@
 module.exports = {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   async up(db) {
     console.log("Begin adding status history to users collection")
     const users = db.collection("users").find({}, { status: 1 })
@@ -24,6 +26,7 @@ module.exports = {
     console.log("Finish adding status history to users collection")
   },
 
+  // @ts-ignore-next-line no-implicit-any error
   async down(db) {
     await removeAttributes(db.collection("users"), ["statusHistory"])
     db.collection("users").updateMany(

--- a/core/api/src/migrations/20220427130214-add-sats-amount-prop-to-payments.ts
+++ b/core/api/src/migrations/20220427130214-add-sats-amount-prop-to-payments.ts
@@ -1,4 +1,6 @@
 module.exports = {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   async up(db) {
     const collection = db.collection("medici_transactions")
     try {
@@ -74,6 +76,7 @@ module.exports = {
     }
   },
 
+  // @ts-ignore-next-line no-implicit-any error
   async down(db) {
     try {
       const result = await db.collection("medici_transactions").update(

--- a/core/api/src/migrations/20220601191441-fix-reimburse-amounts.ts
+++ b/core/api/src/migrations/20220601191441-fix-reimburse-amounts.ts
@@ -2,6 +2,8 @@
 // @ts-nocheck
 
 module.exports = {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   async up(db) {
     const collection = db.collection("medici_transactions")
 

--- a/core/api/src/migrations/20220922030802-update-contact-enabled.ts
+++ b/core/api/src/migrations/20220922030802-update-contact-enabled.ts
@@ -1,4 +1,6 @@
 module.exports = {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   async up(db) {
     try {
       const collection = db.collection("users")

--- a/core/api/src/migrations/20221010162913-add-self-trade-type.ts
+++ b/core/api/src/migrations/20221010162913-add-self-trade-type.ts
@@ -42,6 +42,8 @@ const getNonUserWalletIds = async ({ usersCollection, walletsCollection }) => {
 }
 
 module.exports = {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   async up(db) {
     const usersCollection = db.collection("users")
     const walletsCollection = db.collection("wallets")

--- a/core/api/src/migrations/2022110622030802-users-to-account.ts
+++ b/core/api/src/migrations/2022110622030802-users-to-account.ts
@@ -1,4 +1,6 @@
 module.exports = {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   async up(db) {
     try {
       await db.renameCollection("users", "accounts")

--- a/core/api/src/migrations/2022113010370802-users-migration-1.ts
+++ b/core/api/src/migrations/2022113010370802-users-migration-1.ts
@@ -1,4 +1,6 @@
 module.exports = {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   async up(db) {
     console.log("Begin account to users property migration")
     const accounts = db.collection("accounts").find({})

--- a/core/api/src/migrations/2022113010370803-users-migration-2.ts
+++ b/core/api/src/migrations/2022113010370803-users-migration-2.ts
@@ -1,4 +1,6 @@
 module.exports = {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   async up(db) {
     console.log("Begin account to users property migration")
     const res = db

--- a/core/api/src/migrations/2022121620560802-remove-phone-code.ts
+++ b/core/api/src/migrations/2022121620560802-remove-phone-code.ts
@@ -1,4 +1,6 @@
 module.exports = {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   async up(db) {
     console.log("removing phonecodes")
     const collectionList = await db.listCollections({ name: "phonecodes" }).toArray()

--- a/core/api/src/migrations/20230106142545-fix-onchain-send-usd.ts
+++ b/core/api/src/migrations/20230106142545-fix-onchain-send-usd.ts
@@ -1,4 +1,6 @@
 module.exports = {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   async up(db) {
     const collection = db.collection("medici_transactions")
     const newUsd = {

--- a/core/api/src/migrations/20230116132109-add-sats-amounts-onchain-payments.ts
+++ b/core/api/src/migrations/20230116132109-add-sats-amounts-onchain-payments.ts
@@ -1,4 +1,6 @@
 module.exports = {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   async up(db) {
     const txTypes = ["onchain_payment"]
 
@@ -65,6 +67,7 @@ module.exports = {
     }
   },
 
+  // @ts-ignore-next-line no-implicit-any error
   async down(db) {
     const txTypes = ["onchain_payment"]
 

--- a/core/api/src/migrations/20230116162612-add-sats-amounts-to-receipts.ts
+++ b/core/api/src/migrations/20230116162612-add-sats-amounts-to-receipts.ts
@@ -1,4 +1,6 @@
 module.exports = {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   async up(db) {
     const txTypes = ["invoice", "onchain_receipt"]
 
@@ -63,6 +65,7 @@ module.exports = {
     }
   },
 
+  // @ts-ignore-next-line no-implicit-any error
   async down(db) {
     const txTypes = ["invoice", "onchain_receipt"]
 

--- a/core/api/src/migrations/20230319091251-add-sats-amounts-to-intraledger.ts
+++ b/core/api/src/migrations/20230319091251-add-sats-amounts-to-intraledger.ts
@@ -1,4 +1,6 @@
 module.exports = {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   async up(db) {
     const txTypes = ["on_us", "onchain_on_us"]
 
@@ -65,6 +67,7 @@ module.exports = {
     }
   },
 
+  // @ts-ignore-next-line no-implicit-any error
   async down(db) {
     const txTypes = ["on_us", "onchain_on_us"]
 

--- a/core/api/src/migrations/20230603185541-ledger-request-id.ts
+++ b/core/api/src/migrations/20230603185541-ledger-request-id.ts
@@ -1,10 +1,13 @@
 module.exports = {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   async up(db) {
     await db
       .collection("medici_transactions")
       .updateMany({}, { $rename: { new_address_request_id: "request_id" } })
   },
 
+  // @ts-ignore-next-line no-implicit-any error
   async down(db) {
     await db
       .collection("medici_transactions")

--- a/core/api/src/migrations/20230621225319-remove-deposit-fee-ratio.ts
+++ b/core/api/src/migrations/20230621225319-remove-deposit-fee-ratio.ts
@@ -1,4 +1,6 @@
 module.exports = {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   async up(db) {
     console.log("Begin depositFeeRatio removal")
     const res = await db

--- a/core/api/src/migrations/20230630133505-moving-ip-collection.ts
+++ b/core/api/src/migrations/20230630133505-moving-ip-collection.ts
@@ -1,3 +1,5 @@
+/* eslint @typescript-eslint/ban-ts-comment: "off" */
+// @ts-ignore-next-line no-implicit-any error
 async function* getAccounts(db) {
   const cursor = db.collection("accounts").find()
 
@@ -8,6 +10,7 @@ async function* getAccounts(db) {
 }
 
 module.exports = {
+  // @ts-ignore-next-line no-implicit-any error
   async up(db) {
     console.log("Begin AccountSchema to AccountIpsSchema migration")
 

--- a/core/api/src/migrations/20230709103710-deleted-phone-to-array.ts
+++ b/core/api/src/migrations/20230709103710-deleted-phone-to-array.ts
@@ -1,4 +1,6 @@
 module.exports = {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   async up(db) {
     console.log("Begin migration for deletedPhones")
 

--- a/core/api/src/migrations/20230807205306-add-uuid-to-accounts.ts
+++ b/core/api/src/migrations/20230807205306-add-uuid-to-accounts.ts
@@ -32,6 +32,8 @@ async function migrateAccounts(db, batchSize = 100) {
 }
 
 module.exports = {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   async up(db) {
     console.log("Begin migration to add UUIDs to Accounts Schema")
     await migrateAccounts(db)

--- a/core/api/test/helpers/bitcoin-core.ts
+++ b/core/api/test/helpers/bitcoin-core.ts
@@ -146,6 +146,9 @@ export const createSignerWallet = async (walletName: string) => {
     bitcoind: bitcoindSignerWallet,
     requests: signerDescriptors,
   })
+
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   if (result.some((d) => !d.success)) throw new Error("Invalid descriptors")
 
   return wallet

--- a/core/api/test/helpers/bitcoind.ts
+++ b/core/api/test/helpers/bitcoind.ts
@@ -71,6 +71,8 @@ export const getBitcoinCoreSignerRPCConfig = () => {
 export class BitcoindClient {
   readonly bitcoind
 
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   constructor(connection_obj) {
     const { host, username, password, port, timeout } = connection_obj
     this.bitcoind = authenticatedBitcoind({

--- a/core/api/test/helpers/bria.ts
+++ b/core/api/test/helpers/bria.ts
@@ -33,6 +33,9 @@ export const onceBriaSubscribe = async ({
   const bria = BriaSubscriber()
 
   let eventToReturn: BriaEvent | undefined = undefined
+
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   const eventHandler = ({ resolve, timeoutId }) => {
     return async (event: BriaEvent): Promise<true | ApplicationError> => {
       setTimeout(() => {
@@ -62,6 +65,7 @@ export const onceBriaSubscribe = async ({
   const res = await promise
   if (res instanceof Error) throw res
 
+  // @ts-ignore-next-line no-implicit-any error
   wrapper.cancel()
   return eventToReturn
 }
@@ -76,6 +80,8 @@ export const manyBriaSubscribe = async ({
   const bria = BriaSubscriber()
 
   const eventsToReturn: BriaEvent[] = []
+
+  // @ts-ignore-next-line no-implicit-any error
   const eventHandler = ({ resolve, timeoutId }) => {
     return async (event: BriaEvent): Promise<true | ApplicationError> => {
       setTimeout(() => {
@@ -108,6 +114,7 @@ export const manyBriaSubscribe = async ({
   const res = await promise
   if (res instanceof Error) throw res
 
+  // @ts-ignore-next-line no-implicit-any error
   wrapper.cancel()
   return eventsToReturn
 }
@@ -150,6 +157,7 @@ const waitUntilBriaZeroBalance = async () => {
 }
 
 export const waitUntilBriaConnected = async () => {
+  // @ts-ignore-next-line no-implicit-any error
   const balance = await waitForNoErrorWithCount(OnChainService().getHotBalance, 60)
   if (balance instanceof Error) throw balance
 }

--- a/core/api/test/helpers/ledger.ts
+++ b/core/api/test/helpers/ledger.ts
@@ -564,6 +564,8 @@ export const recordReceiveOnChainFeeReconciliation = async ({
 // Non-LedgerFacade helpers from legacy admin service
 // ======
 
+/* eslint @typescript-eslint/ban-ts-comment: "off" */
+// @ts-ignore-next-line no-implicit-any error
 export const recordLnChannelOpenOrClosingFee = async ({ paymentAmount }) => {
   const amount = Number(paymentAmount.btc.amount)
   const metadata = LedgerFacade.LnChannelOpenOrClosingFee({
@@ -580,6 +582,7 @@ export const recordLnChannelOpenOrClosingFee = async ({ paymentAmount }) => {
   return translateToLedgerJournal(savedEntry)
 }
 
+// @ts-ignore-next-line no-implicit-any error
 export const recordLndEscrowDebit = async ({ paymentAmount }) => {
   const amount = Number(paymentAmount.btc.amount)
   const metadata = LedgerFacade.Escrow()
@@ -592,6 +595,7 @@ export const recordLndEscrowDebit = async ({ paymentAmount }) => {
   return translateToLedgerJournal(savedEntry)
 }
 
+// @ts-ignore-next-line no-implicit-any error
 export const recordLndEscrowCredit = async ({ paymentAmount }) => {
   const amount = Number(paymentAmount.btc.amount)
   const metadata = LedgerFacade.Escrow()
@@ -604,6 +608,7 @@ export const recordLndEscrowCredit = async ({ paymentAmount }) => {
   return translateToLedgerJournal(savedEntry)
 }
 
+// @ts-ignore-next-line no-implicit-any error
 export const recordLnRoutingRevenue = async ({ paymentAmount }) => {
   const amount = Number(paymentAmount.btc.amount)
   const metadata = LedgerFacade.LnRoutingRevenue(new Date())

--- a/core/api/test/helpers/lightning.ts
+++ b/core/api/test/helpers/lightning.ts
@@ -57,7 +57,14 @@ export const getAmount = (request: EncodedPaymentRequest) => {
 export const getPubKey = (request: EncodedPaymentRequest) => {
   return parsePaymentRequest({ request }).destination as Pubkey
 }
-export const getInvoiceAttempt = async ({ lnd, id }) => {
+
+export const getInvoiceAttempt = async ({
+  lnd,
+  id,
+}: {
+  lnd: AuthenticatedLnd
+  id: string
+}) => {
   try {
     const result = await getInvoice({ lnd, id })
     return result
@@ -91,7 +98,13 @@ export const lndOutside2 = authenticatedLndGrpc({
 export const lndsIntegration = [lnd1, lnd2, lndOutside1, lndOutside2]
 export const lndsE2e = [lnd1, lnd2, lndOutside1, lndOutside2]
 
-export const waitUntilBlockHeight = async ({ lnd, blockHeight = 0 }) => {
+export const waitUntilBlockHeight = async ({
+  lnd,
+  blockHeight = 0,
+}: {
+  lnd: AuthenticatedLnd
+  blockHeight?: number
+}) => {
   let block = blockHeight
   if (block <= 0) {
     block = await bitcoindClient.getBlockCount()
@@ -119,6 +132,11 @@ export const openChannelTesting = async ({
   lndPartner,
   socket,
   is_private = false,
+}: {
+  lnd: AuthenticatedLnd
+  lndPartner: AuthenticatedLnd
+  socket: string
+  is_private?: boolean
 }) => {
   await waitUntilSync({ lnds: [lnd, lndPartner] })
 
@@ -140,6 +158,8 @@ export const openChannelTesting = async ({
     }
   })
 
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   let lndNewChannel, lndPartnerNewChannel
   const sub = subscribeToChannels({ lnd })
   sub.once("channel_opened", (channel) => {
@@ -157,16 +177,20 @@ export const openChannelTesting = async ({
   await Promise.all([
     // error: https://github.com/alexbosworth/ln-service/issues/122
     // once(sub, 'channel_opened'),
+
+    // @ts-ignore-next-line no-implicit-any error
     waitFor(() => lndNewChannel && lndPartnerNewChannel),
     mineBlockAndSync({ lnds: [lnd, lndPartner] }),
   ])
 
   if (lnd === lnd1) {
     baseLogger.debug({ lndNewChannel }, "lnd is lnd1 - onChannelUpdated")
+    // @ts-ignore-next-line no-implicit-any error
     await onChannelUpdated({ channel: lndNewChannel, lnd, stateChange: "opened" })
   }
 
   if (lndPartner === lnd1) {
+    // @ts-ignore-next-line no-implicit-any error
     expect(lndPartnerNewChannel.is_partner_initiated).toBe(true)
   }
 
@@ -184,6 +208,11 @@ export const openChannelTestingNoAccounting = async ({
   lndPartner,
   socket,
   is_private = false,
+}: {
+  lnd: AuthenticatedLnd
+  lndPartner: AuthenticatedLnd
+  socket: string
+  is_private?: boolean
 }) => {
   await waitUntilSync({ lnds: [lnd, lndPartner] })
 
@@ -205,12 +234,14 @@ export const openChannelTestingNoAccounting = async ({
     }
   })
 
+  // @ts-ignore-next-line no-implicit-any error
   let lndNewChannel
   const sub = subscribeToChannels({ lnd })
   sub.once("channel_opened", (channel) => {
     lndNewChannel = channel
   })
 
+  // @ts-ignore-next-line no-implicit-any error
   let lndPartnerNewChannel
   const subPartner = subscribeToChannels({ lnd: lndPartner })
   subPartner.once("channel_opened", (channel) => {
@@ -220,6 +251,7 @@ export const openChannelTestingNoAccounting = async ({
   await Promise.all([once(sub, "channel_opening"), openChannelPromise])
 
   await Promise.all([
+    // @ts-ignore-next-line no-implicit-any error
     waitFor(() => lndNewChannel && lndPartnerNewChannel),
     mineBlockAndSync({ lnds: [lnd, lndPartner] }),
   ])
@@ -232,16 +264,17 @@ export const openChannelTestingNoAccounting = async ({
 
 // all the following uses of bitcoind client that send/receive coin must be "outside"
 
-export const fundLnd = async (lnd, amount = 1) => {
+export const fundLnd = async (lnd: AuthenticatedLnd, amount = 1) => {
   const { address } = (await createChainAddress({
     format: "p2wpkh",
     lnd,
   })) as { address: OnChainAddress }
   await sendToAddressAndConfirm({ walletClient: bitcoindOutside, address, amount })
+  // @ts-ignore-next-line no-implicit-any error
   await waitUntilBlockHeight({ lnd })
 }
 
-const resetLnds = async (lnds) => {
+const resetLnds = async (lnds: AuthenticatedLnd[]) => {
   const block = await bitcoindClient.getBlockCount()
   if (!block) return // skip if we are just getting started
   // just in case pending transactions
@@ -273,7 +306,7 @@ const resetLnds = async (lnds) => {
 export const resetIntegrationLnds = () => resetLnds(lndsIntegration)
 export const resetE2eLnds = () => resetLnds(lndsE2e)
 
-export const closeAllChannels = async ({ lnd }) => {
+export const closeAllChannels = async ({ lnd }: { lnd: AuthenticatedLnd }) => {
   let channels
   try {
     ;({ channels } = await getChannels({ lnd }))
@@ -301,7 +334,17 @@ export const closeAllChannels = async ({ lnd }) => {
   }
 }
 
-export const setChannelFees = async ({ lnd, channel, base, rate }) => {
+export const setChannelFees = async ({
+  lnd,
+  channel,
+  base,
+  rate,
+}: {
+  lnd: AuthenticatedLnd
+  channel: Record<string, string>
+  base: number
+  rate: number
+}) => {
   const input = {
     fee_rate: rate,
     base_fee_mtokens: `${base * 1000}`,
@@ -311,6 +354,7 @@ export const setChannelFees = async ({ lnd, channel, base, rate }) => {
 
   const updateRoutingFeesPromise = waitFor(async () => {
     try {
+      // @ts-ignore-next-line no-implicit-any error
       const { failures } = await updateRoutingFees({ lnd, ...input })
       if (failures && failures.length) {
         return failures[0].failure
@@ -360,14 +404,17 @@ export const waitUntilSyncAllE2e = () => waitUntilSync({ lnds: lndsE2e })
 export const waitUntilSync = async ({ lnds }: { lnds: Array<AuthenticatedLnd> }) => {
   const promiseArray: Array<Promise<void>> = []
   for (const lnd of lnds) {
+    // @ts-ignore-next-line no-implicit-any error
     promiseArray.push(waitUntilBlockHeight({ lnd }))
   }
   await Promise.all(promiseArray)
 }
 
-const waitUntilChannelBalanceSyncAll = async (lnds) => {
+const waitUntilChannelBalanceSyncAll = async (lnds: AuthenticatedLnd[]) => {
   const promiseArray: Array<Promise<void>> = []
   for (const lnd of lnds) {
+    /* eslint @typescript-eslint/ban-ts-comment: "off" */
+    // @ts-ignore-next-line no-implicit-any error
     promiseArray.push(waitUntilChannelBalanceSync({ lnd }))
   }
   await Promise.all(promiseArray)
@@ -378,13 +425,20 @@ export const waitUntilChannelBalanceSyncIntegration = () =>
 export const waitUntilChannelBalanceSyncE2e = () =>
   waitUntilChannelBalanceSyncAll(lndsE2e)
 
+// @ts-ignore-next-line no-implicit-any error
 export const waitUntilChannelBalanceSync = ({ lnd }) =>
   waitFor(async () => {
     const { unsettled_balance } = await getChannelBalance({ lnd })
     return unsettled_balance === 0
   })
 
-export const waitUntilGraphIsReady = async ({ lnd, numNodes = 4 }) => {
+export const waitUntilGraphIsReady = async ({
+  lnd,
+  numNodes = 4,
+}: {
+  lnd: AuthenticatedLnd
+  numNodes: number
+}) => {
   await waitFor(async () => {
     const graph = await getNetworkGraph({ lnd })
     if (graph.nodes.length < numNodes) {
@@ -434,6 +488,7 @@ export const fundWalletIdFromLightning = async ({
   if (balance instanceof Error) throw balance
 }
 
+// @ts-ignore-next-line no-implicit-any error
 export const safePay = async (args) => {
   try {
     const res = await pay(args) // 'await' is explicitly needed here
@@ -444,6 +499,7 @@ export const safePay = async (args) => {
   }
 }
 
+// @ts-ignore-next-line no-implicit-any error
 export const safePayNoExpect = async (args) => {
   try {
     return await pay(args) // 'await' is explicitly needed here

--- a/core/api/test/helpers/redis.ts
+++ b/core/api/test/helpers/redis.ts
@@ -12,6 +12,8 @@ export const clearAccountLocks = () => clearKeys("locks:account")
 
 export const clearLimitersWithExclusions = async (exclusions: string[]) => {
   for (const limiter in RateLimitPrefix) {
+    /* eslint @typescript-eslint/ban-ts-comment: "off" */
+    // @ts-ignore-next-line no-implicit-any error
     const limiterValue = RateLimitPrefix[limiter]
     if (exclusions.includes(limiterValue)) continue
     await clearKeys(limiterValue)

--- a/core/api/test/helpers/shared.ts
+++ b/core/api/test/helpers/shared.ts
@@ -1,12 +1,12 @@
 import { sleep } from "@/utils"
 
-export const waitFor = async (f) => {
+export const waitFor = async (f: () => Promise<unknown>) => {
   let res
   while (!(res = await f())) await sleep(500)
   return res
 }
 
-export const waitForNoErrorWithCount = async (f, max) => {
+export const waitForNoErrorWithCount = async (f: () => Promise<Error>, max: number) => {
   let count = 0
   let res = new Error()
   while (res instanceof Error && count < max) {

--- a/core/api/test/integration/app/wallets/send-intraledger.spec.ts
+++ b/core/api/test/integration/app/wallets/send-intraledger.spec.ts
@@ -24,7 +24,7 @@ import {
   recordReceiveLnPayment,
 } from "test/helpers"
 
-let memo
+let memo: string
 
 const calc = AmountCalculator()
 

--- a/core/api/test/integration/app/wallets/send-lightning.spec.ts
+++ b/core/api/test/integration/app/wallets/send-lightning.spec.ts
@@ -43,7 +43,7 @@ import {
 let lnInvoice: LnInvoice
 let noAmountLnInvoice: LnInvoice
 let largeWithAmountLnInvoice: LnInvoice
-let memo
+let memo: string
 
 const calc = AmountCalculator()
 

--- a/core/api/test/integration/app/wallets/send-onchain.spec.ts
+++ b/core/api/test/integration/app/wallets/send-onchain.spec.ts
@@ -38,7 +38,7 @@ import {
 import { getBalanceHelper } from "test/helpers/wallet"
 
 let outsideAddress: OnChainAddress
-let memo
+let memo: string
 
 const dealerFns = DealerPriceService()
 

--- a/core/api/test/integration/services/lnd-service.spec.ts
+++ b/core/api/test/integration/services/lnd-service.spec.ts
@@ -39,7 +39,7 @@ const btcPaymentAmount = { amount: BigInt(amountInvoice), currency: WalletCurren
 const ROUTE_PPM_RATE = 10_000
 const ROUTE_PPM_PERCENT = ROUTE_PPM_RATE / 1_000_000
 
-const loadBitcoindWallet = async (walletName) => {
+const loadBitcoindWallet = async (walletName: string) => {
   const wallets = await bitcoindClient.listWallets()
   if (!wallets.includes(walletName)) {
     try {
@@ -72,6 +72,8 @@ const fundOnChainWallets = async () => {
   await fundLnd(lnd1, btc)
 }
 
+/* eslint @typescript-eslint/ban-ts-comment: "off" */
+// @ts-ignore-next-line no-implicit-any error
 const getChannelWithRetry = async ({ lnd, id }) => {
   const countMax = 9
 
@@ -91,6 +93,7 @@ const getChannelWithRetry = async ({ lnd, id }) => {
   if (!(count < countMax && errMsg !== "FullChannelDetailsNotFound")) {
     throw new Error("Could find updated channel details")
   }
+  // @ts-ignore-next-line no-implicit-any error
   if (!(channel.policies && channel.policies.length)) {
     throw new Error("No channel policies found")
   }
@@ -98,6 +101,7 @@ const getChannelWithRetry = async ({ lnd, id }) => {
   return channel
 }
 
+// @ts-ignore-next-line no-implicit-any error
 const setFeesOnChannel = async ({ localLnd, partnerLnd, base, rate }) => {
   const countMax = 9
 
@@ -115,6 +119,7 @@ const setFeesOnChannel = async ({ localLnd, partnerLnd, base, rate }) => {
 
     setOnChannel = await setChannelFees({
       lnd: localLnd,
+      // @ts-ignore-next-line no-implicit-any error
       channel,
       base,
       rate,
@@ -125,6 +130,7 @@ const setFeesOnChannel = async ({ localLnd, partnerLnd, base, rate }) => {
   }
 
   // Verify policy change
+  // @ts-ignore-next-line no-implicit-any error
   const { policies } = await getChannelWithRetry({ id: channel.id, lnd: localLnd })
   const { base_fee_mtokens, fee_rate } = policies[0]
   if (!(base_fee_mtokens === `${base * 1000}` && fee_rate === rate)) {

--- a/core/api/test/integration/services/wallets-repository.spec.ts
+++ b/core/api/test/integration/services/wallets-repository.spec.ts
@@ -11,7 +11,7 @@ import { toObjectId } from "@/services/mongoose/utils"
 const wallets = WalletsRepository()
 const accountId = "00112233445566778899aabb" as AccountId
 
-const newWallet = async (currency) => {
+const newWallet = async (currency: string) => {
   const wallet = new Wallet({
     _accountId: toObjectId<AccountId>(accountId),
     type: "checking",

--- a/core/api/test/legacy-integration/01-setup/01-lightning-channels.spec.ts
+++ b/core/api/test/legacy-integration/01-setup/01-lightning-channels.spec.ts
@@ -49,7 +49,9 @@ describe("Lightning channels", () => {
     const { channels } = await getChannels({ lnd: lnd1 })
     expect(channels.length).toEqual(channelLengthMain + 1)
 
+    // @ts-ignore-next-line no-implicit-any error
     await setChannelFees({ lnd: lnd1, channel, base: 0, rate: 0 })
+    // @ts-ignore-next-line no-implicit-any error
     await setChannelFees({ lnd: lnd2, channel, base: 0, rate: 0 })
   })
 
@@ -70,7 +72,9 @@ describe("Lightning channels", () => {
     const finalFeeInLedger = await ledgerAdmin.getBankOwnerBalance()
     expect(finalFeeInLedger - initFeeInLedger).toBe(channelFee * -1)
 
+    // @ts-ignore-next-line no-implicit-any error
     await setChannelFees({ lnd: lnd1, channel, base: 1, rate: 0 })
+    // @ts-ignore-next-line no-implicit-any error
     await setChannelFees({ lnd: lndOutside1, channel, base: 1, rate: 0 })
   })
 
@@ -86,7 +90,9 @@ describe("Lightning channels", () => {
     const { channels } = await getChannels({ lnd: lnd1 })
     expect(channels.length).toEqual(channelLengthMain + 1)
 
+    // @ts-ignore-next-line no-implicit-any error
     await setChannelFees({ lnd: lnd1, channel, base: 1, rate: 0 })
+    // @ts-ignore-next-line no-implicit-any error
     await setChannelFees({ lnd: lndOutside1, channel, base: 1, rate: 0 })
   })
 
@@ -114,6 +120,7 @@ describe("Lightning channels", () => {
 
       setOnLndOutside1 = await setChannelFees({
         lnd: lndOutside1,
+        // @ts-ignore-next-line no-implicit-any error
         channel,
         base: 0,
         rate: 5000,
@@ -132,6 +139,8 @@ describe("Lightning channels", () => {
       count++
       await sleep(250)
       try {
+        /* eslint @typescript-eslint/ban-ts-comment: "off" */
+        // @ts-ignore-next-line no-implicit-any error
         ;({ policies } = await getChannel({ id: channel.id, lnd: lndOutside1 }))
         errMsg = undefined
       } catch (err) {
@@ -143,6 +152,7 @@ describe("Lightning channels", () => {
     expect(errMsg).not.toBe("FullChannelDetailsNotFound")
     expect(policies && policies.length).toBeGreaterThan(0)
 
+    // @ts-ignore-next-line no-implicit-any error
     const { base_fee_mtokens, fee_rate } = policies[0]
     expect(base_fee_mtokens).toBe("0")
     expect(fee_rate).toEqual(5000)
@@ -159,6 +169,7 @@ describe("Lightning channels", () => {
     const { channels } = await getChannels({ lnd: lnd1 })
     expect(channels.length).toEqual(channelLengthMain + 1)
 
+    // @ts-ignore-next-line no-implicit-any error
     let closedChannel
     const sub = subscribeToChannels({ lnd: lnd1 })
     sub.on("channel_closed", async (channel) => {
@@ -168,6 +179,7 @@ describe("Lightning channels", () => {
 
     await closeChannel({ lnd: lnd1, id: channels[channels.length - 1].id })
 
+    // @ts-ignore-next-line no-implicit-any error
     await Promise.all([waitFor(() => closedChannel), mineBlockAndSync({ lnds })])
 
     // FIXME

--- a/core/api/test/legacy-integration/02-user-wallet/02-bria.spec.ts
+++ b/core/api/test/legacy-integration/02-user-wallet/02-bria.spec.ts
@@ -66,6 +66,8 @@ describe("BriaSubscriber", () => {
       const receivedEvents: BriaEvent[] = []
       const nExpectedEvents = 2
       let recording = false
+      /* eslint @typescript-eslint/ban-ts-comment: "off" */
+      // @ts-ignore-next-line no-implicit-any error
       const testEventHandler = (resolve) => {
         return async (event: BriaEvent): Promise<true | ApplicationError> => {
           if (
@@ -110,6 +112,7 @@ describe("BriaSubscriber", () => {
       }
       expect(receivedEvents[0].payload.txId).toEqual(expectedTxId)
 
+      // @ts-ignore-next-line no-implicit-any error
       wrapper.cancel()
     })
 
@@ -133,6 +136,7 @@ describe("BriaSubscriber", () => {
       let recording = false
       const receivedEvents: BriaEvent[] = []
       const nExpectedEvents = 3
+      // @ts-ignore-next-line no-implicit-any error
       const testEventHandler = (resolve) => {
         return async (event: BriaEvent): Promise<true | ApplicationError> => {
           if (
@@ -182,6 +186,7 @@ describe("BriaSubscriber", () => {
 
       expect(receivedEvents[1]).toEqual(receivedEvents[2])
 
+      // @ts-ignore-next-line no-implicit-any error
       wrapper.cancel()
     })
   })

--- a/core/api/test/legacy-integration/02-user-wallet/02-receive-rewards.spec.ts
+++ b/core/api/test/legacy-integration/02-user-wallet/02-receive-rewards.spec.ts
@@ -28,6 +28,8 @@ const onBoardingEarnIds = [
 ]
 const onBoardingEarnAmt: number = Object.keys(OnboardingEarn)
   .filter((k) => find(onBoardingEarnIds, (o) => o === k))
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   .reduce((p, k) => p + OnboardingEarn[k], 0)
 
 jest.mock("@/config", () => {
@@ -116,6 +118,7 @@ describe("UserWallet - addEarn", () => {
     }
     expect(txCheck).toBeUndefined()
 
+    // @ts-ignore-next-line no-implicit-any error
     const amount = OnboardingEarn[OnboardingEarnId]
     expect(amount).toBeLessThan(MEMO_SHARING_SATS_THRESHOLD)
 

--- a/core/api/test/legacy-integration/app/trigger/trigger.fn.spec.ts
+++ b/core/api/test/legacy-integration/app/trigger/trigger.fn.spec.ts
@@ -114,13 +114,13 @@ describe("onchainBlockEventHandler", () => {
     const address = await lndCreateOnChainAddress(walletIdA)
     if (address instanceof Error) throw address
 
-    const output0 = {}
+    const output0: Record<string, number> = {}
     output0[address] = sat2btc(amount)
 
     const address2 = await lndCreateOnChainAddress(walletIdD)
     if (address2 instanceof Error) throw address2
 
-    const output1 = {}
+    const output1: Record<string, number> = {}
     output1[address2] = sat2btc(amount2)
 
     const addressBria = await Wallets.createOnChainAddress({
@@ -147,6 +147,8 @@ describe("onchainBlockEventHandler", () => {
       address: RANDOM_ADDRESS,
     })
 
+    /* eslint @typescript-eslint/ban-ts-comment: "off" */
+    // @ts-ignore-next-line no-implicit-any error
     await Promise.all([waitFor(() => isFinalBlock), waitUntilSyncAll()])
 
     // this sleep seems necessary on the CI server. otherwise all the events may not have propagated

--- a/core/api/test/legacy-integration/app/wallets/invoice.spec.ts
+++ b/core/api/test/legacy-integration/app/wallets/invoice.spec.ts
@@ -281,7 +281,7 @@ describe("Wallet - rate limiting test", () => {
       promises.push(lnInvoicePromise)
     }
     const lnInvoices = await Promise.all(promises)
-    const isNotError = (item) => !(item instanceof Error)
+    const isNotError = (item: unknown) => !(item instanceof Error)
     expect(lnInvoices.every(isNotError)).toBe(true)
 
     return testPastSelfInvoiceLimits({ walletId: walletIdBtc, accountId: accountIdB })
@@ -303,7 +303,7 @@ describe("Wallet - rate limiting test", () => {
       promises.push(lnInvoicePromise)
     }
     const lnInvoices = await Promise.all(promises)
-    const isNotError = (item) => !(item instanceof Error)
+    const isNotError = (item: unknown) => !(item instanceof Error)
     expect(lnInvoices.every(isNotError)).toBe(true)
 
     return testPastSelfInvoiceLimits({ walletId: walletIdBtc, accountId: accountIdB })
@@ -326,7 +326,7 @@ describe("Wallet - rate limiting test", () => {
       promises.push(lnInvoicePromise)
     }
     const lnInvoices = await Promise.all(promises)
-    const isNotError = (item) => !(item instanceof Error)
+    const isNotError = (item: unknown) => !(item instanceof Error)
     expect(lnInvoices.every(isNotError)).toBe(true)
 
     return testPastRecipientInvoiceLimits({
@@ -351,7 +351,7 @@ describe("Wallet - rate limiting test", () => {
       promises.push(lnInvoicePromise)
     }
     const lnInvoices = await Promise.all(promises)
-    const isNotError = (item) => !(item instanceof Error)
+    const isNotError = (item: unknown) => !(item instanceof Error)
     expect(lnInvoices.every(isNotError)).toBe(true)
 
     return testPastRecipientInvoiceLimits({

--- a/core/api/test/legacy-integration/notifications/notification.spec.ts
+++ b/core/api/test/legacy-integration/notifications/notification.spec.ts
@@ -20,6 +20,7 @@ import {
 import { WalletCurrency } from "@/domain/shared"
 import { GaloyNotificationCategories } from "@/domain/notifications"
 
+// @ts-ignore-next-line no-implicit-any error
 let spy
 let displayPriceRatios: Record<string, DisplayPriceRatio<"BTC", DisplayCurrency>>
 
@@ -85,6 +86,8 @@ beforeAll(async () => {
 })
 
 afterAll(async () => {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   spy.mockClear()
   // jest.restoreAllMocks()
 })

--- a/core/api/test/legacy-integration/services/cache/index.spec.ts
+++ b/core/api/test/legacy-integration/services/cache/index.spec.ts
@@ -7,7 +7,7 @@ import { uniqueAddressesForTxn } from "@/domain/bitcoin/onchain"
 
 import { RedisCacheService } from "@/services/cache"
 
-const randomString = (length) => {
+const randomString = (length: number) => {
   const sha256 = (buffer: Buffer) => createHash("sha256").update(buffer).digest("hex")
   return sha256(randomBytes(32)).slice(0, length)
 }
@@ -42,7 +42,7 @@ const incomingTxns: IncomingOnChainTransaction[] = [
   },
 ]
 
-const getOnChainTxs = async (key): Promise<IncomingOnChainTransaction[]> =>
+const getOnChainTxs = async (key: string): Promise<IncomingOnChainTransaction[]> =>
   redis.getOrSet({
     key,
     ttlSecs: SECS_PER_10_MINS,

--- a/core/api/test/legacy-integration/services/dealer/hedge-price.spec.ts
+++ b/core/api/test/legacy-integration/services/dealer/hedge-price.spec.ts
@@ -275,6 +275,7 @@ const getMaxBtcAmountToEarn = async ({
 }: {
   startingBtcAmount: BtcPaymentAmount
   accountAndWallets: AccountAndWallets
+  // @ts-ignore-next-line no-implicit-any error
   sentAmountFn
 }): Promise<BtcPaymentAmount> => {
   // 3 steps here to:
@@ -325,6 +326,8 @@ const getMinBtcAmountToSpend = async ({
 }: {
   startingBtcAmount: BtcPaymentAmount
   accountAndWallets: AccountAndWallets
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   sentAmountFn
 }): Promise<BtcPaymentAmount> => {
   let minBtcAmountToSpend = startingBtcAmount

--- a/core/api/test/legacy-integration/services/ledger/facade.spec.ts
+++ b/core/api/test/legacy-integration/services/ledger/facade.spec.ts
@@ -1,4 +1,3 @@
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "testInternalTx", "testExternalTx"] }] */
 import crypto from "crypto"
 
 import { ONE_DAY } from "@/config"
@@ -130,6 +129,8 @@ describe("Volumes", () => {
       calcFn,
     }: {
       recordTx: RecordExternalTxTestFn
+      /* eslint @typescript-eslint/ban-ts-comment: "off" */
+      // @ts-ignore-next-line no-implicit-any error
       calcFn: <S extends WalletCurrency>(a, b) => PaymentAmount<S>
     }) => {
       const currentVolumeAmount = await fetchVolumeAmount(
@@ -160,6 +161,7 @@ describe("Volumes", () => {
       recordTx: RecordInternalTxTestFn
       sender: WalletDescriptor<S>
       recipient: WalletDescriptor<R>
+      // @ts-ignore-next-line no-implicit-any error
       calcFn: <S extends WalletCurrency>(a, b) => PaymentAmount<S>
     }) => {
       const currentVolumeAmount = await fetchVolumeAmount(
@@ -182,16 +184,20 @@ describe("Volumes", () => {
 
     const sendVolumeCalc = calc.add
     const receiveVolumeCalc = calc.sub
+    // @ts-ignore-next-line no-implicit-any error
     const noVolumeCalc = (a) => a
 
     return {
       withVolumeEffect: {
+        // @ts-ignore-next-line no-implicit-any error
         testExternalTxSendWLE: (args) =>
           it(`${args.recordTx.name}`, async () =>
             testExternalTx({ ...args, calcFn: sendVolumeCalc })),
+        // @ts-ignore-next-line no-implicit-any error
         testExternalTxReceiveWLE: (args) =>
           it(`${args.recordTx.name}`, async () =>
             testExternalTx({ ...args, calcFn: receiveVolumeCalc })),
+        // @ts-ignore-next-line no-implicit-any error
         testInternalTxSendWLE: (args) =>
           it(`send ${args.recordTx.name}`, async () =>
             testInternalTx({
@@ -200,6 +206,7 @@ describe("Volumes", () => {
               recipient: walletDescriptorOther,
               calcFn: sendVolumeCalc,
             })),
+        // @ts-ignore-next-line no-implicit-any error
         testInternalTxReceiveWLE: (args) =>
           it(`receive ${args.recordTx.name}`, async () =>
             testInternalTx({
@@ -210,9 +217,11 @@ describe("Volumes", () => {
             })),
       },
       noVolumeEffect: {
+        // @ts-ignore-next-line no-implicit-any error
         testExternalTxNLE: (args) =>
           it(`${args.recordTx.name}`, async () =>
             testExternalTx({ ...args, calcFn: noVolumeCalc })),
+        // @ts-ignore-next-line no-implicit-any error
         testInternalTxSendNLE: (args) =>
           it(`send ${args.recordTx.name}`, async () =>
             testInternalTx({
@@ -221,6 +230,7 @@ describe("Volumes", () => {
               recipient: walletDescriptorOther,
               calcFn: noVolumeCalc,
             })),
+        // @ts-ignore-next-line no-implicit-any error
         testInternalTxReceiveNLE: (args) =>
           it(`receive ${args.recordTx.name}`, async () =>
             testInternalTx({
@@ -264,6 +274,7 @@ describe("Volumes", () => {
     volumeType,
   }: {
     volumeAmountFn: GetVolumeAmountSinceFn
+    // @ts-ignore-next-line no-implicit-any error
     volumeType
   }): fetchVolumeAmountType<S> => {
     const fetchVolumeAmountFn: fetchVolumeAmountType<S> = async (

--- a/core/api/test/legacy-integration/services/ledger/service.spec.ts
+++ b/core/api/test/legacy-integration/services/ledger/service.spec.ts
@@ -1,4 +1,3 @@
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "testInternalTx", "testExternalTx"] }] */
 import crypto from "crypto"
 
 import { ONE_DAY } from "@/config"
@@ -130,6 +129,8 @@ describe("Volumes", () => {
       calcFn,
     }: {
       recordTx: RecordExternalTxTestFn
+      /* eslint @typescript-eslint/ban-ts-comment: "off" */
+      // @ts-ignore-next-line no-implicit-any error
       calcFn: <S extends WalletCurrency>(a, b) => PaymentAmount<S>
     }) => {
       const currentVolumeAmount = await fetchVolumeAmount(
@@ -160,6 +161,7 @@ describe("Volumes", () => {
       recordTx: RecordInternalTxTestFn
       sender: WalletDescriptor<S>
       recipient: WalletDescriptor<R>
+      // @ts-ignore-next-line no-implicit-any error
       calcFn: <S extends WalletCurrency>(a, b) => PaymentAmount<S>
     }) => {
       const currentVolumeAmount = await fetchVolumeAmount(
@@ -182,16 +184,20 @@ describe("Volumes", () => {
 
     const sendVolumeCalc = calc.add
     const receiveVolumeCalc = calc.sub
+    // @ts-ignore-next-line no-implicit-any error
     const noVolumeCalc = (a) => a
 
     return {
       withVolumeEffect: {
+        // @ts-ignore-next-line no-implicit-any error
         testExternalTxSendWLE: (args) =>
           it(`${args.recordTx.name}`, async () =>
             testExternalTx({ ...args, calcFn: sendVolumeCalc })),
+        // @ts-ignore-next-line no-implicit-any error
         testExternalTxReceiveWLE: (args) =>
           it(`${args.recordTx.name}`, async () =>
             testExternalTx({ ...args, calcFn: receiveVolumeCalc })),
+        // @ts-ignore-next-line no-implicit-any error
         testInternalTxSendWLE: (args) =>
           it(`send ${args.recordTx.name}`, async () =>
             testInternalTx({
@@ -200,6 +206,7 @@ describe("Volumes", () => {
               recipient: walletDescriptorOther,
               calcFn: sendVolumeCalc,
             })),
+        // @ts-ignore-next-line no-implicit-any error
         testInternalTxReceiveWLE: (args) =>
           it(`receive ${args.recordTx.name}`, async () =>
             testInternalTx({
@@ -210,9 +217,11 @@ describe("Volumes", () => {
             })),
       },
       noVolumeEffect: {
+        // @ts-ignore-next-line no-implicit-any error
         testExternalTxNLE: (args) =>
           it(`${args.recordTx.name}`, async () =>
             testExternalTx({ ...args, calcFn: noVolumeCalc })),
+        // @ts-ignore-next-line no-implicit-any error
         testInternalTxSendNLE: (args) =>
           it(`send ${args.recordTx.name}`, async () =>
             testInternalTx({
@@ -221,6 +230,7 @@ describe("Volumes", () => {
               recipient: walletDescriptorOther,
               calcFn: noVolumeCalc,
             })),
+        // @ts-ignore-next-line no-implicit-any error
         testInternalTxReceiveNLE: (args) =>
           it(`receive ${args.recordTx.name}`, async () =>
             testInternalTx({
@@ -264,6 +274,7 @@ describe("Volumes", () => {
     volumeType,
   }: {
     volumeAmountFn: GetVolumeAmountSinceFn
+    // @ts-ignore-next-line no-implicit-any error
     volumeType
   }): fetchVolumeAmountType<S> => {
     const fetchVolumeAmountFn: fetchVolumeAmountType<S> = async (

--- a/core/api/test/legacy-integration/services/lnd/parse-errors.spec.ts
+++ b/core/api/test/legacy-integration/services/lnd/parse-errors.spec.ts
@@ -110,9 +110,15 @@ describe("'lightning' library error handling", () => {
 
     const nestedFailureErr = err[2].failures[0]
     expect(nestedFailureErr).toHaveLength(3)
+
+    /* eslint @typescript-eslint/ban-ts-comment: "off" */
+    // @ts-ignore-next-line no-implicit-any error
     expect(nestedFailureErr[0]).toEqual(err[0])
+
+    // @ts-ignore-next-line no-implicit-any error
     expect(nestedFailureErr[1]).toBe(err[1])
 
+    // @ts-ignore-next-line no-implicit-any error
     const nestedErrObj = nestedFailureErr[2].err
     expect(nestedErrObj).toBeInstanceOf(Error)
     expect(nestedErrObj).toHaveProperty("code")

--- a/core/api/test/legacy-integration/services/lnd/utils.spec.ts
+++ b/core/api/test/legacy-integration/services/lnd/utils.spec.ts
@@ -68,6 +68,8 @@ describe("lndUtils", () => {
       isCanceled = invoice.is_canceled
     })
 
+    /* eslint @typescript-eslint/ban-ts-comment: "off" */
+    // @ts-ignore-next-line no-implicit-any error
     await waitFor(() => isCanceled)
 
     sub.removeAllListeners()

--- a/core/api/test/legacy-integration/services/lock.spec.ts
+++ b/core/api/test/legacy-integration/services/lock.spec.ts
@@ -28,8 +28,11 @@ describe("Lock", () => {
 
 const walletId = "1234"
 
+/* eslint @typescript-eslint/ban-ts-comment: "off" */
+// @ts-ignore-next-line no-implicit-any error
 const checkLockExist = (client) =>
   new Promise((resolve) =>
+    // @ts-ignore-next-line no-implicit-any error
     client.get(walletId, (err, res) => {
       resolve(!!res)
     }),

--- a/core/api/test/legacy-integration/services/mongoose/wallet-onchain-pending-receive.spec.ts
+++ b/core/api/test/legacy-integration/services/mongoose/wallet-onchain-pending-receive.spec.ts
@@ -12,6 +12,9 @@ import { generateHash } from "test/helpers"
 
 // TODO: Remove this when we unify amounts in PartialBaseWalletTransaction and
 // BaseWalletTransaction types
+
+/* eslint @typescript-eslint/ban-ts-comment: "off" */
+// @ts-ignore-next-line no-implicit-any error
 const translatePendingToSettledTx = (pendingTx) => ({
   ...pendingTx,
   settlementAmount: Number(pendingTx.settlementAmount.amount),

--- a/core/api/test/unit/app/prices/get-current-price.spec.ts
+++ b/core/api/test/unit/app/prices/get-current-price.spec.ts
@@ -7,6 +7,8 @@ import { LocalCacheService } from "@/services/cache/local-cache"
 import { getCurrentSatPrice, getCurrentUsdCentPrice } from "@/app/prices"
 
 jest.mock("@/services/tracing", () => ({
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   wrapAsyncFunctionsToRunInSpan: ({ fns }) => fns,
 }))
 

--- a/core/api/test/unit/app/prices/get-price-history.spec.ts
+++ b/core/api/test/unit/app/prices/get-price-history.spec.ts
@@ -19,6 +19,8 @@ beforeEach(async () => {
 })
 
 jest.mock("@/services/tracing", () => ({
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   wrapAsyncFunctionsToRunInSpan: ({ fns }) => fns,
 }))
 

--- a/core/api/test/unit/app/prices/list-currencies.spec.ts
+++ b/core/api/test/unit/app/prices/list-currencies.spec.ts
@@ -5,6 +5,8 @@ import { PriceCurrenciesNotAvailableError } from "@/domain/price"
 import { listCurrencies } from "@/app/prices"
 
 jest.mock("@/services/tracing", () => ({
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   wrapAsyncFunctionsToRunInSpan: ({ fns }) => fns,
 }))
 

--- a/core/api/test/unit/config.spec.ts
+++ b/core/api/test/unit/config.spec.ts
@@ -9,6 +9,9 @@ import { toCents } from "@/domain/fiat"
 import { configSchema, getAccountLimits, yamlConfig } from "@/config"
 
 const ajv = new Ajv()
+
+/* eslint @typescript-eslint/ban-ts-comment: "off" */
+// @ts-ignore-next-line no-implicit-any error
 let validate
 
 const merge = (defaultConfig: unknown, customConfig: unknown) =>
@@ -42,6 +45,7 @@ describe("config.ts", () => {
     })
 
     it("passes validation with valid config", () => {
+      // @ts-ignore-next-line no-implicit-any error
       const valid = validate(yamlConfig)
       expect(valid).toBeTruthy()
 
@@ -70,6 +74,8 @@ describe("config.ts", () => {
       }
 
       const updatedYamlConfig = merge(freshYamlConfig, customYamlConfig)
+
+      // @ts-ignore-next-line no-implicit-any error
       const valid = validate(updatedYamlConfig)
       expect(valid).toBeTruthy()
     })
@@ -85,6 +91,8 @@ describe("config.ts", () => {
       }
 
       const updatedYamlConfig = merge(freshYamlConfig, customYamlConfig)
+
+      // @ts-ignore-next-line no-implicit-any error
       const valid = validate(updatedYamlConfig)
       expect(valid).toBeFalsy()
     })
@@ -92,6 +100,8 @@ describe("config.ts", () => {
     it("fails validation missing required property", () => {
       const clonedConfig = JSON.parse(JSON.stringify(yamlConfig))
       delete clonedConfig.buildVersion
+
+      // @ts-ignore-next-line no-implicit-any error
       const valid = validate(clonedConfig)
       expect(valid).toBeFalsy()
     })
@@ -101,6 +111,7 @@ describe("config.ts", () => {
       clonedConfig.cronConfig.swapEnabled = true
       delete clonedConfig.cronConfig.swapEnabled
 
+      // @ts-ignore-next-line no-implicit-any error
       const valid = validate(clonedConfig)
       expect(valid).toBeFalsy()
     })
@@ -108,6 +119,8 @@ describe("config.ts", () => {
     it("fails validation with additional property", () => {
       const clonedConfig = JSON.parse(JSON.stringify(yamlConfig))
       clonedConfig.newProperty = "NEW PROPERTY"
+
+      // @ts-ignore-next-line no-implicit-any error
       const valid = validate(clonedConfig)
       expect(valid).toBeFalsy()
     })
@@ -115,6 +128,8 @@ describe("config.ts", () => {
     it("fails validation with wrong type", () => {
       const clonedConfig = JSON.parse(JSON.stringify(yamlConfig))
       clonedConfig.buildVersion.android.minBuildNumber = "WRONG TYPE"
+
+      // @ts-ignore-next-line no-implicit-any error
       const valid = validate(clonedConfig)
       expect(valid).toBeFalsy()
     })

--- a/core/api/test/unit/domain/shared/amount-calculator.spec.ts
+++ b/core/api/test/unit/domain/shared/amount-calculator.spec.ts
@@ -77,7 +77,7 @@ describe("AmountCalculator", () => {
         down: "up",
       },
     ]
-    const itCases = ({ up, down }) => [
+    const itCases = ({ up, down }: { up: string; down: string }) => [
       {
         title: `no rounding if remainder is 0`,
         amount: pivot,
@@ -139,6 +139,9 @@ describe("AmountCalculator", () => {
         const { up, down } = describeGroup
         for (const testCase of itCases({ up, down })) {
           const { title, amount } = testCase
+
+          /* eslint @typescript-eslint/ban-ts-comment: "off" */
+          // @ts-ignore-next-line no-implicit-any error
           const expectedResult = testCase.result[describeGroup.type]
 
           it(`${title}`, () => {

--- a/core/api/test/unit/domain/wallets/settlement-amounts.spec.ts
+++ b/core/api/test/unit/domain/wallets/settlement-amounts.spec.ts
@@ -64,7 +64,7 @@ describe("SettlementAmounts", () => {
       cents: centsAmount - centsFee,
       display: displayAmount - displayFee,
     },
-  }
+  } as const
 
   describe("Check all possible BTC entries", () => {
     const txnForBtcWallet = {
@@ -74,8 +74,10 @@ describe("SettlementAmounts", () => {
     }
 
     describe("debit", () => {
-      for (const testCase of Object.keys(debitCreditScenarios)) {
-        it(`${testCase}`, () => {
+      for (const testCaseString of Object.keys(debitCreditScenarios)) {
+        it(`${testCaseString}`, () => {
+          const testCase = testCaseString as keyof typeof debitCreditScenarios
+
           const testValues = debitCreditScenarios[testCase]
           const debit = testValues.sats
 
@@ -109,8 +111,10 @@ describe("SettlementAmounts", () => {
     })
 
     describe("credit", () => {
-      for (const testCase of Object.keys(debitCreditScenarios)) {
-        it(`${testCase}`, () => {
+      for (const testCaseString of Object.keys(debitCreditScenarios)) {
+        it(`${testCaseString}`, () => {
+          const testCase = testCaseString as keyof typeof debitCreditScenarios
+
           const testValues = debitCreditScenarios[testCase]
           const credit = testValues.sats
 
@@ -152,8 +156,10 @@ describe("SettlementAmounts", () => {
     }
 
     describe("debit", () => {
-      for (const testCase of Object.keys(debitCreditScenarios)) {
-        it(`${testCase}`, () => {
+      for (const testCaseString of Object.keys(debitCreditScenarios)) {
+        it(`${testCaseString}`, () => {
+          const testCase = testCaseString as keyof typeof debitCreditScenarios
+
           const testValues = debitCreditScenarios[testCase]
           const debit = testValues.cents
 
@@ -187,8 +193,10 @@ describe("SettlementAmounts", () => {
     })
 
     describe("credit", () => {
-      for (const testCase of Object.keys(debitCreditScenarios)) {
-        it(`${testCase}`, () => {
+      for (const testCaseString of Object.keys(debitCreditScenarios)) {
+        it(`${testCaseString}`, () => {
+          const testCase = testCaseString as keyof typeof debitCreditScenarios
+
           const testValues = debitCreditScenarios[testCase]
           const credit = testValues.cents
 

--- a/core/api/test/unit/payments/onchain-payment-flow-builder.spec.ts
+++ b/core/api/test/unit/payments/onchain-payment-flow-builder.spec.ts
@@ -21,6 +21,17 @@ import { ImbalanceCalculator } from "@/domain/ledger/imbalance-calculator"
 const feeConfig = getFeesConfig()
 const { dustThreshold } = getOnChainWalletConfig()
 
+interface ConversionBtc {
+  sats: number
+  spread: number
+  round: (x: number) => number
+}
+interface ConversionUsd {
+  cents: number
+  spread: number
+  round: (x: number) => number
+}
+
 describe("OnChainPaymentFlowBuilder", () => {
   const address = "address" as OnChainAddress
   const uncheckedAmount = 10000
@@ -92,9 +103,9 @@ describe("OnChainPaymentFlowBuilder", () => {
   const immediateSpread = 0.001 // 0.10 %
   // const futureSpread = 0.0012 // 0.12%
 
-  const centsFromSats = ({ sats, spread, round }): bigint =>
+  const centsFromSats = ({ sats, spread, round }: ConversionBtc): bigint =>
     BigInt(round(sats * midPriceRatio * spread))
-  const satsFromCents = ({ cents, spread, round }): bigint =>
+  const satsFromCents = ({ cents, spread, round }: ConversionUsd): bigint =>
     BigInt(round((cents / midPriceRatio) * spread))
 
   const usdFromBtcMid = async (amount: BtcPaymentAmount) => {
@@ -201,6 +212,9 @@ describe("OnChainPaymentFlowBuilder", () => {
 
     describe("with address", () => {
       const withAddressBuilder = onChainBuilder.withAddress(address)
+
+      /* eslint @typescript-eslint/ban-ts-comment: "off" */
+      // @ts-ignore-next-line no-implicit-any error
       const checkAddress = (payment) => {
         expect(payment).toEqual(
           expect.objectContaining({
@@ -215,6 +229,7 @@ describe("OnChainPaymentFlowBuilder", () => {
           account: senderAccount,
         })
 
+        // @ts-ignore-next-line no-implicit-any error
         const checkSenderWallet = (payment) => {
           expect(payment).toEqual(
             expect.objectContaining({
@@ -238,6 +253,7 @@ describe("OnChainPaymentFlowBuilder", () => {
 
         const amountCurrency = WalletCurrency.Btc
         describe("onchain settled", () => {
+          // @ts-ignore-next-line no-implicit-any error
           const checkSettlementMethod = (payment) => {
             expect(payment).toEqual(
               expect.objectContaining({
@@ -253,6 +269,8 @@ describe("OnChainPaymentFlowBuilder", () => {
               const withAmountBuilder = withBtcWalletBuilder
                 .withoutRecipientWallet()
                 .withAmount({ amount: BigInt(uncheckedAmount), currency: amountCurrency })
+
+              // @ts-ignore-next-line no-implicit-any error
               const checkInputAmount = (payment) => {
                 expect(payment).toEqual(
                   expect.objectContaining({
@@ -365,6 +383,7 @@ describe("OnChainPaymentFlowBuilder", () => {
         })
 
         describe("intraledger settled", () => {
+          // @ts-ignore-next-line no-implicit-any error
           const checkSettlementMethod = (payment) => {
             expect(payment).toEqual(
               expect.objectContaining({
@@ -379,6 +398,7 @@ describe("OnChainPaymentFlowBuilder", () => {
           describe("with btc recipient wallet", () => {
             const convertForBtcWalletToBtcWallet = mid
 
+            // @ts-ignore-next-line no-implicit-any error
             const checkRecipientWallet = (payment) => {
               expect(payment).toEqual(
                 expect.objectContaining({
@@ -399,6 +419,7 @@ describe("OnChainPaymentFlowBuilder", () => {
                 currency: amountCurrency,
               })
 
+              // @ts-ignore-next-line no-implicit-any error
               const checkInputAmount = (payment) => {
                 expect(payment).toEqual(
                   expect.objectContaining({
@@ -441,6 +462,7 @@ describe("OnChainPaymentFlowBuilder", () => {
                 currency: amountCurrency,
               })
 
+              // @ts-ignore-next-line no-implicit-any error
               const checkInputAmount = (payment) => {
                 expect(payment).toEqual(
                   expect.objectContaining({
@@ -483,6 +505,7 @@ describe("OnChainPaymentFlowBuilder", () => {
                 currency: amountCurrency,
               })
 
+              // @ts-ignore-next-line no-implicit-any error
               const checkInputAmount = (payment) => {
                 expect(payment).toEqual(
                   expect.objectContaining({
@@ -522,6 +545,7 @@ describe("OnChainPaymentFlowBuilder", () => {
           describe("with usd recipient wallet", () => {
             const convertForBtcWalletToUsdWallet = hedgeBuyUsd
 
+            // @ts-ignore-next-line no-implicit-any error
             const checkRecipientWallet = (payment) => {
               expect(payment).toEqual(
                 expect.objectContaining({
@@ -547,6 +571,8 @@ describe("OnChainPaymentFlowBuilder", () => {
                 amount: BigInt(amount),
                 currency: amountCurrency,
               })
+
+              // @ts-ignore-next-line no-implicit-any error
               const checkInputAmount = (payment) => {
                 expect(payment).toEqual(
                   expect.objectContaining({
@@ -588,6 +614,8 @@ describe("OnChainPaymentFlowBuilder", () => {
                 amount: BigInt(amount),
                 currency: amountCurrency,
               })
+
+              // @ts-ignore-next-line no-implicit-any error
               const checkInputAmount = (payment) => {
                 expect(payment).toEqual(
                   expect.objectContaining({
@@ -629,6 +657,8 @@ describe("OnChainPaymentFlowBuilder", () => {
                 amount: BigInt(amount),
                 currency: amountCurrency,
               })
+
+              // @ts-ignore-next-line no-implicit-any error
               const checkInputAmount = (payment) => {
                 expect(payment).toEqual(
                   expect.objectContaining({
@@ -703,6 +733,7 @@ describe("OnChainPaymentFlowBuilder", () => {
           account: senderAccount,
         })
 
+        // @ts-ignore-next-line no-implicit-any error
         const checkSenderWallet = (payment) => {
           expect(payment).toEqual(
             expect.objectContaining({
@@ -731,6 +762,7 @@ describe("OnChainPaymentFlowBuilder", () => {
         for (const { amountCurrency, uncheckedAmount } of amountCurrencyCases) {
           describe(`${amountCurrency.toLowerCase()} send amount`, () => {
             describe("onchain settled", () => {
+              // @ts-ignore-next-line no-implicit-any error
               const checkSettlementMethod = (payment) => {
                 expect(payment).toEqual(
                   expect.objectContaining({
@@ -751,6 +783,8 @@ describe("OnChainPaymentFlowBuilder", () => {
                       amount: BigInt(uncheckedAmount),
                       currency: amountCurrency,
                     })
+
+                  // @ts-ignore-next-line no-implicit-any error
                   const checkInputAmount = (payment) => {
                     expect(payment).toEqual(
                       expect.objectContaining({
@@ -891,6 +925,7 @@ describe("OnChainPaymentFlowBuilder", () => {
             })
 
             describe("intraledger settled", () => {
+              // @ts-ignore-next-line no-implicit-any error
               const checkSettlementMethod = (payment) => {
                 expect(payment).toEqual(
                   expect.objectContaining({
@@ -905,6 +940,7 @@ describe("OnChainPaymentFlowBuilder", () => {
               describe("with btc recipient wallet", () => {
                 const convertForUsdWalletToBtcWallet = hedgeSellUsd
 
+                // @ts-ignore-next-line no-implicit-any error
                 const checkRecipientWallet = (payment) => {
                   expect(payment).toEqual(
                     expect.objectContaining({
@@ -924,6 +960,8 @@ describe("OnChainPaymentFlowBuilder", () => {
                     amount: BigInt(amount),
                     currency: amountCurrency,
                   })
+
+                  // @ts-ignore-next-line no-implicit-any error
                   const checkInputAmount = (payment) => {
                     expect(payment).toEqual(
                       expect.objectContaining({
@@ -978,6 +1016,8 @@ describe("OnChainPaymentFlowBuilder", () => {
                     amount: BigInt(amount),
                     currency: amountCurrency,
                   })
+
+                  // @ts-ignore-next-line no-implicit-any error
                   const checkInputAmount = (payment) => {
                     expect(payment).toEqual(
                       expect.objectContaining({
@@ -1030,6 +1070,7 @@ describe("OnChainPaymentFlowBuilder", () => {
               describe("with usd recipient wallet", () => {
                 const convertForUsdWalletToUsdWallet = mid
 
+                // @ts-ignore-next-line no-implicit-any error
                 const checkRecipientWallet = (payment) => {
                   expect(payment).toEqual(
                     expect.objectContaining({
@@ -1049,6 +1090,8 @@ describe("OnChainPaymentFlowBuilder", () => {
                     amount: BigInt(amount),
                     currency: amountCurrency,
                   })
+
+                  // @ts-ignore-next-line no-implicit-any error
                   const checkInputAmount = (payment) => {
                     expect(payment).toEqual(
                       expect.objectContaining({
@@ -1105,6 +1148,8 @@ describe("OnChainPaymentFlowBuilder", () => {
                     amount: BigInt(amount),
                     currency: amountCurrency,
                   })
+
+                  // @ts-ignore-next-line no-implicit-any error
                   const checkInputAmount = (payment) => {
                     expect(payment).toEqual(
                       expect.objectContaining({

--- a/core/api/test/unit/payments/payment-flow-builder.spec.ts
+++ b/core/api/test/unit/payments/payment-flow-builder.spec.ts
@@ -16,6 +16,17 @@ const skippedPubkey =
 const skippedChanId = "1x0x0" as ChanId
 const skipProbe = { pubkey: [skippedPubkey], chanId: [skippedChanId] }
 
+interface ConversionBtc {
+  sats: number
+  spread: number
+  round: (x: number) => number
+}
+interface ConversionUsd {
+  cents: number
+  spread: number
+  round: (x: number) => number
+}
+
 describe("LightningPaymentFlowBuilder", () => {
   const paymentRequestWithAmount =
     "lnbc210u1p32zq9xpp5dpzhj6e7y6d4ggs6awh7m4eupuemas0gq06pqjgy9tq35740jlfsdqqcqzpgxqyz5vqsp58t3zalj5sc563g0xpcgx9lfkeqrx7m7xw53v2txc2pr60jcwn0vq9qyyssqkatadajwt0n285teummg4urul9t3shddnf05cfxzsfykvscxm4zqz37j87sahvz3kul0lzgz2svltdm933yr96du84zpyn8rx6fst4sp43jh32" as EncodedPaymentRequest
@@ -104,16 +115,16 @@ describe("LightningPaymentFlowBuilder", () => {
   const immediateSpread = 0.001 // 0.10 %
   // const futureSpread = 0.0012 // 0.12%
 
-  const centsFromSatsForMid = ({ sats, spread, round }): bigint => {
+  const centsFromSatsForMid = ({ sats, spread, round }: ConversionBtc): bigint => {
     if (Number(sats) === 0) return 0n
 
     const result = BigInt(round(sats * midPriceRatio * spread))
     return result || 1n
   }
 
-  const centsFromSats = ({ sats, spread, round }): bigint =>
+  const centsFromSats = ({ sats, spread, round }: ConversionBtc): bigint =>
     BigInt(round(sats * midPriceRatio * spread))
-  const satsFromCents = ({ cents, spread, round }): bigint =>
+  const satsFromCents = ({ cents, spread, round }: ConversionUsd): bigint =>
     BigInt(round((cents / midPriceRatio) * spread))
 
   const usdFromBtcMid = async (amount: BtcPaymentAmount) => {
@@ -193,6 +204,9 @@ describe("LightningPaymentFlowBuilder", () => {
       localNodeIds: [],
       skipProbe,
     })
+
+    /* eslint @typescript-eslint/ban-ts-comment: "off" */
+    // @ts-ignore-next-line no-implicit-any error
     const checkSettlementMethod = (payment) => {
       expect(payment).toEqual(
         expect.objectContaining({
@@ -210,6 +224,7 @@ describe("LightningPaymentFlowBuilder", () => {
       const withSkippedChanIdAmountBuilder = lightningBuilder.withInvoice(
         skippedChanIdInvoiceWithAmount,
       )
+      // @ts-ignore-next-line no-implicit-any error
       const checkInvoice = (payment) => {
         expect(payment).toEqual(
           expect.objectContaining({
@@ -232,6 +247,7 @@ describe("LightningPaymentFlowBuilder", () => {
           .withSenderWallet(senderBtcWalletDescriptor)
           .withoutRecipientWallet()
 
+        // @ts-ignore-next-line no-implicit-any error
         const checkSenderWallet = (payment) => {
           expect(payment).toEqual(
             expect.objectContaining({
@@ -345,6 +361,7 @@ describe("LightningPaymentFlowBuilder", () => {
           .withSenderWallet(senderUsdWalletDescriptor)
           .withoutRecipientWallet()
 
+        // @ts-ignore-next-line no-implicit-any error
         const checkSenderWallet = (payment) => {
           expect(payment).toEqual(
             expect.objectContaining({
@@ -436,6 +453,7 @@ describe("LightningPaymentFlowBuilder", () => {
         invoice: invoiceWithNoAmount,
         uncheckedAmount: Number(uncheckedAmount),
       })
+      // @ts-ignore-next-line no-implicit-any error
       const checkInvoice = (payment) => {
         expect(payment).toEqual(
           expect.objectContaining({
@@ -450,6 +468,7 @@ describe("LightningPaymentFlowBuilder", () => {
           .withSenderWallet(senderBtcWalletDescriptor)
           .withoutRecipientWallet()
 
+        // @ts-ignore-next-line no-implicit-any error
         const checkSenderWallet = (payment) => {
           expect(payment).toEqual(
             expect.objectContaining({
@@ -513,6 +532,7 @@ describe("LightningPaymentFlowBuilder", () => {
           .withSenderWallet(senderUsdWalletDescriptor)
           .withoutRecipientWallet()
 
+        // @ts-ignore-next-line no-implicit-any error
         const checkSenderWallet = (payment) => {
           expect(payment).toEqual(
             expect.objectContaining({
@@ -562,6 +582,8 @@ describe("LightningPaymentFlowBuilder", () => {
       localNodeIds: [invoiceWithAmount.destination, invoiceWithNoAmount.destination],
       skipProbe,
     })
+
+    // @ts-ignore-next-line no-implicit-any error
     const checkSettlementMethod = (payment) => {
       expect(payment).toEqual(
         expect.objectContaining({
@@ -574,6 +596,8 @@ describe("LightningPaymentFlowBuilder", () => {
     }
     describe("invoice with amount", () => {
       const withAmountBuilder = intraledgerBuilder.withInvoice(invoiceWithAmount)
+
+      // @ts-ignore-next-line no-implicit-any error
       const checkInvoice = (payment) => {
         expect(payment).toEqual(
           expect.objectContaining({
@@ -587,6 +611,7 @@ describe("LightningPaymentFlowBuilder", () => {
           senderBtcWalletDescriptor,
         )
 
+        // @ts-ignore-next-line no-implicit-any error
         const checkSenderWallet = (payment) => {
           expect(payment).toEqual(
             expect.objectContaining({
@@ -599,6 +624,8 @@ describe("LightningPaymentFlowBuilder", () => {
         describe("with btc recipient", () => {
           const withBtcRecipientBuilder =
             withBtcWalletBuilder.withRecipientWallet(recipientBtcArgs)
+
+          // @ts-ignore-next-line no-implicit-any error
           const checkRecipientWallet = (payment) => {
             expect(payment).toEqual(
               expect.objectContaining({
@@ -651,6 +678,8 @@ describe("LightningPaymentFlowBuilder", () => {
             ...recipientUsdArgs,
             usdPaymentAmount,
           })
+
+          // @ts-ignore-next-line no-implicit-any error
           const checkRecipientWallet = (payment) => {
             expect(payment).toEqual(
               expect.objectContaining({
@@ -693,6 +722,7 @@ describe("LightningPaymentFlowBuilder", () => {
           senderUsdWalletDescriptor,
         )
 
+        // @ts-ignore-next-line no-implicit-any error
         const checkSenderWallet = (payment) => {
           expect(payment).toEqual(
             expect.objectContaining({
@@ -705,6 +735,8 @@ describe("LightningPaymentFlowBuilder", () => {
         describe("with btc recipient", () => {
           const withBtcRecipientBuilder =
             withUsdWalletBuilder.withRecipientWallet(recipientBtcArgs)
+
+          // @ts-ignore-next-line no-implicit-any error
           const checkRecipientWallet = (payment) => {
             expect(payment).toEqual(
               expect.objectContaining({
@@ -757,6 +789,8 @@ describe("LightningPaymentFlowBuilder", () => {
             ...recipientUsdArgs,
             usdPaymentAmount,
           })
+
+          // @ts-ignore-next-line no-implicit-any error
           const checkRecipientWallet = (payment) => {
             expect(payment).toEqual(
               expect.objectContaining({
@@ -809,6 +843,7 @@ describe("LightningPaymentFlowBuilder", () => {
         uncheckedAmount: Number(lessThan1CentAmount),
       })
 
+      // @ts-ignore-next-line no-implicit-any error
       const checkInvoice = (payment) => {
         expect(payment).toEqual(
           expect.objectContaining({
@@ -824,6 +859,7 @@ describe("LightningPaymentFlowBuilder", () => {
         const lessThan1CentWithBtcWalletBuilder =
           lessThan1CentWithAmountBuilder.withSenderWallet(senderBtcWalletDescriptor)
 
+        // @ts-ignore-next-line no-implicit-any error
         const checkSenderWallet = (payment) => {
           expect(payment).toEqual(
             expect.objectContaining({
@@ -843,6 +879,7 @@ describe("LightningPaymentFlowBuilder", () => {
           const lessThan1CentWithBtcRecipientBuilder =
             lessThan1CentWithBtcWalletBuilder.withRecipientWallet(recipientBtcArgs)
 
+          // @ts-ignore-next-line no-implicit-any error
           const checkRecipientWallet = (payment) => {
             expect(payment).toEqual(
               expect.objectContaining({
@@ -927,6 +964,7 @@ describe("LightningPaymentFlowBuilder", () => {
               senderUsdAsRecipientArgs,
             )
 
+          // @ts-ignore-next-line no-implicit-any error
           const checkRecipientWallet = (payment) => {
             expect(payment).toEqual(
               expect.objectContaining({
@@ -1023,6 +1061,7 @@ describe("LightningPaymentFlowBuilder", () => {
           senderUsdWalletDescriptor,
         )
 
+        // @ts-ignore-next-line no-implicit-any error
         const checkSenderWallet = (payment) => {
           expect(payment).toEqual(
             expect.objectContaining({
@@ -1039,6 +1078,8 @@ describe("LightningPaymentFlowBuilder", () => {
         describe("with btc recipient", () => {
           const withBtcRecipientBuilder =
             withUsdWalletBuilder.withRecipientWallet(recipientBtcArgs)
+
+          // @ts-ignore-next-line no-implicit-any error
           const checkRecipientWallet = (payment) => {
             expect(payment).toEqual(
               expect.objectContaining({
@@ -1086,6 +1127,8 @@ describe("LightningPaymentFlowBuilder", () => {
         describe("with usd recipient", () => {
           const withUsdRecipientBuilder =
             withUsdWalletBuilder.withRecipientWallet(recipientUsdArgs)
+
+          // @ts-ignore-next-line no-implicit-any error
           const checkRecipientWallet = (payment) => {
             expect(payment).toEqual(
               expect.objectContaining({
@@ -1140,6 +1183,8 @@ describe("LightningPaymentFlowBuilder", () => {
       localNodeIds: [],
       skipProbe,
     })
+
+    // @ts-ignore-next-line no-implicit-any error
     const checkSettlementMethod = (payment) => {
       expect(payment).toEqual(
         expect.objectContaining({
@@ -1163,6 +1208,7 @@ describe("LightningPaymentFlowBuilder", () => {
         description: "",
       })
 
+      // @ts-ignore-next-line no-implicit-any error
       const checkInvoice = (payment) => {
         expect(payment).toEqual(
           expect.objectContaining({
@@ -1178,6 +1224,7 @@ describe("LightningPaymentFlowBuilder", () => {
         const lessThan1CentWithBtcWalletBuilder =
           lessThan1CentWithAmountBuilder.withSenderWallet(senderBtcWalletDescriptor)
 
+        // @ts-ignore-next-line no-implicit-any error
         const checkSenderWallet = (payment) => {
           expect(payment).toEqual(
             expect.objectContaining({
@@ -1198,6 +1245,7 @@ describe("LightningPaymentFlowBuilder", () => {
           const lessThan1CentWithBtcRecipientBuilder =
             lessThan1CentWithBtcWalletBuilder.withRecipientWallet(recipientBtcArgs)
 
+          // @ts-ignore-next-line no-implicit-any error
           const checkRecipientWallet = (payment) => {
             expect(payment).toEqual(
               expect.objectContaining({
@@ -1282,6 +1330,7 @@ describe("LightningPaymentFlowBuilder", () => {
               senderUsdAsRecipientArgs,
             )
 
+          // @ts-ignore-next-line no-implicit-any error
           const checkRecipientWallet = (payment) => {
             expect(payment).toEqual(
               expect.objectContaining({
@@ -1378,6 +1427,7 @@ describe("LightningPaymentFlowBuilder", () => {
           senderUsdWalletDescriptor,
         )
 
+        // @ts-ignore-next-line no-implicit-any error
         const checkSenderWallet = (payment) => {
           expect(payment).toEqual(
             expect.objectContaining({
@@ -1394,6 +1444,8 @@ describe("LightningPaymentFlowBuilder", () => {
         describe("with btc recipient", () => {
           const withBtcRecipientBuilder =
             withUsdWalletBuilder.withRecipientWallet(recipientBtcArgs)
+
+          // @ts-ignore-next-line no-implicit-any error
           const checkRecipientWallet = (payment) => {
             expect(payment).toEqual(
               expect.objectContaining({
@@ -1441,6 +1493,8 @@ describe("LightningPaymentFlowBuilder", () => {
         describe("with usd recipient", () => {
           const withUsdRecipientBuilder =
             withUsdWalletBuilder.withRecipientWallet(recipientUsdArgs)
+
+          // @ts-ignore-next-line no-implicit-any error
           const checkRecipientWallet = (payment) => {
             expect(payment).toEqual(
               expect.objectContaining({

--- a/core/api/test/unit/services/ipfetcher/fetch-ip-info.spec.ts
+++ b/core/api/test/unit/services/ipfetcher/fetch-ip-info.spec.ts
@@ -3,6 +3,8 @@ import MockAdapter from "axios-mock-adapter"
 
 import { IpFetcher } from "@/services/ipfetcher"
 
+/* eslint @typescript-eslint/ban-ts-comment: "off" */
+// @ts-ignore-next-line no-implicit-any error
 let mock
 
 beforeAll(() => {
@@ -10,12 +12,14 @@ beforeAll(() => {
 })
 
 afterEach(() => {
+  // @ts-ignore-next-line no-implicit-any error
   mock.reset()
 })
 
 describe("IpFetcher - fetchIPInfo", () => {
   it("returns proxy false when proxy is no", async () => {
     const ip = "152.231.190.229" as IpAddress
+    // @ts-ignore-next-line no-implicit-any error
     mock.onGet(new RegExp(`${ip}`)).reply(200, getIpInfo(ip))
 
     const ipInfo = await IpFetcher().fetchIPInfo(ip)
@@ -30,8 +34,10 @@ describe("IpFetcher - fetchIPInfo", () => {
   it("returns proxy true when proxy is yes", async () => {
     const ip = "152.231.190.229" as IpAddress
     const data = getIpInfo(ip)
+    // @ts-ignore-next-line no-implicit-any error
     data[ip]["proxy"] = "yes"
 
+    // @ts-ignore-next-line no-implicit-any error
     mock.onGet(new RegExp(`${ip}`)).reply(200, data)
 
     const ipInfo = await IpFetcher().fetchIPInfo(ip)
@@ -46,8 +52,11 @@ describe("IpFetcher - fetchIPInfo", () => {
   it("returns proxy false when proxy is undefined", async () => {
     const ip = "152.231.190.229" as IpAddress
     const data = getIpInfo(ip)
+
+    // @ts-ignore-next-line no-implicit-any error
     delete data[ip]["proxy"]
 
+    // @ts-ignore-next-line no-implicit-any error
     mock.onGet(new RegExp(`${ip}`)).reply(200, data)
 
     const ipInfo = await IpFetcher().fetchIPInfo(ip)

--- a/core/api/test/unit/services/ledger/domain/entry-builder.spec.ts
+++ b/core/api/test/unit/services/ledger/domain/entry-builder.spec.ts
@@ -27,7 +27,10 @@ describe("EntryBuilder", () => {
     return entry
   }
 
-  const expectEntryToEqual = (entry: ILedgerTransaction, amount) => {
+  const expectEntryToEqual = (
+    entry: ILedgerTransaction,
+    amount: Amount<WalletCurrency>,
+  ) => {
     expect(entry.debit + entry.credit).toEqual(Number(amount.amount))
     expect(entry.currency).toEqual(amount.currency)
   }

--- a/core/api/test/unit/services/ledger/domain/fee-only-entry-builder.spec.ts
+++ b/core/api/test/unit/services/ledger/domain/fee-only-entry-builder.spec.ts
@@ -15,7 +15,10 @@ describe("FeeOnlyEntryBuilder", () => {
     return entry
   }
 
-  const expectEntryToEqual = (entry: ILedgerTransaction, amount) => {
+  const expectEntryToEqual = (
+    entry: ILedgerTransaction,
+    amount: Amount<WalletCurrency>,
+  ) => {
     expect(entry.debit + entry.credit).toEqual(Number(amount.amount))
     expect(entry.currency).toEqual(amount.currency)
   }

--- a/core/api/test/unit/services/ledger/domain/tx-metadata.spec.ts
+++ b/core/api/test/unit/services/ledger/domain/tx-metadata.spec.ts
@@ -100,14 +100,19 @@ describe("Tx metadata", () => {
             pubkey: Pubkey
           }
         | undefined
+      /* eslint @typescript-eslint/ban-ts-comment: "off" */
+      // @ts-ignore-next-line no-implicit-any error
       expectedCommonMetadata
+      // @ts-ignore-next-line no-implicit-any error
       expectedAdditionalDebitMetadata
       crossAccount: {
+        // @ts-ignore-next-line no-implicit-any error
         MetadataFn
         title: string
         type: LedgerTransactionType
       }
       selfTrade: {
+        // @ts-ignore-next-line no-implicit-any error
         MetadataFn
         title: string
         type: LedgerTransactionType

--- a/core/api/test/unit/utils/grpc-stream-client/stream.spec.ts
+++ b/core/api/test/unit/utils/grpc-stream-client/stream.spec.ts
@@ -12,11 +12,17 @@ afterAll(() => {
 })
 
 describe("Stream", () => {
+  /* eslint @typescript-eslint/ban-ts-comment: "off" */
+  // @ts-ignore-next-line no-implicit-any error
   let mockStreamMethod
+  // @ts-ignore-next-line no-implicit-any error
   let mockGrpcData
+  // @ts-ignore-next-line no-implicit-any error
   let mockMetaData
+  // @ts-ignore-next-line no-implicit-any error
   let mockBackoff
   let mockOptions
+  // @ts-ignore-next-line no-implicit-any error
   let mockStream
 
   beforeEach(() => {
@@ -28,6 +34,7 @@ describe("Stream", () => {
 
     mockStream = new Stream(
       mockStreamMethod,
+      // @ts-ignore-next-line no-implicit-any error
       mockGrpcData,
       mockMetaData,
       mockBackoff,
@@ -37,37 +44,52 @@ describe("Stream", () => {
 
   it("should add a listener to the specified event", () => {
     const mockListener = jest.fn()
+    // @ts-ignore-next-line no-implicit-any error
     mockStream.addEventListener(StreamEvents.data, mockListener)
+    // @ts-ignore-next-line no-implicit-any error
     expect(mockStream.eventListeners.data).toHaveLength(1)
   })
 
   it("should remove a listener from the specified event", () => {
     const mockListener = jest.fn()
+    // @ts-ignore-next-line no-implicit-any error
     mockStream.addEventListener(StreamEvents.data, mockListener)
+    // @ts-ignore-next-line no-implicit-any error
     mockStream.removeEventListener(StreamEvents.data, mockListener)
+    // @ts-ignore-next-line no-implicit-any error
     expect(mockStream.eventListeners.data).toHaveLength(0)
   })
 
   it("should create a new stream using the provided method", () => {
+    // @ts-ignore-next-line no-implicit-any error
     mockStreamMethod.mockClear()
+    // @ts-ignore-next-line no-implicit-any error
     mockStream.connect()
+    // @ts-ignore-next-line no-implicit-any error
     expect(mockStreamMethod).toHaveBeenCalledWith(mockGrpcData, mockMetaData)
   })
 
   it("should dispatch the event to the listeners", () => {
     const mockListener = jest.fn()
     const mockEvent = {} as ServiceError
+    // @ts-ignore-next-line no-implicit-any error
     mockStream.addEventListener(StreamEvents.error, mockListener)
+    // @ts-ignore-next-line no-implicit-any error
     mockStream.handleEvent(StreamEvents.error, mockEvent)
+    // @ts-ignore-next-line no-implicit-any error
     expect(mockListener).toHaveBeenCalledWith(mockStream, mockEvent)
   })
 
   it("should schedule a reconnect using backoff", () => {
     const backoff = 5000
+    // @ts-ignore-next-line no-implicit-any error
     mockBackoff.next.mockReturnValue(backoff)
+    // @ts-ignore-next-line no-implicit-any error
     mockStreamMethod.mockClear()
+    // @ts-ignore-next-line no-implicit-any error
     mockStream.reconnect()
     jest.advanceTimersByTime(backoff)
+    // @ts-ignore-next-line no-implicit-any error
     expect(mockStreamMethod).toHaveBeenCalledWith(mockGrpcData, mockMetaData)
   })
 })

--- a/core/api/tsconfig.json
+++ b/core/api/tsconfig.json
@@ -5,7 +5,6 @@
     "sourceMap": true,
     "strict": true,
     "target": "es2020",
-    "noImplicitAny": false,
     "esModuleInterop": true,
     "baseUrl": "./",
     "moduleResolution": "node",


### PR DESCRIPTION
this would enable us to activate noImplicitAny everywhere, and help us not add more to the tests/migration files