### PR TITLE
chore: pin to Tilt 0.33.5 until upstream Nix pkg is fixed

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,27 +34,11 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1697851979,
-        "narHash": "sha256-lJ8k4qkkwdvi+t/Xc6Fn74kUuobpu9ynPGxNZR6OwoA=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "5550a85a087c04ddcace7f892b0bdc9d8bb080c8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-23.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-stable": "nixpkgs-stable"
+        "tilt-pin-pkgs": "tilt-pin-pkgs"
       }
     },
     "systems": {
@@ -70,6 +54,17 @@
         "owner": "nix-systems",
         "repo": "default",
         "type": "github"
+      }
+    },
+    "tilt-pin-pkgs": {
+      "locked": {
+        "narHash": "sha256-Qy2e5VZRoLZ61ee7XmuaUOUgprW3AyE0uLyfohTPxMM=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/e1ee359d16a1886f0771cc433a00827da98d861c.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/e1ee359d16a1886f0771cc433a00827da98d861c.tar.gz"
       }
     }
   },


### PR DESCRIPTION
## Description

_Cherry-picked from: https://github.com/systeminit/si/commit/bbd13efa2543b4219303f9252a3248ae97c817a8_

This changes pins the version of Tilt back to 0.33.5 as the 0.33.6-built version emits the following error:

```
Error: running in prod mode, but JS/CSS files are not available
```

Once NixOS/nixpkgs#260712 merges then we should be able to drop the version pin.

References: tilt-dev/tilt#6214
References: NixOS/nixpkgs#260411