### PR TITLE
fix(core): move pending ln-state-update to final return

### DIFF
--- a/core/api/src/app/payments/send-lightning.ts
+++ b/core/api/src/app/payments/send-lightning.ts
@@ -414,7 +414,7 @@ const executePaymentViaIntraledger = async <
   const recipientUser = await UsersRepository().findById(recipientUserId)
   if (recipientUser instanceof Error) return recipientUser
 
-  const txRecipientNotificationArgs = {
+  const recipientAsNotificationRecipient = {
     accountId: recipientAccount.id,
     walletId: recipientWalletDescriptor.id,
     userId: recipientUser.id,
@@ -424,7 +424,7 @@ const executePaymentViaIntraledger = async <
   const senderUser = await UsersRepository().findById(senderAccount.kratosUserId)
   if (senderUser instanceof Error) return senderUser
 
-  const txSenderNotificationArgs = {
+  const senderAsNotificationRecipient = {
     accountId: senderAccount.id,
     walletId: senderWallet.id,
     userId: senderUser.id,
@@ -554,22 +554,22 @@ const executePaymentViaIntraledger = async <
     if (newWalletInvoice instanceof Error) return newWalletInvoice
 
     const recipientWalletTransaction = await getTransactionForWalletByJournalId({
-      walletId: txRecipientNotificationArgs.walletId,
+      walletId: recipientAsNotificationRecipient.walletId,
       journalId: journal.journalId,
     })
     if (recipientWalletTransaction instanceof Error) return recipientWalletTransaction
     NotificationsService().sendTransaction({
-      recipient: txRecipientNotificationArgs,
+      recipient: recipientAsNotificationRecipient,
       transaction: recipientWalletTransaction,
     })
 
     const senderWalletTransaction = await getTransactionForWalletByJournalId({
-      walletId: txSenderNotificationArgs.walletId,
+      walletId: senderAsNotificationRecipient.walletId,
       journalId: journal.journalId,
     })
     if (senderWalletTransaction instanceof Error) return senderWalletTransaction
     NotificationsService().sendTransaction({
-      recipient: txSenderNotificationArgs,
+      recipient: senderAsNotificationRecipient,
       transaction: senderWalletTransaction,
     })
 
@@ -634,7 +634,7 @@ const executePaymentViaLn = async ({
   const senderUser = await UsersRepository().findById(senderAccount.kratosUserId)
   if (senderUser instanceof Error) return senderUser
 
-  const txSenderNotificationArgs = {
+  const notificationRecipient = {
     accountId: senderWallet.accountId,
     walletId: senderWallet.id,
     userId: senderUser.id,
@@ -761,6 +761,7 @@ const executePaymentViaLn = async ({
           revealedPreImage: payResult.revealedPreImage,
         })
     }
+
     if (payResult instanceof LnPaymentPendingError) {
       paymentFlow.paymentSentAndPending = true
       const updateResult = await paymentFlowRepo.updateLightningPaymentFlow(paymentFlow)
@@ -768,26 +769,12 @@ const executePaymentViaLn = async ({
         recordExceptionInCurrentSpan({ error: updateResult })
       }
 
-      const updateStateAfterPending = await LedgerFacade.updateLnPaymentState({
+      return finalizePaymentViaLn({
+        payResult,
         walletIds,
         paymentHash,
         journalId,
-      })
-      if (updateStateAfterPending instanceof Error) return updateStateAfterPending
-
-      const walletTransaction = await getTransactionForWalletByJournalId({
-        walletId: txSenderNotificationArgs.walletId,
-        journalId: journal.journalId,
-      })
-      if (walletTransaction instanceof Error) return walletTransaction
-      NotificationsService().sendTransaction({
-        recipient: txSenderNotificationArgs,
-        transaction: walletTransaction,
-      })
-
-      return getPendingPaymentResponse({
-        walletId: senderWallet.id,
-        paymentHash,
+        notificationRecipient,
       })
     }
 
@@ -802,29 +789,13 @@ const executePaymentViaLn = async ({
       })
       if (voided instanceof Error) return voided
 
-      const updateStateAfterRevert = await LedgerFacade.updateLnPaymentState({
+      return finalizePaymentViaLn({
+        payResult,
         walletIds,
         paymentHash,
         journalId,
+        notificationRecipient,
       })
-      if (updateStateAfterRevert instanceof Error) return updateStateAfterRevert
-
-      const walletTransaction = await getTransactionForWalletByJournalId({
-        walletId: txSenderNotificationArgs.walletId,
-        journalId: journal.journalId,
-      })
-      if (walletTransaction instanceof Error) return walletTransaction
-      NotificationsService().sendTransaction({
-        recipient: txSenderNotificationArgs,
-        transaction: walletTransaction,
-      })
-
-      return payResult instanceof LnAlreadyPaidError
-        ? getAlreadyPaidResponse({
-            walletId: senderWallet.id,
-            paymentHash,
-          })
-        : payResult
     }
 
     // Settle and conditionally record reimbursement entries
@@ -843,28 +814,69 @@ const executePaymentViaLn = async ({
       if (reimbursed instanceof Error) return reimbursed
     }
 
-    const updateStateAfterSettle = await LedgerFacade.updateLnPaymentState({
+    return finalizePaymentViaLn({
+      payResult,
       walletIds,
       paymentHash,
       journalId,
+      notificationRecipient,
     })
-    if (updateStateAfterSettle instanceof Error) return updateStateAfterSettle
-
-    const walletTransaction = await getTransactionForWalletByJournalId({
-      walletId: txSenderNotificationArgs.walletId,
-      journalId: journal.journalId,
-    })
-    if (walletTransaction instanceof Error) return walletTransaction
-    NotificationsService().sendTransaction({
-      recipient: txSenderNotificationArgs,
-      transaction: walletTransaction,
-    })
-
-    return {
-      status: PaymentSendStatus.Success,
-      transaction: walletTransaction,
-    }
   })
+}
+
+const finalizePaymentViaLn = async ({
+  payResult,
+  walletIds,
+  paymentHash,
+  journalId,
+  notificationRecipient,
+}: {
+  payResult: PayInvoiceResult | LightningServiceError
+  walletIds: WalletId[]
+  paymentHash: PaymentHash
+  journalId: LedgerJournalId
+  notificationRecipient: NotificationRecipient
+}) => {
+  const { walletId } = notificationRecipient
+  const updateJournalTxnsState = await LedgerFacade.updateLnPaymentState({
+    walletIds,
+    paymentHash,
+    journalId,
+  })
+  if (updateJournalTxnsState instanceof Error) return updateJournalTxnsState
+
+  const walletTransaction = await getTransactionForWalletByJournalId({
+    walletId,
+    journalId,
+  })
+  if (walletTransaction instanceof Error) return walletTransaction
+  NotificationsService().sendTransaction({
+    recipient: notificationRecipient,
+    transaction: walletTransaction,
+  })
+
+  switch (true) {
+    case payResult instanceof LnPaymentPendingError:
+      return getPendingPaymentResponse({
+        walletId,
+        paymentHash,
+      })
+
+    case payResult instanceof LnAlreadyPaidError:
+      return getAlreadyPaidResponse({
+        walletId,
+        paymentHash,
+      })
+
+    case payResult instanceof Error:
+      return payResult
+
+    default:
+      return {
+        status: PaymentSendStatus.Success,
+        transaction: walletTransaction,
+      }
+  }
 }
 
 const getAlreadyPaidResponse = async ({

--- a/core/api/src/app/payments/send-lightning.ts
+++ b/core/api/src/app/payments/send-lightning.ts
@@ -719,13 +719,6 @@ const executePaymentViaLn = async ({
     if (journal instanceof Error) return journal
     const { journalId } = journal
 
-    const updateStateAfterSend = await LedgerFacade.updateLnPaymentState({
-      walletIds,
-      paymentHash,
-      journalId,
-    })
-    if (updateStateAfterSend instanceof Error) return updateStateAfterSend
-
     // Execute payment
     let payResult: PayInvoiceResult | LightningServiceError
     if (rawRoute) {
@@ -774,6 +767,13 @@ const executePaymentViaLn = async ({
       if (updateResult instanceof Error) {
         recordExceptionInCurrentSpan({ error: updateResult })
       }
+
+      const updateStateAfterPending = await LedgerFacade.updateLnPaymentState({
+        walletIds,
+        paymentHash,
+        journalId,
+      })
+      if (updateStateAfterPending instanceof Error) return updateStateAfterPending
 
       const walletTransaction = await getTransactionForWalletByJournalId({
         walletId: txSenderNotificationArgs.walletId,

--- a/core/api/src/app/payments/send-lightning.ts
+++ b/core/api/src/app/payments/send-lightning.ts
@@ -688,6 +688,12 @@ const executePaymentViaLn = async ({
       memoOfPayer: memo || paymentFlow.descriptionFromInvoice,
     })
 
+    const walletPriceRatio = WalletPriceRatio({
+      usd: paymentFlow.usdPaymentAmount,
+      btc: paymentFlow.btcPaymentAmount,
+    })
+    if (walletPriceRatio instanceof Error) return walletPriceRatio
+
     // Record pending payment entries
     const journal = await LedgerFacade.recordSendOffChain({
       description: paymentFlow.descriptionFromInvoice || memo || "",
@@ -721,12 +727,6 @@ const executePaymentViaLn = async ({
     if (updateStateAfterSend instanceof Error) return updateStateAfterSend
 
     // Execute payment
-    const walletPriceRatio = WalletPriceRatio({
-      usd: paymentFlow.usdPaymentAmount,
-      btc: paymentFlow.btcPaymentAmount,
-    })
-    if (walletPriceRatio instanceof Error) return walletPriceRatio
-
     let payResult: PayInvoiceResult | LightningServiceError
     if (rawRoute) {
       payResult = await lndService.payInvoiceViaRoutes({

--- a/core/api/src/app/payments/update-pending-payments.ts
+++ b/core/api/src/app/payments/update-pending-payments.ts
@@ -355,6 +355,13 @@ const updatePendingPayment = wrapAsyncToRunInSpan({
       }
 
       if (pendingPayment.feeKnownInAdvance) {
+        const updateStateAfterSuccess = await LedgerFacade.updateLnPaymentState({
+          walletIds,
+          paymentHash,
+          journalId,
+        })
+        if (updateStateAfterSuccess instanceof Error) return updateStateAfterSuccess
+
         const walletTransaction = await getTransactionForWalletByJournalId({
           walletId: txSenderNotificationArgs.walletId,
           journalId,

--- a/core/api/src/app/payments/update-pending-payments.ts
+++ b/core/api/src/app/payments/update-pending-payments.ts
@@ -379,7 +379,7 @@ const updatePendingPayment = wrapAsyncToRunInSpan({
       if (!displayAmount || !displayFee || !displayCurrency) {
         return new MissingExpectedDisplayAmountsForTransactionError()
       }
-      const reimbursed = reimburseFee({
+      const reimbursed = await reimburseFee({
         paymentFlow,
         senderDisplayAmount: displayAmount,
         senderDisplayCurrency: displayCurrency,

--- a/core/api/src/domain/ledger/ln-payment-state.ts
+++ b/core/api/src/domain/ledger/ln-payment-state.ts
@@ -16,17 +16,28 @@ export const LnPaymentState = {
     "ln_payment.failed_after_success_with_reimbursement",
 } as const
 
-const count = <T>({ arr, valueToCount }: { arr: T[]; valueToCount: T }): number =>
-  arr.reduce((count, currentValue) => {
-    return currentValue === valueToCount ? count + 1 : count
-  }, 0)
-
-const sum = <T>({ arr, propertyName }: { arr: T[]; propertyName: keyof T }): number =>
-  arr.reduce((sum, currentItem) => {
-    return sum + Number(currentItem[propertyName] || 0)
-  }, 0)
-
 const isDebit = (txn: LedgerTransaction<WalletCurrency>) => (txn.debit || 0) > 0
+
+const bundleErrMsg = ({
+  msg,
+  txns,
+}: {
+  msg: string
+  txns: LedgerTransaction<WalletCurrency>[]
+}) =>
+  JSON.stringify({
+    msg,
+    txns: txns.map((tx) => ({
+      id: tx.id,
+      journalId: tx.journalId,
+      type: tx.type,
+      pendingConfirmaton: tx.pendingConfirmation,
+      currency: tx.currency,
+      debit: tx.debit,
+      credit: tx.credit,
+      lnMemo: tx.lnMemo,
+    })),
+  })
 
 const checkTxns = (
   txns: LedgerTransaction<WalletCurrency>[],
@@ -37,7 +48,9 @@ const checkTxns = (
   ]
   for (const txn of txns) {
     if (!validTypes.includes(txn.type as (typeof validTypes)[number])) {
-      return new InvalidLnPaymentTxnsBundleError(`Invalid '${txn.type}' type found`)
+      return new InvalidLnPaymentTxnsBundleError(
+        bundleErrMsg({ msg: `Invalid '${txn.type}' type found`, txns }),
+      )
     }
   }
 
@@ -46,19 +59,8 @@ const checkTxns = (
   return true
 }
 
-const bundleErrMsg = (txns: LedgerTransaction<WalletCurrency>[]) =>
-  JSON.stringify(
-    txns.map((tx) => ({
-      id: tx.id,
-      journalId: tx.journalId,
-      type: tx.type,
-      pendingConfirmaton: tx.pendingConfirmation,
-      currency: tx.currency,
-      debit: tx.debit,
-      credit: tx.credit,
-      lnMemo: tx.lnMemo,
-    })),
-  )
+const sortTxnsByTimestampDesc = (txns: LedgerTransaction<WalletCurrency>[]) =>
+  txns.sort((txA, txB) => txB.timestamp.getTime() - txA.timestamp.getTime())
 
 export const LnPaymentStateDeterminator = (
   unsortedTxns: LedgerTransaction<WalletCurrency>[],
@@ -67,76 +69,79 @@ export const LnPaymentStateDeterminator = (
     const check = checkTxns(unsortedTxns)
     if (check instanceof Error) return check
 
-    const txns = unsortedTxns.sort(
-      (txA, txB) => txB.timestamp.getTime() - txA.timestamp.getTime(),
-    )
+    const txns = sortTxnsByTimestampDesc(unsortedTxns)
 
-    const txPendingStates = txns.map((txn) => txn.pendingConfirmation)
-    if (txPendingStates.includes(true)) {
-      const pendingCount = count({ arr: txPendingStates, valueToCount: true })
-
+    // Pending txns
+    const pendingTxns = txns.filter((tx) => tx.pendingConfirmation)
+    if (pendingTxns.length) {
       switch (true) {
         case txns.length === 1:
           return LnPaymentState.Pending
 
-        case txns.length % 2 === 1 && pendingCount === 1:
+        case txns.length % 2 === 1 && pendingTxns.length === 1:
           return LnPaymentState.PendingAfterRetry
 
         default:
-          return new InvalidLnPaymentTxnsBundleError(bundleErrMsg(txns))
+          return new InvalidLnPaymentTxnsBundleError(
+            bundleErrMsg({ msg: "There should be only 1 pending txn", txns }),
+          )
       }
     }
 
-    const txTypes = txns.map((txn) => txn.type)
-    const txPaymentCount = count({
-      arr: txTypes,
-      valueToCount: LedgerTransactionType.Payment,
-    })
-    if (txTypes.includes(LedgerTransactionType.LnFeeReimbursement)) {
-      const reimburseTxn = txns.find(
-        (tx) => tx.type === LedgerTransactionType.LnFeeReimbursement,
+    // LnFeeReimbursement txns
+    const reimburseTxns = txns.filter(
+      (tx) => tx.type === LedgerTransactionType.LnFeeReimbursement,
+    )
+    if (reimburseTxns.length) {
+      const paymentTypeTxns = txns.filter(
+        (tx) => tx.type === LedgerTransactionType.Payment,
       )
-      if (reimburseTxn === undefined) {
-        return new InvalidLnPaymentTxnsBundleError("Impossible state")
-      }
 
       const txnsAfterReimburse = txns.filter(
-        (tx) => tx.timestamp > reimburseTxn.timestamp,
+        (tx) => tx.timestamp > reimburseTxns[0].timestamp,
       )
+
       switch (true) {
-        case txPaymentCount === 1:
+        case paymentTypeTxns.length === 1:
           return LnPaymentState.SuccessWithReimbursement
+
         case !!txnsAfterReimburse.length:
           return LnPaymentState.FailedAfterSuccessWithReimbursement
-        default:
+
+        case paymentTypeTxns.length > 1 && reimburseTxns.length === 1:
           return LnPaymentState.SuccessWithReimbursementAfterRetry
+
+        default:
+          return new InvalidLnPaymentTxnsBundleError(
+            bundleErrMsg({
+              msg: "There should be payment txns and only 1 reimbursement txn",
+              txns,
+            }),
+          )
       }
     }
 
-    const sumTxAmounts =
-      sum({ arr: txns, propertyName: "debit" }) -
-      sum({ arr: txns, propertyName: "credit" })
-    const failedUsdPayment = !!txns.find((tx) => tx.lnMemo === FAILED_USD_MEMO)
-    // FIXME: 'failedUsdPayment' is a brittle check, but voided can't be used because
-    //        we don't currently mark failed usd entries as void.
+    // Pure success and fail txns
     switch (true) {
       case txns.length === 1:
         return LnPaymentState.Success
 
-      case txns.length === 2 && (sumTxAmounts === 0 || failedUsdPayment):
+      case txns.length === 2:
         return LnPaymentState.Failed
 
+      case txns.length % 2 === 1 && isDebit(txns[0]):
+        return LnPaymentState.SuccessAfterRetry
+
       case txns.length % 2 === 1:
-        if (isDebit(txns[0])) {
-          return LnPaymentState.SuccessAfterRetry
-        }
         return LnPaymentState.FailedAfterSuccess
 
-      case txns.length % 2 === 0 && (sumTxAmounts === 0 || failedUsdPayment):
+      case txns.length % 2 === 0:
         return LnPaymentState.FailedAfterRetry
 
       default:
-        return new InvalidLnPaymentTxnsBundleError(bundleErrMsg(txns))
+        return new InvalidLnPaymentTxnsBundleError(
+          bundleErrMsg({ msg: "Impossible state", txns }),
+        )
     }
   }
 

--- a/core/api/src/domain/ledger/ln-payment-state.ts
+++ b/core/api/src/domain/ledger/ln-payment-state.ts
@@ -46,6 +46,20 @@ const checkTxns = (
   return true
 }
 
+const bundleErrMsg = (txns: LedgerTransaction<WalletCurrency>[]) =>
+  JSON.stringify(
+    txns.map((tx) => ({
+      id: tx.id,
+      journalId: tx.journalId,
+      type: tx.type,
+      pendingConfirmaton: tx.pendingConfirmation,
+      currency: tx.currency,
+      debit: tx.debit,
+      credit: tx.credit,
+      lnMemo: tx.lnMemo,
+    })),
+  )
+
 export const LnPaymentStateDeterminator = (
   unsortedTxns: LedgerTransaction<WalletCurrency>[],
 ): LnPaymentStateDeterminator => {
@@ -69,7 +83,7 @@ export const LnPaymentStateDeterminator = (
           return LnPaymentState.PendingAfterRetry
 
         default:
-          return new InvalidLnPaymentTxnsBundleError()
+          return new InvalidLnPaymentTxnsBundleError(bundleErrMsg(txns))
       }
     }
 
@@ -122,7 +136,7 @@ export const LnPaymentStateDeterminator = (
         return LnPaymentState.FailedAfterRetry
 
       default:
-        return new InvalidLnPaymentTxnsBundleError()
+        return new InvalidLnPaymentTxnsBundleError(bundleErrMsg(txns))
     }
   }
 

--- a/core/api/src/services/ledger/facade/update-state.ts
+++ b/core/api/src/services/ledger/facade/update-state.ts
@@ -67,6 +67,7 @@ export const updateLnPaymentState = async ({
           "walletIds, determine the transaction state type, and manually update " +
           "transactions with this '_journal' and 'related_journal' to the correct state.",
         ["error.actionRequired.paymentHash"]: paymentHash,
+        ["error.actionRequired.journalId"]: journalId,
         ["error.actionRequired.walletIds"]: JSON.stringify(walletIds),
       },
     })


### PR DESCRIPTION
## Description

This PR abstracts and moves the follow actions into a final return for the `send-lightning` and `update-pending-payments` use-cases:
- update ln payment state
- send notification

In doing so it fixes some inconsistencies with how we were calling  `updateLnPaymentState` in both use-cases