### PR TITLE
chore(notifications): always set initial_retry_delay to 10s

### DIFF
--- a/core/notifications/src/job/mod.rs
+++ b/core/notifications/src/job/mod.rs
@@ -69,7 +69,8 @@ pub async fn start_job_runner(
 
 #[job(
     name = "all_user_event_dispatch",
-    channel_name = "all_user_event_dispatch"
+    channel_name = "all_user_event_dispatch",
+    backoff_secs = 10
 )]
 async fn all_user_event_dispatch(
     mut current_job: CurrentJob,
@@ -78,6 +79,7 @@ async fn all_user_event_dispatch(
 ) -> Result<(), JobError> {
     let pool = current_job.pool().clone();
     JobExecutor::builder(&mut current_job)
+        .initial_retry_delay(std::time::Duration::from_secs(10))
         .build()
         .expect("couldn't build JobExecutor")
         .execute(|data| async move {
@@ -112,7 +114,11 @@ async fn all_user_event_dispatch(
     Ok(())
 }
 
-#[job(name = "link_email_reminder", channel_name = "link_email_reminder")]
+#[job(
+    name = "link_email_reminder",
+    channel_name = "link_email_reminder",
+    backoff_secs = 10
+)]
 async fn link_email_reminder(
     mut current_job: CurrentJob,
     email_reminder_projection: EmailReminderProjection,
@@ -120,6 +126,7 @@ async fn link_email_reminder(
 ) -> Result<(), JobError> {
     let pool = current_job.pool().clone();
     JobExecutor::builder(&mut current_job)
+        .initial_retry_delay(std::time::Duration::from_secs(10))
         .build()
         .expect("couldn't build JobExecutor")
         .execute(|data| async move {
@@ -186,7 +193,7 @@ async fn kickoff_link_email_reminder(
 #[job(
     name = "multi_user_event_dispatch",
     channel_name = "multi_user_event_dispatch",
-    backoff_secs = 20
+    backoff_secs = 10
 )]
 async fn multi_user_event_dispatch(
     mut current_job: CurrentJob,
@@ -194,7 +201,7 @@ async fn multi_user_event_dispatch(
 ) -> Result<(), JobError> {
     let pool = current_job.pool().clone();
     JobExecutor::builder(&mut current_job)
-        .initial_retry_delay(std::time::Duration::from_secs(20))
+        .initial_retry_delay(std::time::Duration::from_secs(10))
         .build()
         .expect("couldn't build JobExecutor")
         .execute(|data| async move {
@@ -237,13 +244,15 @@ async fn multi_user_event_dispatch(
 
 #[job(
     name = "send_push_notification",
-    channel_name = "send_push_notification"
+    channel_name = "send_push_notification",
+    backoff_secs = 10
 )]
 async fn send_push_notification(
     mut current_job: CurrentJob,
     executor: PushExecutor,
 ) -> Result<(), JobError> {
     JobExecutor::builder(&mut current_job)
+        .initial_retry_delay(std::time::Duration::from_secs(10))
         .build()
         .expect("couldn't build JobExecutor")
         .execute(|data| async move {
@@ -356,13 +365,15 @@ pub async fn spawn_kickoff_link_email_reminder(
 
 #[job(
     name = "send_email_notification",
-    channel_name = "send_email_notification"
+    channel_name = "send_email_notification",
+    backoff_secs = 10
 )]
 async fn send_email_notification(
     mut current_job: CurrentJob,
     executor: EmailExecutor,
 ) -> Result<(), JobError> {
     JobExecutor::builder(&mut current_job)
+        .initial_retry_delay(std::time::Duration::from_secs(10))
         .build()
         .expect("couldn't build JobExecutor")
         .execute(|data| async move {


### PR DESCRIPTION
Setting initial retry to 10s for all jobs to avoid duplicate job executions.