### PR TITLE
test(quickstart): wallet balance is updated when btc is sent to a user's wallet

### DIFF
--- a/quickstart/bin/quickstart.sh
+++ b/quickstart/bin/quickstart.sh
@@ -51,7 +51,12 @@ main() {
     sleep 1
   done
 
-  initialize_user_from_onchain "alice" "+16505554328" "000000" 
+  initialize_user_from_onchain "alice" "+16505554328" "000000"
+  bitcoin_cli -generate 3
+
+  exec_graphql "alice" "wallets-for-account"
+  echo $output
+
   echo "Alice account set up, token: $(read_value "alice")"
   
   echo "TOKEN_ALICE=$(read_value "alice")"


### PR DESCRIPTION
This test PR ensures that an account's BTC wallet balance updates correctly after receiving funds via bitcoin-cli, addressing a balance reporting issue in our mobile app's quickstart setup.