### PR TITLE
chore(core): only check batch inclusion when sending

### DIFF
--- a/core/api/src/graphql/shared/types/abstract/settlement-via.ts
+++ b/core/api/src/graphql/shared/types/abstract/settlement-via.ts
@@ -59,6 +59,9 @@ const SettlementViaOnChain = GT.Object({
     arrivalInMempoolEstimatedAt: {
       type: Timestamp,
       resolve: async (source) => {
+        if (source.parent.settlementAmount > 0) {
+          return null
+        }
         const estimation = await OnChain.getBatchInclusionEstimatedAt({
           ledgerTransactionId: source.parent.id,
         })


### PR DESCRIPTION
We are seeing lots of errors because we are hitting bria for every unchain transaction - but we should only hit it when its outgoing.