### PR TITLE
chore(core): enforce non-negative 'volumeRemaining'

### DIFF
--- a/core/api/src/domain/accounts/limits-volume.ts
+++ b/core/api/src/domain/accounts/limits-volume.ts
@@ -77,7 +77,8 @@ export const AccountTxVolumeRemaining = (
       "txVolume.limitCheck": AccountLimitsType.IntraLedger,
     })
 
-    return calc.sub(limitAmount, outgoingUsdVolumeAmount)
+    const rawVolumeRemaining = calc.sub(limitAmount, outgoingUsdVolumeAmount)
+    return calc.max(ZERO_CENTS, rawVolumeRemaining)
   }
 
   const withdrawal = async ({
@@ -110,7 +111,8 @@ export const AccountTxVolumeRemaining = (
     })
 
     const netVolumeAmount = calc.sub(outgoingUsdVolumeAmount, incomingUsdVolumeAmount)
-    return calc.sub(limitAmount, netVolumeAmount)
+    const rawVolumeRemaining = calc.sub(limitAmount, netVolumeAmount)
+    return calc.max(ZERO_CENTS, rawVolumeRemaining)
   }
 
   const tradeIntraAccount = async ({
@@ -138,7 +140,8 @@ export const AccountTxVolumeRemaining = (
       "txVolume.limitCheck": AccountLimitsType.SelfTrade,
     })
 
-    return calc.sub(limitAmount, outgoingUsdVolumeAmount)
+    const rawVolumeRemaining = calc.sub(limitAmount, outgoingUsdVolumeAmount)
+    return calc.max(ZERO_CENTS, rawVolumeRemaining)
   }
 
   return {

--- a/core/api/test/unit/domain/accounts/limits-volume.spec.ts
+++ b/core/api/test/unit/domain/accounts/limits-volume.spec.ts
@@ -129,7 +129,7 @@ describe("LimitsChecker", () => {
     })
   })
 
-  describe.skip("returns 0n for walletVolumes above limit", () => {
+  describe("returns 0n for walletVolumes above limit", () => {
     it("intraLedger", async () => {
       const remaining = await volumeRemainingCalc.intraLedger({
         priceRatio,


### PR DESCRIPTION
## Description

This is to handle the edge-cases where WalletVolume calculated exceeds the limit amount (conversion inconsistencies for e.g.), which leads to negative values for `volumeRemaining`.

The volumes here are used in 2 places:
- limit checks (e.g. [here](https://github.com/GaloyMoney/galoy/blob/b695d2fb460757bd6e12e0a4026139aaa8263c8b/core/api/src/app/accounts/account-limit.ts#L55))
- remaining limits query (e.g. [here](https://github.com/GaloyMoney/galoy/blob/b695d2fb460757bd6e12e0a4026139aaa8263c8b/core/api/src/graphql/public/types/object/one-day-account-limit.ts#L51))

In the first case negative values don't matter when comparing against amount-to-be-sent, but in the 2nd case where the value is returned from a query to the client, seeing negative "volume remaining" amounts can be confusing.