### PR TITLE
chore(test): skip failing test until price server is fixed

### DIFF
--- a/bats/core/api/public.bats
+++ b/bats/core/api/public.bats
@@ -55,6 +55,7 @@ load "../../helpers/subscriber.bash"
 }
 
 @test "public: can subscribe to realtime price" {
+  skip "until price server can take a mocked realtime price config"
   subscribe_to 'anon' real-time-price-sub '{"currency": "EUR"}'
   retry 10 1 grep 'Data.*\brealtimePrice\b.*EUR' "${SUBSCRIBER_LOG_FILE}"
 


### PR DESCRIPTION
## Description

The currency rates provider we are using in pipelines and staging are currently broken. This is to unblock the pipeline temporarily until price service is fixed by adding the ability to pass a config to return mocked values.