### PR TITLE
build: switch nix docker image to 'buildImage'

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -179,8 +179,6 @@
             name = "galoy-dev";
             tag = "latest";
 
-            # TODO: confirm if we want to stick with this example base image, do none,
-            #       or switch to another base image.
             fromImage = pkgs.dockerTools.pullImage {
               imageName = "nixos/nix";
               imageDigest = "sha256:85299d86263a3059cf19f419f9d286cc9f06d3c13146a8ebbb21b3437f598357";
@@ -189,9 +187,7 @@
               finalImageName = "nix";
             };
 
-            # Configuration
             config = {
-              # The default entrypoint when running image for local debugging
               Cmd = ["bash"];
             };
 

--- a/flake.nix
+++ b/flake.nix
@@ -175,11 +175,30 @@
           consent = nextDerivation {pkgName = "consent";};
           dashboard = nextDerivation {pkgName = "dashboard";};
 
-          dockerImage = pkgs.dockerTools.buildNixShellImage {
+          dockerImage = pkgs.dockerTools.buildImage {
+            name = "galoy-dev";
             tag = "latest";
-            drv = pkgs.stdenv.mkDerivation {
-              name = "galoy-dev";
-              inherit nativeBuildInputs;
+
+            # TODO: confirm if we want to stick with this example base image, do none,
+            #       or switch to another base image.
+            fromImage = pkgs.dockerTools.pullImage {
+              imageName = "nixos/nix";
+              imageDigest = "sha256:85299d86263a3059cf19f419f9d286cc9f06d3c13146a8ebbb21b3437f598357";
+              sha256 = "19fw0n3wmddahzr20mhdqv6jkjn1kanh6n2mrr08ai53dr8ph5n7";
+              finalImageTag = "2.2.1";
+              finalImageName = "nix";
+            };
+
+            # Configuration
+            config = {
+              # The default entrypoint when running image for local debugging
+              Cmd = ["bash"];
+            };
+
+            copyToRoot = pkgs.buildEnv {
+              name = "image-root";
+              paths = nativeBuildInputs ++ [ pkgs.bash ];
+              pathsToLink = [ "/bin" ];
             };
           };
         };


### PR DESCRIPTION
## Description

This is to solve the issue where the `PATH` variable doesn't get properly set if entering the container through any pathway other than the default entrypoint.


### Context

Below is context added from our diagnosis process that lead us to decide to switch to `dockerTools.buildImage`.

**For image build with `dockerTools.buildNixShellImage`**

`docker run -it <image-name>` gets a shell with:
```bash
echo $SHELL
>  /nix/store/yi5aswh4a0mb82kbi0afr26j5ilsghjl-bash-interactive-5.2-p15/bin/bash

echo $PATH
>  /nix/store/yi5aswh4a0mb82kbi0afr26j5ilsghjl-bash-interactive-5.2-p15/bin:/nix/store/7snc8ip3rgjsfwrpjg42ynmh630vzx88-buildDerivation/bin:/nix/store/vc6d64vv2fbqbjl55ilq7q3a0cmpmxpz-envsubst-1.4.2/bin:/nix/store/qs5b5msb3jj13140k7ffqx39bphanghg-nodejs-20.8.0/bin:/nix/store/m94slj1lw64fn0frsr8y65nx5kc7ygha-tilt-0.33.5/bin:/nix/store/ifrndaxpywlp6ywcn38m8ci43x4myjxz-yarn-1.22.19/bin:/nix/store/s3842vk6ccqdkknyias5jfjspr3jchai-typescript-5.2.2/bin:/nix/store/v6mhbfyc0l7yrd5dk4xiwzf67mvpifln-bats-1.10.0/bin:/nix/store/ki3srrjjzqalvh0hd9lmqavp5v9wr9jp-postgresql-14.9/bin:/nix/store/nmi8k2yj302i5dd2kv09a6kgipkfb1d0-alejandra-3.0.0/bin:/nix/store/5rdxplg3cczslq4banvk3449ry5k9hx7-gnumake-4.4.1/bin:/nix/store/kg5sf0d7rz84vvdc9fm96yc3jmrz91r1-docker-20.10.26/bin:/nix/store/n2vg8v76r9izwilsggrn6szdq15jjl7n-docker-compose-2.21.0/bin:/nix/store/mk7291nr3a1241pfw9vls74xmakqjyw7-shellcheck-0.9.0-bin/bin:/nix/store/m3accnxhbcsh2i9yf04din5brm2ylj40-shfmt-3.7.0/bin:/nix/store/4c40qfh9cgqyc8h12z0ykgfxhhxd8gdr-vendir-0.35.0/bin:/nix/store/3lwrcxnxvfskh7m98fq0n5kqj2001ci7-jq-1.7-bin/bin:/nix/store/ijhy1ilav7ccy5qcrl6vac9wkw5x2p34-ytt-0.46.0/bin:/nix/store/qq4isqfasf2qpg4rmw9bj7bspglf7qwy-buck2-unstable-2023-10-15/bin:/nix/store/770mk66lrxwrqb2acfxzkg5iz6apdiwj-pnpm-8.8.0/bin:/nix/store/pzf6dnxg8gf04xazzjdwarm7s03cbrgz-python3-3.10.12/bin:/nix/store/pdi30qh576mpk6bjmixkgvqls481cj15-ripgrep-13.0.0/bin:/nix/store/07ppiimvlmpsqjx60gpyxdw1q582hprp-xvfb-run-1+g87f6705/bin:/nix/store/mnc43cr5cph3ms2zgv9mqzc4w6hrf8lx-cypress-13.2.0/bin:/nix/store/ay0p9mbw1w3zkvwzx3c94xq7x8jrn9wq-patchelf-0.15.0/bin:/nix/store/18bs92p6yf6w2wwxhbplgx02y6anq092-gcc-wrapper-12.3.0/bin:/nix/store/h5kvfrjmpw792v8jg7nrzfkffmn0iyy8-gcc-12.3.0/bin:/nix/store/f6in5kb2y5v06zinz1a6xy6cyg67q026-glibc-2.37-8-bin/bin:/nix/store/y9gr7abwxvzcpg5g73vhnx1fpssr5frr-coreutils-9.3/bin:/nix/store/mc6q3cdz5s0p1aj4y586bglsfsnsf2k8-binutils-wrapper-2.40/bin:/nix/store/74y3751gsixaz9797ib0hp7c658sp1y5-binutils-2.40/bin:/nix/store/y9gr7abwxvzcpg5g73vhnx1fpssr5frr-coreutils-9.3/bin:/nix/store/b6izr8wh0p7dyvh3cyg14wq2rn8d31ik-findutils-4.9.0/bin:/nix/store/q56n7lhjw724i7b33qaqra61p7m7c0cd-diffutils-3.10/bin:/nix/store/x23by79p38ll0js1alifmf3y56vqfs49-gnused-4.9/bin:/nix/store/xafzciap7acqhfx84dvqkp18bg4lrai3-gnugrep-3.11/bin:/nix/store/8kkn44iwdbgqkrj661nr4cjcpmrqqmx8-gawk-5.2.2/bin:/nix/store/89s3w7b4g78989kpzc7sy4phv0nqfira-gnutar-1.35/bin:/nix/store/2a9na7bp4r3290yqqzg503325dwglxyq-gzip-1.13/bin:/nix/store/gxknjk51s7q86llkbzpaqv43kflj9d8j-bzip2-1.0.8-bin/bin:/nix/store/2jp6cv2q4cgh91f5lp57p945rq98ldhr-gnumake-4.4.1/bin:/nix/store/xdqlrixlspkks50m9b0mpvag65m3pf2w-bash-5.2-p15/bin:/nix/store/c15ama0p8jr4mn0943yjk4rpa2hxk7ml-patch-2.7.6/bin:/nix/store/sb3sxnp4g40gfw758a0m4sjm7slvmax9-xz-5.4.4-bin/bin:/nix/store/xfjqspcc9442hi0lm0szv3sw75zswvml-file-5.45/bin
```

`docker run -it <image-name> bash` gets a shell with:
```bash
echo $SHELL
>  /noshell

echo $PATH
>  /nix/store/yi5aswh4a0mb82kbi0afr26j5ilsghjl-bash-interactive-5.2-p15/bin:/nix/store/7snc8ip3rgjsfwrpjg42ynmh630vzx88-buildDerivation/bin
```

#### Additional context

```bash
docker inspect <image-name> | jq -r '.[0].Config.Cmd'
[
  "/nix/store/yi5aswh4a0mb82kbi0afr26j5ilsghjl-bash-interactive-5.2-p15/bin/bash",
  "--rcfile",
  "/nix/store/5h1y5xn0yj2qrdfgrjljkv8j377vqccw-nix-shell-rc"
]
```

```bash
docker inspect <image-name> | jq -r '.[0].Config.Env'
[
  "HOME=/build",
  "NIX_BUILD_CORES=1",
  "NIX_BUILD_TOP=/build",
  "NIX_STORE=/nix/store",
  "PATH=/nix/store/yi5aswh4a0mb82kbi0afr26j5ilsghjl-bash-interactive-5.2-p15/bin:/nix/store/7snc8ip3rgjsfwrpjg42ynmh630vzx88-buildDerivation/bin",
  "PWD=/build",
  "SSL_CERT_FILE=/nix/store/x8gc1s6hr6xh9mh0q1kj9pyb5v5281kd-nss-cacert-3.92/etc/ssl/certs/ca-bundle.crt",
  "TEMP=/build",
  "TEMPDIR=/build",
  "TERM=xterm-256color",
  "TMP=/build",
  "TMPDIR=/build",
  "__ignoreNulls=1",
  "__structuredAttrs=",
  "args=-e /nix/store/6xg259477c90a229xwmb53pdfkn6ig3g-default-builder.sh",
  "buildInputs=",
  "builder=/nix/store/xdqlrixlspkks50m9b0mpvag65m3pf2w-bash-5.2-p15/bin/bash",
  "cmakeFlags=",
  "configureFlags=",
  "depsBuildBuild=",
  "depsBuildBuildPropagated=",
  "depsBuildTarget=",
  "depsBuildTargetPropagated=",
  "depsHostHost=",
  "depsHostHostPropagated=",
  "depsTargetTarget=",
  "depsTargetTargetPropagated=",
  "doCheck=",
  "doInstallCheck=",
  "mesonFlags=",
  "name=galoy-dev",
  "nativeBuildInputs=/nix/store/vc6d64vv2fbqbjl55ilq7q3a0cmpmxpz-envsubst-1.4.2 /nix/store/qs5b5msb3jj13140k7ffqx39bphanghg-nodejs-20.8.0 /nix/store/m94slj1lw64fn0frsr8y65nx5kc7ygha-tilt-0.33.5 /nix/store/ifrndaxpywlp6ywcn38m8ci43x4myjxz-yarn-1.22.19 /nix/store/s3842vk6ccqdkknyias5jfjspr3jchai-typescript-5.2.2 /nix/store/v6mhbfyc0l7yrd5dk4xiwzf67mvpifln-bats-1.10.0 /nix/store/ki3srrjjzqalvh0hd9lmqavp5v9wr9jp-postgresql-14.9 /nix/store/nmi8k2yj302i5dd2kv09a6kgipkfb1d0-alejandra-3.0.0 /nix/store/5rdxplg3cczslq4banvk3449ry5k9hx7-gnumake-4.4.1 /nix/store/kg5sf0d7rz84vvdc9fm96yc3jmrz91r1-docker-20.10.26 /nix/store/n2vg8v76r9izwilsggrn6szdq15jjl7n-docker-compose-2.21.0 /nix/store/8xiz8vma1khw762xwr64ls8av96f0cw2-shellcheck-0.9.0 /nix/store/m3accnxhbcsh2i9yf04din5brm2ylj40-shfmt-3.7.0 /nix/store/4c40qfh9cgqyc8h12z0ykgfxhhxd8gdr-vendir-0.35.0 /nix/store/czm348wvxl654cl4mj44sw4mqgw79yhi-jq-1.7-dev /nix/store/ijhy1ilav7ccy5qcrl6vac9wkw5x2p34-ytt-0.46.0 /nix/store/qq4isqfasf2qpg4rmw9bj7bspglf7qwy-buck2-unstable-2023-10-15 /nix/store/qs5b5msb3jj13140k7ffqx39bphanghg-nodejs-20.8.0 /nix/store/770mk66lrxwrqb2acfxzkg5iz6apdiwj-pnpm-8.8.0 /nix/store/pzf6dnxg8gf04xazzjdwarm7s03cbrgz-python3-3.10.12 /nix/store/pdi30qh576mpk6bjmixkgvqls481cj15-ripgrep-13.0.0 /nix/store/x8gc1s6hr6xh9mh0q1kj9pyb5v5281kd-nss-cacert-3.92 /nix/store/07ppiimvlmpsqjx60gpyxdw1q582hprp-xvfb-run-1+g87f6705 /nix/store/mnc43cr5cph3ms2zgv9mqzc4w6hrf8lx-cypress-13.2.0",
  "out=/nix/store/p9c76cbj4flcyrwa01vi88lw7rp3i7vf-galoy-dev",
  "outputs=out",
  "patches=",
  "propagatedBuildInputs=",
  "propagatedNativeBuildInputs=",
  "stdenv=/nix/store/3pfjacvdg9f491lfqc9qb2d0nknx73fb-stdenv-linux",
  "strictDeps=",
  "system=x86_64-linux",
  "userHook="
]
```