### PR TITLE
chore: add unique id to write-sdl bin script

### DIFF
--- a/toolchains/workspace-pnpm/package_prod_tsc_build_bin.py
+++ b/toolchains/workspace-pnpm/package_prod_tsc_build_bin.py
@@ -4,9 +4,37 @@ Builds an isolated dist tree containing a pruned sub-package and all
 production node_modules.
 """
 import argparse
+import hashlib
 import os
 import stat
-from uuid import uuid4
+
+def hash_dir(dir_path):
+    def hash_file(filepath):
+        """Hash a single file using SHA-256 and return the hex digest."""
+        hasher = hashlib.sha256()
+        with open(filepath, 'rb') as f:
+            buf = f.read()
+            hasher.update(buf)
+        return hasher.hexdigest()
+
+    def hash_directory(directory_path):
+        """Recursively hash all files in directory and return a dictionary of file paths and their hashes."""
+        file_hashes = {}
+        for root, dirs, files in os.walk(directory_path):
+            for filename in files:
+                filepath = os.path.join(root, filename)
+                file_hashes[filepath] = hash_file(filepath)
+        return file_hashes
+
+    def combine_hashes(file_hashes):
+        """Combine file hashes into a single directory fingerprint."""
+        combined_hash_string = ''.join(hash_val for _, hash_val in sorted(file_hashes.items()))
+        return hashlib.sha256(combined_hash_string.encode()).hexdigest()
+
+    file_hashes = hash_directory(dir_path)
+
+    return combine_hashes(file_hashes)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
@@ -50,7 +78,11 @@ if __name__ == "__main__":
         js_path = os.path.join(dist_path, args.run_file)
         binary_content = [
             "#!/usr/bin/env sh",
-            f"# Random uuid to represent unique build: {uuid4()}",
+            "",
+            f"# TODO: execute natively in buck by figuring out some way to make the 'prod_tsc_build_bin'",
+            f"#       rule return a changed state of its deps for any consuming rules.",
+            f"# Deps hash: {hash_dir(dist_path)}",
+            "",
             f"exec node \"{js_path}\" \"$@\""
         ]
 

--- a/toolchains/workspace-pnpm/package_prod_tsc_build_bin.py
+++ b/toolchains/workspace-pnpm/package_prod_tsc_build_bin.py
@@ -6,6 +6,7 @@ production node_modules.
 import argparse
 import os
 import stat
+from uuid import uuid4
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
@@ -49,6 +50,7 @@ if __name__ == "__main__":
         js_path = os.path.join(dist_path, args.run_file)
         binary_content = [
             "#!/usr/bin/env sh",
+            f"# Random uuid to represent unique build: {uuid4()}",
             f"exec node \"{js_path}\" \"$@\""
         ]
 


### PR DESCRIPTION
The issue here is that on first creation `public-sdl`/`admin-sdl` detects that there was a change in `:write-sdl` and correctly executes. On subsequent builds though, the output from `:write-sdl` does not change and so `public-sdl` or `admin-sdl` does not re-execute.

This fix adds a unique uuid to the output script of `:write-sdl` to signal that it was re-executed and that there was some build change in one of its dependencies.