### PR TITLE
build: add pnpm workspace context to Dockerfile-migrate

### DIFF
--- a/core/api/Dockerfile-migrate
+++ b/core/api/Dockerfile-migrate
@@ -6,9 +6,14 @@ RUN apk update && apk add git
 
 RUN npm install -g pnpm
 
+COPY tmp/workspace/* ./
+
+RUN mkdir -p core/api
+WORKDIR /app/core/api
+
 COPY ./*.json ./
 
-RUN pnpm install
+RUN pnpm install --frozen-lockfile
 
 COPY ./src ./src
 COPY ./test ./test
@@ -18,18 +23,19 @@ RUN pnpm run build
 COPY ./scripts ./scripts
 
 FROM node:20-alpine
-COPY --from=BUILD_IMAGE /app/dist /app/dist
-COPY --from=BUILD_IMAGE /app/src/config/locales /app/dist/config/locales
 COPY --from=BUILD_IMAGE /app/node_modules /app/node_modules
-COPY --from=BUILD_IMAGE /app/scripts /app/scripts
+COPY --from=BUILD_IMAGE /app/core/api/dist /app/core/api/dist
+COPY --from=BUILD_IMAGE /app/core/api/src/config/locales /app/core/api/dist/config/locales
+COPY --from=BUILD_IMAGE /app/core/api/node_modules /app/core/api/node_modules
+COPY --from=BUILD_IMAGE /app/core/api/scripts /app/core/api/scripts
 
-WORKDIR /app
+WORKDIR /app/core/api
 COPY ./*.js ./package.json ./tsconfig.json ./
 RUN touch .env
 
 ### debug only
-COPY --from=BUILD_IMAGE /app/src /app/src
-COPY --from=BUILD_IMAGE /app/test /app/test
+COPY --from=BUILD_IMAGE /app/core/api/src /app/core/api/src
+COPY --from=BUILD_IMAGE /app/core/api/test /app/core/api/test
 COPY ./junit.xml ./
 ###
 

--- a/core/api/Makefile
+++ b/core/api/Makefile
@@ -59,9 +59,12 @@ reset-deps-integration: clean-deps start-deps-integration
 test: unit legacy-integration integration
 
 test-migrate:
+	mkdir -p tmp/workspace
+	cp ../../pnpm-*.yaml ../../package.json tmp/workspace/
 	docker compose down -v -t 3
 	docker compose build
 	docker compose -f docker-compose.yml up mongodb-migrate --exit-code-from mongodb-migrate
+	rm -r tmp/workspace
 
 unit:
 	pnpm run test:unit


### PR DESCRIPTION
## Description

This is to nest the files inside Dockerfile-migrate in the same structure as the monorepo and to bring in pnpm lock and workspace files so that packages can be installed from frozen versions.

Needed to fix: https://github.com/GaloyMoney/galoy/actions/runs/6714989030/job/18249348323?pr=3454