### PR TITLE
fix: s3 backup

### DIFF
--- a/core/api/src/app/admin/backup.ts
+++ b/core/api/src/app/admin/backup.ts
@@ -1,3 +1,5 @@
+import { createHash } from "crypto"
+
 import { Storage } from "@google-cloud/storage"
 import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3"
 
@@ -22,7 +24,6 @@ import {
   asyncRunInSpan,
   recordExceptionInCurrentSpan,
 } from "@/services/tracing"
-import { createHash } from "crypto"
 
 export const uploadBackup =
   (logger: Logger) =>

--- a/core/api/src/app/admin/backup.ts
+++ b/core/api/src/app/admin/backup.ts
@@ -22,6 +22,7 @@ import {
   asyncRunInSpan,
   recordExceptionInCurrentSpan,
 } from "@/services/tracing"
+import { createHash } from "crypto"
 
 export const uploadBackup =
   (logger: Logger) =>
@@ -133,6 +134,7 @@ export const uploadBackup =
             Bucket: LND_SCB_BACKUP_BUCKET_NAME,
             Key: `lnd_scb/${filename}`,
             Body: backup,
+            ContentMD5: createHash("md5").update(backup).digest("base64"),
           })
           try {
             client.send(command)


### PR DESCRIPTION
We need to provide a checksum to upload to buckets with object lock enabled, otherwise the upload fails with:
```
InvalidRequest: Content-MD5 OR x-amz-checksum- HTTP header is required for Put Object requests with Object Lock parameters
```
