### PR TITLE
chore(core): add 'feature pair exists' error to lnd handling

### DIFF
--- a/core/api/src/domain/bitcoin/lightning/errors.ts
+++ b/core/api/src/domain/bitcoin/lightning/errors.ts
@@ -47,6 +47,7 @@ export class PaymentInTransitionError extends LightningServiceError {}
 export class TemporaryChannelFailureError extends LightningServiceError {}
 export class TemporaryNodeFailureError extends LightningServiceError {}
 export class DestinationMissingDependentFeatureError extends LightningServiceError {}
+export class InvalidFeatureBitsForLndInvoiceError extends LightningServiceError {}
 export class LookupPaymentTimedOutError extends LightningServiceError {
   level = ErrorLevel.Critical
 }

--- a/core/api/src/graphql/error-map.ts
+++ b/core/api/src/graphql/error-map.ts
@@ -352,6 +352,10 @@ export const mapError = (error: ApplicationError): CustomGraphQLError => {
       message = "Issue with lightning payment, please try again."
       return new LightningPaymentError({ message, logger: baseLogger })
 
+    case "InvalidFeatureBitsForLndInvoiceError":
+      message = "Invoice may have invalid feature bits set, please check again."
+      return new LightningPaymentError({ message, logger: baseLogger })
+
     case "UsernameNotAvailableError":
       message = "username not available"
       return new UsernameError({ message, logger: baseLogger })

--- a/core/api/src/services/lnd/errors.ts
+++ b/core/api/src/services/lnd/errors.ts
@@ -20,6 +20,7 @@ export const KnownLndErrorDetails = {
   TemporaryNodeFailure: /TemporaryNodeFailure/,
   InvoiceAlreadySettled: /invoice already settled/,
   MissingDependentFeature: /missing dependent feature/,
+  FeaturePairExists: /feature pair exists/,
 
   // On-chain
   InsufficientFunds: /insufficient funds available to construct transaction/,

--- a/core/api/src/services/lnd/index.ts
+++ b/core/api/src/services/lnd/index.ts
@@ -52,6 +52,7 @@ import {
   DestinationMissingDependentFeatureError,
   InsufficientBalanceForLnPaymentError,
   InsufficientBalanceForRoutingError,
+  InvalidFeatureBitsForLndInvoiceError,
   InvoiceExpiredOrBadPaymentHashError,
   InvoiceNotFoundError,
   LightningServiceError,
@@ -1211,6 +1212,8 @@ const handleSendPaymentLndErrors = ({
       return new TemporaryNodeFailureError(paymentHash)
     case match(KnownLndErrorDetails.InsufficientBalanceToAttemptPayment):
       return new InsufficientBalanceForLnPaymentError()
+    case match(KnownLndErrorDetails.FeaturePairExists):
+      return new InvalidFeatureBitsForLndInvoiceError()
 
     default:
       return handleCommonLightningServiceErrors(err)
@@ -1244,6 +1247,9 @@ const handleCommonRouteNotFoundErrors = (err: Error | unknown) => {
 
     case match(KnownLndErrorDetails.MissingDependentFeature):
       return new DestinationMissingDependentFeatureError()
+
+    case match(KnownLndErrorDetails.FeaturePairExists):
+      return new InvalidFeatureBitsForLndInvoiceError()
 
     default:
       return new UnknownRouteNotFoundError(msgForUnknown(err as LnError))


### PR DESCRIPTION
## Description

This is to address the `feature pair exists` error in these [traces](https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/pNzvTkHgFbk).

_Initial attempt at addressing this in closed #3834_