### PR TITLE
build: add 'env' variables handling to next_build rule

### DIFF
--- a/toolchains/workspace-pnpm/build_next_build.py
+++ b/toolchains/workspace-pnpm/build_next_build.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
         help="Directory of the package",
         )
     parser.add_argument(
-        "--env",
+        "--build-env",
         action="append",
         default=[],
         help="Environment variables in the format ENV=path, to pass to next build",
@@ -40,7 +40,7 @@ if __name__ == "__main__":
     build_out_dir = os.path.join(app_dir, ".next")
 
     env = os.environ.copy()
-    for env_pair in args.env:
+    for env_pair in args.build_env:
         key, val = env_pair.split('=')
         env[key] = val
 

--- a/toolchains/workspace-pnpm/build_next_build.py
+++ b/toolchains/workspace-pnpm/build_next_build.py
@@ -19,6 +19,12 @@ if __name__ == "__main__":
         help="Directory of the package",
         )
     parser.add_argument(
+        "--env",
+        action="append",
+        default=[],
+        help="Environment variables in the format ENV=path, to pass to next build",
+        )
+    parser.add_argument(
         "out_path",
         help="Path to output directory",
         )
@@ -33,7 +39,12 @@ if __name__ == "__main__":
     app_dir = os.path.join(args.root_dir, args.package_dir)
     build_out_dir = os.path.join(app_dir, ".next")
 
-    exit_code = subprocess.call(next_cmd, cwd=app_dir)
+    env = os.environ.copy()
+    for env_pair in args.env:
+        key, val = env_pair.split('=')
+        env[key] = val
+
+    exit_code = subprocess.call(next_cmd, cwd=app_dir, env=env)
 
     shutil.copytree(
         build_out_dir,

--- a/toolchains/workspace-pnpm/macros.bzl
+++ b/toolchains/workspace-pnpm/macros.bzl
@@ -448,8 +448,14 @@ def next_build_impl(ctx: AnalysisContext) -> list[[DefaultInfo, RunInfo]]:
         build_context.workspace_root,
         "--package-dir",
         ctx.label.package,
-        out.as_output()
     )
+
+    for (key, val) in ctx.attrs.env.items():
+        cmd.add(
+            "--env",
+            cmd_args([key, val], delimiter = "="),
+        )
+    cmd.add(out.as_output())
 
     ctx.actions.run(cmd, category = "next", identifier = "build " + ctx.label.package)
 
@@ -485,6 +491,13 @@ _next_build = rule(
         ),
         "node_modules": attrs.source(
             doc = """Target which builds `node_modules`.""",
+        ),
+        "env": attrs.dict(
+            key = attrs.string(),
+            value = attrs.arg(),
+            sorted = False,
+            default = {},
+            doc = """Include env variables to pass to 'next build' command""",
         ),
         "_python_toolchain": attrs.toolchain_dep(
             default = "toolchains//:python",

--- a/toolchains/workspace-pnpm/macros.bzl
+++ b/toolchains/workspace-pnpm/macros.bzl
@@ -450,9 +450,9 @@ def next_build_impl(ctx: AnalysisContext) -> list[[DefaultInfo, RunInfo]]:
         ctx.label.package,
     )
 
-    for (key, val) in ctx.attrs.env.items():
+    for (key, val) in ctx.attrs.build_env.items():
         cmd.add(
-            "--env",
+            "--build-env",
             cmd_args([key, val], delimiter = "="),
         )
     cmd.add(out.as_output())
@@ -492,7 +492,7 @@ _next_build = rule(
         "node_modules": attrs.source(
             doc = """Target which builds `node_modules`.""",
         ),
-        "env": attrs.dict(
+        "build_env": attrs.dict(
             key = attrs.string(),
             value = attrs.arg(),
             sorted = False,


### PR DESCRIPTION
## Description

This will allow for things like
```py
next_build(
    name = "build",
    srcs = [":src"],
    build_env = {
        "NEXT_PUBLIC_CORE_GQL_URL": "http://localhost:4455/graphql",
    }
)
```