### PR TITLE
refactor(core): add new 'absoluteAllTxBaseVolumeAmountSince' method

### DIFF
--- a/core/api/src/app/accounts/active-accounts.ts
+++ b/core/api/src/app/accounts/active-accounts.ts
@@ -22,7 +22,7 @@ export const getRecentlyActiveAccounts = async function* ():
   if (walletPriceRatio instanceof Error) return walletPriceRatio
 
   const activityChecker = ActivityChecker({
-    getVolumeAmountFn: LedgerFacade.allTxBaseVolumeAmountSince,
+    getVolumeAmountFn: LedgerFacade.absoluteAllTxBaseVolumeAmountSince,
     priceRatio: walletPriceRatio,
     monthlyVolumeThreshold: USER_ACTIVENESS_MONTHLY_VOLUME_THRESHOLD,
   })

--- a/core/api/src/domain/ledger/index.types.d.ts
+++ b/core/api/src/domain/ledger/index.types.d.ts
@@ -331,7 +331,7 @@ interface ILedgerService {
 
 type GetVolumeAmountFn = <S extends WalletCurrency>(
   args: IGetVolumeAmountArgs<S>,
-) => Promise<TxBaseVolumeAmount<S> | LedgerServiceError>
+) => Promise<PaymentAmount<S> | LedgerServiceError>
 
 type ActivityCheckerConfig = {
   monthlyVolumeThreshold: UsdCents

--- a/core/api/src/services/ledger/facade/volume.ts
+++ b/core/api/src/services/ledger/facade/volume.ts
@@ -210,8 +210,6 @@ export const tradeIntraAccountTxBaseVolumeAmountSince = txVolumeAmountFactory.cr
 export const allPaymentVolumeAmountSince = txVolumeAmountFactory.create(
   "allPaymentVolumeSince",
 )
-export const allTxBaseVolumeAmountSince =
-  txVolumeAmountFactory.create("allTxBaseVolumeSince")
 export const onChainTxBaseVolumeAmountSince = txVolumeAmountFactory.create(
   "onChainTxBaseVolumeSince",
 )

--- a/core/api/test/integration/services/ledger-facade.spec.ts
+++ b/core/api/test/integration/services/ledger-facade.spec.ts
@@ -1999,15 +1999,12 @@ describe("Facade", () => {
       ) as (keyof typeof UserLedgerTransactionType)[]
 
       const currentVolumeAmount = async () => {
-        // Uses 'allTxBaseVolumeAmountSince'
-        const vol = await LedgerFacade.allTxBaseVolumeAmountSince({
+        const volume = await LedgerFacade.absoluteAllTxBaseVolumeAmountSince({
           walletDescriptor: btcWalletDescriptor,
           timestamp: timestamp1DayAgo,
         })
-        if (vol instanceof Error) throw vol
-
-        // Uses absolute 'outgoing' & 'incoming'
-        return calc.add(vol.outgoingBaseAmount, vol.incomingBaseAmount)
+        if (volume instanceof Error) throw volume
+        return volume
       }
 
       const {


### PR DESCRIPTION
_Merge after #3846_

## Description

This is to codify the application of `incoming` and `outgoing` volumes directly  in the respective volume method