### PR TITLE
refactor(notifications): more expressive error on ConcurrentModification

### DIFF
--- a/core/notifications/src/user_notification_settings/error.rs
+++ b/core/notifications/src/user_notification_settings/error.rs
@@ -3,7 +3,24 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum UserNotificationSettingsError {
     #[error("UserNotificationSettingsError - Sqlx: {0}")]
-    Sqlx(#[from] sqlx::Error),
+    Sqlx(sqlx::Error),
     #[error("UserNotificationSettingsError - EntityError: {0}")]
     EntityError(#[from] es_entity::EntityError),
+    #[error("UserNotificationSettingsError - ConcurrentModification")]
+    ConcurrentModification,
+}
+
+impl From<sqlx::Error> for UserNotificationSettingsError {
+    fn from(error: sqlx::Error) -> Self {
+        if let Some(err) = error.as_database_error() {
+            if let Some(constraint) = err.constraint() {
+                if constraint.contains("duplicate key value violates unique constraint")
+                    && constraint.contains("events_id_sequence_key")
+                {
+                    return Self::ConcurrentModification;
+                }
+            }
+        }
+        Self::Sqlx(error)
+    }
 }


### PR DESCRIPTION
This PR will now correctly return the [ABORTED](https://grpc.github.io/grpc/core/md_doc_statuscodes.html) code when the `UserNotificationSettings` entity is concurrently modified. For better identification and processing in clients. Should probably be identified and set to non-critical in core code base.