### PR TITLE
refactor: change tilt buck target to be runnable from any dir

### DIFF
--- a/dev/BUCK
+++ b/dev/BUCK
@@ -1,14 +1,16 @@
 load("@toolchains//rover:macros.bzl", "supergraph", "diff_check", "dev_update_file")
-load( ":tilt.bzl", "tilt_down", "tilt_up",)
+load( ":tilt.bzl", "tilt",)
 
 # Bring up the full set of services for development
-tilt_up(
+tilt(
     name = "up",
+    subcmd = "up",
 )
 
 # Bring down any remaining/running services
-tilt_down(
+tilt(
     name = "down",
+    subcmd = "down",
 )
 
 python_bootstrap_binary(

--- a/dev/tilt.bzl
+++ b/dev/tilt.bzl
@@ -1,32 +1,10 @@
-def tilt_up_impl(ctx: AnalysisContext) -> list[[DefaultInfo, RunInfo]]:
-    return _invoke_tilt(ctx, "up")
+def tilt_impl(ctx: AnalysisContext) -> list[[DefaultInfo, RunInfo]]:
+    return _invoke_tilt(ctx, ctx.attrs.subcmd)
 
-tilt_up = rule(
-    impl = tilt_up_impl,
+tilt = rule(
+    impl = tilt_impl,
     attrs = {
-        "tiltfile": attrs.string(
-            default = "Tiltfile",
-            doc = """The Tiltfile to run.""",
-        ),
-        "args": attrs.list(
-            attrs.string(),
-            default = [],
-            doc = """Additional arguments passed as <Tiltfile args>.""",
-        ),
-        "tilt_args": attrs.list(
-            attrs.string(),
-            default = [],
-            doc = """Additional arguments passed as `tilt` arguments.""",
-        ),
-    },
-)
-
-def tilt_down_impl(ctx: AnalysisContext) -> list[[DefaultInfo, RunInfo]]:
-    return _invoke_tilt(ctx, "down")
-
-tilt_down = rule(
-    impl = tilt_down_impl,
-    attrs = {
+        "subcmd": attrs.enum(["up", "down"]),
         "tiltfile": attrs.string(
             default = "Tiltfile",
             doc = """The Tiltfile to run.""",

--- a/dev/tilt.bzl
+++ b/dev/tilt.bzl
@@ -9,6 +9,11 @@ tilt = rule(
             default = "Tiltfile",
             doc = """The Tiltfile to run.""",
         ),
+        "args": attrs.list(
+            attrs.string(),
+            default = [],
+            doc = """Additional arguments passed as <Tiltfile args>.""",
+        ),
     },
 )
 
@@ -25,14 +30,16 @@ set -euo pipefail
 rootpath="$(git rev-parse --show-toplevel)"
 subcmd="$1"
 tiltfile="$2"
+args=("${@:3}")
 
-tilt "$subcmd" --file "$rootpath"/"$tiltfile"
+tilt "$subcmd" --file "$rootpath"/"$tiltfile" -- "${args[@]}"
 """, is_executable = True)
 
     run_cmd_args = cmd_args([
         script,
         subcmd,
         tiltfile,
+        ctx.attrs.args
     ])
 
     args_file = ctx.actions.write("tilt-args.txt", run_cmd_args)


### PR DESCRIPTION
## Description

This would fix the issue where someone would have to be at the top-level dir for `//dev:up` and `//dev:down` to work