### PR TITLE
fix(api): withdrawal volumes handling for failed payments

### DIFF
--- a/core/api/src/services/ledger/facade/volume.ts
+++ b/core/api/src/services/ledger/facade/volume.ts
@@ -21,6 +21,7 @@ export const TxnGroups = {
   ],
   externalPaymentVolumeSince: [
     LedgerTransactionType.Payment,
+    LedgerTransactionType.LnFeeReimbursement,
     LedgerTransactionType.OnchainPayment,
   ],
   intraledgerTxBaseVolumeSince: [

--- a/core/api/src/services/ledger/facade/volume.ts
+++ b/core/api/src/services/ledger/facade/volume.ts
@@ -10,6 +10,7 @@ import { timestampDaysAgo } from "@/utils"
 
 import { paymentAmountFromNumber } from "@/domain/shared"
 import { addAttributesToCurrentSpan } from "@/services/tracing"
+import { MS_PER_DAY } from "@/config"
 
 export const TxnGroups = {
   allPaymentVolumeSince: [
@@ -70,6 +71,34 @@ const TxVolumeAmountSinceFactory = () => {
             accounts: liabilitiesWalletId,
             $or: txnTypesObj,
             $and: [{ timestamp: { $gte: timestamp } }],
+          },
+        },
+        {
+          $lookup: {
+            from: "medici_transactions",
+            localField: "_original_journal",
+            foreignField: "_journal",
+            as: "original_transactions",
+          },
+        },
+        {
+          $addFields: {
+            is_transaction_valid: {
+              $or: [
+                { $eq: [{ $size: "$original_transactions" }, 0] },
+                {
+                  $gte: [
+                    { $arrayElemAt: ["$original_transactions.datetime", 0] },
+                    new Date(Date.now() - MS_PER_DAY),
+                  ],
+                },
+              ],
+            },
+          },
+        },
+        {
+          $match: {
+            is_transaction_valid: true,
           },
         },
         {

--- a/core/api/test/integration/services/ledger-facade.spec.ts
+++ b/core/api/test/integration/services/ledger-facade.spec.ts
@@ -595,6 +595,32 @@ describe("Facade", () => {
         const remaining = await remainingWithdrawalLimit({ priceRatio: sendPriceRatio })
         expect(remaining).toStrictEqual(accountLimitAmountsLevelOne.withdrawalLimit)
       })
+
+      it("returns correct volume for a fee reimbursed btc transaction", async () => {
+        const resBtc = await recordSendLnPayment({
+          walletDescriptor: accountWalletDescriptors.BTC,
+          paymentAmount: sendAmount,
+          bankFee,
+          displayAmounts: displaySendEurAmounts,
+        })
+        if (resBtc instanceof Error) throw resBtc
+
+        const reimbursed = await recordLnFeeReimbursement({
+          walletDescriptor: accountWalletDescriptors.BTC,
+          paymentAmount: bankFee,
+          bankFee,
+          displayAmounts: displayReceiveEurAmounts,
+        })
+        if (reimbursed instanceof Error) throw reimbursed
+
+        const expectedRemaining = calc.sub(
+          accountLimitAmountsLevelOne.withdrawalLimit,
+          calc.sub(sendAmount.usd, bankFee.usd),
+        )
+
+        const remaining = await remainingWithdrawalLimit({ priceRatio: sendPriceRatio })
+        expect(remaining).toStrictEqual(expectedRemaining)
+      })
     })
   })
 })

--- a/core/api/test/integration/services/ledger-facade.spec.ts
+++ b/core/api/test/integration/services/ledger-facade.spec.ts
@@ -576,6 +576,25 @@ describe("Facade", () => {
         const remaining = await remainingWithdrawalLimit({ priceRatio: sendPriceRatio })
         expect(remaining).toStrictEqual(expectedRemaining)
       })
+
+      it("returns 0 volume for a voided btc transaction", async () => {
+        const resBtc = await recordSendLnPayment({
+          walletDescriptor: accountWalletDescriptors.BTC,
+          paymentAmount: sendAmount,
+          bankFee,
+          displayAmounts: displaySendEurAmounts,
+        })
+        if (resBtc instanceof Error) throw resBtc
+
+        const voided = await LedgerFacade.recordLnSendRevert({
+          journalId: resBtc.journalId,
+          paymentHash: resBtc.paymentHash,
+        })
+        if (voided instanceof Error) return voided
+
+        const remaining = await remainingWithdrawalLimit({ priceRatio: sendPriceRatio })
+        expect(remaining).toStrictEqual(accountLimitAmountsLevelOne.withdrawalLimit)
+      })
     })
   })
 })


### PR DESCRIPTION
## Description

This fixes an issue that was discovered where a user tried to send $700 twice (and got routing errors) and then on the third attempt was hit was a `WithdrawalLimitExceeded` error since the previous 2 failed attempts were wrongly accounted for when calculating volumes.

_See pattern in [traces](https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/FjAzT7CJvnt)_