### PR TITLE
chore: record paymentRequest with WalletInvoice

### DIFF
--- a/core/api/src/domain/wallet-invoices/index.types.d.ts
+++ b/core/api/src/domain/wallet-invoices/index.types.d.ts
@@ -74,7 +74,7 @@ type WIBWithAmountState = WIBWithExpirationState & {
 }
 
 type LnAndWalletInvoice = {
-  walletInvoice: WalletInvoice
+  walletInvoice: WalletInvoice & { paymentRequest: EncodedPaymentRequest }
   lnInvoice: LnInvoice
 }
 
@@ -91,6 +91,7 @@ type WalletInvoice = {
   recipientWalletDescriptor: PartialWalletDescriptor<WalletCurrency>
   paid: boolean
   createdAt: Date
+  paymentRequest?: EncodedPaymentRequest
 }
 
 type WalletAddress<S extends WalletCurrency> = {
@@ -156,7 +157,9 @@ type WalletAddressReceiverArgs<S extends WalletCurrency> = {
   walletAddress: WalletAddress<S>
 }
 
-type WalletInvoicesPersistNewArgs = Omit<WalletInvoice, "createdAt">
+type WalletInvoicesPersistNewArgs = Omit<WalletInvoice, "createdAt"> & {
+  paymentRequest: EncodedPaymentRequest
+}
 
 interface IWalletInvoicesRepository {
   persistNew: (

--- a/core/api/src/domain/wallet-invoices/wallet-invoice-builder.ts
+++ b/core/api/src/domain/wallet-invoices/wallet-invoice-builder.ts
@@ -143,7 +143,7 @@ export const WIBWithAmount = (state: WIBWithAmountState): WIBWithAmount => {
       return new InvalidWalletInvoiceBuilderStateError()
     }
 
-    const walletInvoice: WalletInvoice = {
+    const walletInvoice = {
       paymentHash,
       secret,
       selfGenerated: state.selfGenerated,
@@ -152,6 +152,7 @@ export const WIBWithAmount = (state: WIBWithAmountState): WIBWithAmount => {
       recipientWalletDescriptor: state.recipientWalletDescriptor,
       paid: false,
       createdAt: new Date(),
+      paymentRequest: registeredInvoice.invoice.paymentRequest,
     }
     return {
       walletInvoice,

--- a/core/api/src/services/mongoose/schema.ts
+++ b/core/api/src/services/mongoose/schema.ts
@@ -79,6 +79,10 @@ const walletInvoiceSchema = new Schema<WalletInvoiceRecord>({
     type: Boolean,
     default: false,
   },
+
+  paymentRequest: {
+    type: String,
+  },
 })
 
 walletInvoiceSchema.index({ walletId: 1, paid: 1 })

--- a/core/api/src/services/mongoose/schema.types.d.ts
+++ b/core/api/src/services/mongoose/schema.types.d.ts
@@ -63,6 +63,7 @@ interface WalletInvoiceRecord {
   selfGenerated: boolean
   pubkey: string
   paid: boolean
+  paymentRequest?: string // optional because we historically did not store it
 }
 
 interface AccountRecord {

--- a/core/api/src/services/mongoose/wallet-invoices.ts
+++ b/core/api/src/services/mongoose/wallet-invoices.ts
@@ -18,6 +18,7 @@ export const WalletInvoicesRepository = (): IWalletInvoicesRepository => {
     pubkey,
     paid,
     usdAmount,
+    paymentRequest,
   }: WalletInvoicesPersistNewArgs): Promise<WalletInvoice | RepositoryError> => {
     try {
       const walletInvoice = await new WalletInvoice({
@@ -29,6 +30,7 @@ export const WalletInvoicesRepository = (): IWalletInvoicesRepository => {
         paid,
         cents: usdAmount ? Number(usdAmount.amount) : undefined,
         currency: recipientWalletDescriptor.currency,
+        paymentRequest,
       }).save()
       return walletInvoiceFromRaw(walletInvoice)
     } catch (err) {
@@ -135,4 +137,5 @@ const walletInvoiceFromRaw = (result: WalletInvoiceRecord): WalletInvoice => ({
   paid: result.paid as boolean,
   usdAmount: result.cents ? UsdPaymentAmount(BigInt(result.cents)) : undefined,
   createdAt: new Date(result.timestamp.getTime()),
+  paymentRequest: result.paymentRequest as EncodedPaymentRequest,
 })

--- a/core/api/test/integration/app/wallets/send-lightning.spec.ts
+++ b/core/api/test/integration/app/wallets/send-lightning.spec.ts
@@ -512,6 +512,7 @@ describe("initiated via lightning", () => {
         pubkey: destination,
         recipientWalletDescriptor,
         paid: false,
+        paymentRequest: lnInvoice.paymentRequest,
       })
       if (persisted instanceof Error) throw persisted
 
@@ -561,6 +562,7 @@ describe("initiated via lightning", () => {
         pubkey: lnInvoice.destination,
         recipientWalletDescriptor: newWalletDescriptor,
         paid: false,
+        paymentRequest: lnInvoice.paymentRequest,
       })
       if (persisted instanceof Error) throw persisted
 
@@ -632,6 +634,7 @@ describe("initiated via lightning", () => {
         recipientWalletDescriptor: usdWalletDescriptor,
         paid: false,
         usdAmount,
+        paymentRequest: lnInvoice.paymentRequest,
       })
       if (persisted instanceof Error) throw persisted
 
@@ -652,6 +655,7 @@ describe("initiated via lightning", () => {
         pubkey: noAmountLnInvoice.destination,
         recipientWalletDescriptor: usdWalletDescriptor,
         paid: false,
+        paymentRequest: lnInvoice.paymentRequest,
       })
       if (noAmountPersisted instanceof Error) throw noAmountPersisted
 
@@ -710,6 +714,7 @@ describe("initiated via lightning", () => {
         pubkey: largeWithAmountLnInvoice.destination,
         recipientWalletDescriptor: otherWalletDescriptor,
         paid: false,
+        paymentRequest: lnInvoice.paymentRequest,
       })
       if (persisted instanceof Error) throw persisted
 
@@ -730,6 +735,7 @@ describe("initiated via lightning", () => {
         pubkey: noAmountLnInvoice.destination,
         recipientWalletDescriptor: otherWalletDescriptor,
         paid: false,
+        paymentRequest: lnInvoice.paymentRequest,
       })
       if (noAmountPersisted instanceof Error) throw noAmountPersisted
 
@@ -782,6 +788,7 @@ describe("initiated via lightning", () => {
         pubkey: noAmountLnInvoice.destination,
         recipientWalletDescriptor: usdWalletDescriptor,
         paid: false,
+        paymentRequest: lnInvoice.paymentRequest,
       })
       if (persisted instanceof Error) throw persisted
 

--- a/core/api/test/integration/app/wallets/update-pending-invoices.spec.ts
+++ b/core/api/test/integration/app/wallets/update-pending-invoices.spec.ts
@@ -35,6 +35,7 @@ describe("update pending invoices", () => {
           currency: WalletCurrency.Usd,
         },
         paid: false,
+        paymentRequest: "paymentRequest" as EncodedPaymentRequest,
       }
       const persisted = await WalletInvoicesRepository().persistNew(
         expiredUsdWalletInvoice,
@@ -84,6 +85,7 @@ describe("update pending invoices", () => {
           currency: WalletCurrency.Btc,
         },
         paid: false,
+        paymentRequest: "paymentRequest" as EncodedPaymentRequest,
       }
       const persisted = await WalletInvoicesRepository().persistNew(
         expiredBtcWalletInvoice,

--- a/core/api/test/legacy-integration/services/mongoose/wallet-invoices.spec.ts
+++ b/core/api/test/legacy-integration/services/mongoose/wallet-invoices.spec.ts
@@ -12,7 +12,7 @@ beforeAll(async () => {
   await createUserAndWalletFromPhone(phoneB)
 })
 
-const createTestWalletInvoice = (): WalletInvoice => {
+const createTestWalletInvoice = () => {
   return {
     ...getSecretAndPaymentHash(),
     selfGenerated: false,
@@ -27,6 +27,7 @@ const createTestWalletInvoice = (): WalletInvoice => {
       amount: 10n,
     },
     createdAt: new Date(),
+    paymentRequest: "paymentRequest" as EncodedPaymentRequest,
   }
 }
 


### PR DESCRIPTION
- start recording payment requests with each wallet invoice
- this pr will be followed by a migration and then a pr to make paymentRequest mandatory