### PR TITLE
feat(dashboard) separate connection strings for BTCPay wallet

### DIFF
--- a/apps/dashboard/app/api-keys/page.tsx
+++ b/apps/dashboard/app/api-keys/page.tsx
@@ -6,6 +6,8 @@ import { getServerSession } from "next-auth"
 
 import { authOptions } from "../api/auth/[...nextauth]/route"
 
+import { getBTCWallet, getUSDWallet } from "../utils"
+
 import ContentContainer from "@/components/content-container"
 import ApiKeysList from "@/components/api-keys/list"
 import ApiKeyCreate from "@/components/api-keys/create"
@@ -26,7 +28,8 @@ export default async function Home() {
   const activeKeys = keys.filter(({ expired, revoked }) => !expired && !revoked)
   const expiredKeys = keys.filter(({ expired }) => expired)
   const revokedKeys = keys.filter(({ revoked }) => revoked)
-  const defaultWalletId = session.userData.data.me?.defaultAccount.defaultWalletId
+  const usdWalletId = getUSDWallet(session.userData.data)?.id
+  const btcWalletId = getBTCWallet(session.userData.data)?.id
 
   return (
     <ContentContainer>
@@ -56,7 +59,7 @@ export default async function Home() {
             Your API Keys that can be used to access the{" "}
             <Link href="https://dev.blink.sv/">Blink API</Link>
           </Typography>
-          <ApiKeyCreate defaultWalletId={defaultWalletId} />
+          <ApiKeyCreate btcWalletId={btcWalletId} usdWalletId={usdWalletId} />
         </Box>
         <Typography fontSize={17}>
           Our team will never ask for the API keys. Anyone with access to the key with

--- a/apps/dashboard/components/api-keys/btc-pay-tabs.tsx
+++ b/apps/dashboard/components/api-keys/btc-pay-tabs.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from "react"
+import Box from "@mui/joy/Box"
+import Typography from "@mui/joy/Typography"
+import Tooltip from "@mui/joy/Tooltip"
+import CopyIcon from "@mui/icons-material/CopyAll"
+
+type Props = {
+  apiKeySecret: string
+  btcWalletId: string
+  usdWalletId: string
+}
+
+const BtcPayConnectionGroup = ({ apiKeySecret, btcWalletId, usdWalletId }: Props) => {
+  const [btcPayCopiedUsdWallet, setBtcPayCopiedUsdWallet] = useState(false)
+  const [btcPayCopiedBtcWallet, setBtcPayCopiedBtcWallet] = useState(false)
+
+  const handleBtcPayCopy = (walletId: string, walletType: string) => {
+    if (walletType === "BTC") {
+      setBtcPayCopiedBtcWallet(true)
+      setTimeout(() => {
+        setBtcPayCopiedBtcWallet(false)
+      }, 2000)
+    } else {
+      setBtcPayCopiedUsdWallet(true)
+      setTimeout(() => {
+        setBtcPayCopiedUsdWallet(false)
+      }, 2000)
+    }
+    navigator.clipboard.writeText(
+      `type=blink;server=https://api.blink.sv/graphql;api-key=${apiKeySecret};wallet-id=${walletId}`,
+    )
+  }
+
+  const renderConnectionStringBox = (walletId: string, walletType: string) => (
+    <Box
+      sx={{
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+        width: "100%",
+        backgroundColor: "neutral.solidDisabledBg",
+        padding: "0.5em",
+        borderRadius: "0.5em",
+      }}
+    >
+      <Typography>BTCPay connection string {walletType} Wallet</Typography>
+      <Tooltip
+        title="Copied to Clipboard"
+        open={walletType === "BTC" ? btcPayCopiedBtcWallet : btcPayCopiedUsdWallet}
+        onClick={() => handleBtcPayCopy(walletId, walletType)}
+        sx={{
+          cursor: "pointer",
+        }}
+      >
+        <CopyIcon
+          sx={{
+            fontSize: "1.2em",
+          }}
+        />
+      </Tooltip>
+    </Box>
+  )
+
+  return (
+    <Box
+      sx={{
+        width: "100%",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: "1em",
+      }}
+    >
+      {renderConnectionStringBox(btcWalletId, "BTC")}
+      {renderConnectionStringBox(usdWalletId, "USD")}
+    </Box>
+  )
+}
+
+export default BtcPayConnectionGroup

--- a/apps/dashboard/components/api-keys/create.tsx
+++ b/apps/dashboard/components/api-keys/create.tsx
@@ -27,19 +27,21 @@ import { useFormState } from "react-dom"
 
 import FormSubmitButton from "../form-submit-button"
 
+import BtcPayConnectionGroup from "./btc-pay-tabs"
+
 import { createApiKeyServerAction } from "@/app/api-keys/server-actions"
 import { ApiKeyResponse } from "@/app/api-keys/api-key.types"
 
 type Prop = {
-  defaultWalletId: string | undefined
+  usdWalletId: string | undefined
+  btcWalletId: string | undefined
 }
 
-const ApiKeyCreate = ({ defaultWalletId }: Prop) => {
+const ApiKeyCreate = ({ usdWalletId, btcWalletId }: Prop) => {
   const router = useRouter()
 
   const [open, setOpen] = useState(false)
   const [apiKeyCopied, setApiKeyCopied] = useState(false)
-  const [btcPayCopied, setBtcPayCopied] = useState(false)
   const [state, formAction] = useFormState<ApiKeyResponse, FormData>(
     createApiKeyServerAction,
     {
@@ -60,16 +62,6 @@ const ApiKeyCreate = ({ defaultWalletId }: Prop) => {
     state.responsePayload = null
     console.log("Modal has been closed")
     router.refresh()
-  }
-
-  const handleBtcPayCopy = () => {
-    setBtcPayCopied(true)
-    setTimeout(() => {
-      setBtcPayCopied(false)
-    }, 2000)
-    navigator.clipboard.writeText(
-      `type=blink;server=https://api.blink.sv/graphql;api-key=${state?.responsePayload?.apiKeySecret};wallet-id=${defaultWalletId}`,
-    )
   }
 
   return (
@@ -149,29 +141,13 @@ const ApiKeyCreate = ({ defaultWalletId }: Prop) => {
                   <CopyIcon />
                 </Tooltip>
               </Box>
-              <Tooltip
-                sx={{
-                  cursor: "pointer",
-                  position: "absolute",
-                }}
-                open={btcPayCopied}
-                title="Copied to Clipboard"
-                variant="plain"
-              >
-                <Button
-                  variant="outlined"
-                  color="primary"
-                  sx={{
-                    width: "100%",
-                    display: "flex",
-                    justifyContent: "center",
-                    alignItems: "center",
-                  }}
-                  onClick={handleBtcPayCopy}
-                >
-                  Copy connection settings for BTCPay server
-                </Button>
-              </Tooltip>
+              {btcWalletId && usdWalletId && state?.responsePayload?.apiKeySecret && (
+                <BtcPayConnectionGroup
+                  apiKeySecret={state?.responsePayload?.apiKeySecret}
+                  btcWalletId={btcWalletId}
+                  usdWalletId={usdWalletId}
+                />
+              )}
 
               <Typography
                 sx={{


### PR DESCRIPTION
Users can choose between BTC or USD wallet for connection string.
<img width="360" alt="image" src="https://github.com/GaloyMoney/galoy/assets/59279771/58528766-f64f-4127-bf39-926ae5c5484b">


updated to 
<img width="361" alt="image" src="https://github.com/GaloyMoney/galoy/assets/59279771/308846be-7a74-4893-a3ee-830967df7f8a">
