### PR TITLE
fix: filter invoices without paymentRequest

### DIFF
--- a/core/api/dev/apollo-federation/supergraph.graphql
+++ b/core/api/dev/apollo-federation/supergraph.graphql
@@ -644,6 +644,8 @@ input IntraLedgerUsdPaymentSendInput
 interface Invoice
   @join__type(graph: PUBLIC)
 {
+  createdAt: Timestamp!
+
   """The payment hash of the lightning invoice."""
   paymentHash: PaymentHash!
 
@@ -717,11 +719,12 @@ type LnInvoice implements Invoice
   @join__implements(graph: PUBLIC, interface: "Invoice")
   @join__type(graph: PUBLIC)
 {
+  createdAt: Timestamp!
   paymentHash: PaymentHash!
   paymentRequest: LnPaymentRequest!
   paymentSecret: LnPaymentSecret!
   paymentStatus: InvoicePaymentStatus!
-  satoshis: SatAmount
+  satoshis: SatAmount!
 }
 
 input LnInvoiceCreateInput
@@ -803,6 +806,7 @@ type LnNoAmountInvoice implements Invoice
   @join__implements(graph: PUBLIC, interface: "Invoice")
   @join__type(graph: PUBLIC)
 {
+  createdAt: Timestamp!
   paymentHash: PaymentHash!
   paymentRequest: LnPaymentRequest!
   paymentSecret: LnPaymentSecret!

--- a/core/api/src/graphql/admin/schema.graphql
+++ b/core/api/src/graphql/admin/schema.graphql
@@ -197,6 +197,8 @@ type InitiationViaOnChain {
 
 """A lightning invoice."""
 interface Invoice {
+  createdAt: Timestamp!
+
   """The payment hash of the lightning invoice."""
   paymentHash: PaymentHash!
 

--- a/core/api/src/graphql/public/schema.graphql
+++ b/core/api/src/graphql/public/schema.graphql
@@ -474,6 +474,8 @@ input IntraLedgerUsdPaymentSendInput {
 
 """A lightning invoice."""
 interface Invoice {
+  createdAt: Timestamp!
+
   """The payment hash of the lightning invoice."""
   paymentHash: PaymentHash!
 
@@ -516,11 +518,12 @@ enum InvoicePaymentStatus {
 scalar Language
 
 type LnInvoice implements Invoice {
+  createdAt: Timestamp!
   paymentHash: PaymentHash!
   paymentRequest: LnPaymentRequest!
   paymentSecret: LnPaymentSecret!
   paymentStatus: InvoicePaymentStatus!
-  satoshis: SatAmount
+  satoshis: SatAmount!
 }
 
 input LnInvoiceCreateInput {
@@ -585,6 +588,7 @@ type LnInvoicePaymentStatusPayload {
 }
 
 type LnNoAmountInvoice implements Invoice {
+  createdAt: Timestamp!
   paymentHash: PaymentHash!
   paymentRequest: LnPaymentRequest!
   paymentSecret: LnPaymentSecret!

--- a/core/api/src/graphql/shared/types/abstract/invoice.ts
+++ b/core/api/src/graphql/shared/types/abstract/invoice.ts
@@ -5,6 +5,8 @@ import LnPaymentSecret from "../scalar/ln-payment-secret"
 
 import InvoicePaymentStatus from "../scalar/invoice-payment-status"
 
+import Timestamp from "../scalar/timestamp"
+
 import { GT } from "@/graphql/index"
 import { connectionDefinitions } from "@/graphql/connections"
 
@@ -28,6 +30,9 @@ const IInvoice = GT.Interface({
     paymentStatus: {
       type: GT.NonNull(InvoicePaymentStatus),
       description: "The payment status of the invoice.",
+    },
+    createdAt: {
+      type: GT.NonNull(Timestamp),
     },
   }),
 })

--- a/core/api/src/graphql/shared/types/object/ln-invoice.ts
+++ b/core/api/src/graphql/shared/types/object/ln-invoice.ts
@@ -7,6 +7,8 @@ import IInvoice from "../abstract/invoice"
 
 import InvoicePaymentStatus from "../scalar/invoice-payment-status"
 
+import Timestamp from "../scalar/timestamp"
+
 import { GT } from "@/graphql/index"
 import { WalletInvoiceStatusChecker } from "@/domain/wallet-invoices/wallet-invoice-status-checker"
 
@@ -28,7 +30,7 @@ const LnInvoice = GT.Object<WalletInvoice>({
       resolve: (source) => source.lnInvoice.paymentSecret,
     },
     satoshis: {
-      type: SatAmount,
+      type: GT.NonNull(SatAmount),
       resolve: (source) => source.lnInvoice.amount,
     },
     paymentStatus: {
@@ -38,6 +40,10 @@ const LnInvoice = GT.Object<WalletInvoice>({
         const status = statusChecker.status(new Date())
         return status
       },
+    },
+    createdAt: {
+      type: GT.NonNull(Timestamp),
+      resolve: (source) => source.createdAt,
     },
   }),
 })

--- a/core/api/src/graphql/shared/types/object/ln-noamount-invoice.ts
+++ b/core/api/src/graphql/shared/types/object/ln-noamount-invoice.ts
@@ -4,6 +4,8 @@ import LnPaymentSecret from "../scalar/ln-payment-secret"
 
 import IInvoice from "../abstract/invoice"
 
+import Timestamp from "../scalar/timestamp"
+
 import { GT } from "@/graphql/index"
 import InvoicePaymentStatus from "@/graphql/shared/types/scalar/invoice-payment-status"
 import { WalletInvoiceStatusChecker } from "@/domain/wallet-invoices/wallet-invoice-status-checker"
@@ -32,6 +34,10 @@ const LnNoAmountInvoice = GT.Object<WalletInvoice>({
         const status = statusChecker.status(new Date())
         return status
       },
+    },
+    createdAt: {
+      type: GT.NonNull(Timestamp),
+      resolve: (source) => source.createdAt,
     },
   }),
 })

--- a/core/api/src/services/mongoose/wallet-invoices.ts
+++ b/core/api/src/services/mongoose/wallet-invoices.ts
@@ -163,8 +163,12 @@ export const WalletInvoicesRepository = (): IWalletInvoicesRepository => {
           $lt?: Date
           $gt?: Date
         }
+        paymentRequest: {
+          $exists: true
+        }
       } = {
         walletId: { $in: walletIds },
+        paymentRequest: { $exists: true },
       }
 
       // this could cause a bug if there are multiple invoices with the same timestamp

