### PR TITLE
refactor(core): move 'watch:compile' from make to buck

### DIFF
--- a/core/api/BUCK
+++ b/core/api/BUCK
@@ -199,3 +199,9 @@ dev_pnpm_task_binary(
   srcs = [":src"],
   visibility = ["PUBLIC"],
 )
+
+dev_pnpm_task_binary(
+  name = "watch-compile",
+  command = "watch:compile",
+  srcs = [":src"] + [":test_src"],
+)

--- a/core/api/Makefile
+++ b/core/api/Makefile
@@ -70,9 +70,6 @@ watch-unit:
 	$(BIN_DIR)/jest --config ./test/unit/jest.config.js --clearCache
 	NODE_ENV=test LOGLEVEL=warn $(BIN_DIR)/jest --watch --config ./test/unit/jest.config.js
 
-watch-compile:
-	$(BIN_DIR)/tsc --watch  --noEmit
-
 del-containers:
 	docker compose rm -sfv
 

--- a/core/api/package.json
+++ b/core/api/package.json
@@ -8,6 +8,7 @@
     "trigger": "pnpm run build && node dist/servers/trigger.js | pino-pretty -c -l",
     "ws": "pnpm run build && node dist/servers/ws-server.js | pino-pretty -c -l",
     "watch": "nodemon -V -e ts,graphql -w ./src -x pnpm run start",
+    "watch:compile": "tsc --watch  --noEmit",
     "watch-trigger": "nodemon -V -e ts,graphql -w ./src -x pnpm run trigger",
     "graphql-check": "curl -fsS https://raw.githubusercontent.com/GaloyMoney/galoy-mobile/main/app/graphql/generated.gql -o generated.gql && npx @graphql-inspector/cli validate ./generated.gql src/graphql/public/schema.graphql --apollo --noStrictFragments",
     "cron": ". ../../.env && pnpm run build && node dist/servers/cron.js",

--- a/toolchains/workspace-pnpm/macros.bzl
+++ b/toolchains/workspace-pnpm/macros.bzl
@@ -1019,7 +1019,11 @@ cd "$rootpath/$npm_package_path"
 if [ "$install_node_modules" = "True" ]; then
     pnpm install
 fi
-exec pnpm run --report-summary "$npm_run_command" -- "${@:4}"
+if [ "${*:4}" ]; then
+    exec pnpm run --report-summary "$npm_run_command" -- "${@:4}"
+else
+    exec pnpm run --report-summary "$npm_run_command"
+fi
 """, is_executable = True)
     args = cmd_args([script, str(ctx.attrs.local_node_modules), ctx.label.package, ctx.attrs.command])
     args.hidden([ctx.attrs.deps])


### PR DESCRIPTION
## Description

This change would mean that to watch-compile we would now do:
```bash
$ buck2 run //core/api:watch-compile
```

cc @nicolasburtey @dolcalmi 