### PR TITLE
fix: add bash to /bin/bash in image

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -194,7 +194,7 @@
 
             copyToRoot = pkgs.buildEnv {
               name = "image-root";
-              paths = nativeBuildInputs;
+              paths = nativeBuildInputs ++ [ pkgs.bash ];
               pathsToLink = [ "/bin" ];
             };
           };


### PR DESCRIPTION
## Description

Ubuntu brings bash in at `/usr/bin/bash` but our script shebangs set the expectation for it to be at `/bin/bash`. This adds bash to `/bin` in a way that's independent of any base images we use.