### PR TITLE
chore(api-keys): add tracing to graphql schema

### DIFF
--- a/core/api-keys/src/graphql/mod.rs
+++ b/core/api-keys/src/graphql/mod.rs
@@ -1,7 +1,7 @@
 mod convert;
 mod schema;
 
-use async_graphql::*;
+use async_graphql::{extensions::Tracing, *};
 
 pub use schema::*;
 
@@ -9,6 +9,7 @@ use crate::app::ApiKeysApp;
 
 pub fn schema(app: Option<ApiKeysApp>) -> Schema<Query, Mutation, EmptySubscription> {
     let schema = Schema::build(Query, Mutation, EmptySubscription);
+    let schema = schema.extension(Tracing);
     if let Some(app) = app {
         schema.data(app).finish()
     } else {


### PR DESCRIPTION
Adds tracing for async_graphql schema