### PR TITLE
chore(pay): changes in sign in flow

### DIFF
--- a/apps/pay/app/api/auth/[...nextauth]/auth.ts
+++ b/apps/pay/app/api/auth/[...nextauth]/auth.ts
@@ -66,5 +66,15 @@ export const authOptions: NextAuthOptions = {
       session.accessToken = token.accessToken
       return session
     },
+    async signIn({ account }) {
+      if (!account?.access_token) {
+        return false
+      }
+      const res = await fetchUserData({ token: account.access_token })
+      if (res instanceof Error || !res.data.me?.username) {
+        return "/error?errorMessage=This account does not have a username. Please update your profile from the mobile app and update your username"
+      }
+      return true
+    },
   },
 }

--- a/apps/pay/app/error/page.tsx
+++ b/apps/pay/app/error/page.tsx
@@ -1,0 +1,32 @@
+"use client"
+import { signOut } from "next-auth/react"
+import React from "react"
+
+type Prop = {
+  searchParams: {
+    errorMessage: string
+  }
+}
+
+function page({ searchParams }: Prop) {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
+      <p className="mb-4 text-lg font-semibold text-gray-700 text-center p-1 max-w-96">
+        {searchParams.errorMessage}
+      </p>
+      <div
+        onClick={() => {
+          localStorage.removeItem("username")
+          signOut({
+            callbackUrl: "/setuppwa",
+          })
+        }}
+        className="px-4 py-2 text-sm font-semibold text-white bg-[var(--primaryColor)] rounded-full cursor-pointer"
+      >
+        <div>Go Back</div>
+      </div>
+    </div>
+  )
+}
+
+export default page

--- a/apps/pay/app/graphql/queries/me-query.ts
+++ b/apps/pay/app/graphql/queries/me-query.ts
@@ -8,6 +8,9 @@ gql`
     me {
       id
       username
+      defaultAccount {
+        displayCurrency
+      }
     }
   }
 `

--- a/apps/pay/app/setuppwa/page.tsx
+++ b/apps/pay/app/setuppwa/page.tsx
@@ -4,6 +4,8 @@ import React, { Suspense, useEffect, useState } from "react"
 
 import Image from "next/image"
 
+import { useSession } from "next-auth/react"
+
 import CurrencyDropdown from "../../components/currency/currency-dropdown"
 
 import styles from "./setuppwa.module.css"
@@ -12,18 +14,35 @@ import LoadingComponent from "@/components/loading"
 
 const SetupPwa = () => {
   const router = useRouter()
+  const session = useSession()
+  const signedInUser = session?.data?.userData?.me
   const [username, setUsername] = useState<string>("")
   const [usernameFromLocal, setUsernameFromLocal] = useState<string | null>(null)
+  const [loading, setLoading] = useState<boolean>(true)
   const [displayCurrencyFromLocal, setDisplayCurrencyFromLocal] = useState<string | null>(
     null,
   )
 
   useEffect(() => {
+    setLoading(true)
     const localUsername = localStorage.getItem("username")
     const localDisplayCurrency = localStorage.getItem("display")
     setUsernameFromLocal(localUsername)
     setDisplayCurrencyFromLocal(localDisplayCurrency)
-  }, [])
+
+    if (signedInUser) {
+      if (!signedInUser.username) {
+        localStorage.removeItem("username")
+      } else {
+        localStorage.setItem("username", signedInUser.username)
+        localStorage.setItem("display", signedInUser.defaultAccount.displayCurrency)
+        router.push(
+          `${signedInUser.username}?display=${signedInUser.defaultAccount.displayCurrency}`,
+        )
+      }
+    }
+    setLoading(false)
+  }, [router, signedInUser])
 
   const [selectedDisplayCurrency, setSelectedDisplayCurrency] = useState("USD")
 
@@ -49,7 +68,7 @@ const SetupPwa = () => {
     router.push(`${username}?display=${selectedDisplayCurrency}`)
   }
 
