### PR TITLE
refactor(core): add accountId field to WalletInvoice

### DIFF
--- a/core/api/src/domain/accounts/index.ts
+++ b/core/api/src/domain/accounts/index.ts
@@ -2,9 +2,8 @@ import { InvalidAccountIdError } from "./errors"
 
 import { AccountLevel, AccountStatus } from "./primitives"
 
-import { UUIDV4 } from "@/utils/uuid"
-
 import { toSats } from "@/domain/bitcoin"
+import { UuidRegex } from "@/domain/shared"
 import {
   InvalidCoordinatesError,
   InvalidBusinessTitleLengthError,
@@ -22,8 +21,8 @@ export * from "./limits-volume"
 export * from "./account-validator"
 export * from "./primitives"
 
-const KratosUserIdRegex = UUIDV4
-const AccountIdRegex = UUIDV4
+const KratosUserIdRegex = UuidRegex
+const AccountIdRegex = UuidRegex
 
 // device id format from AppCheck: 1:72279297366:android:35666807ae916c5aa75af7
 const DeviceIdRegex = /^[0-9]+:[0-9]+:[a-z]+:[0-9a-z]+$/i

--- a/core/api/src/domain/accounts/index.ts
+++ b/core/api/src/domain/accounts/index.ts
@@ -22,7 +22,7 @@ export * from "./account-validator"
 export * from "./primitives"
 
 const KratosUserIdRegex = UuidRegex
-const AccountIdRegex = UuidRegex
+export const AccountIdRegex = UuidRegex
 
 // device id format from AppCheck: 1:72279297366:android:35666807ae916c5aa75af7
 const DeviceIdRegex = /^[0-9]+:[0-9]+:[a-z]+:[0-9a-z]+$/i

--- a/core/api/src/domain/merchants/index.ts
+++ b/core/api/src/domain/merchants/index.ts
@@ -1,8 +1,8 @@
 import { InvalidMerchantIdError } from "./errors"
 
-import { UUIDV4 } from "@/utils/uuid"
+import { UuidRegex } from "@/domain/shared"
 
-const MerchantIdRegex = UUIDV4
+const MerchantIdRegex = UuidRegex
 
 export const checkedToMerchantId = (
   merchantId: string,

--- a/core/api/src/domain/shared/index.ts
+++ b/core/api/src/domain/shared/index.ts
@@ -7,6 +7,7 @@ export * from "./safe"
 export * from "./errors"
 export * from "./error-parsers"
 export * from "./error-parsers-unknown"
+export * from "./validation"
 
 export const setErrorWarn = (error: DomainError): DomainError => {
   error.level = ErrorLevel.Warn

--- a/core/api/src/domain/shared/index.types.d.ts
+++ b/core/api/src/domain/shared/index.types.d.ts
@@ -41,6 +41,7 @@ type BalanceAmount<T extends WalletCurrency> = Amount<T> & {
 type PartialWalletDescriptor<T extends WalletCurrency> = {
   id: WalletId
   currency: T
+  accountId?: AccountId // TODO: unify when we migrate accountId to invoices collection
 }
 type WalletDescriptor<T extends WalletCurrency> = PartialWalletDescriptor<T> & {
   accountId: AccountId

--- a/core/api/src/domain/shared/validation.ts
+++ b/core/api/src/domain/shared/validation.ts
@@ -1,2 +1,2 @@
-export const UUIDV4 =
+export const UuidRegex =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i

--- a/core/api/src/domain/users/index.ts
+++ b/core/api/src/domain/users/index.ts
@@ -1,5 +1,7 @@
 import { Languages } from "./languages"
 
+import { UuidRegex } from "@/domain/shared"
+
 import {
   InvalidDeviceId,
   InvalidDeviceTokenError,
@@ -18,9 +20,6 @@ export * from "./phone-metadata-validator"
 const PhoneNumberRegex = /^\+\d{7,14}$/i // FIXME {7,14} to be refined
 
 const EmailAddressRegex = /^[\w-.+]+@([\w-]+\.)+[\w-]{2,4}$/i
-
-const UuidRegex =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 export const checkedToPhoneNumber = (
   phoneNumber: string,

--- a/core/api/src/domain/wallets/validation.ts
+++ b/core/api/src/domain/wallets/validation.ts
@@ -1,7 +1,5 @@
+import { UuidRegex } from "@/domain/shared"
 import { InvalidWalletId } from "@/domain/errors"
-
-const UuidRegex =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 export const WalletIdRegex = UuidRegex
 

--- a/core/api/src/servers/middlewares/idempotency.ts
+++ b/core/api/src/servers/middlewares/idempotency.ts
@@ -4,14 +4,13 @@ import { NextFunction, Request, Response } from "express"
 
 import { InvalidIdempotencyKeyError } from "@/domain/errors"
 import { ResourceAttemptsTimelockServiceError } from "@/domain/lock"
+import { UuidRegex } from "@/domain/shared"
+
 import { LockService } from "@/services/lock"
 import { addAttributesToCurrentSpan } from "@/services/tracing"
 
 // Create lock service instance
 const lockService = LockService()
-
-const UuidRegex =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 const checkedToIdempotencyKey = (input: string) => {
   if (!input.match(UuidRegex)) {

--- a/core/api/src/services/kratos/index.ts
+++ b/core/api/src/services/kratos/index.ts
@@ -4,6 +4,7 @@ import { kratosAdmin, kratosPublic, toDomainSession } from "./private"
 
 import { KRATOS_MASTER_USER_PASSWORD } from "@/config"
 
+import { UuidRegex } from "@/domain/shared"
 import { InvalidFlowId, InvalidTotpCode } from "@/domain/errors"
 
 export * from "./auth-phone-no-password"
@@ -14,9 +15,6 @@ export * from "./errors"
 export * from "./identity"
 export * from "./totp"
 export * from "./schema"
-
-export const UuidRegex =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 export const checkedToEmailRegistrationId = (
   flow: string,

--- a/core/api/src/services/mongoose/schema.ts
+++ b/core/api/src/services/mongoose/schema.ts
@@ -3,7 +3,7 @@ import crypto from "crypto"
 import mongoose from "mongoose"
 
 import { getDefaultAccountsConfig, Levels } from "@/config"
-import { AccountStatus, UsernameRegex } from "@/domain/accounts"
+import { AccountIdRegex, AccountStatus, UsernameRegex } from "@/domain/accounts"
 import { WalletIdRegex, WalletType } from "@/domain/wallets"
 import { WalletCurrency } from "@/domain/shared"
 
@@ -32,6 +32,15 @@ const walletInvoiceSchema = new Schema<WalletInvoiceRecord>({
     validate: {
       validator: function (v: string) {
         return v.match(WalletIdRegex)
+      },
+    },
+  },
+
+  accountId: {
+    type: String,
+    validate: {
+      validator: function (v: string) {
+        return v.match(AccountIdRegex)
       },
     },
   },

--- a/core/api/src/services/mongoose/schema.types.d.ts
+++ b/core/api/src/services/mongoose/schema.types.d.ts
@@ -61,6 +61,7 @@ interface WalletRecord {
 interface WalletInvoiceRecord {
   _id: string
   walletId: string
+  accountId: string
   cents: number
   secret: string
   currency: string

--- a/core/api/src/services/mongoose/wallet-invoices.ts
+++ b/core/api/src/services/mongoose/wallet-invoices.ts
@@ -145,6 +145,7 @@ export const WalletInvoicesRepository = (): IWalletInvoicesRepository => {
         _id: paymentHash,
         secret,
         walletId: recipientWalletDescriptor.id,
+        accountId: recipientWalletDescriptor.accountId,
         selfGenerated,
         pubkey,
         paid,
@@ -297,6 +298,7 @@ const walletInvoiceFromRaw = (
     recipientWalletDescriptor: {
       id: result.walletId as WalletId,
       currency: result.currency as WalletCurrency,
+      accountId: result.accountId as AccountId,
     },
     selfGenerated: result.selfGenerated,
     pubkey: result.pubkey as Pubkey,


### PR DESCRIPTION
## Description

This is the 1st of 3 PRs to add `accountId` to wallet invoices and setting up a unique index on `(accountId, externalId)`:
- add accountId field for new invoices (this PR)
- migrate accountId in existing invoices
- make `accountId` required field in schema and add `externalId` index