### PR TITLE
chore: add 'PaymentPathfindingFailedToFindPossibleRoute' error handling

### DIFF
--- a/core/api/src/services/lnd/errors.ts
+++ b/core/api/src/services/lnd/errors.ts
@@ -5,6 +5,7 @@ export const KnownLndErrorDetails = {
   InvoiceNotFound: /unable to locate invoice/,
   InvoiceAlreadyPaid: /invoice is already paid/,
   UnableToFindRoute: /PaymentPathfindingFailedToFindPossibleRoute/,
+  FailedToFindRoute: /FailedToFindPayableRouteToDestination/,
   UnknownNextPeer: /UnknownNextPeer/,
   LndDbCorruption: /payment isn't initiated/,
   PaymentRejectedByDestination: /PaymentRejectedByDestination/,

--- a/core/api/src/services/lnd/index.ts
+++ b/core/api/src/services/lnd/index.ts
@@ -1112,6 +1112,7 @@ const handleSendPaymentLndErrors = ({
     case match(KnownLndErrorDetails.InvoiceAlreadyPaid):
       return new LnAlreadyPaidError()
     case match(KnownLndErrorDetails.UnableToFindRoute):
+    case match(KnownLndErrorDetails.FailedToFindRoute):
       return new RouteNotFoundError()
     case match(KnownLndErrorDetails.UnknownNextPeer):
       return new UnknownNextPeerError()


### PR DESCRIPTION
From [trace](https://ui.honeycomb.io/galoy/datasets/galoy-bbw?query=%7B%22start_time%22%3A1697489035%2C%22end_time%22%3A1697489733%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22service.name%22%2C%22name%22%2C%22error.name%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22COUNT%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22error%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3Atrue%7D%2C%7B%22column%22%3A%22error.level%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22critical%22%7D%2C%7B%22column%22%3A%22error.name%22%2C%22op%22%3A%22!%3D%22%2C%22value%22%3A%22CouldNotFindExpectedTransactionMetadataError%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22op%22%3A%22COUNT%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A1000%7D)