### PR TITLE
build: separate build_context rule

### DIFF
--- a/.github/workflows/check-code-and-unit-test.yaml
+++ b/.github/workflows/check-code-and-unit-test.yaml
@@ -49,7 +49,7 @@ jobs:
             case "$LABEL" in
               dashboard|consent|pay|admin-panel|map)
                 ARGS+=" //apps/$LABEL:test"
-                BUILD_ARGS+=" //apps/$LABEL:node_modules"
+                BUILD_ARGS+=" //apps/$LABEL:eslint_build_context"
                 ;;
               core)
                 ARGS+=" //core/api:test"

--- a/.github/workflows/check-code-and-unit-test.yaml
+++ b/.github/workflows/check-code-and-unit-test.yaml
@@ -31,13 +31,21 @@ jobs:
 
           DEFAULT_LABELS=("dashboard" "consent" "pay" "core" "api-keys" "notifications" "admin-panel" "map")
           LABELS=($(jq -r '.[]' < labels.json))
-          if [ ${#LABELS[@]} -eq 0 ]; then
-              LABELS=("${DEFAULT_LABELS[@]}")
-          elif [ ${#LABELS[@]} -eq 1 ] && [ "${LABELS[0]}" = "ci" ]; then
-              LABELS=("${DEFAULT_LABELS[@]}")
+
+          found_ci=0
+          for label in "${LABELS[@]}"; do
+              if [ "$label" = "ci" ]; then
+                  found_ci=1
+                  break
+              fi
+          done
+
+          UPDATED_LABELS=("${LABELS[@]}")
+          if [ ${#LABELS[@]} -eq 0 ] || [ $found_ci -eq 1 ]; then
+              UPDATED_LABELS=("${DEFAULT_LABELS[@]}")
           fi
 
-          for LABEL in "${LABELS[@]}"; do
+          for LABEL in "${UPDATED_LABELS[@]}"; do
             case "$LABEL" in
               dashboard|consent|pay|admin-panel|map)
                 ARGS+=" //apps/$LABEL:test"

--- a/.github/workflows/check-code-and-unit-test.yaml
+++ b/.github/workflows/check-code-and-unit-test.yaml
@@ -45,6 +45,11 @@ jobs:
                 ;;
               core)
                 ARGS+=" //core/api:test"
+                BUILD_ARGS+=" //core/api:eslint_build_context"
+                BUILD_ARGS+=" //core/api:tsc_check_build_context"
+                BUILD_ARGS+=" //core/api:yaml_build_context"
+                BUILD_ARGS+=" //core/api:madge_build_context"
+                BUILD_ARGS+=" //core/api:jest_build_context"
                 BUILD_ARGS+=" //core/api:prod_build"
                 ;;
               api-keys|notifications)

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -29,13 +29,21 @@ jobs:
 
           DEFAULT_LABELS=("dashboard" "consent" "pay" "core" "admin-panel" "map")
           LABELS=($(jq -r '.[]' < labels.json))
-          if [ ${#LABELS[@]} -eq 0 ]; then
-              LABELS=("${DEFAULT_LABELS[@]}")
-          elif [ ${#LABELS[@]} -eq 1 ] && [ "${LABELS[0]}" = "ci" ]; then
-              LABELS=("${DEFAULT_LABELS[@]}")
+
+          found_ci=0
+          for label in "${LABELS[@]}"; do
+              if [ "$label" = "ci" ]; then
+                  found_ci=1
+                  break
+              fi
+          done
+
+          UPDATED_LABELS=("${LABELS[@]}")
+          if [ ${#LABELS[@]} -eq 0 ] || [ $found_ci -eq 1 ]; then
+              UPDATED_LABELS=("${DEFAULT_LABELS[@]}")
           fi
 
-          for LABEL in "${LABELS[@]}"; do
+          for LABEL in "${UPDATED_LABELS[@]}"; do
             case "$LABEL" in
               dashboard|consent|pay|core|admin-panel|map)
                 ARGS+=" $LABEL"

--- a/apps/admin-panel/BUCK
+++ b/apps/admin-panel/BUCK
@@ -1,95 +1,102 @@
 load(
-    "@toolchains//workspace-pnpm:macros.bzl",
-    "dev_pnpm_task_binary",
-    "dev_pnpm_task_test",
-    "build_node_modules",
-    "next_build",
-    "next_build_bin",
-    "eslint",
-    "audit",
+  "@toolchains//workspace-pnpm:macros.bzl",
+  "dev_pnpm_task_binary",
+  "dev_pnpm_task_test",
+  "build_node_modules",
+  "prepare_build_context",
+  "next_build",
+  "next_build_bin",
+  "eslint",
+  "audit",
 )
 
 dev_pnpm_task_binary(
-    name="dev",
-    command="dev",
+  name="dev",
+  command="dev",
 )
 
 dev_pnpm_task_binary(
-    name="lint-fix",
-    command="lint:fix",
+  name="lint-fix",
+  command="lint:fix",
 )
 
 dev_pnpm_task_binary(
-    name="cypress-open",
-    command="cypress:open",
+  name="cypress-open",
+  command="cypress:open",
 )
 
 dev_pnpm_task_binary(
-    name="codegen",
-    command="codegen",
+  name="codegen",
+  command="codegen",
 )
 
 dev_pnpm_task_test(
-    name="test-integration",
-    command="cypress:run",
+  name="test-integration",
+  command="cypress:run",
 )
 
 export_file(
-    name="package.json",
-    visibility=["PUBLIC"],
+  name="package.json",
+  visibility=["PUBLIC"],
 )
 
 build_node_modules(
-    name="node_modules",
+  name="node_modules",
 )
 
 filegroup(
-    name="src",
-    srcs=glob(
-        [
-            "app/**",
-            "public/**",
-            "components/**",
-            "tailwind.config.ts",
-            "postcss.config.js",
-            "next.config.js",
-            "tsconfig.json",
-            "*.ts",
-            "instrumentation.node.ts",
-        ]
-    ),
+  name="src",
+  srcs=glob(
+    [
+      "app/**",
+      "public/**",
+      "components/**",
+      "tailwind.config.ts",
+      "postcss.config.js",
+      "next.config.js",
+      "tsconfig.json",
+      "*.ts",
+      "instrumentation.node.ts",
+    ]
+  ),
 )
 
 next_build(
-    name="build",
-    srcs=[":src"],
+  name="build",
+  srcs=[":src"],
 )
 
 next_build_bin(
-    name="admin-panel",
+  name="admin-panel",
 )
 
 dev_deps_srcs = {
-    "lib/eslint-config": "//lib/eslint-config:src",
+  "lib/eslint-config": "//lib/eslint-config:src",
 }
 
 audit(
-    name="audit",
-    level="critical",
+  name="audit",
+  level="critical",
+)
+
+prepare_build_context(
+    name = "eslint_build_context",
+    srcs = [":src"] + glob([".eslint*"]),
+    dev_deps_srcs = dev_deps_srcs,
 )
 
 eslint(
-    name="lint",
-    srcs=[":src"] + glob([".eslint*"]),
-    extensions=[".ts", ".tsx"],
-    allow_warnings=True,
-    dev_deps_srcs=dev_deps_srcs,
+  name="lint",
+  srcs=[":src"] + glob([".eslint*"]),
+  extensions=[".ts", ".tsx"],
+  allow_warnings=True,
+  dev_deps_srcs=dev_deps_srcs,
 )
 
 test_suite(
-    name="test",
-    tests=[
-        ":audit",
-        ":lint",
-    ],
+  name="test",
+  tests=[
+    ":audit",
+    ":lint",
+  ],
 )

--- a/apps/consent/BUCK
+++ b/apps/consent/BUCK
@@ -1,11 +1,13 @@
-load("@toolchains//workspace-pnpm:macros.bzl",
-"dev_pnpm_task_binary",
-"dev_pnpm_task_test",
-"build_node_modules",
-"next_build",
-"next_build_bin",
-"eslint",
-"audit",
+load(
+  "@toolchains//workspace-pnpm:macros.bzl",
+  "dev_pnpm_task_binary",
+  "dev_pnpm_task_test",
+  "build_node_modules",
+  "prepare_build_context",
+  "next_build",
+  "next_build_bin",
+  "eslint",
+  "audit",
 )
 
 dev_pnpm_task_binary(
@@ -80,6 +82,12 @@ next_build_bin(
 audit(
     name = "audit",
     level = "critical",
+)
+
+prepare_build_context(
+    name = "eslint_build_context",
+    srcs = [":src"] + glob([".eslint*"]),
+    dev_deps_srcs = dev_deps_srcs,
 )
 
 eslint(

--- a/apps/dashboard/BUCK
+++ b/apps/dashboard/BUCK
@@ -3,6 +3,7 @@ load(
   "dev_pnpm_task_binary",
   "dev_pnpm_task_test",
   "build_node_modules",
+  "prepare_build_context",
   "next_build",
   "next_build_bin",
   "eslint",
@@ -75,6 +76,12 @@ dev_deps_srcs = {
 audit(
     name = "audit",
     level = "critical",
+)
+
+prepare_build_context(
+    name = "eslint_build_context",
+    srcs = [":src"] + glob([".eslint*"]),
+    dev_deps_srcs = dev_deps_srcs,
 )
 
 eslint(

--- a/apps/map/BUCK
+++ b/apps/map/BUCK
@@ -3,6 +3,7 @@ load(
   "dev_pnpm_task_binary",
   "dev_pnpm_task_test",
   "build_node_modules",
+  "prepare_build_context",
   "next_build",
   "next_build_bin",
   "eslint",
@@ -66,6 +67,12 @@ dev_deps_srcs = {
 audit(
     name = "audit",
     level = "critical",
+)
+
+prepare_build_context(
+    name = "eslint_build_context",
+    srcs = [":src"] + glob([".eslint*"]),
+    dev_deps_srcs = dev_deps_srcs,
 )
 
 eslint(

--- a/apps/pay/BUCK
+++ b/apps/pay/BUCK
@@ -3,6 +3,7 @@ load(
   "dev_pnpm_task_binary",
   "dev_pnpm_task_test",
   "build_node_modules",
+  "prepare_build_context",
   "next_build",
   "next_build_bin",
   "eslint",
@@ -93,6 +94,12 @@ dev_deps_srcs = {
 audit(
     name = "audit",
     level = "critical",
+)
+
+prepare_build_context(
+    name = "eslint_build_context",
+    srcs = [":src"] + glob([".eslint*"]),
+    dev_deps_srcs = dev_deps_srcs,
 )
 
 eslint(

--- a/core/api/BUCK
+++ b/core/api/BUCK
@@ -3,6 +3,7 @@ load(
   "dev_pnpm_task_binary",
   "dev_pnpm_task_test",
   "build_node_modules",
+  "prepare_build_context",
   "tsc_build",
   "prod_tsc_build",
   "prod_tsc_build_bin",
@@ -129,6 +130,12 @@ dev_update_file(
   name = "update-admin-schema",
   generated = ":admin-sdl",
   out = "src/graphql/admin/schema.graphql"
+)
+
+prepare_build_context(
+    name = "checks_build_context",
+    srcs = [":src"] + [":test_src"],
+    prod_deps_srcs = prod_deps_srcs,
 )
 
 audit(

--- a/core/api/BUCK
+++ b/core/api/BUCK
@@ -132,15 +132,14 @@ dev_update_file(
   out = "src/graphql/admin/schema.graphql"
 )
 
-prepare_build_context(
-    name = "checks_build_context",
-    srcs = [":src"] + [":test_src"],
-    prod_deps_srcs = prod_deps_srcs,
-)
-
 audit(
     name = "audit",
     level = "critical",
+)
+
+prepare_build_context(
+    name = "eslint_build_context",
+    srcs = [":src"] + [":test_src"] + glob([".eslint*"]),
 )
 
 eslint(
@@ -155,6 +154,11 @@ dev_pnpm_task_test(
   command = "eslint-check",
 )
 
+prepare_build_context(
+    name = "tsc_check_build_context",
+    srcs = [":src"] + [":test_src"],
+)
+
 typescript_check(
     name = "check-type",
     srcs = [":src"] + [":test_src"],
@@ -163,6 +167,16 @@ typescript_check(
 dev_pnpm_task_test(
   name = "dev-check-type",
   command = "tsc-check",
+)
+
+prepare_build_context(
+    name = "yaml_build_context",
+    srcs = glob([
+        ".prettier*",
+        "prettier*",
+        "*.yml",
+        "*.yaml",
+    ]),
 )
 
 yaml_check(
@@ -175,6 +189,11 @@ yaml_check(
     ]),
 )
 
+prepare_build_context(
+    name = "madge_build_context",
+    srcs = [":src"],
+)
+
 madge_check(
     name = "check-circular-dependencies",
     srcs = [":src"],
@@ -183,6 +202,12 @@ madge_check(
 dev_pnpm_task_test(
   name = "dev-check-circular-dependencies",
   command = "circular-deps-check",
+)
+
+prepare_build_context(
+    name = "jest_build_context",
+    srcs = [":src"] + [":test_src"] + glob([".env", "galoy.yaml"]),
+    prod_deps_srcs = prod_deps_srcs,
 )
 
 jest_test(

--- a/toolchains/workspace-pnpm/macros.bzl
+++ b/toolchains/workspace-pnpm/macros.bzl
@@ -952,7 +952,7 @@ def typescript_check(
         node_modules = ":node_modules",
         visibility = ["PUBLIC"],
         **kwargs):
-    build_context = "typescript_build_context"
+    build_context = "tsc_check_build_context"
     if not rule_exists(build_context):
         prepare_build_context(
             name = build_context,


### PR DESCRIPTION
## Description

This PR separates the `prepare_build_context` function into its own rule so that it can optionally be executed outside of its downstream tasks. This is useful for example in the `Check Code and Unit Test` github action to properly separate build and test run stages.

To compare test performance:
- Sample from before: https://github.com/GaloyMoney/galoy/actions/runs/7857036456/job/21440456836
- Sample from after: https://github.com/GaloyMoney/galoy/actions/runs/7907032197/job/21584589172?pr=3999