### PR TITLE
feat: adding a fetchByUserId admin endpoint

### DIFF
--- a/core/api/src/app/admin/index.ts
+++ b/core/api/src/app/admin/index.ts
@@ -1,7 +1,7 @@
 export * from "./update-user-phone"
 export * from "./send-admin-push-notification"
 
-import { checkedToAccountId, checkedToUsername } from "@/domain/accounts"
+import { checkedToAccountId, checkedToUserId, checkedToUsername } from "@/domain/accounts"
 import { IdentityRepository } from "@/services/kratos"
 import { AccountsRepository, UsersRepository } from "@/services/mongoose"
 
@@ -37,4 +37,11 @@ export const getAccountByAccountId = async (accountIdRaw: string) => {
   if (accountId instanceof Error) return accountId
   const accounts = AccountsRepository()
   return accounts.findById(accountId)
+}
+
+export const getAccountByUserId = async (userIdRaw: string) => {
+  const userId = checkedToUserId(userIdRaw)
+  if (userId instanceof Error) return userId
+  const accounts = AccountsRepository()
+  return accounts.findByUserId(userId)
 }

--- a/core/api/src/graphql/admin/queries.ts
+++ b/core/api/src/graphql/admin/queries.ts
@@ -9,6 +9,7 @@ import AccountDetailsByUserEmailQuery from "./root/query/account-details-by-emai
 import ListWalletIdsQuery from "./root/query/all-walletids"
 import WalletQuery from "./root/query/wallet"
 import AccountDetailsByAccountId from "./root/query/account-details-by-account-id"
+import AccountDetailsByUserId from "./root/query/account-details-by-user-id"
 
 import { GT } from "@/graphql/index"
 
@@ -20,6 +21,7 @@ export const queryFields = {
     accountDetailsByUsername: AccountDetailsByUsernameQuery,
     accountDetailsByEmail: AccountDetailsByUserEmailQuery,
     accountDetailsByAccountId: AccountDetailsByAccountId,
+    accountDetailsByUserId: AccountDetailsByUserId,
     transactionById: TransactionByIdQuery,
     transactionsByHash: TransactionsByHashQuery,
     lightningInvoice: LightningInvoiceQuery,

--- a/core/api/src/graphql/admin/root/query/account-details-by-user-id.ts
+++ b/core/api/src/graphql/admin/root/query/account-details-by-user-id.ts
@@ -1,0 +1,27 @@
+import { GT } from "@/graphql/index"
+
+import AuditedAccount from "@/graphql/admin/types/object/account"
+import { mapError } from "@/graphql/error-map"
+
+import { Admin } from "@/app"
+
+const AccountDetailsByUserId = GT.Field({
+  args: {
+    userId: { type: GT.NonNullID },
+  },
+  type: GT.NonNull(AuditedAccount),
+  resolve: async (_, { userId }) => {
+    if (userId instanceof Error) {
+      throw userId
+    }
+
+    const account = await Admin.getAccountByUserId(userId)
+    if (account instanceof Error) {
+      throw mapError(account)
+    }
+
+    return account
+  },
+})
+
+export default AccountDetailsByUserId

--- a/core/api/src/graphql/admin/schema.graphql
+++ b/core/api/src/graphql/admin/schema.graphql
@@ -271,6 +271,7 @@ type PriceOfOneSettlementMinorUnitInDisplayMinorUnit implements PriceInterface {
 type Query {
   accountDetailsByAccountId(accountId: ID!): AuditedAccount!
   accountDetailsByEmail(email: EmailAddress!): AuditedAccount!
+  accountDetailsByUserId(userId: ID!): AuditedAccount!
   accountDetailsByUserPhone(phone: Phone!): AuditedAccount!
   accountDetailsByUsername(username: Username!): AuditedAccount!
   allLevels: [AccountLevel!]!

--- a/core/api/test/bats/admin-gql/account-details-by-account-id.gql
+++ b/core/api/test/bats/admin-gql/account-details-by-account-id.gql
@@ -1,5 +1,8 @@
 query accountDetailsByAccountId($accountId: ID!) {
   accountDetailsByAccountId(accountId: $accountId) {
     id
+    owner {
+      id
+    }
   }
 }

--- a/core/api/test/bats/admin-gql/account-details-by-user-id.gql
+++ b/core/api/test/bats/admin-gql/account-details-by-user-id.gql
@@ -1,0 +1,8 @@
+query accountDetailsByUserId($userId: ID!) {
+  accountDetailsByUserId(userId: $userId) {
+    id
+    owner {
+      id
+    }
+  }
+}

--- a/core/api/test/bats/admin.bats
+++ b/core/api/test/bats/admin.bats
@@ -160,6 +160,20 @@ gql_admin_file() {
   returnedId="$(graphql_output '.data.accountDetailsByAccountId.id')"
   [[ "$returnedId" == "$id" ]] || exit 1
 
+  userId="$(graphql_output '.data.accountDetailsByAccountId.owner.id')"
+  echo "userId: $userId"
+  
+  variables=$(
+    jq -n \
+    --arg userId "$userId" \
+    '{userId: $userId}'
+  )
+
+  exec_admin_graphql "$admin_token" 'account-details-by-user-id' "$variables"
+  returnedId="$(graphql_output '.data.accountDetailsByUserId.owner.id')"
+  [[ "$returnedId" == "$userId" ]] || exit 1
+
+
   # TODO: add check by email
   
   # TODO: business update map info


### PR DESCRIPTION
subgraph that need authenticated are been returned a signed JWT that contain the subject/userId returned from oathkeeper.

so that subgraph can do operation on the account, we need to expose a way to do the mapping userId --> accountId through the admin api

this PR update expose this ability