### PR TITLE
fix: pending payments notifications

### DIFF
--- a/core/api/src/app/payments/update-pending-payments.ts
+++ b/core/api/src/app/payments/update-pending-payments.ts
@@ -253,20 +253,11 @@ const updatePendingPayment = wrapAsyncToRunInSpan({
       )
 
       const revealedPreImage = lnPaymentLookup.confirmedDetails?.revealedPreImage
-      if (revealedPreImage)
-        LedgerService().updateMetadataByHash({
+      if (revealedPreImage) {
+        await LedgerService().updateMetadataByHash({
           hash: paymentHash,
           revealedPreImage,
         })
-      if (pendingPayment.feeKnownInAdvance) return true
-
-      const { displayAmount, displayFee, displayCurrency } = pendingPayment
-      if (
-        displayAmount === undefined ||
-        displayFee === undefined ||
-        displayCurrency === undefined
-      ) {
-        return new MissingExpectedDisplayAmountsForTransactionError()
       }
 
       const senderWallet = await WalletsRepository().findById(walletId)
@@ -303,6 +294,12 @@ const updatePendingPayment = wrapAsyncToRunInSpan({
         })
       }
 
+      if (pendingPayment.feeKnownInAdvance) return true
+
+      const { displayAmount, displayFee, displayCurrency } = pendingPayment
+      if (!displayAmount || !displayFee || !displayCurrency) {
+        return new MissingExpectedDisplayAmountsForTransactionError()
+      }
       return reimburseFee({
         paymentFlow,
         senderDisplayAmount: displayAmount,


### PR DESCRIPTION
fix a bug with notifications for pending payments with known fee (i.e with probe)

basically this line `if (pendingPayment.feeKnownInAdvance) return true` was causing an early return so the users did not receive notifications when a pending payment is confirmed