### PR TITLE
fix: add axios option withCredentials to acceptOAuth2LoginRequest

### DIFF
--- a/apps/consent/app/consent/page.tsx
+++ b/apps/consent/app/consent/page.tsx
@@ -38,14 +38,14 @@ const submitForm = async (form: FormData) => {
         error: "access_denied",
         error_description: "The resource owner denied the request",
       },
-    });
+    }, { withCredentials: true });
     redirect(response.data.redirect_to);
   }
 
   let responseConfirm;
   const responseInit = await hydraClient.getOAuth2ConsentRequest({
     consentChallenge: consent_challenge,
-  });
+  }, { withCredentials: true });
 
   const body = responseInit.data;
   responseConfirm = await hydraClient.acceptOAuth2ConsentRequest({
@@ -56,7 +56,7 @@ const submitForm = async (form: FormData) => {
       remember: remember,
       remember_for: 3600,
     },
-  });
+  }, { withCredentials: true });
   redirect(responseConfirm.data.redirect_to);
 };
 
@@ -69,7 +69,7 @@ const Consent = async ({ searchParams }: { searchParams: ConsentProps }) => {
 
   const data = await hydraClient.getOAuth2ConsentRequest({
     consentChallenge: consent_challenge,
-  });
+  }, { withCredentials: true });
 
   const body = data.data;
   const login_challenge = data.data.login_challenge;
@@ -86,7 +86,7 @@ const Consent = async ({ searchParams }: { searchParams: ConsentProps }) => {
         grant_scope: body.requested_scope,
         grant_access_token_audience: body.requested_access_token_audience,
       },
-    });
+    }, { withCredentials: true });
     redirect(String(response.data.redirect_to));
   }
 

--- a/apps/consent/app/login/page.tsx
+++ b/apps/consent/app/login/page.tsx
@@ -56,7 +56,7 @@ async function submitForm(
         error: "access_denied",
         error_description: "The resource owner denied the request",
       },
-    });
+    }, { withCredentials: true });
     redirect(response.data.redirect_to);
   }
 
@@ -106,7 +106,7 @@ const Login = async ({ searchParams }: { searchParams: LoginProps }) => {
 
   const { data } = await hydraClient.getOAuth2LoginRequest({
     loginChallenge: login_challenge,
-  });
+  }, { withCredentials: true });
 
   body = data;
   if (body.skip) {
@@ -116,7 +116,7 @@ const Login = async ({ searchParams }: { searchParams: LoginProps }) => {
       acceptOAuth2LoginRequest: {
         subject: String(body.subject),
       },
-    });
+    }, { withCredentials: true });
     response = data;
     redirect(String(response.redirect_to));
   }


### PR DESCRIPTION
This is the equivalent to what we had to do in the web wallet here: https://github.com/GaloyMoney/web-wallet/blob/5bb016a1adbe556ae4d09070daa3c18fb9599ce9/src/components/pages/login-email.tsx#L75 (ie pass options down to axios to forward cross site cookies)