### PR TITLE
chore(core): add txLimit span attributes

### DIFF
--- a/core/api/src/domain/accounts/limits-checker.ts
+++ b/core/api/src/domain/accounts/limits-checker.ts
@@ -3,6 +3,7 @@ import {
   TradeIntraAccountLimitsExceededError,
   WithdrawalLimitsExceededError,
 } from "@/domain/errors"
+import { addAttributesToCurrentSpan } from "@/services/tracing"
 
 export const AccountTxVolumeLimitChecker = (
   accountLimits: IAccountLimits,
@@ -14,6 +15,11 @@ export const AccountTxVolumeLimitChecker = (
     amount: UsdPaymentAmount
     volumeRemaining: UsdPaymentAmount
   }) => {
+    addAttributesToCurrentSpan({
+      "txLimit.volumeRemainingInUsd": `${volumeRemaining.amount}`,
+      "txLimit.amountToCheckInUsd": `${amount.amount}`,
+    })
+
     const limitAsUsd = `$${(accountLimits.intraLedgerLimit / 100).toFixed(2)}`
     const limitErrMsg = `Cannot transfer more than ${limitAsUsd} in 24 hours`
 
@@ -29,6 +35,11 @@ export const AccountTxVolumeLimitChecker = (
     amount: UsdPaymentAmount
     volumeRemaining: UsdPaymentAmount
   }) => {
+    addAttributesToCurrentSpan({
+      "txLimit.volumeRemainingInUsd": `${volumeRemaining.amount}`,
+      "txLimit.amountToCheckInUsd": `${amount.amount}`,
+    })
+
     const limitAsUsd = `$${(accountLimits.withdrawalLimit / 100).toFixed(2)}`
     const limitErrMsg = `Cannot transfer more than ${limitAsUsd} in 24 hours`
 
@@ -44,6 +55,11 @@ export const AccountTxVolumeLimitChecker = (
     amount: UsdPaymentAmount
     volumeRemaining: UsdPaymentAmount
   }) => {
+    addAttributesToCurrentSpan({
+      "txLimit.volumeRemainingInUsd": `${volumeRemaining.amount}`,
+      "txLimit.amountToCheckInUsd": `${amount.amount}`,
+    })
+
     const limitAsUsd = `$${(accountLimits.tradeIntraAccountLimit / 100).toFixed(2)}`
     const limitErrMsg = `Cannot transfer more than ${limitAsUsd} in 24 hours`
 


### PR DESCRIPTION
## Description

We have `txVolume` attributes to give us details about volumes fetched but we can't easily tell the usd value of the amount being checked against volumes for limits. This helps with that.