### PR TITLE
fix(core): add success field to 'UserLoginUpgradeMutation' error return

### DIFF
--- a/core/api/src/graphql/error.ts
+++ b/core/api/src/graphql/error.ts
@@ -500,3 +500,15 @@ export class LnurlRequestInvoiceError extends CustomGraphQLError {
     })
   }
 }
+
+export class IpMissingInContextError extends CustomGraphQLError {
+  constructor(errData: CustomGraphQLErrorData) {
+    super({
+      message:
+        "IP missing from request. Please try again or contact support if problem persists.",
+      forwardToClient: true,
+      code: "IP_MISSING_IN_CONTEXT_ERROR",
+      ...errData,
+    })
+  }
+}

--- a/core/api/src/graphql/public/root/mutation/user-login-upgrade.ts
+++ b/core/api/src/graphql/public/root/mutation/user-login-upgrade.ts
@@ -1,10 +1,15 @@
+import { Authentication } from "@/app"
+
+import { ErrorLevel } from "@/domain/shared"
+import { recordExceptionInCurrentSpan } from "@/services/tracing"
+import { baseLogger } from "@/services/logger"
+
 import { GT } from "@/graphql/index"
 import OneTimeAuthCode from "@/graphql/shared/types/scalar/one-time-auth-code"
-
 import Phone from "@/graphql/shared/types/scalar/phone"
-import { Authentication } from "@/app"
-import { mapAndParseErrorForGqlResponse } from "@/graphql/error-map"
 import UpgradePayload from "@/graphql/public/types/payload/upgrade-payload"
+import { mapAndParseErrorForGqlResponse } from "@/graphql/error-map"
+import { IpMissingInContextError } from "@/graphql/error"
 
 const UserLoginUpgradeInput = GT.Input({
   name: "UserLoginUpgradeInput",
@@ -47,7 +52,15 @@ const UserLoginUpgradeMutation = GT.Field<
     }
 
     if (ip === undefined) {
-      return { errors: [{ message: "ip is undefined" }], success: false }
+      const error = new IpMissingInContextError({ logger: baseLogger })
+      recordExceptionInCurrentSpan({
+        error,
+        level: ErrorLevel.Critical,
+      })
+      return {
+        errors: [error],
+        success: false,
+      }
     }
 
     const res = await Authentication.loginDeviceUpgradeWithPhone({

--- a/core/api/src/graphql/public/root/mutation/user-login-upgrade.ts
+++ b/core/api/src/graphql/public/root/mutation/user-login-upgrade.ts
@@ -39,15 +39,15 @@ const UserLoginUpgradeMutation = GT.Field<
     const { phone, code } = args.input
 
     if (phone instanceof Error) {
-      return { errors: [{ message: phone.message }] }
+      return { errors: [{ message: phone.message }], success: false }
     }
 
     if (code instanceof Error) {
-      return { errors: [{ message: code.message }] }
+      return { errors: [{ message: code.message }], success: false }
     }
 
     if (ip === undefined) {
-      return { errors: [{ message: "ip is undefined" }] }
+      return { errors: [{ message: "ip is undefined" }], success: false }
     }
 
     const res = await Authentication.loginDeviceUpgradeWithPhone({


### PR DESCRIPTION
## Description

Add missing `success` fields and add a new error from missing IP issue. This is response to [this trace](https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/9iR9XDXLTzD/trace/aPjf8ZNK7AB?fields[]=s_name&fields[]=s_serviceName&source=query&span=a1949975fd0adf9d).