### PR TITLE
fix: check if 'lineTypeIntelligence' property exists

### DIFF
--- a/core/api/src/domain/phone-provider/errors.ts
+++ b/core/api/src/domain/phone-provider/errors.ts
@@ -10,6 +10,9 @@ export class RestrictedRegionPhoneProviderError extends PhoneProviderServiceErro
 export class UnsubscribedRecipientPhoneProviderError extends PhoneProviderServiceError {}
 export class RestrictedRecipientPhoneNumberError extends PhoneProviderServiceError {}
 export class InvalidOrApprovedVerificationError extends PhoneProviderServiceError {}
+export class MissingTypePhoneProviderError extends PhoneProviderServiceError {
+  level = ErrorLevel.Critical
+}
 
 export class PhoneCodeInvalidError extends PhoneProviderServiceError {}
 

--- a/core/api/src/graphql/error-map.ts
+++ b/core/api/src/graphql/error-map.ts
@@ -179,6 +179,10 @@ export const mapError = (error: ApplicationError): CustomGraphQLError => {
       message = "Invalid phone number type. Please use a mobile number."
       return new ValidationInternalError({ message, logger: baseLogger })
 
+    case "MissingTypePhoneProviderError":
+      message = "Issue checking phone number. Please try again later or contact support."
+      return new ValidationInternalError({ message, logger: baseLogger })
+
     case "RestrictedRegionPhoneProviderError":
       message = "Phone number is not from a valid region"
       return new ValidationInternalError({ message, logger: baseLogger })

--- a/core/api/src/services/twilio-service.ts
+++ b/core/api/src/services/twilio-service.ts
@@ -16,6 +16,7 @@ import {
   InvalidOrApprovedVerificationError,
   InvalidPhoneNumberPhoneProviderError,
   InvalidTypePhoneProviderError,
+  MissingTypePhoneProviderError,
   PhoneCodeInvalidError,
   PhoneProviderConnectionError,
   PhoneProviderRateLimitExceededError,
@@ -57,6 +58,9 @@ export const TwilioClient = (): IPhoneProviderService => {
         fields: "line_type_intelligence",
       })
       // https://www.twilio.com/docs/lookup/v2-api/line-type-intelligence#type-property-values
+      if (!lookup.lineTypeIntelligence) {
+        return new MissingTypePhoneProviderError()
+      }
       if (lookup.lineTypeIntelligence.type === "nonFixedVoip") {
         return new InvalidTypePhoneProviderError("nonFixedVoip")
       }


### PR DESCRIPTION
## Description

Improves visibility for [this trace](https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/goLn2oFXeQi/trace/y31jmYHA5af?fields[]=s_name&fields[]=s_serviceName&source=query&span=cee07c2f2f2b5477)