### PR TITLE
fix: audit command

### DIFF
--- a/core/api/Makefile
+++ b/core/api/Makefile
@@ -122,9 +122,8 @@ create-tmp-env-ci:
 	. ./.env && \
 	envsubst < ./.env.ci > tmp.env.ci
 
-# 16 is exit code for critical https://classic.yarnpkg.com/lang/en/docs/cli/audit
 audit:
-	bash -c 'pnpm audit --audit-level critical; [[ $$? -ge 16 ]] && exit 1 || exit 0'
+	bash -c 'pnpm audit --audit-level critical --ignore-registry-errors --json | jq -e ".metadata.vulnerabilities.critical > 0" && exit 1 || exit 0'
 
 mine-block:
 	container_id=$$(docker ps -q -f status=running -f name="bitcoind-1"); \


### PR DESCRIPTION
current cmd is not working because pnpm does not return same exit codes as yarn

FYI: needs to be rebased once the critical issue is fixed