### PR TITLE
docs: add test account credentials to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Every service should eventually have a green checkmark next to them, which ensur
 
 ### (5) Test account credentials
 
-For account login, you can input any random mobile number/email and then use `000000` as the OTP.
+For account login on regtest, you can input any random mobile number and then use `000000` as the OTP.
 
 ### (6) Troubleshooting in Tilt
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ buck2 run dev:up
 Once Tilt starts, you can check on the status of all services by accessing the UI through the given port on your local host (e.g. [http://localhost:10350/](http://localhost:10350/)).
 Every service should eventually have a green checkmark next to them, which ensures that they are in "ready" states.
 
+
+### (5) Test account credentials
+
+For account login, you can input any random mobile number/email and then use `000000` as the OTP.
+
 ### (6) Troubleshooting in Tilt
 
 If some services fail to start, you can restart them on the Tilt dashboard.
@@ -177,11 +182,6 @@ It will also remove the containers and, consequentially, the data held in them.
 ```bash
 buck2 run dev:down
 ```
-
-### (8) Test account credentials
-
-For account login, you can input any random mobile number/email and then use `000000` as the OTP.
-
 
 ## Run integration tests with Galoy as a dependency?
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,11 @@ It will also remove the containers and, consequentially, the data held in them.
 buck2 run dev:down
 ```
 
+### (8) Test account credentials
+
+For account login, you can input any random mobile number/email and then use `000000` as the OTP.
+
+
 ## Run integration tests with Galoy as a dependency?
 
 Take a look at the [Quickstart](./quickstart) if you want to take it for a spin.


### PR DESCRIPTION
Added test account credentials in README for ease in login in dev mode.