### PR TITLE
build: add dockerImage dev env package to nix flake

### DIFF
--- a/ci/apps/pipeline.yml
+++ b/ci/apps/pipeline.yml
@@ -8,8 +8,8 @@
 #@   "bump_image_in_chart_name",
 #@   "bump_image_in_chart")
 
-#@ def consent_image():
-#@   return data.values.docker_registry + "/galoy-consent"
+#@ def galoy_dev_image():
+#@   return data.values.docker_registry + "/galoy-dev"
 #@ end
 
 #@ apps = ["consent", "dashboard"]
@@ -27,12 +27,47 @@ groups:
     - #@ build_edge_image_name(app)
     - #@ bump_image_in_chart_name(app)
 #@ end
+  - name: dev-image
+    jobs:
+    - build-galoy-dev-image
 
 jobs:
 #@ for app in apps:
   - #@ build_edge_image(app)
   - #@ bump_image_in_chart(app)
 #@ end
+  - name: build-galoy-dev-image
+    serial: true
+    plan:
+      - in_parallel:
+          - { get: galoy-dev-image-def, trigger: true }
+      - task: build
+        attempts: 2
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: nixos/nix
+          inputs:
+            - name: galoy-dev-image-def
+              path: repo
+          outputs:
+            - name: repo
+          run:
+            path: bash
+            args:
+            - -c
+            - |
+              cd repo && \
+                nix \
+                    --extra-experimental-features "nix-command flakes impure-derivations ca-derivations" \
+                    build \
+                    ".#dockerImage"
+      - put: galoy-dev-image
+        params:
+          image: repo/result
 
 resources:
 #@ for app in apps:
@@ -61,3 +96,19 @@ resources:
       uri: #@ data.values.git_charts_uri
       branch: "image-bump-bot-branch"
       private_key: #@ data.values.github_private_key
+
+  - name: galoy-dev-image-def
+    type: git
+    source:
+      paths: [flake.*]
+      uri: #@ data.values.git_uri
+      branch: #@ data.values.git_branch
+      private_key: #@ data.values.github_private_key
+
+  - name: galoy-dev-image
+    type: registry-image
+    source:
+      tag: edge
+      username: #@ data.values.docker_registry_user
+      password: #@ data.values.docker_registry_password
+      repository: #@ galoy_dev_image()

--- a/flake.nix
+++ b/flake.nix
@@ -163,6 +163,14 @@
           api-cron = tscDerivation {pkgName = "api-cron";};
           consent = nextDerivation {pkgName = "consent";};
           dashboard = nextDerivation {pkgName = "dashboard";};
+
+          dockerImage = pkgs.dockerTools.buildNixShellImage {
+            tag = "latest";
+            drv = pkgs.stdenv.mkDerivation {
+              name = "galoy-dev";
+              inherit nativeBuildInputs;
+            };
+          };
         };
 
         devShells.default = mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,7 @@
           postgresql
           alejandra
           gnumake
+          docker
           docker-compose
           shellcheck
           shfmt


### PR DESCRIPTION
## Description

This adds a package to `nix.flake` that builds an image with the `nativeBuildInputs` as the environment.

Build with:
```bash
$ nix build .#dockerImage
```

Load with:
```bash
$ docker load < result
```

Run with:
```bash
$ docker run -it galoy-dev-env:latest
```

---

## Nix Outputs

From running `$ nix flake show`:

```bash
git+file:///home/arvinda/Developer/Projects/GaloyMoney/galoy?ref=refs%2fheads%2fdocker-nix-image&rev=9808c4b59205a08786dba2fe44c9daf42ff2ee41
├───devShells
│   ├───aarch64-darwin
│   │   └───default: development environment 'nix-shell'
│   ├───aarch64-linux
│   │   └───default: development environment 'nix-shell'
│   ├───x86_64-darwin
│   │   └───default: development environment 'nix-shell'
│   └───x86_64-linux
│       └───default: development environment 'nix-shell'
├───formatter
│   ├───aarch64-darwin: package 'alejandra-3.0.0'
│   ├───aarch64-linux: package 'alejandra-3.0.0'
│   ├───x86_64-darwin: package 'alejandra-3.0.0'
│   └───x86_64-linux: package 'alejandra-3.0.0'
└───packages
    ├───aarch64-darwin
    │   ├───api: package 'api'
    │   ├───api-cron: package 'api-cron'
    │   ├───api-exporter: package 'api-exporter'
    │   ├───api-trigger: package 'api-trigger'
    │   ├───api-ws-server: package 'api-ws-server'
    │   ├───consent: package 'consent'
    │   ├───dashboard: package 'dashboard'
    │   └───dockerImage: package 'galoy-dev-env.tar.gz'
    ├───aarch64-linux
    │   ├───api: package 'api'
    │   ├───api-cron: package 'api-cron'
    │   ├───api-exporter: package 'api-exporter'
    │   ├───api-trigger: package 'api-trigger'
    │   ├───api-ws-server: package 'api-ws-server'
    │   ├───consent: package 'consent'
    │   ├───dashboard: package 'dashboard'
    │   └───dockerImage: package 'galoy-dev-env.tar.gz'
    ├───x86_64-darwin
    │   ├───api: package 'api'
    │   ├───api-cron: package 'api-cron'
    │   ├───api-exporter: package 'api-exporter'
    │   ├───api-trigger: package 'api-trigger'
    │   ├───api-ws-server: package 'api-ws-server'
    │   ├───consent: package 'consent'
    │   ├───dashboard: package 'dashboard'
    │   └───dockerImage: package 'galoy-dev-env.tar.gz'
    └───x86_64-linux
        ├───api: package 'api'
        ├───api-cron: package 'api-cron'
        ├───api-exporter: package 'api-exporter'
        ├───api-trigger: package 'api-trigger'
        ├───api-ws-server: package 'api-ws-server'
        ├───consent: package 'consent'
        ├───dashboard: package 'dashboard'
        └───dockerImage: package 'galoy-dev-env.tar.gz'
```