### PR TITLE
fix(core): handle invalid feature bits in invoice

### DIFF
--- a/core/api/src/domain/bitcoin/lightning/errors.ts
+++ b/core/api/src/domain/bitcoin/lightning/errors.ts
@@ -5,6 +5,7 @@ export class LightningError extends DomainError {}
 export class LnInvoiceDecodeError extends LightningError {}
 export class LnInvoiceMissingPaymentSecretError extends LnInvoiceDecodeError {}
 export class InvalidChecksumForLnInvoiceError extends LnInvoiceDecodeError {}
+export class InvalidFeatureBitsInLndInvoiceError extends LnInvoiceDecodeError {}
 export class UnknownLnInvoiceDecodeError extends LnInvoiceDecodeError {
   level = ErrorLevel.Critical
 }

--- a/core/api/src/domain/bitcoin/lightning/ln-invoice.ts
+++ b/core/api/src/domain/bitcoin/lightning/ln-invoice.ts
@@ -2,6 +2,7 @@ import { parsePaymentRequest } from "invoices"
 
 import {
   InvalidChecksumForLnInvoiceError,
+  InvalidFeatureBitsInLndInvoiceError,
   LnInvoiceDecodeError,
   LnInvoiceMissingPaymentSecretError,
   UnknownLnInvoiceDecodeError,
@@ -50,6 +51,12 @@ export const decodeInvoice = (
     )
   }
 
+  const features = (decodedInvoice.features || []) as LnInvoiceFeature[]
+  const featureTypes = features.map((feature) => feature.type)
+  if (featureTypes.length > new Set(featureTypes).size) {
+    return new InvalidFeatureBitsInLndInvoiceError()
+  }
+
   return {
     amount,
     paymentAmount,
@@ -63,7 +70,7 @@ export const decodeInvoice = (
     paymentHash: decodedInvoice.id as PaymentHash,
     destination: decodedInvoice.destination as Pubkey,
     milliSatsAmount: toMilliSatsFromNumber(amount ? amount * 1000 : 0),
-    features: (decodedInvoice.features || []) as LnInvoiceFeature[],
+    features,
   }
 }
 

--- a/core/api/src/graphql/error-map.ts
+++ b/core/api/src/graphql/error-map.ts
@@ -135,6 +135,10 @@ export const mapError = (error: ApplicationError): CustomGraphQLError => {
       message = "Invoice has an invalid checksum, please check again"
       return new InvoiceDecodeError({ message, logger: baseLogger })
 
+    case "InvalidFeatureBitsInLndInvoiceError":
+      message = "Invoice has invalid feature bits set, please check again"
+      return new InvoiceDecodeError({ message, logger: baseLogger })
+
     case "LnPaymentRequestInTransitError":
       message = "There is a pending payment for this invoice"
       return new ValidationInternalError({ message, logger: baseLogger })

--- a/core/api/test/unit/domain/bitcoin/lightning/ln-invoice.spec.ts
+++ b/core/api/test/unit/domain/bitcoin/lightning/ln-invoice.spec.ts
@@ -1,4 +1,8 @@
-import { LnInvoiceDecodeError, decodeInvoice } from "@/domain/bitcoin/lightning"
+import {
+  InvalidFeatureBitsInLndInvoiceError,
+  LnInvoiceDecodeError,
+  decodeInvoice,
+} from "@/domain/bitcoin/lightning"
 import { toSats } from "@/domain/bitcoin"
 
 describe("decodeInvoice", () => {
@@ -28,5 +32,12 @@ describe("decodeInvoice", () => {
   it("returns a decode error", () => {
     const result = decodeInvoice("bad input data" as EncodedPaymentRequest)
     expect(result).toBeInstanceOf(LnInvoiceDecodeError)
+  })
+
+  it("returns a decode error for feature bit pairs", () => {
+    const bolt11InvoiceWithFeaturePairs =
+      "lnbc210n1pj6fdampp5u2hav4ulqy0kj9m3qrqq282x4jfhzge4zxa838uw4u3vf78ef68qsp5f5shw0zqygzsjzl73x63t78uqk9xfmjdzcjf5lltlatfzrpgshaqdqqcqzynxqyz5vq9qy9scqrzjq03smfrnw9knnsyn2m2nwt8c88vwuwsum0ve8m598s36hx7lhnn0sz3qgyqqzqsqqyqqqqqqqqqqqqqq9qrzjqv7cv43pj3u8qy38rxwt6mm8qv6u34qg4y4w3zuk93yafhqws0sz2z03l5qqpxsqqqqqqqqqqqqq86qqjqrzjq2kklwxkj0wpu3tfhnk7lt047u4fxxhqylwq7rz5fv6vr3hnhxszkzwqdyqq2rgqqqqqqqqqqqqq86qr7qwazn2gu3vjukeeas70vhndmg03sl4pjnasjupmgshh728u8ed3zpp023k3vaxgyppqkcj0p7twg670kmu7m6pvm68v2aws0lrlw07rgqhe4w2g" as EncodedPaymentRequest
+    const result = decodeInvoice(bolt11InvoiceWithFeaturePairs)
+    expect(result).toBeInstanceOf(InvalidFeatureBitsInLndInvoiceError)
   })
 })


### PR DESCRIPTION
## Description

This is to address the `feature pair exists` error in these [traces](https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/pNzvTkHgFbk).

### Notes
- For future reference, we may also want to filter feature bits [like this](https://github.com/alexbosworth/balanceofsatoshis/blob/3ef4444/network/probe_destination.js#L267) for fee probes in future if any other issues ever come up.

- `is_known` checks if the lnd knows about the invoice, and so it requires an AuthenticatedLnd in [`lightning.decodePaymentRequest`](https://github.com/alexbosworth/lightning/blob/8409909987c59d3ce778114e92a4b41609a7a5f6/lnd_methods/offchain/decode_payment_request.js#L30) but does not need one and isn't included in the features returned from [`invoices.parsePaymentRequest`](https://github.com/alexbosworth/invoices/blob/3145ca06ea5ce73bf06cd38a29616fe0230fbc0a/bolt11/parse_payment_request.js#L41C10-L41C10).