### PR TITLE
chore(core): genericise kratos errors

### DIFF
--- a/core/api/src/services/kratos/totp.ts
+++ b/core/api/src/services/kratos/totp.ts
@@ -28,7 +28,7 @@ export const kratosInitiateTotp = async (token: AuthToken) => {
       .text as TotpSecret
     return { totpSecret, totpRegistrationId: res.data.id as TotpRegistrationId }
   } catch (err) {
-    return new UnknownKratosError(err)
+    return handleKratosErrors(err)
   }
 }
 
@@ -56,7 +56,6 @@ export const kratosValidateTotp = async ({
         return new LikelyBadCoreError()
       }
     }
-    console.log(err, "err123")
 
     return new UnknownKratosError(err)
   }

--- a/core/api/src/services/kratos/totp.ts
+++ b/core/api/src/services/kratos/totp.ts
@@ -87,15 +87,7 @@ export const kratosElevatingSessionWithTotp = async ({
       xSessionToken: authToken,
     })
   } catch (err) {
-    if (err instanceof Error && err.message === "Request failed with status code 400") {
-      return new LikelyNoUserWithThisPhoneExistError(err.message)
-    }
-
-    if (err instanceof Error && err.message === "Request failed with status code 401") {
-      return new AuthenticationKratosError(err.message)
-    }
-
-    return new UnknownKratosError(err)
+    return handleKratosErrors(err)
   }
 
   return true
@@ -113,3 +105,24 @@ export const kratosRemoveTotp = async (userId: UserId) => {
     return new UnknownKratosError(err)
   }
 }
+
+const handleKratosErrors = (err: Error | unknown) => {
+  if (!(err instanceof Error)) {
+    return new UnknownKratosError(err)
+  }
+
+  const match = (knownErrDetail: RegExp): boolean => knownErrDetail.test(err.message)
+  switch (true) {
+    case match(KnownKratosErrorDetails.BadRequestError):
+      return new LikelyNoUserWithThisPhoneExistError(err.message)
+    case match(KnownKratosErrorDetails.UnauthorizedError):
+      return new AuthenticationKratosError(err.message)
+    default:
+      return new UnknownKratosError(err.message)
+  }
+}
+
+const KnownKratosErrorDetails = {
+  BadRequestError: /Request failed with status code 400/,
+  UnauthorizedError: /Request failed with status code 401/,
+} as const


### PR DESCRIPTION
## Description

Refactor to apply error pattern matching to `kratosInitiateTotp` method for these [traces](https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/6BGS3pjVeoG/trace?source=query&span=79a275403c7fb696&trace_id=14ebf970fd15578f).