### PR TITLE
fix(core): medici balance performance

### DIFF
--- a/core/api/src/services/ledger/schema.ts
+++ b/core/api/src/services/ledger/schema.ts
@@ -163,6 +163,17 @@ transactionSchema.index({ _original_journal: 1 })
 transactionSchema.index({ related_journal: 1 })
 transactionSchema.index({ external_id: 1 })
 
+// indexes used by balance queries
+transactionSchema.index({ book: 1, accounts: 1, currency: 1, _id: 1 })
+transactionSchema.index({
+  "book": 1,
+  "account_path.0": 1,
+  "account_path.1": 1,
+  "account_path.2": 1,
+  "currency": 1,
+  "_id": 1,
+})
+
 setTransactionSchema(transactionSchema, undefined, { defaultIndexes: true })
 
 export const Transaction = mongoose.model<ILedgerTransaction>(


### PR DESCRIPTION
[Admin balance queries](https://github.com/GaloyMoney/galoy/blob/main/core/api/src/services/ledger/admin-legacy.ts#L20 ) are not working properly after indexes update. This update includes specific index to support `currency` and `_id` when balance snapshot is used 