### PR TITLE
fix(core): remove critical level from CouldNotFindLnPaymentFromHashError

### DIFF
--- a/core/api/src/app/lightning/delete-ln-payments.ts
+++ b/core/api/src/app/lightning/delete-ln-payments.ts
@@ -1,17 +1,20 @@
-import { UnknownLightningServiceError } from "@/domain/bitcoin/lightning"
+import { ErrorLevel } from "@/domain/shared"
 import { CouldNotFindLnPaymentFromHashError } from "@/domain/errors"
-import { LndService } from "@/services/lnd"
-import { LnPaymentsRepository } from "@/services/mongoose"
+import { UnknownLightningServiceError } from "@/domain/bitcoin/lightning"
+
 import {
   addAttributesToCurrentSpan,
   asyncRunInSpan,
+  recordExceptionInCurrentSpan,
   SemanticAttributes,
 } from "@/services/tracing"
+import { LndService } from "@/services/lnd"
+import { LnPaymentsRepository } from "@/services/mongoose"
 
 export const deleteLnPaymentsBefore = async (
   timestamp: Date,
 ): Promise<true | ApplicationError> => {
-  const paymentHashesBefore = await listAllPaymentsBefore(timestamp)
+  const paymentHashesBefore = listAllPaymentsBefore(timestamp)
 
   for await (const paymentHash of paymentHashesBefore) {
     if (paymentHash instanceof Error) return paymentHash
@@ -43,6 +46,7 @@ const checkAndDeletePaymentForHash = async ({
       const lnPayment = await LnPaymentsRepository().findByPaymentHash(paymentHash)
       if (lnPayment instanceof Error) {
         if (lnPayment instanceof CouldNotFindLnPaymentFromHashError) {
+          recordExceptionInCurrentSpan({ error: lnPayment, level: ErrorLevel.Critical })
           // Attempt to get paymentRequest from lnd
           const lndService = LndService()
           if (lndService instanceof Error) return lndService

--- a/core/api/src/domain/errors.ts
+++ b/core/api/src/domain/errors.ts
@@ -58,9 +58,7 @@ export class NoExpiredLightningPaymentFlowsError extends CouldNotFindError {}
 export class CouldNotFindBtcWalletForAccountError extends CouldNotFindError {
   level = ErrorLevel.Critical
 }
-export class CouldNotFindLnPaymentFromHashError extends CouldNotFindError {
-  level = ErrorLevel.Critical
-}
+export class CouldNotFindLnPaymentFromHashError extends CouldNotFindError {}
 
 export class CouldNotFindAccountFromIdError extends CouldNotFindError {}
 export class CouldNotFindAccountFromUsernameError extends CouldNotFindError {}

--- a/core/api/src/services/mongoose/ln-payments.ts
+++ b/core/api/src/services/mongoose/ln-payments.ts
@@ -58,7 +58,7 @@ export const LnPaymentsRepository = (): ILnPaymentsRepository => {
         payment,
         { new: true },
       )
-      if (!result) return new CouldNotFindLnPaymentFromHashError()
+      if (!result) return new CouldNotFindLnPaymentFromHashError(payment.paymentHash)
       return lnPaymentFromRaw(result)
     } catch (err) {
       return parseRepositoryError(err)


### PR DESCRIPTION
Fix [critical alert](https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/bKoLF7MvsCp) for old txs in getPaymentRequestByTransactionId 