### PR TITLE
refactor(core): move notification steps out of payment send locks

### DIFF
--- a/core/api/src/app/payments/index.types.d.ts
+++ b/core/api/src/app/payments/index.types.d.ts
@@ -21,8 +21,20 @@ type IntraLedgerSendAttemptResult =
       error: ApplicationError
     }
 
-type PaymentSendAttemptResult =
-  | IntraLedgerSendAttemptResult
+type LnSendAttemptResult =
+  | {
+      type: PaymentSendAttemptResultTypeObj["Ok"]
+      journalId: LedgerJournalId
+    }
   | {
       type: PaymentSendAttemptResultTypeObj["Pending"]
+      journalId: LedgerJournalId
+    }
+  | {
+      type: PaymentSendAttemptResultTypeObj["AlreadyPaid"]
+      journalId: LedgerJournalId
+    }
+  | {
+      type: PaymentSendAttemptResultTypeObj["Error"]
+      error: ApplicationError
     }

--- a/core/api/src/app/payments/index.types.d.ts
+++ b/core/api/src/app/payments/index.types.d.ts
@@ -2,3 +2,27 @@ type PaymentSendResult = {
   status: PaymentSendStatus
   transaction: WalletTransaction
 }
+
+type PaymentSendAttemptResultTypeObj =
+  typeof import("./ln-send-result").PaymentSendAttemptResultType
+type PaymentSendAttemptResultType =
+  PaymentSendAttemptResultTypeObj[keyof PaymentSendAttemptResultTypeObj]
+
+type IntraLedgerSendAttemptResult =
+  | {
+      type: PaymentSendAttemptResultTypeObj["Ok"]
+      journalId: LedgerJournalId
+    }
+  | {
+      type: PaymentSendAttemptResultTypeObj["AlreadyPaid"]
+    }
+  | {
+      type: PaymentSendAttemptResultTypeObj["Error"]
+      error: ApplicationError
+    }
+
+type PaymentSendAttemptResult =
+  | IntraLedgerSendAttemptResult
+  | {
+      type: PaymentSendAttemptResultTypeObj["Pending"]
+    }

--- a/core/api/src/app/payments/index.types.d.ts
+++ b/core/api/src/app/payments/index.types.d.ts
@@ -35,6 +35,11 @@ type LnSendAttemptResult =
       journalId: LedgerJournalId
     }
   | {
+      type: PaymentSendAttemptResultTypeObj["ErrorWithJournal"]
+      journalId: LedgerJournalId
+      error: ApplicationError
+    }
+  | {
       type: PaymentSendAttemptResultTypeObj["Error"]
       error: ApplicationError
     }

--- a/core/api/src/app/payments/ln-send-result.ts
+++ b/core/api/src/app/payments/ln-send-result.ts
@@ -2,6 +2,7 @@ export const PaymentSendAttemptResultType = {
   Ok: "success",
   Pending: "pending",
   AlreadyPaid: "alreadyPaid",
+  ErrorWithJournal: "errorWithJournal",
   Error: "error",
 } as const
 
