### PR TITLE
build: allow run script to handle multiline env variables

### DIFF
--- a/toolchains/workspace-pnpm/run_in_dir.py
+++ b/toolchains/workspace-pnpm/run_in_dir.py
@@ -21,8 +21,11 @@ def merge_env_from_file(file_path):
     lines = result.stdout.strip().split('\n')
     env_dict = {}
     for line in lines:
-        key, value = line.split('=', 1)
-        env_dict[key] = value
+        if "=" in line:
+            key, value = line.split('=', 1)
+            env_dict[key] = value
+        elif key in env_dict:  # Handle multi-line values
+            env_dict[key] += "\n" + line
 
     return env_dict
 


### PR DESCRIPTION
## Description

This fixes being able to handle an env that has multiline variables like `buildPhase` like this:
```env
AR_FOR_BUILD=ar
LND2_PUBKEY=039341ef13e776dc1611502cf510110d9ac5cdc252141f5997adcfd72cef34c3a7
buildPhase={ echo "------------------------------------------------------------";
  echo " WARNING: the existence of this path is not guaranteed.";
  echo " It is an internal implementation detail for pkgs.mkShell.";
  echo "------------------------------------------------------------";
  echo;
  # Record all build inputs as runtime dependencies
  export;
} >> "$out"

REDIS_PASSWORD=
PRICE_PORT=50051
REDIS_0_PORT=6379
```