### PR TITLE
chore: improve twilio 'InvalidMobileNumber' regex

### DIFF
--- a/core/api/src/domain/users/phone-metadata-validator.ts
+++ b/core/api/src/domain/users/phone-metadata-validator.ts
@@ -43,11 +43,11 @@ export const PhoneMetadataValidator = (): PhoneMetadataValidator => {
     if (type instanceof Error) return type
 
     if (typeof error_code !== "string") {
-      return new InvalidErrorCodeForPhoneMetadataError(countryCode)
+      return new InvalidErrorCodeForPhoneMetadataError(error_code)
     }
 
     if (typeof mobile_country_code !== "string") {
-      return new InvalidMobileCountryCodeForPhoneMetadataError(countryCode)
+      return new InvalidMobileCountryCodeForPhoneMetadataError(mobile_country_code)
     }
 
     if (typeof countryCode !== "string") {

--- a/core/api/src/services/twilio-service.ts
+++ b/core/api/src/services/twilio-service.ts
@@ -168,7 +168,7 @@ const handleCommonErrors = (err: Error | string | unknown) => {
 }
 export const KnownTwilioErrorMessages = {
   InvalidPhoneNumber: /not a valid phone number/,
-  InvalidMobileNumber: /not a mobile number/,
+  InvalidMobileNumber: /not a .*mobile number/,
   InvalidPhoneNumberParameter: /Invalid parameter `To`/,
   InvalidCodeParameter: /Invalid parameter: Code/,
   RestrictedRegion: /has not been enabled for the region/,


### PR DESCRIPTION
To accommodate traces [like this](https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/nE1MygZ55nf/trace/DYKBR5EjFYN?fields[]=c_name&fields[]=c_service.name&span=5bc454ee89c76aa2)