@@ -31,6 +32,17 @@ export const LnSendAttemptResult = {
   alreadyPaid: (journalId: LedgerJournalId): LnSendAttemptResult => ({
     type: PaymentSendAttemptResultType.AlreadyPaid,
     journalId,
+  }),
+  errWithJournal: ({
+    journalId,
+    error,
+  }: {
+    journalId: LedgerJournalId
+    error: ApplicationError
+  }): LnSendAttemptResult => ({
+    type: PaymentSendAttemptResultType.ErrorWithJournal,
+    journalId,
+    error,
   }),
   err: (error: ApplicationError): LnSendAttemptResult => ({
     type: PaymentSendAttemptResultType.Error,

--- a/core/api/src/app/payments/ln-send-result.ts
+++ b/core/api/src/app/payments/ln-send-result.ts
@@ -20,18 +20,20 @@ export const IntraLedgerSendAttemptResult = {
 }
 
 export const LnSendAttemptResult = {
-  ok: (journalId: LedgerJournalId): PaymentSendAttemptResult => ({
+  ok: (journalId: LedgerJournalId): LnSendAttemptResult => ({
     type: PaymentSendAttemptResultType.Ok,
     journalId,
   }),
-  alreadyPaid: (): PaymentSendAttemptResult => ({
-    type: PaymentSendAttemptResultType.AlreadyPaid,
+  pending: (journalId: LedgerJournalId): LnSendAttemptResult => ({
+    type: PaymentSendAttemptResultType.Pending,
+    journalId,
   }),
-  err: (error: ApplicationError): PaymentSendAttemptResult => ({
+  alreadyPaid: (journalId: LedgerJournalId): LnSendAttemptResult => ({
+    type: PaymentSendAttemptResultType.AlreadyPaid,
+    journalId,
+  }),
+  err: (error: ApplicationError): LnSendAttemptResult => ({
     type: PaymentSendAttemptResultType.Error,
     error,
-  }),
-  pending: (): PaymentSendAttemptResult => ({
-    type: PaymentSendAttemptResultType.Pending,
   }),
 }

--- a/core/api/src/app/payments/ln-send-result.ts
+++ b/core/api/src/app/payments/ln-send-result.ts
@@ -1,0 +1,37 @@
+export const PaymentSendAttemptResultType = {
+  Ok: "success",
+  Pending: "pending",
+  AlreadyPaid: "alreadyPaid",
+  Error: "error",
+} as const
+
+export const IntraLedgerSendAttemptResult = {
+  ok: (journalId: LedgerJournalId): IntraLedgerSendAttemptResult => ({
+    type: PaymentSendAttemptResultType.Ok,
+    journalId,
+  }),
+  alreadyPaid: (): IntraLedgerSendAttemptResult => ({
+    type: PaymentSendAttemptResultType.AlreadyPaid,
+  }),
+  err: (error: ApplicationError): IntraLedgerSendAttemptResult => ({
+    type: PaymentSendAttemptResultType.Error,
+    error,
+  }),
+}
+
+export const LnSendAttemptResult = {
+  ok: (journalId: LedgerJournalId): PaymentSendAttemptResult => ({
+    type: PaymentSendAttemptResultType.Ok,
+    journalId,
+  }),
+  alreadyPaid: (): PaymentSendAttemptResult => ({
+    type: PaymentSendAttemptResultType.AlreadyPaid,
+  }),
+  err: (error: ApplicationError): PaymentSendAttemptResult => ({
+    type: PaymentSendAttemptResultType.Error,
+    error,
+  }),
+  pending: (): PaymentSendAttemptResult => ({
+    type: PaymentSendAttemptResultType.Pending,
+  }),
+}

--- a/core/api/src/app/payments/send-lightning.ts
+++ b/core/api/src/app/payments/send-lightning.ts
@@ -778,6 +778,9 @@ const executePaymentViaLn = async ({
 
   const { paymentHash } = decodedInvoice
   switch (paymentSendAttemptResult.type) {
+    case PaymentSendAttemptResultType.ErrorWithJournal:
+      return paymentSendAttemptResult.error
+
     case PaymentSendAttemptResultType.Pending:
       return getPendingPaymentResponse({
         walletId: senderWalletId,
@@ -994,7 +997,7 @@ const lockedPaymentViaLnSteps = async ({
     }
     return payResult instanceof LnAlreadyPaidError
       ? LnSendAttemptResult.alreadyPaid(journalId)
-      : LnSendAttemptResult.err(payResult)
+      : LnSendAttemptResult.errWithJournal({ journalId, error: payResult })
   }
 
   // Settle and conditionally record reimbursement entries

--- a/core/api/src/app/payments/send-lightning.ts
+++ b/core/api/src/app/payments/send-lightning.ts
@@ -458,21 +458,12 @@ const executePaymentViaIntraledger = async <
   })
   if (limitCheck instanceof Error) return limitCheck
 
-  const {
-    walletDescriptor: recipientWalletDescriptor,
-    recipientUserId: recipientUserIdFromFlow,
-  } = paymentFlow.recipientDetails()
-  if (!recipientWalletDescriptor) {
+  const { walletDescriptor: recipientWalletDescriptor, recipientUserId } =
+    paymentFlow.recipientDetails()
+  if (!(recipientWalletDescriptor && recipientUserId)) {
     return new InvalidLightningPaymentFlowBuilderStateError(
       "Expected recipient details missing",
     )
-  }
-
-  let recipientUserId = recipientUserIdFromFlow
-  if (!recipientUserId) {
-    const recipientUser = await UsersRepository().findById(recipientAccount.kratosUserId)
-    if (recipientUser instanceof Error) return recipientUser
-    recipientUserId = recipientUser.id
   }
 
   const recipientAsNotificationRecipient = {

--- a/core/api/src/app/payments/send-lightning.ts
+++ b/core/api/src/app/payments/send-lightning.ts
@@ -459,9 +459,8 @@ const executePaymentViaIntraledger = async <
   })
   if (limitCheck instanceof Error) return limitCheck
 
-  const { walletDescriptor: recipientWalletDescriptor, recipientUserId } =
-    paymentFlow.recipientDetails()
-  if (!(recipientWalletDescriptor && recipientUserId)) {
+  const { walletDescriptor: recipientWalletDescriptor } = paymentFlow.recipientDetails()
+  if (!recipientWalletDescriptor) {
     return new InvalidLightningPaymentFlowBuilderStateError(
       "Expected recipient details missing",
     )
@@ -470,7 +469,7 @@ const executePaymentViaIntraledger = async <
   const recipientAsNotificationRecipient = {
     accountId: recipientAccount.id,
     walletId: recipientWalletDescriptor.id,
-    userId: recipientUserId,
+    userId: recipientAccount.kratosUserId,
     level: recipientAccount.level,
   }
 
@@ -480,7 +479,7 @@ const executePaymentViaIntraledger = async <
   const senderAsNotificationRecipient = {
     accountId: senderAccount.id,
     walletId: senderWalletId,
-    userId: senderUser.id,
+    userId: senderAccount.kratosUserId,
     level: senderAccount.level,
   }
 
@@ -741,13 +740,10 @@ const executePaymentViaLn = async ({
   if (accountWalletDescriptors instanceof Error) return accountWalletDescriptors
   const walletIds = [accountWalletDescriptors.BTC.id, accountWalletDescriptors.USD.id]
 
-  const senderUser = await UsersRepository().findById(senderAccount.kratosUserId)
-  if (senderUser instanceof Error) return senderUser
-
   const notificationRecipient = {
     accountId: senderAccount.id,
     walletId: senderWalletId,
-    userId: senderUser.id,
+    userId: senderAccount.kratosUserId,
     level: senderAccount.level,
   }
 


### PR DESCRIPTION
## Description

This PR adds a new result type for ln send locks and then moves notification steps out of all payment send locks .