### PR TITLE
test(core): correct external address to random regtest one

### DIFF
--- a/bats/core/api/onchain-send.bats
+++ b/bats/core/api/onchain-send.bats
@@ -440,7 +440,7 @@ grep_in_trigger_logs() {
   payout_id=$(bria_cli submit-payout \
     -w dev-wallet \
     -q dev-queue \
-    -d bc1qxnjv6rqqzxc6kglyasljmwupwrlv5n5uqkyuk0 \
+    -d bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw \
     -a 1000000000 \
     | jq -r '.id'
   )


### PR DESCRIPTION
## Description

This fixes an issue in bats tests that was exposed by an upstream change to bria in [`v0.1.77`](https://github.com/GaloyMoney/bria/releases/tag/0.1.77).

_Build that broke: [235](https://ci.galoy.io/teams/dev/pipelines/galoy-legacy-core/jobs/bats-tests/builds/235)_