### PR TITLE
ci: reset integration action timeout to 15 mins

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,7 +8,7 @@ jobs:
   integration:
     name: Integration test
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 15
     steps:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v4


### PR DESCRIPTION
The new integration action still comes in at an average of 12 mins.