### PR TITLE
feat: add payout cancelled event handler

### DIFF
--- a/core/api/src/graphql/error-map.ts
+++ b/core/api/src/graphql/error-map.ts
@@ -613,6 +613,7 @@ export const mapError = (error: ApplicationError): CustomGraphQLError => {
     case "ExpectedPayoutCommittedPayloadNotFoundError":
     case "ExpectedPayoutBroadcastPayloadNotFoundError":
     case "ExpectedPayoutSettledPayloadNotFoundError":
+    case "ExpectedPayoutCancelledPayloadNotFoundError":
     case "UnknownPayloadTypeReceivedError":
     case "ExpectedAddressInfoMissingInEventError":
     case "MissingCreatedAtKratosError":

--- a/core/api/src/services/bria/errors.ts
+++ b/core/api/src/services/bria/errors.ts
@@ -16,6 +16,7 @@ export class ExpectedPayoutSubmittedPayloadNotFoundError extends BriaPayloadErro
 export class ExpectedPayoutCommittedPayloadNotFoundError extends BriaPayloadError {}
 export class ExpectedPayoutBroadcastPayloadNotFoundError extends BriaPayloadError {}
 export class ExpectedPayoutSettledPayloadNotFoundError extends BriaPayloadError {}
+export class ExpectedPayoutCancelledPayloadNotFoundError extends BriaPayloadError {}
 export class UnknownPayloadTypeReceivedError extends BriaPayloadError {}
 export class ExpectedAddressInfoMissingInEventError extends BriaPayloadError {}
 

--- a/core/api/src/services/bria/event-handler.ts
+++ b/core/api/src/services/bria/event-handler.ts
@@ -2,6 +2,7 @@ import {
   EventAugmentationMissingError,
   ExpectedAddressInfoMissingInEventError,
   ExpectedPayoutBroadcastPayloadNotFoundError,
+  ExpectedPayoutCancelledPayloadNotFoundError,
   ExpectedPayoutCommittedPayloadNotFoundError,
   ExpectedPayoutSettledPayloadNotFoundError,
   ExpectedPayoutSubmittedPayloadNotFoundError,
@@ -32,6 +33,7 @@ export const BriaPayloadType = {
   PayoutCommitted: "payout_committed",
   PayoutBroadcast: "payout_broadcast",
   PayoutSettled: "payout_settled",
+  PayoutCancelled: "payout_cancelled",
 } as const
 
 const eventRepo = BriaEventRepo()
@@ -245,6 +247,22 @@ export const translate = (rawEvent: RawBriaEvent): BriaEvent | BriaEventError =>
         },
         txId: rawPayload.getTxId() as OnChainTxHash,
         vout: rawPayload.getVout() as OnChainTxVout,
+        address: rawPayload.getOnchainAddress() as OnChainAddress,
+      }
+      break
+    case RawBriaEvent.PayloadCase.PAYOUT_CANCELLED:
+      rawPayload = rawEvent.getPayoutCancelled()
+      if (rawPayload === undefined) {
+        return new ExpectedPayoutCancelledPayloadNotFoundError()
+      }
+
+      payload = {
+        type: BriaPayloadType.PayoutCancelled,
+        id: rawPayload.getId() as PayoutId,
+        satoshis: {
+          amount: BigInt(rawPayload.getSatoshis()),
+          currency: WalletCurrency.Btc,
+        },
         address: rawPayload.getOnchainAddress() as OnChainAddress,
       }
       break

--- a/core/api/src/services/bria/index.types.d.ts
+++ b/core/api/src/services/bria/index.types.d.ts
@@ -77,6 +77,14 @@ type PayoutSettled = {
   vout: OnChainTxVout
   address: OnChainAddress
 }
+
+type PayoutCancelled = {
+  type: "payout_cancelled"
+  id: PayoutId
+  satoshis: BtcPaymentAmount
+  address: OnChainAddress
+}
+
 type BriaPayload =
   | UtxoDetected
   | UtxoDropped
@@ -85,6 +93,7 @@ type BriaPayload =
   | PayoutCommitted
   | PayoutBroadcast
   | PayoutSettled
+  | PayoutCancelled
 
 type BriaEvent = {
   payload: BriaPayload


### PR DESCRIPTION
## Description

This adds:
- a `PayoutCancelled` event type to the expected event types Bria produces
- an interim `payoutCancelled` handler to the bria event handler