### PR TITLE
fix: #3311

### DIFF
--- a/core/api/dev/ory/kratos.yml
+++ b/core/api/dev/ory/kratos.yml
@@ -60,7 +60,9 @@ selfservice:
 
     settings:
       ui_url: http://127.0.0.1:4002/settings
-      privileged_session_max_age: 15m
+
+      # very short time frame because this has impact in the totp flow
+      privileged_session_max_age: 1s
 
       # to enforce the user to paste his 2fa to deactivate it, this could be set to highest_available
       required_aal: aal1

--- a/core/api/src/services/kratos/totp.ts
+++ b/core/api/src/services/kratos/totp.ts
@@ -40,6 +40,10 @@ export const kratosValidateTotp = async ({
   totpCode: string
   totpRegistrationId: string
 }) => {
+  // TODO: instead of refreshing, we could ask the user to re-authenticate
+  const res = await refreshToken(authToken)
+  if (res instanceof Error) return res
+
   try {
     await kratosPublic.updateSettingsFlow({
       flow,

--- a/core/api/test/bats/auth.bats
+++ b/core/api/test/bats/auth.bats
@@ -190,6 +190,8 @@ generateTotpCode() {
 @test "auth: adding totp" {
   authToken=$(read_value "$TOKEN_NAME")
 
+  sleep 2
+
   # Initiate TOTP Registration
   variables="{\"input\": {\"authToken\": \"$authToken\"}}"
   exec_graphql 'charlie' 'user-totp-registration-initiate' "$variables"


### PR DESCRIPTION
adding 2fa requires privilege session.

for now, we elevate the session when we add totp (the same way we do when we remove totp).

as a follow up, eventually, we should re-authenticate the user when doing those operations. 


this PR removes an active alert everytime someone try to set up 2fa. 