### PR TITLE
chore: follow up migration for location refactoring

### DIFF
--- a/core/api/src/migrations/20240201124500-location-migration-2.ts
+++ b/core/api/src/migrations/20240201124500-location-migration-2.ts
@@ -1,0 +1,26 @@
+/* eslint @typescript-eslint/ban-ts-comment: "off" */
+// @ts-nocheck
+
+async function migrateAccounts(db, batchSize = 100) {
+  db.collection("accounts")
+    .updateMany(
+      {},
+      {
+        $unset: { title: "", coordinates: "" },
+      },
+    )
+    .then((result) => {
+      console.log(`Processed ${result.modifiedCount} accounts`)
+    })
+    .catch((err) => {
+      console.error("Error updating documents: ", err)
+    })
+}
+
+module.exports = {
+  async up(db) {
+    console.log("Begin migration removal of title/location")
+    await migrateAccounts(db)
+    console.log("Migration completed removal of title/location")
+  },
+}


### PR DESCRIPTION
now that main migration has been rolled out, we can remove the left over data in accounts.

note: the reason I'm running 2 migrations instead of 1 is to avoid potential api disruption. Maybe that's an overkill for maps related things, but it's good practice nonetheless