### PR TITLE
chore(core): add .envrc for local pnpm execution

### DIFF
--- a/core/api/.envrc
+++ b/core/api/.envrc
@@ -1,0 +1,7 @@
+use flake
+
+INTEGRATION_ENV_FILE=../../dev/core-bundle/integration-env.json
+for key in $(jq -r 'keys[]' $INTEGRATION_ENV_FILE); do
+  value=$(jq -r --arg k "$key" '.[$k]' $INTEGRATION_ENV_FILE)
+  export $key="$value"
+done


### PR DESCRIPTION
For running integration tests locally we currently have the option of executing:
```
buck2 test //core/api:test-integration -- --env TEST="auth-service"
```

but this takes 40s when there is no change and > 3m when there has been a change.
This is not good for a local dev workflow.

Introducing `buck2` has achieved a lot in terms of being able to reproducibly, reliably bring up the entire system in a deterministic way as well as have easy to adapt templates for creating production builds.
But for development on a single subproject going down to the native task runner (like `pnpm` or `cargo`) seems to yield better results / faster feedback. At least how we have the `buck2` tasks setup up at the moment.

Hence adding this `.envrc` allows us to run:
```
cd core/api
TEST="auth-service" pnpm run test:integration
```
Which executes in <40s being the fastest option of all.