### PR TITLE
fix(core): CouldNotFindLnPaymentFromHashError alert

### DIFF
--- a/core/api/src/domain/bitcoin/lightning/index.types.d.ts
+++ b/core/api/src/domain/bitcoin/lightning/index.types.d.ts
@@ -165,7 +165,7 @@ type ListLnInvoicesArgs = {
 }
 
 interface ILightningService {
-  isLocal(pubkey: Pubkey): boolean | LightningServiceError
+  isLocal(pubkey: Pubkey): boolean
 
   defaultPubkey(): Pubkey
 

--- a/core/api/src/services/lnd/index.ts
+++ b/core/api/src/services/lnd/index.ts
@@ -102,7 +102,7 @@ export const LndService = (): ILightningService | LightningServiceError => {
     return activeOnchainNode.lnd
   }
 
-  const isLocal = (pubkey: Pubkey): boolean | LightningServiceError =>
+  const isLocal = (pubkey: Pubkey): boolean =>
     getLnds({ type: "offchain" }).some((item) => item.pubkey === pubkey)
 
   const listActivePubkeys = (): Pubkey[] =>


### PR DESCRIPTION
we have 3 cases: failures (related to empty htlcs lnd issue),  manual rebalances,  internal rebalance (cron).

This PR fix internal/manual rebalances alerts