--- a/dev/config/apollo-federation/supergraph.graphql
+++ b/dev/config/apollo-federation/supergraph.graphql
@@ -644,6 +644,8 @@ input IntraLedgerUsdPaymentSendInput
 interface Invoice
   @join__type(graph: PUBLIC)
 {
+  createdAt: Timestamp!
+
   """The payment hash of the lightning invoice."""
   paymentHash: PaymentHash!
 
@@ -717,11 +719,12 @@ type LnInvoice implements Invoice
   @join__implements(graph: PUBLIC, interface: "Invoice")
   @join__type(graph: PUBLIC)
 {
+  createdAt: Timestamp!
   paymentHash: PaymentHash!
   paymentRequest: LnPaymentRequest!
   paymentSecret: LnPaymentSecret!
   paymentStatus: InvoicePaymentStatus!
-  satoshis: SatAmount
+  satoshis: SatAmount!
 }
 
 input LnInvoiceCreateInput
@@ -803,6 +806,7 @@ type LnNoAmountInvoice implements Invoice
   @join__implements(graph: PUBLIC, interface: "Invoice")
   @join__type(graph: PUBLIC)
 {
+  createdAt: Timestamp!
   paymentHash: PaymentHash!
   paymentRequest: LnPaymentRequest!
   paymentSecret: LnPaymentSecret!


### PR DESCRIPTION
- filter out legacy invoices during pagination that dont contain paymentRequests
- add createdAt field to gql invoice interface