### PR TITLE
feat: store wallets creation date

### DIFF
--- a/core/api/src/domain/wallets/index.types.d.ts
+++ b/core/api/src/domain/wallets/index.types.d.ts
@@ -158,6 +158,7 @@ type NewWalletInfo = {
   readonly accountId: AccountId
   readonly type: WalletType
   readonly currency: WalletCurrency
+  readonly created_at: Date
 }
 
 type Wallet = NewWalletInfo & {

--- a/core/api/src/services/mongoose/schema.ts
+++ b/core/api/src/services/mongoose/schema.ts
@@ -122,6 +122,10 @@ const WalletSchema = new Schema<WalletRecord>({
     required: true,
     default: WalletCurrency.Btc,
   },
+  created_ad: {
+    type: Date,
+    default: Date.now
+  },
   onchain: {
     type: [
       {

--- a/core/api/src/services/mongoose/schema.types.d.ts
+++ b/core/api/src/services/mongoose/schema.types.d.ts
@@ -55,6 +55,7 @@ interface WalletRecord {
   accountId: string
   type: string
   currency: string
+  created_at: Date
   onchain: OnChainMongooseType[]
 }
 

--- a/core/api/src/services/mongoose/wallets.ts
+++ b/core/api/src/services/mongoose/wallets.ts
@@ -21,6 +21,7 @@ export const WalletsRepository = (): IWalletsRepository => {
     accountId,
     type,
     currency,
+    created_at,
   }: NewWalletInfo): Promise<Wallet | RepositoryError> => {
     const account = await AccountsRepository().findById(accountId)
     // verify that the account exist
@@ -31,6 +32,7 @@ export const WalletsRepository = (): IWalletsRepository => {
         accountId,
         type,
         currency,
+        created_at,
       })
       await wallet.save()
       return resultToWallet(wallet)


### PR DESCRIPTION
## Description 
Fix issue: #1617 
This pull request introduces a new field `created_at`  to the wallet collection, ensuring specific tracking for each wallet, whether USD or BTC. 