### PR TITLE
perf(core): run watchHeldInvoices only if held invoices count gt 0

### DIFF
--- a/core/api/src/servers/trigger.ts
+++ b/core/api/src/servers/trigger.ts
@@ -33,6 +33,7 @@ import {
 } from "@/config"
 
 import {
+  Lightning,
   Payments,
   Prices as PricesWithSpans,
   Swap as SwapWithSpans,
@@ -185,7 +186,11 @@ const publishCurrentPrice = () => {
 
 const watchHeldInvoices = () => {
   return setInterval(async () => {
-    await Wallets.handleHeldInvoices(logger)
+    const heldInvoicesCount = await Lightning.getHeldInvoicesCount()
+    if (heldInvoicesCount instanceof Error) return
+    if (heldInvoicesCount > 0) {
+      await Wallets.handleHeldInvoices(logger)
+    }
   }, MS_PER_5_MINS)
 }
 


### PR DESCRIPTION
the watcher is adding [more traces](https://ui.honeycomb.io/teams/galoy/usage) than expected (above daily threshold), this will reduce this consumption and lnd grpc api usage 