### PR TITLE
fix(core): add watcher for pending held invoices

### DIFF
--- a/core/api/src/config/index.ts
+++ b/core/api/src/config/index.ts
@@ -15,6 +15,7 @@ import { ConfigError } from "./error"
 import { toDays } from "@/domain/primitives"
 
 export const MS_PER_SEC = 1000 as MilliSeconds
+export const MS_PER_5_MINS = (60 * 5 * MS_PER_SEC) as MilliSeconds
 export const MS_PER_HOUR = (60 * 60 * MS_PER_SEC) as MilliSeconds
 export const MS_PER_DAY = (24 * MS_PER_HOUR) as MilliSeconds
 export const TWO_MONTHS_IN_MS = (60 * MS_PER_DAY) as MilliSeconds

--- a/core/api/src/servers/trigger.ts
+++ b/core/api/src/servers/trigger.ts
@@ -24,7 +24,13 @@ import { briaEventHandler } from "./event-handlers/bria"
 
 import healthzHandler from "./middlewares/healthz"
 
-import { getSwapConfig, NETWORK, ONCHAIN_MIN_CONFIRMATIONS, TRIGGER_PORT } from "@/config"
+import {
+  getSwapConfig,
+  MS_PER_5_MINS,
+  NETWORK,
+  ONCHAIN_MIN_CONFIRMATIONS,
+  TRIGGER_PORT,
+} from "@/config"
 
 import {
   Payments,
@@ -175,6 +181,12 @@ const publishCurrentPrice = () => {
   return setInterval(async () => {
     await publishCurrentPrices()
   }, interval)
+}
+
+const watchHeldInvoices = () => {
+  return setInterval(async () => {
+    await Wallets.handleHeldInvoices(logger)
+  }, MS_PER_5_MINS)
 }
 
 const listenerOnchain = (lnd: AuthenticatedLnd) => {
@@ -488,6 +500,7 @@ const main = () => {
 
   activateLndHealthCheck()
   publishCurrentPrice()
+  watchHeldInvoices()
 
   if (getSwapConfig().feeAccountingEnabled) listenerSwapMonitor()
 


### PR DESCRIPTION
there were [multiple cases](https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/6PPbsaCmy2Y) not fixed manually (probably fixed by the new deployments). This PR adds a watcher to trigger that runs handleHeldInvoices (same used in cron) every 5 mins.

Please keep in mind that this will not fix edge case mentioned in the meeting so we still need to create/update the alert.

fyi: I tested the alternatives but were slower because they validated against lnds and not db like with this solution