### PR TITLE
fix(core): throw unknown errors without mapping at server entrypoint

### DIFF
--- a/core/api/src/graphql/error-map.ts
+++ b/core/api/src/graphql/error-map.ts
@@ -40,8 +40,7 @@ import {
 import { baseLogger } from "@/services/logger"
 
 const assertUnreachable = (x: never): never => {
-  const stacktrace = `\nUnreachableError stacktrace:\n${(x as Error).stack}`
-  throw new Error(`This should never compile with ${x}` + stacktrace)
+  throw new Error(`This should never compile with ${x}`)
 }
 
 export const mapError = (error: ApplicationError): CustomGraphQLError => {

--- a/core/api/src/servers/graphql-server.ts
+++ b/core/api/src/servers/graphql-server.ts
@@ -77,7 +77,7 @@ export const startApolloServer = async ({
           code: formattedError.extensions?.code,
         }
       } catch (err) {
-        throw mapError(parseUnknownDomainErrorFromUnknown(err))
+        throw parseUnknownDomainErrorFromUnknown(err)
       }
     },
   })

--- a/core/api/src/servers/graphql-server.ts
+++ b/core/api/src/servers/graphql-server.ts
@@ -66,8 +66,9 @@ export const startApolloServer = async ({
     plugins: apolloPlugins,
     formatError: (formattedError, error) => {
       try {
-        if (unwrapResolverError(error) instanceof DomainError) {
-          return mapError(parseUnknownDomainErrorFromUnknown(error))
+        const unwrappedErr = unwrapResolverError(error)
+        if (unwrappedErr instanceof DomainError) {
+          return mapError(parseUnknownDomainErrorFromUnknown(unwrappedErr))
         }
 
         return {


### PR DESCRIPTION
## Description

To improve visibility in cases like with this test failure
https://github.com/GaloyMoney/galoy/actions/runs/8065227268/attempts/2

This will not stop the error, but it should show us the original error trace instead of the obfuscated `assertUnreachable` one.