### PR TITLE
fix: typo in earn persistence

### DIFF
--- a/core/api/src/migrations/20231030191242-fix-earn-typo.ts
+++ b/core/api/src/migrations/20231030191242-fix-earn-typo.ts
@@ -1,0 +1,16 @@
+/* eslint @typescript-eslint/ban-ts-comment: "off" */
+// @ts-nocheck
+module.exports = {
+  async up(db) {
+    const incorrectSpelling = "moneySocialAggrement"
+    const correctSpelling = "moneySocialAgreement" // spelling fixed in this pr https://github.com/GaloyMoney/galoy/pull/3306/files
+
+    try {
+      await db
+        .collection("accounts")
+        .updateMany({ earn: incorrectSpelling }, { $set: { "earn.$": correctSpelling } })
+    } catch (error) {
+      console.log({ result: error }, `Couldn't update accounts`)
+    }
+  },
+}


### PR DESCRIPTION
- db migration fixing typo "moneySocialAggrement" that was fixed in the domain in pr #3306 