-  if (!usernameFromLocal) {
+  if (!usernameFromLocal && !loading) {
     return (
       <div className={styles.container}>
         <div className="flex flex-col justify-center items-center">
@@ -79,21 +98,34 @@ const SetupPwa = () => {
           autoComplete="off"
           onSubmit={handleSubmit}
         >
-          <div className="flex flex-col justify-center items-center w-full gap-2 rounded-md ">
-            <div className="flex flex-col w-full">
-              <input
-                data-testid="username-input"
-                className="w-full p-1.5 border-2 rounded-md bg-[var(--lighterGrey)]"
-                type="text"
-                name="username"
-                value={username}
-                onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-                  setUsername(event.target.value)
-                }
-                placeholder="username"
-                required
-              />
+          <div className="flex flex-col justify-center items-center w-full gap-3 rounded-md ">
+            <div
+              className="flex flex-col gap-0 print-paycode-button p-2 m-0 rounded-md cursor-pointer w-full justify-center align-content-center text-center mt-2"
+              onClick={() => {
+                router.push("/api/auth/signin")
+              }}
+            >
+              Sign in with Blink
             </div>
+
+            <div className="flex items-center justify-center w-full">
+              <div className="flex-grow border-t border-gray-300"></div>
+              <span className="flex-shrink mx-4 text-gray-600">or</span>
+              <div className="flex-grow border-t border-gray-300"></div>
+            </div>
+
+            <input
+              data-testid="username-input"
+              className="w-full p-1.5 border-2 rounded-md bg-[var(--lighterGrey)]"
+              type="text"
+              name="username"
+              value={username}
+              onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                setUsername(event.target.value)
+              }
+              placeholder="username"
+              required
+            />
             <div className="flex flex-col w-full">
               <Suspense fallback={<div>Loading...</div>}>
                 <CurrencyDropdown
@@ -106,7 +138,7 @@ const SetupPwa = () => {
             </div>
           </div>
           <button data-testid="submit-btn" className="print-paycode-button w-full mt-3">
-            Submit
+            Next
           </button>
         </form>
       </div>

--- a/apps/pay/components/sidebar/index.tsx
+++ b/apps/pay/components/sidebar/index.tsx
@@ -55,6 +55,7 @@ export function SideBar({ username }: { username: string }) {
       icon: "/icons/cash-register-icon.svg",
       dataTestId: "cash-register-link",
       hardRefresh: true,
+      protected: false,
     },
     {
       name: "Printable Paycode",
@@ -62,6 +63,7 @@ export function SideBar({ username }: { username: string }) {
       icon: "/icons/print-sharp.svg",
       dataTestId: "printable-paycode-link",
       hardRefresh: false,
+      protected: false,
     },
     {
       name: "Transactions",
@@ -69,6 +71,7 @@ export function SideBar({ username }: { username: string }) {
       icon: "/icons/receipt-sharp.svg",
       dataTestId: "transaction-link",
       hardRefresh: false,
+      protected: true,
     },
   ]
 
@@ -159,7 +162,9 @@ export function SideBar({ username }: { username: string }) {
                 <SheetClose key={link.name} asChild>
                   <Link
                     data-testid={link.dataTestId}
-                    href={link.href}
+                    href={
+                      link.protected && !signedInUser ? "/api/auth/signin" : link.href
+                    }
                     className="bg-white text-black p-2 rounded-md no-underline hover:no-underline visited:text-black flex items-center gap-2"
                   >
                     <Image src={link.icon} alt={link.name} width={24} height={24} />

--- a/apps/pay/components/sidebar/index.tsx
+++ b/apps/pay/components/sidebar/index.tsx
@@ -119,21 +119,13 @@ export function SideBar({ username }: { username: string }) {
             <div
               className="flex flex-col gap-0 bg-slate-200 p-2 m-0 rounded-md cursor-pointer"
               onClick={() => {
-                router.push("/api/auth/signin")
+                if (!signedInUser) router.push("/api/auth/signin")
               }}
             >
               {signedInUser ? (
                 <>
                   <div className="flex justify-between">
                     <p className="text-md font-semibold mb-1">Signed in as</p>
-                    <Image
-                      className="cursor-pointer"
-                      onClick={() => signOut()}
-                      alt="logout"
-                      src={"/icons/logout.svg"}
-                      width={20}
-                      height={20}
-                    ></Image>
                   </div>
                   <p className="text-sm mb-0">
                     {signedInUser.username || signedInUser.id}
@@ -176,7 +168,21 @@ export function SideBar({ username }: { username: string }) {
                 </SheetClose>
               ),
             )}
-
+            <div
+              className="bg-white text-black p-2 rounded-md no-underline hover:no-underline visited:text-black flex items-center gap-2 cursor-pointer"
+              onClick={() => {
+                localStorage.removeItem("username")
+                signOut({ callbackUrl: "/setuppwa" })
+              }}
+            >
+              <Image
+                width={24}
+                height={24}
+                src="/icons/log-out.svg"
+                alt="change username"
+              />
+              {signedInUser ? "Log out" : "Change username"}
+            </div>
             <div className="flex flex-col justify-start align-content-center gap-1">
               <div className="text-md font-semibold flex ">Currency</div>
               <CurrencyDropdown

--- a/apps/pay/lib/graphql/generated.ts
+++ b/apps/pay/lib/graphql/generated.ts
@@ -2137,7 +2137,7 @@ export type GetPaginatedTransactionsQuery = { readonly __typename: 'Query', read
 export type MeQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type MeQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly username?: string | null } | null };
+export type MeQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly username?: string | null, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly displayCurrency: string } } | null };
 
 export type LnInvoiceCreateOnBehalfOfRecipientMutationVariables = Exact<{
   walletId: Scalars['WalletId'];
@@ -2343,6 +2343,9 @@ export const MeDocument = gql`
   me {
     id
     username
+    defaultAccount {
+      displayCurrency
+    }
   }
 }
     `;

--- a/apps/pay/middleware.ts
+++ b/apps/pay/middleware.ts
@@ -1,3 +1,2 @@
 export { default } from "next-auth/middleware"
-// TODO no such page right now, this is just so other pages are not blocked
 export const config = { matcher: ["/:username/transaction"] }

--- a/apps/pay/public/icons/log-out.svg
+++ b/apps/pay/public/icons/log-out.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="ionicon" viewBox="0 0 512 512"><path d="M304 336v40a40 40 0 01-40 40H104a40 40 0 01-40-40V136a40 40 0 0140-40h152c22.09 0 48 17.91 48 40v40M368 336l80-80-80-80M176 256h256" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32"/></svg>


### PR DESCRIPTION
- Added a sign-in option on the landing page; this will work as an alternative to typing the username and currency.
- Do not allow sign-in if the user does not have a username.
- If the user signs in from the sidebar and already has a username in the URL, the sign-in username will take precedence.
- Added a logout/change username button to return to the landing page:
    - If not signed in, "Change Username" will be shown.
    - If signed in, "Logout" will be shown.

<img width="300" alt="image" src="https://github.com/GaloyMoney/galoy/assets/59279771/0bd98b04-f413-4c53-b7ed-889234cea8c2">


