### PR TITLE
fix(toolchain): sdl macro should re-trigger correctly

### DIFF
--- a/core/api/BUCK
+++ b/core/api/BUCK
@@ -98,6 +98,7 @@ sdl(
   name = "public-sdl",
   generator = ":write-sdl",
   args = ["public"],
+  src = ":src",
   visibility = ["PUBLIC"],
 )
 

--- a/toolchains/rover/macros.bzl
+++ b/toolchains/rover/macros.bzl
@@ -142,7 +142,7 @@ def sdl_impl(ctx: AnalysisContext) -> list[DefaultInfo]:
 sdl = rule(
     impl = sdl_impl,
     attrs = {
-        "generator": attrs.dep(
+        "generator": attrs.exec_dep(
             providers = [RunInfo],
             doc = """Generator that will output the sdl""",
         ),

--- a/toolchains/rover/macros.bzl
+++ b/toolchains/rover/macros.bzl
@@ -136,6 +136,9 @@ def sdl_impl(ctx: AnalysisContext) -> list[DefaultInfo]:
         out.as_output()
     )
 
+    if ctx.attrs.src:
+        cmd.hidden(ctx.attrs.src)
+
     ctx.actions.run(cmd, category = "sdl")
     return [DefaultInfo(default_output = out)]
 
@@ -149,6 +152,11 @@ sdl = rule(
         "args": attrs.list(
             attrs.string(),
             default = [],
+        ),
+        "src": attrs.option(
+            attrs.source(),
+            default = None,
+            doc = """Source files that the generator will depends on""",
         ),
         "_python_toolchain": attrs.toolchain_dep(
             default = "toolchains//:python",


### PR DESCRIPTION
This works but still looking for a way to do it without the `src` dep