### PR TITLE
fix(core): add correct states for already-paid failed txns

### DIFF
--- a/core/api/src/domain/wallets/tx-history.ts
+++ b/core/api/src/domain/wallets/tx-history.ts
@@ -241,6 +241,8 @@ const statusFromTxn = (txn: LedgerTransaction<WalletCurrency>): TxStatus => {
 
     case LnPaymentState.Failed:
     case LnPaymentState.FailedAfterRetry:
+    case LnPaymentState.FailedAfterSuccess:
+    case LnPaymentState.FailedAfterSuccessWithReimbursement:
       return TxStatus.Failure
   }
 }

--- a/core/api/test/unit/ledger/ln-payment-state.spec.ts
+++ b/core/api/test/unit/ledger/ln-payment-state.spec.ts
@@ -5,11 +5,15 @@ import {
   LnPaymentStateDeterminator,
 } from "@/domain/ledger/ln-payment-state"
 
+const now = new Date(Date.now())
+const prev = new Date(now.getTime() - 1000)
+
 describe("LnPaymentState", () => {
   describe("Pending", () => {
     it("return Pending", () => {
       const txns = [
         {
+          timestamp: now,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: true,
         } as LedgerTransaction<"BTC">,
@@ -21,14 +25,17 @@ describe("LnPaymentState", () => {
     it("return PendingAfterRetry", () => {
       const txns = [
         {
+          timestamp: now,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: false,
         } as LedgerTransaction<"BTC">,
         {
+          timestamp: now,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: false,
         } as LedgerTransaction<"BTC">,
         {
+          timestamp: now,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: true,
         } as LedgerTransaction<"BTC">,
@@ -42,6 +49,7 @@ describe("LnPaymentState", () => {
     it("return Success", () => {
       const txns = [
         {
+          timestamp: now,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: false,
         } as LedgerTransaction<"BTC">,
@@ -53,10 +61,12 @@ describe("LnPaymentState", () => {
     it("return SuccessWithReimbursement", () => {
       const txns = [
         {
+          timestamp: now,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: false,
         } as LedgerTransaction<"BTC">,
         {
+          timestamp: now,
           type: LedgerTransactionType.LnFeeReimbursement,
           pendingConfirmation: false,
         } as LedgerTransaction<"BTC">,
@@ -68,16 +78,22 @@ describe("LnPaymentState", () => {
     it("return SuccessAfterRetry", () => {
       const txns = [
         {
+          timestamp: now,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: false,
+          debit: 100,
         } as LedgerTransaction<"BTC">,
         {
+          timestamp: prev,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: false,
+          credit: 100,
         } as LedgerTransaction<"BTC">,
         {
+          timestamp: prev,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: false,
+          debit: 100,
         } as LedgerTransaction<"BTC">,
       ]
       const txState = LnPaymentStateDeterminator(txns).determine()
@@ -87,24 +103,28 @@ describe("LnPaymentState", () => {
     it("return SuccessWithReimbursementAfterRetry", () => {
       const txns = [
         {
+          timestamp: now,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: false,
           debit: 100,
           credit: 0,
         } as LedgerTransaction<"BTC">,
         {
+          timestamp: now,
           type: LedgerTransactionType.LnFeeReimbursement,
           pendingConfirmation: false,
           debit: 0,
           credit: 2,
         } as LedgerTransaction<"BTC">,
         {
+          timestamp: now,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: false,
           credit: 100,
           debit: 0,
         } as LedgerTransaction<"BTC">,
         {
+          timestamp: now,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: false,
           debit: 100,
@@ -120,12 +140,14 @@ describe("LnPaymentState", () => {
     it("return Failed", () => {
       const txnsBtc = [
         {
+          timestamp: now,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: false,
           debit: 100,
           credit: 0,
         } as LedgerTransaction<"BTC">,
         {
+          timestamp: now,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: false,
           credit: 100,
@@ -137,12 +159,14 @@ describe("LnPaymentState", () => {
 
       const txnsUsd = [
         {
+          timestamp: now,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: false,
           debit: 5,
           credit: 0,
         } as LedgerTransaction<"USD">,
         {
+          timestamp: now,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: false,
           credit: 100,
@@ -157,12 +181,14 @@ describe("LnPaymentState", () => {
     it("return Failed with USD", () => {
       const txnsBtc = [
         {
+          timestamp: now,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: false,
           debit: 2,
           credit: 0,
         } as LedgerTransaction<"USD">,
         {
+          timestamp: now,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: false,
           credit: 100,
@@ -175,12 +201,14 @@ describe("LnPaymentState", () => {
 
       const txnsUsd = [
         {
+          timestamp: now,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: false,
           debit: 5,
           credit: 0,
         } as LedgerTransaction<"USD">,
         {
+          timestamp: now,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: false,
           credit: 100,
@@ -195,24 +223,28 @@ describe("LnPaymentState", () => {
     it("return FailedAfterRetry", () => {
       const txns = [
         {
+          timestamp: now,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: false,
           debit: 100,
           credit: 0,
         } as LedgerTransaction<"BTC">,
         {
+          timestamp: now,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: false,
           credit: 100,
           debit: 0,
         } as LedgerTransaction<"BTC">,
         {
+          timestamp: now,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: false,
           debit: 100,
           credit: 0,
         } as LedgerTransaction<"BTC">,
         {
+          timestamp: now,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: false,
           credit: 100,
@@ -226,24 +258,28 @@ describe("LnPaymentState", () => {
     it("return FailedAfterRetry with USD", () => {
       const txns = [
         {
+          timestamp: now,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: false,
           debit: 100,
           credit: 0,
         } as LedgerTransaction<"BTC">,
         {
+          timestamp: now,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: false,
           credit: 100,
           debit: 0,
         } as LedgerTransaction<"BTC">,
         {
+          timestamp: now,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: false,
           debit: 2,
           credit: 0,
         } as LedgerTransaction<"USD">,
         {
+          timestamp: now,
           type: LedgerTransactionType.Payment,
           pendingConfirmation: false,
           credit: 100,
@@ -253,6 +289,132 @@ describe("LnPaymentState", () => {
       ]
       const txState = LnPaymentStateDeterminator(txns).determine()
       expect(txState).toEqual(LnPaymentState.FailedAfterRetry)
+    })
+
+    it("return FailedAfterSuccess", () => {
+      const now = new Date(Date.now())
+      const prev = new Date(now.getTime() - 1000)
+      const txns = [
+        {
+          timestamp: now,
+          type: LedgerTransactionType.Payment,
+          pendingConfirmation: false,
+          credit: 100,
+        } as LedgerTransaction<"BTC">,
+        {
+          timestamp: now,
+          type: LedgerTransactionType.Payment,
+          pendingConfirmation: false,
+          debit: 100,
+        } as LedgerTransaction<"BTC">,
+        {
+          timestamp: prev,
+          type: LedgerTransactionType.Payment,
+          pendingConfirmation: false,
+          debit: 100,
+        } as LedgerTransaction<"BTC">,
+      ]
+
+      const txState = LnPaymentStateDeterminator(txns).determine()
+      expect(txState).toEqual(LnPaymentState.FailedAfterSuccess)
+    })
+
+    it("return FailedAfterSuccess with USD", () => {
+      const now = new Date(Date.now())
+      const prev = new Date(now.getTime() - 1000)
+      const txns = [
+        {
+          timestamp: now,
+          type: LedgerTransactionType.Payment,
+          pendingConfirmation: false,
+          credit: 100,
+          debit: 0,
+          lnMemo: FAILED_USD_MEMO,
+        } as LedgerTransaction<"BTC">,
+        {
+          timestamp: now,
+          type: LedgerTransactionType.Payment,
+          pendingConfirmation: false,
+          debit: 2,
+          credit: 0,
+        } as LedgerTransaction<"USD">,
+        {
+          timestamp: prev,
+          type: LedgerTransactionType.Payment,
+          pendingConfirmation: false,
+          debit: 100,
+        } as LedgerTransaction<"BTC">,
+      ]
+
+      const txState = LnPaymentStateDeterminator(txns).determine()
+      expect(txState).toEqual(LnPaymentState.FailedAfterSuccess)
+    })
+
+    it("return FailedAfterSuccessWithReimbursement", () => {
+      const txns = [
+        {
+          timestamp: now,
+          type: LedgerTransactionType.Payment,
+          pendingConfirmation: false,
+          credit: 100,
+        } as LedgerTransaction<"BTC">,
+        {
+          timestamp: now,
+          type: LedgerTransactionType.Payment,
+          pendingConfirmation: false,
+          debit: 100,
+        } as LedgerTransaction<"BTC">,
+        {
+          timestamp: prev,
+          type: LedgerTransactionType.LnFeeReimbursement,
+          pendingConfirmation: false,
+          credit: 1,
+        } as LedgerTransaction<"BTC">,
+        {
+          timestamp: prev,
+          type: LedgerTransactionType.Payment,
+          pendingConfirmation: false,
+          debit: 100,
+        } as LedgerTransaction<"BTC">,
+      ]
+
+      const txState = LnPaymentStateDeterminator(txns).determine()
+      expect(txState).toEqual(LnPaymentState.FailedAfterSuccessWithReimbursement)
+    })
+
+    it("return FailedAfterSuccessWithReimbursement with USD", () => {
+      const txns = [
+        {
+          timestamp: now,
+          type: LedgerTransactionType.Payment,
+          pendingConfirmation: false,
+          credit: 100,
+          debit: 0,
+          lnMemo: FAILED_USD_MEMO,
+        } as LedgerTransaction<"BTC">,
+        {
+          timestamp: now,
+          type: LedgerTransactionType.Payment,
+          pendingConfirmation: false,
+          debit: 2,
+          credit: 0,
+        } as LedgerTransaction<"USD">,
+        {
+          timestamp: prev,
+          type: LedgerTransactionType.LnFeeReimbursement,
+          pendingConfirmation: false,
+          credit: 1,
+        } as LedgerTransaction<"BTC">,
+        {
+          timestamp: prev,
+          type: LedgerTransactionType.Payment,
+          pendingConfirmation: false,
+          debit: 100,
+        } as LedgerTransaction<"BTC">,
+      ]
+
+      const txState = LnPaymentStateDeterminator(txns).determine()
+      expect(txState).toEqual(LnPaymentState.FailedAfterSuccessWithReimbursement)
     })
   })
 })


### PR DESCRIPTION
## Description

Before this fix these states would appear as `success_after_retry` and `success_with_reimbursement_after_retry` for already paid txns.