### PR TITLE
chore(core): fallback for language query

### DIFF
--- a/core/api/src/app/users/get-user-language.ts
+++ b/core/api/src/app/users/get-user-language.ts
@@ -1,11 +1,10 @@
+import { DefaultLanguage } from "@/domain/users"
 import { NotificationsService } from "@/services/notifications"
 
-export const getUserLanguage = async (
-  user: User,
-): Promise<UserLanguageOrEmpty | ApplicationError> => {
+export const getUserLanguage = async (user: User): Promise<UserLanguageOrEmpty> => {
   const settings = await NotificationsService().getUserNotificationSettings(user.id)
 
-  if (settings instanceof Error) return settings
+  if (settings instanceof Error) return DefaultLanguage
 
   return settings.language
 }

--- a/core/api/src/config/index.ts
+++ b/core/api/src/config/index.ts
@@ -32,6 +32,8 @@ export const MAX_LENGTH_FOR_FEEDBACK = 1024
 
 export const MIN_SATS_FOR_PRICE_RATIO_PRECISION = 5000n
 
+export const USER_NOTIFICATION_SETTINGS_TIMEOUT_MS = MS_PER_SEC * 5
+
 export const Levels: Levels = [0, 1, 2]
 
 export const getGaloyBuildInformation = () => {

--- a/core/api/src/domain/users/index.ts
+++ b/core/api/src/domain/users/index.ts
@@ -39,6 +39,8 @@ export const checkedToEmailAddress = (
   return emailAddress as EmailAddress
 }
 
+export const DefaultLanguage = "" as UserLanguageOrEmpty
+
 export const checkedToLanguage = (
   language: string,
 ): UserLanguageOrEmpty | ValidationError => {

--- a/core/api/src/services/notifications/grpc-client.ts
+++ b/core/api/src/services/notifications/grpc-client.ts
@@ -1,6 +1,6 @@
 import { promisify } from "util"
 
-import { credentials, Metadata } from "@grpc/grpc-js"
+import { credentials, Metadata, CallOptions } from "@grpc/grpc-js"
 
 import { NotificationsServiceClient } from "./proto/notifications_grpc_pb"
 
@@ -67,6 +67,7 @@ export const disableNotificationChannel = promisify<
 export const getNotificationSettings = promisify<
   GetNotificationSettingsRequest,
   Metadata,
+  Partial<CallOptions>,
   GetNotificationSettingsResponse
 >(notificationsClient.getNotificationSettings.bind(notificationsClient))
 

--- a/core/api/src/services/notifications/index.ts
+++ b/core/api/src/services/notifications/index.ts
@@ -29,11 +29,10 @@ import * as notificationsGrpc from "./grpc-client"
 
 import { handleCommonNotificationErrors } from "./errors"
 
-import { getCallbackServiceConfig } from "@/config"
+import { getCallbackServiceConfig, USER_NOTIFICATION_SETTINGS_TIMEOUT_MS } from "@/config"
 
 import {
   DeepLink,
-  NotificationCategory,
   NotificationsServiceError,
   NotificationType,
   UnknownNotificationsServiceError,
@@ -65,6 +64,9 @@ export const NotificationsService = (): INotificationsService => {
       const response = await notificationsGrpc.getNotificationSettings(
         request,
         notificationsGrpc.notificationsMetadata,
+        {
+          deadline: Date.now() + USER_NOTIFICATION_SETTINGS_TIMEOUT_MS,
+        },
       )
 
       const notificationSettings = grpcNotificationSettingsToNotificationSettings(


### PR DESCRIPTION
- use empty language when notifictions service returns an error
- add timeout to notification settings grpc call