### PR TITLE
fix(core): avoid unknown exceptions in setGqlContext

### DIFF
--- a/core/api/src/servers/graphql-main-server.ts
+++ b/core/api/src/servers/graphql-main-server.ts
@@ -30,14 +30,13 @@ import {
   ACCOUNT_USERNAME,
   SemanticAttributes,
   addAttributesToCurrentSpanAndPropagate,
-  recordExceptionInCurrentSpan,
 } from "@/services/tracing"
 
 import { parseIps } from "@/domain/accounts-ips"
 
 export const isAuthenticated = rule({ cache: "contextual" })((
-  parent,
-  args,
+  _parent,
+  _args,
   ctx: GraphQLPublicContext,
 ) => {
   return "domainAccount" in ctx && !!ctx.domainAccount
@@ -45,7 +44,7 @@ export const isAuthenticated = rule({ cache: "contextual" })((
 
 const setGqlContext = async (
   req: Request,
-  res: Response,
+  _res: Response,
   next: NextFunction,
 ): Promise<void> => {
   const tokenPayload = req.token
@@ -60,15 +59,6 @@ const setGqlContext = async (
     tokenPayload,
     ip,
   })
-
-  if (gqlContext instanceof Error) {
-    recordExceptionInCurrentSpan({
-      error: gqlContext,
-      fallbackMsg: "error executing sessionPublicContext",
-    })
-    next(gqlContext)
-    return
-  }
 
   req.gqlContext = gqlContext
 


### PR DESCRIPTION
Avoid 500 errors for [CouldNotFindAccountFromKratosIdError](https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/6XnXpZ12jLz/trace/f9RTg5P266F?fields[]=s_name&fields[]=s_serviceName&span=1aeaee98a7b2420b)