### PR TITLE
fix(consent): adding hydra test client

### DIFF
--- a/apps/consent/cypress.config.ts
+++ b/apps/consent/cypress.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "cypress"
 import dotenv from "dotenv"
-dotenv.config({ path: "../../dev/.envs/consent.env" })
+dotenv.config({ path: "../../dev/.envs/consent-test.env" })
 
 export default defineConfig({
   e2e: {

--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -309,6 +309,26 @@ local_resource(
   ]
 )
 
+local_resource(
+  name='hydra-consent-test-client',
+  labels = ['auth'],
+  cmd=[
+    'buck2',
+    'run',
+    '//dev:setup-hydra-client',
+    '--',
+    'consent-test',
+    'authorization_code,refresh_token',
+    'http://localhost:3000',
+  ],
+  allow_parallel = True,
+  auto_init = run_apps,
+  resource_deps = [
+    "hydra",
+    "api",
+  ]
+)
+
 consent_test_target = "//apps/consent:test-integration"
 local_resource(
   "test-consent",
@@ -450,6 +470,7 @@ local_resource(
         "apollo-router",
         "hydra",
         "api",
+        "hydra-consent-test-client",
     ],
     links = [
         link("http://localhost:3000", "consent"),


### PR DESCRIPTION
Reverting changes from https://github.com/GaloyMoney/galoy/pull/4346/files
This client is used to test consent standalone.