### PR TITLE
chore: add pnpm store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ target
 
 # vendir
 /.vendir-tmp/
+
+#pnpm
+.pnpm-store


### PR DESCRIPTION
This should fix the failing proto syncing pipelines that were trying to upload the pnpm store dir in the bot branch put step.
