### PR TITLE
test(core): fix admin tests flakiness

### DIFF
--- a/bats/admin-gql/account-update-level.gql
+++ b/bats/admin-gql/account-update-level.gql
@@ -10,7 +10,6 @@ mutation accountUpdateLevel($input: AccountUpdateLevelInput!) {
       status
       owner {
         id
-        language
         phone
         createdAt
       }

--- a/bats/admin-gql/account-update-status.gql
+++ b/bats/admin-gql/account-update-status.gql
@@ -10,7 +10,6 @@ mutation accountUpdateStatus($input: AccountUpdateStatusInput!) {
       status
       owner {
         id
-        language
         phone
         createdAt
       }

--- a/core/api/src/graphql/error-map.ts
+++ b/core/api/src/graphql/error-map.ts
@@ -666,7 +666,6 @@ export const mapError = (error: ApplicationError): CustomGraphQLError => {
     case "LikelyNoUserWithThisPhoneExistError":
     case "LikelyUserAlreadyExistError":
     case "CouldNotUnsetPhoneFromUserError":
-    case "NotificationsServiceUnreachableServerError":
     case "InvalidDeviceTokenError":
     case "EventAugmentationMissingError":
     case "NoPayloadFoundError":
@@ -710,6 +709,10 @@ export const mapError = (error: ApplicationError): CustomGraphQLError => {
       message = `Unexpected error occurred, please try again or contact support if it persists (code: ${
         error.name
       }${error.message ? ": " + error.message : ""})`
+      return new UnexpectedClientError({ message, logger: baseLogger })
+
+    case "NotificationsServiceUnreachableServerError":
+      message = `Unexpected error occurred, please try again or contact support if it persists (code: ${error.name})`
       return new UnexpectedClientError({ message, logger: baseLogger })
 
     case "MissingSessionIdError":

--- a/core/api/src/services/notifications/index.ts
+++ b/core/api/src/services/notifications/index.ts
@@ -75,7 +75,7 @@ export const NotificationsService = (): INotificationsService => {
 
       return notificationSettings
     } catch (err) {
-      return new UnknownNotificationsServiceError(err)
+      return handleCommonNotificationErrors(err)
     }
   }
 

--- a/core/api/src/services/notifications/push-notifications.ts
+++ b/core/api/src/services/notifications/push-notifications.ts
@@ -202,6 +202,7 @@ export const handleCommonNotificationErrors = (err: Error | string | unknown) =>
   switch (true) {
     case match(KnownNotificationErrorMessages.GoogleBadGatewayError):
     case match(KnownNotificationErrorMessages.GoogleInternalServerError):
+    case match(KnownNotificationErrorMessages.NoConnectionError):
       return new NotificationsServiceUnreachableServerError(errMsg)
 
     default:
@@ -212,6 +213,7 @@ export const handleCommonNotificationErrors = (err: Error | string | unknown) =>
 export const KnownNotificationErrorMessages = {
   GoogleBadGatewayError: /Raw server response .* Error 502/,
   GoogleInternalServerError: /Raw server response .* Error 500/,
+  NoConnectionError: /UNAVAILABLE: No connection established/,
 } as const
 
 export const SendFilteredPushNotificationStatus = {


### PR DESCRIPTION
## Description

This is to remove an unnecessary `language` field from the admin tests gql query that is dependent on the `notifications` pod which we currently do not wait for before starting the tests.