### PR TITLE
feat(core): add username usd suffix handling

### DIFF
--- a/bats/gql/account-default-wallet-by-username.gql
+++ b/bats/gql/account-default-wallet-by-username.gql
@@ -1,0 +1,12 @@
+query accountDefaultWalletByUsername(
+  $username: UsernameWithFlags!
+  $walletCurrency: WalletCurrency
+) {
+  accountDefaultWalletByUsername(
+    username: $username
+    walletCurrency: $walletCurrency
+  ) {
+    id
+    currency
+  }
+}

--- a/bats/gql/account-default-wallet.gql
+++ b/bats/gql/account-default-wallet.gql
@@ -1,6 +1,0 @@
-query accountDefaultWallet($username: Username!, $walletCurrency: WalletCurrency) {
-  accountDefaultWallet(username: $username, walletCurrency: $walletCurrency) {
-    id
-    currency
-  }
-}

--- a/core/api/dev/apollo-federation/supergraph.graphql
+++ b/core/api/dev/apollo-federation/supergraph.graphql
@@ -1562,7 +1562,8 @@ type Query
   @join__type(graph: NOTIFICATIONS)
   @join__type(graph: PUBLIC)
 {
-  accountDefaultWallet(username: Username!, walletCurrency: WalletCurrency): PublicWallet! @join__field(graph: PUBLIC)
+  accountDefaultWallet(username: Username!, walletCurrency: WalletCurrency): PublicWallet! @join__field(graph: PUBLIC) @deprecated(reason: "will be migrated to AccountDefaultWalletIdByUsername")
+  accountDefaultWalletByUsername(username: UsernameWithFlags!, walletCurrency: WalletCurrency): PublicWallet! @join__field(graph: PUBLIC)
   btcPriceList(range: PriceGraphRange!): [PricePoint] @join__field(graph: PUBLIC)
   businessMapMarkers: [MapMarker!]! @join__field(graph: PUBLIC)
   currencyList: [Currency!]! @join__field(graph: PUBLIC)
@@ -2077,6 +2078,10 @@ input UserLogoutInput
 
 """Unique identifier of a user"""
 scalar Username
+  @join__type(graph: PUBLIC)
+
+"""Unique identifier of a user, with optional flags"""
+scalar UsernameWithFlags
   @join__type(graph: PUBLIC)
 
 enum UserNotificationCategory

--- a/core/api/src/domain/accounts/index.ts
+++ b/core/api/src/domain/accounts/index.ts
@@ -68,10 +68,20 @@ export const checkedAccountStatus = (status: string) => {
   return status as AccountStatus
 }
 
-export const UsernameRegex = /(?!^(1|3|bc1|lnbc1))^[0-9a-z+_]{3,50}$/i
+export const UsernameRegex = /(?!^(1|3|bc1|lnbc1))^[0-9a-z_]{3,50}$/i
+export const UsernameWithFlagsRegex = /(?!^(1|3|bc1|lnbc1))^[0-9a-z+_]{3,50}$/i
 
 export const checkedToUsername = (username: string): Username | ValidationError => {
   if (!username.match(UsernameRegex)) {
+    return new InvalidUsername(username)
+  }
+  return username as Username
+}
+
+export const checkedToUsernameWithFlags = (
+  username: string,
+): Username | ValidationError => {
+  if (!username.match(UsernameWithFlagsRegex)) {
     return new InvalidUsername(username)
   }
   return username as Username

--- a/core/api/src/domain/accounts/index.ts
+++ b/core/api/src/domain/accounts/index.ts
@@ -21,6 +21,7 @@ export * from "./limits-checker"
 export * from "./limits-volume"
 export * from "./account-validator"
 export * from "./primitives"
+export * from "./parse-username"
 
 const KratosUserIdRegex = UUIDV4
 const AccountIdRegex = UUIDV4

--- a/core/api/src/domain/accounts/index.ts
+++ b/core/api/src/domain/accounts/index.ts
@@ -21,7 +21,7 @@ export * from "./limits-checker"
 export * from "./limits-volume"
 export * from "./account-validator"
 export * from "./primitives"
-export * from "./parse-username"
+export * from "./username-parser"
 
 const KratosUserIdRegex = UUIDV4
 const AccountIdRegex = UUIDV4

--- a/core/api/src/domain/accounts/index.ts
+++ b/core/api/src/domain/accounts/index.ts
@@ -67,7 +67,7 @@ export const checkedAccountStatus = (status: string) => {
   return status as AccountStatus
 }
 
-export const UsernameRegex = /(?!^(1|3|bc1|lnbc1))^[0-9a-z_]{3,50}$/i
+export const UsernameRegex = /(?!^(1|3|bc1|lnbc1))^[0-9a-z+_]{3,50}$/i
 
 export const checkedToUsername = (username: string): Username | ValidationError => {
   if (!username.match(UsernameRegex)) {

--- a/core/api/src/domain/accounts/parse-username.ts
+++ b/core/api/src/domain/accounts/parse-username.ts
@@ -1,5 +1,0 @@
-export const UsernameParser = (username: Username) => {
-  return {
-    isUsd: () => username.slice(-4).toLowerCase() === "+usd",
-  }
-}

--- a/core/api/src/domain/accounts/parse-username.ts
+++ b/core/api/src/domain/accounts/parse-username.ts
@@ -1,0 +1,5 @@
+export const UsernameParser = (username: Username) => {
+  return {
+    isUsd: () => username.slice(-4).toLowerCase() === "+usd",
+  }
+}

--- a/core/api/src/domain/accounts/username-parser.ts
+++ b/core/api/src/domain/accounts/username-parser.ts
@@ -1,0 +1,26 @@
+import { checkedToUsername } from "."
+
+export const UsernameParser = (username: UsernameWithFlags) => {
+  const stripUsdFlag = () => checkedToUsername(username.slice(0, -4))
+  const isUsdCheck = () => username.slice(-4).toLowerCase() === "+usd"
+
+  const isUsd = () => {
+    const usdCheck = isUsdCheck()
+    if (usdCheck) {
+      const strippedUsername = stripUsdFlag()
+      if (strippedUsername instanceof Error) return strippedUsername
+    }
+
+    return usdCheck
+  }
+
+  const parsedUsername = (): Username | ValidationError => {
+    const usdCheck = isUsdCheck()
+    return usdCheck ? stripUsdFlag() : checkedToUsername(username)
+  }
+
+  return {
+    isUsd,
+    parsedUsername,
+  }
+}

--- a/core/api/src/domain/primitives/index.types.d.ts
+++ b/core/api/src/domain/primitives/index.types.d.ts
@@ -1,6 +1,7 @@
 type DisplayCurrencyPerSat = number & { readonly brand: unique symbol }
 type DisplayCurrencyBasePerSat = number & { readonly brand: unique symbol }
 type Username = string & { readonly brand: unique symbol }
+type UsernameWithFlags = string & { readonly brand: unique symbol }
 type Pubkey = string & { readonly brand: unique symbol }
 type WalletId = string & { readonly brand: unique symbol }
 type AccountId = string & { readonly brand: unique symbol }

--- a/core/api/src/graphql/public/queries.ts
+++ b/core/api/src/graphql/public/queries.ts
@@ -12,6 +12,7 @@ import OnChainUsdTxFeeAsBtcDenominatedQuery from "@/graphql/public/root/query/on
 import UsernameAvailableQuery from "@/graphql/public/root/query/username-available"
 import BusinessMapMarkersQuery from "@/graphql/public/root/query/business-map-markers"
 import AccountDefaultWalletQuery from "@/graphql/public/root/query/account-default-wallet"
+import AccountDefaultWalletByUsernameQuery from "@/graphql/public/root/query/account-default-wallet-by-username"
 import AccountDefaultWalletIdQuery from "@/graphql/public/root/query/account-default-wallet-id"
 import LnInvoicePaymentStatusQuery from "@/graphql/public/root/query/ln-invoice-payment-status"
 import LnInvoicePaymentStatusByHashQuery from "@/graphql/public/root/query/ln-invoice-payment-status-by-hash"
@@ -23,6 +24,7 @@ export const queryFields = {
     usernameAvailable: UsernameAvailableQuery,
     userDefaultWalletId: AccountDefaultWalletIdQuery, // FIXME: migrate to AccountDefaultWalletId
     accountDefaultWallet: AccountDefaultWalletQuery,
+    accountDefaultWalletByUsername: AccountDefaultWalletByUsernameQuery,
     businessMapMarkers: BusinessMapMarkersQuery,
     currencyList: CurrencyListQuery,
     mobileVersions: MobileVersionsQuery,

--- a/core/api/src/graphql/public/root/query/account-default-wallet-by-username.ts
+++ b/core/api/src/graphql/public/root/query/account-default-wallet-by-username.ts
@@ -1,29 +1,36 @@
 import { Wallets } from "@/app"
 
+import { UsernameParser } from "@/domain/accounts"
+import { WalletCurrency as DomainWalletCurrency } from "@/domain/shared"
 import { CouldNotFindWalletFromUsernameAndCurrencyError } from "@/domain/errors"
 
 import { AccountsRepository } from "@/services/mongoose"
 
 import { mapError } from "@/graphql/error-map"
 import { GT } from "@/graphql/index"
-import Username from "@/graphql/shared/types/scalar/username"
+import UsernameWithFlags from "@/graphql/shared/types/scalar/username-with-flags"
 import WalletCurrency from "@/graphql/shared/types/scalar/wallet-currency"
 import PublicWallet from "@/graphql/public/types/object/public-wallet"
 
-const AccountDefaultWalletQuery = GT.Field({
-  deprecationReason: "will be migrated to AccountDefaultWalletIdByUsername",
+const AccountDefaultWalletByUsernameQuery = GT.Field({
   type: GT.NonNull(PublicWallet),
   args: {
     username: {
-      type: GT.NonNull(Username),
+      type: GT.NonNull(UsernameWithFlags),
     },
     walletCurrency: { type: WalletCurrency },
   },
   resolve: async (_, args) => {
-    const { username, walletCurrency } = args
+    const { username: usernameWithFlags, walletCurrency } = args
 
+    if (usernameWithFlags instanceof Error) {
+      throw usernameWithFlags
+    }
+
+    const parser = UsernameParser(usernameWithFlags)
+    const username = parser.parsedUsername()
     if (username instanceof Error) {
-      throw username
+      throw mapError(username)
     }
 
     const account = await AccountsRepository().findByUsername(username)
@@ -36,17 +43,30 @@ const AccountDefaultWalletQuery = GT.Field({
       throw mapError(wallets)
     }
 
+    if (parser.isUsd()) {
+      const wallet = wallets.find(
+        (wallet) => wallet.currency === DomainWalletCurrency.Usd,
+      )
+      if (!wallet) {
+        throw mapError(new CouldNotFindWalletFromUsernameAndCurrencyError(username))
+      }
+
+      return wallet
+    }
+
     if (!walletCurrency) {
       return wallets.find((wallet) => wallet.id === account.defaultWalletId)
     }
 
     const wallet = wallets.find((wallet) => wallet.currency === walletCurrency)
     if (!wallet) {
-      throw mapError(new CouldNotFindWalletFromUsernameAndCurrencyError(username))
+      throw mapError(
+        new CouldNotFindWalletFromUsernameAndCurrencyError(usernameWithFlags),
+      )
     }
 
     return wallet
   },
 })
 
-export default AccountDefaultWalletQuery
+export default AccountDefaultWalletByUsernameQuery

--- a/core/api/src/graphql/public/schema.graphql
+++ b/core/api/src/graphql/public/schema.graphql
@@ -1204,7 +1204,8 @@ type PublicWallet {
 }
 
 type Query {
-  accountDefaultWallet(username: Username!, walletCurrency: WalletCurrency): PublicWallet!
+  accountDefaultWallet(username: Username!, walletCurrency: WalletCurrency): PublicWallet! @deprecated(reason: "will be migrated to AccountDefaultWalletIdByUsername")
+  accountDefaultWalletByUsername(username: UsernameWithFlags!, walletCurrency: WalletCurrency): PublicWallet!
   btcPriceList(range: PriceGraphRange!): [PricePoint]
   businessMapMarkers: [MapMarker!]!
   currencyList: [Currency!]!
@@ -1666,6 +1667,9 @@ type UserUpdateUsernamePayload {
 
 """Unique identifier of a user"""
 scalar Username
+
+"""Unique identifier of a user, with optional flags"""
+scalar UsernameWithFlags
 
 """
 A generic wallet which stores value in one of our supported currencies.

--- a/core/api/src/graphql/shared/types/scalar/username-with-flags.ts
+++ b/core/api/src/graphql/shared/types/scalar/username-with-flags.ts
@@ -1,0 +1,35 @@
+import { UsernameWithFlagsRegex } from "@/domain/accounts"
+import { InputValidationError } from "@/graphql/error"
+import { GT } from "@/graphql/index"
+
+const UsernameWithFlags = GT.Scalar({
+  name: "UsernameWithFlags",
+  description: "Unique identifier of a user, with optional flags",
+  parseValue(value) {
+    if (typeof value !== "string") {
+      return new InputValidationError({
+        message: "Invalid type for Username with optional flags",
+      })
+    }
+    return validUsernameWithFlagsValue(value)
+  },
+  parseLiteral(ast) {
+    if (ast.kind === GT.Kind.STRING) {
+      return validUsernameWithFlagsValue(ast.value)
+    }
+    return new InputValidationError({
+      message: "Invalid type for Username with optional flags",
+    })
+  },
+})
+
+function validUsernameWithFlagsValue(value: string) {
+  if (value.match(UsernameWithFlagsRegex)) {
+    return value.toLowerCase()
+  }
+  return new InputValidationError({
+    message: "Invalid value for Username with optional flags",
+  })
+}
+
+export default UsernameWithFlags

--- a/core/api/test/unit/domain/accounts/username-parser.spec.ts
+++ b/core/api/test/unit/domain/accounts/username-parser.spec.ts
@@ -1,0 +1,13 @@
+import { UsernameParser } from "@/domain/accounts"
+
+describe("UsernameParser", () => {
+  describe("isUsd", () => {
+    it("parses a '+usd' flag", () => {
+      expect(UsernameParser("user+usd" as Username).isUsd()).toBeTruthy()
+    })
+
+    it("parses a non-'+usd' flag", () => {
+      expect(UsernameParser("user" as Username).isUsd()).toBeFalsy()
+    })
+  })
+})

--- a/core/api/test/unit/domain/accounts/username-parser.spec.ts
+++ b/core/api/test/unit/domain/accounts/username-parser.spec.ts
@@ -1,13 +1,24 @@
 import { UsernameParser } from "@/domain/accounts"
+import { InvalidUsername } from "@/domain/errors"
 
 describe("UsernameParser", () => {
   describe("isUsd", () => {
     it("parses a '+usd' flag", () => {
-      expect(UsernameParser("user+usd" as Username).isUsd()).toBeTruthy()
+      const parser = UsernameParser("user+usd" as UsernameWithFlags)
+      expect(parser.parsedUsername()).toEqual("user")
+      expect(parser.isUsd()).toBeTruthy()
     })
 
     it("parses a non-'+usd' flag", () => {
-      expect(UsernameParser("user" as Username).isUsd()).toBeFalsy()
+      const parser = UsernameParser("user" as UsernameWithFlags)
+      expect(parser.parsedUsername()).toEqual("user")
+      expect(parser.isUsd()).toBeFalsy()
+    })
+
+    it("errors for a short username with '+usd' flag", () => {
+      const parser = UsernameParser("bo+usd" as UsernameWithFlags)
+      expect(parser.parsedUsername()).toBeInstanceOf(InvalidUsername)
+      expect(parser.isUsd()).toBeInstanceOf(InvalidUsername)
     })
   })
 })

--- a/core/api/test/unit/domain/users/checked-to-username.spec.ts
+++ b/core/api/test/unit/domain/users/checked-to-username.spec.ts
@@ -6,6 +6,11 @@ describe("username-check", () => {
     expect(username).toEqual("alice_12")
   })
 
+  it("Passes usd-tagged username", () => {
+    const username = checkedToUsername("alice_12+usd")
+    expect(username).toEqual("alice_12+usd")
+  })
+
   it("Fails legacy address", () => {
     const username = checkedToUsername("1LKvxGL8ejTsgBjRVUNCGi7adiwaVnM9cn")
     expect(username).toBeInstanceOf(Error)

--- a/core/api/test/unit/domain/users/checked-to-username.spec.ts
+++ b/core/api/test/unit/domain/users/checked-to-username.spec.ts
@@ -1,75 +1,92 @@
-import { checkedToUsername } from "@/domain/accounts"
+import { checkedToUsername, checkedToUsernameWithFlags } from "@/domain/accounts"
+import { InvalidUsername } from "@/domain/errors"
 
 describe("username-check", () => {
-  it("Passes alphanumeric username", () => {
-    const username = checkedToUsername("alice_12")
-    expect(username).toEqual("alice_12")
-  })
+  for (const checkedToFn of [checkedToUsername, checkedToUsernameWithFlags]) {
+    describe("common checks", () => {
+      describe(`${checkedToFn.name}`, () => {
+        it("Passes alphanumeric username", () => {
+          const username = checkedToFn("alice_12")
+          expect(username).toEqual("alice_12")
+        })
 
-  it("Passes usd-tagged username", () => {
-    const username = checkedToUsername("alice_12+usd")
-    expect(username).toEqual("alice_12+usd")
-  })
+        it("Fails legacy address", () => {
+          const username = checkedToFn("1LKvxGL8ejTsgBjRVUNCGi7adiwaVnM9cn")
+          expect(username).toBeInstanceOf(Error)
+        })
 
-  it("Fails legacy address", () => {
-    const username = checkedToUsername("1LKvxGL8ejTsgBjRVUNCGi7adiwaVnM9cn")
-    expect(username).toBeInstanceOf(Error)
-  })
+        it("Fails if starting with 1", () => {
+          const username = checkedToFn("1ab")
+          expect(username).toBeInstanceOf(Error)
+        })
 
-  it("Fails if starting with 1", () => {
-    const username = checkedToUsername("1ab")
-    expect(username).toBeInstanceOf(Error)
-  })
+        it("Fails wrapped segwit address", () => {
+          const username = checkedToFn("32ksNi7zSt3t2aesvoEWhGMUEwCFg9UCCG")
+          expect(username).toBeInstanceOf(Error)
+        })
 
-  it("Fails wrapped segwit address", () => {
-    const username = checkedToUsername("32ksNi7zSt3t2aesvoEWhGMUEwCFg9UCCG")
-    expect(username).toBeInstanceOf(Error)
-  })
+        it("Fails if starting with 3", () => {
+          const username = checkedToFn("3basd")
+          expect(username).toBeInstanceOf(Error)
+        })
 
-  it("Fails if starting with 3", () => {
-    const username = checkedToUsername("3basd")
-    expect(username).toBeInstanceOf(Error)
-  })
+        it("Fails segwit address", () => {
+          const username = checkedToFn("bc1qpl8ehyzu44yhwu92w892uxwxdfp9dhu3d0zj2g")
+          expect(username).toBeInstanceOf(Error)
+        })
 
-  it("Fails segwit address", () => {
-    const username = checkedToUsername("bc1qpl8ehyzu44yhwu92w892uxwxdfp9dhu3d0zj2g")
-    expect(username).toBeInstanceOf(Error)
-  })
+        it("Fails if starting with bc1", () => {
+          const username = checkedToFn("bc1be")
+          expect(username).toBeInstanceOf(Error)
+        })
 
-  it("Fails if starting with bc1", () => {
-    const username = checkedToUsername("bc1be")
-    expect(username).toBeInstanceOf(Error)
-  })
+        it("Fails lightning payment request", () => {
+          const username = checkedToFn(
+            "lnbc1500n1ps36h3rpp5qtgvy47pu6n3t2ggf47vahl3kdjql0d68egtaschvd34atvu5eysdpa2fjkzep6ypyx7aeqw3hjqct4w3hk6ct5d93kzmrv0ys82uryv96x2greda6hycqzpgxqr23ssp5makumjtdy54vz80ayytgld7420uuw5m6pdtq5x2n38gg7z5gd9ms9qyyssq64faagqrfa6qp45jsx8enwgs62fquqfejxk0gmtuf67z7v7d9364c5tw679cd635nmllfwzur348whvrgnf94sx6w40n6ttwa4x8grcqa0ms0d",
+          )
+          expect(username).toBeInstanceOf(Error)
+        })
 
-  it("Fails lightning payment request", () => {
-    const username = checkedToUsername(
-      "lnbc1500n1ps36h3rpp5qtgvy47pu6n3t2ggf47vahl3kdjql0d68egtaschvd34atvu5eysdpa2fjkzep6ypyx7aeqw3hjqct4w3hk6ct5d93kzmrv0ys82uryv96x2greda6hycqzpgxqr23ssp5makumjtdy54vz80ayytgld7420uuw5m6pdtq5x2n38gg7z5gd9ms9qyyssq64faagqrfa6qp45jsx8enwgs62fquqfejxk0gmtuf67z7v7d9364c5tw679cd635nmllfwzur348whvrgnf94sx6w40n6ttwa4x8grcqa0ms0d",
-    )
-    expect(username).toBeInstanceOf(Error)
-  })
+        it("Fails if starting with lnbc1", () => {
+          const username = checkedToFn("lnbc1qwe1")
+          expect(username).toBeInstanceOf(Error)
+        })
 
-  it("Fails if starting with lnbc1", () => {
-    const username = checkedToUsername("lnbc1qwe1")
-    expect(username).toBeInstanceOf(Error)
-  })
+        it("Fails non-underscore special characters", () => {
+          const username = checkedToFn("alice-12")
+          expect(username).toBeInstanceOf(Error)
+        })
 
-  it("Fails non-underscore special characters", () => {
-    const username = checkedToUsername("alice-12")
-    expect(username).toBeInstanceOf(Error)
-  })
+        it("Fails if length is less than 3", () => {
+          const username = checkedToFn("ab")
+          expect(username).toBeInstanceOf(Error)
+        })
 
-  it("Fails if length is less than 3", () => {
-    const username = checkedToUsername("ab")
-    expect(username).toBeInstanceOf(Error)
-  })
+        it("Fails if contains invalid characters", () => {
+          const username = checkedToFn("ab+/")
+          expect(username).toBeInstanceOf(Error)
+        })
 
-  it("Fails if contains invalid characters", () => {
-    const username = checkedToUsername("ab+/")
-    expect(username).toBeInstanceOf(Error)
-  })
+        it("Fails if non english characters", () => {
+          const username = checkedToFn("ñ_user1")
+          expect(username).toBeInstanceOf(Error)
+        })
+      })
+    })
+  }
 
-  it("Fails if non english characters", () => {
-    const username = checkedToUsername("ñ_user1")
-    expect(username).toBeInstanceOf(Error)
+  describe("usd flag checks", () => {
+    describe("checkedToUsername", () => {
+      it("Fails usd-tagged username", () => {
+        const username = checkedToUsername("alice_12+usd")
+        expect(username).toBeInstanceOf(InvalidUsername)
+      })
+    })
+    describe("checkedToUsernameWithFlags", () => {
+      it("Passes usd-tagged username", () => {
+        const username = checkedToUsernameWithFlags("alice_12+usd")
+        expect(username).toEqual("alice_12+usd")
+      })
+    })
   })
 })

--- a/dev/config/apollo-federation/supergraph.graphql
+++ b/dev/config/apollo-federation/supergraph.graphql
@@ -1562,7 +1562,8 @@ type Query
   @join__type(graph: NOTIFICATIONS)
   @join__type(graph: PUBLIC)
 {
-  accountDefaultWallet(username: Username!, walletCurrency: WalletCurrency): PublicWallet! @join__field(graph: PUBLIC)
+  accountDefaultWallet(username: Username!, walletCurrency: WalletCurrency): PublicWallet! @join__field(graph: PUBLIC) @deprecated(reason: "will be migrated to AccountDefaultWalletIdByUsername")
+  accountDefaultWalletByUsername(username: UsernameWithFlags!, walletCurrency: WalletCurrency): PublicWallet! @join__field(graph: PUBLIC)
   btcPriceList(range: PriceGraphRange!): [PricePoint] @join__field(graph: PUBLIC)
   businessMapMarkers: [MapMarker!]! @join__field(graph: PUBLIC)
   currencyList: [Currency!]! @join__field(graph: PUBLIC)
@@ -2077,6 +2078,10 @@ input UserLogoutInput
 
 """Unique identifier of a user"""
 scalar Username
+  @join__type(graph: PUBLIC)
+
+"""Unique identifier of a user, with optional flags"""
+scalar UsernameWithFlags
   @join__type(graph: PUBLIC)
 
 enum UserNotificationCategory


### PR DESCRIPTION
## Description

This PR adds a new `AccountDefaultWalletIdByUsername` query that has a new `UsernameWithFlags` param to handle accepting usernames with `+usd` suffix that can be used to return USD wallet by default.