### PR TITLE
ci: add mock config for realtime price server

### DIFF
--- a/dev/config/price.yml
+++ b/dev/config/price.yml
@@ -1,0 +1,13 @@
+exchanges:
+  - provider: "dev-mock"
+    base: "BTC"
+    quote: "*"
+    enabled: true
+    config:
+      devMockPrice:
+        BTC:
+          EUR: 17500
+          USD: 20000
+    # Following require dummy values
+    name: ""
+    cron: "*/5 * * * * *"

--- a/dev/docker-compose.deps.yml
+++ b/dev/docker-compose.deps.yml
@@ -7,6 +7,8 @@ services:
     ports:
     - 50051:50051
     - 9464:9464
+    volumes:
+      - ${HOST_PROJECT_PATH:-.}/config/price.yml:/var/yaml/custom.yaml
   price-history:
     image: us.gcr.io/galoy-org/price-history:edge
     ports:


### PR DESCRIPTION
## Description

Pulls in the mock functionality introduced in https://github.com/GaloyMoney/price/pull/62